### PR TITLE
Upgrade Symfony package to 6.4.40 and twig/twig to 3.26.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -18285,51 +18285,48 @@
         },
         {
             "name": "vincentlanglet/twig-cs-fixer",
-            "version": "3.1.0",
+            "version": "3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/VincentLanglet/Twig-CS-Fixer.git",
-                "reference": "a0e552fbd6fe264f09f6389a950347a7bf70cfb9"
+                "reference": "599f110f192c31af5deb5736d6c1a970afdf51f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/VincentLanglet/Twig-CS-Fixer/zipball/a0e552fbd6fe264f09f6389a950347a7bf70cfb9",
-                "reference": "a0e552fbd6fe264f09f6389a950347a7bf70cfb9",
+                "url": "https://api.github.com/repos/VincentLanglet/Twig-CS-Fixer/zipball/599f110f192c31af5deb5736d6c1a970afdf51f3",
+                "reference": "599f110f192c31af5deb5736d6c1a970afdf51f3",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.0.0",
                 "ext-ctype": "*",
-                "ext-json": "*",
-                "php": ">=8.0",
-                "symfony/console": "^5.4.9 || ^6.4 || ^7.0",
-                "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
-                "symfony/finder": "^5.4 || ^6.4 || ^7.0",
-                "symfony/string": "^5.4.42 || ^6.4.10 || ~7.0.10 || ^7.1.3",
+                "php": ">=8.1",
+                "symfony/console": "^5.4.9 || ^6.4 || ^7.0 || ^8.0",
+                "symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+                "symfony/finder": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+                "symfony/string": "^5.4.42 || ^6.4.10 || ~7.0.10 || ^7.1.3 || ^8.0",
                 "twig/twig": "^3.4",
-                "webmozart/assert": "^1.10"
+                "webmozart/assert": "^1.10 || ^2.0"
             },
             "require-dev": {
                 "composer/semver": "^3.2.0",
                 "dereuromark/composer-prefer-lowest": "^0.1.10",
                 "ergebnis/composer-normalize": "^2.29",
                 "friendsofphp/php-cs-fixer": "^3.13.0",
-                "infection/infection": "^0.26.16 || ^0.27.0",
-                "phpstan/phpstan": "^1.9.1",
-                "phpstan/phpstan-phpunit": "^1.2.2",
-                "phpstan/phpstan-strict-rules": "^1.4.4",
-                "phpstan/phpstan-symfony": "^1.2.16",
-                "phpstan/phpstan-webmozart-assert": "^1.2.2",
-                "phpunit/phpunit": "^9.5.26 || ^10.0.9",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "psalm/plugin-symfony": "^5.0.0",
-                "rector/rector": "^1.0.0",
+                "infection/infection": "^0.26.16 || ^0.32.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpstan/phpstan-symfony": "^2.0",
+                "phpstan/phpstan-webmozart-assert": "^2.0",
+                "phpunit/phpunit": "^9.5.26 || ^11.5.18 || ^12.1.3",
+                "rector/rector": "^2.0.0",
                 "shipmonk/composer-dependency-analyser": "^1.6",
-                "symfony/process": "^5.4 || ^6.4 || ^7.0",
-                "symfony/twig-bridge": "^5.4 || ^6.4 || ^7.0",
+                "symfony/process": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+                "symfony/twig-bridge": "^5.4 || ^6.4 || ^7.0 || ^8.0",
                 "symfony/ux-twig-component": "^2.2.0",
-                "twig/cache-extra": "^3.2",
-                "vimeo/psalm": "^5.2.0"
+                "twig/cache-extra": "^3.2"
             },
             "bin": [
                 "bin/twig-cs-fixer"
@@ -18353,7 +18350,7 @@
             "homepage": "https://github.com/VincentLanglet/Twig-CS-Fixer",
             "support": {
                 "issues": "https://github.com/VincentLanglet/Twig-CS-Fixer/issues",
-                "source": "https://github.com/VincentLanglet/Twig-CS-Fixer/tree/3.1.0"
+                "source": "https://github.com/VincentLanglet/Twig-CS-Fixer/tree/3.14.0"
             },
             "funding": [
                 {
@@ -18361,7 +18358,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-30T11:23:49+00:00"
+            "time": "2026-02-23T13:21:35+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -8273,16 +8273,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.4.38",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "6ae5a11f1e7506751390ee320a79bda9cb65cdcd"
+                "reference": "8f9b022e63fa02bd984c06dc886039936ea17714"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/6ae5a11f1e7506751390ee320a79bda9cb65cdcd",
-                "reference": "6ae5a11f1e7506751390ee320a79bda9cb65cdcd",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/8f9b022e63fa02bd984c06dc886039936ea17714",
+                "reference": "8f9b022e63fa02bd984c06dc886039936ea17714",
                 "shasum": ""
             },
             "require": {
@@ -8349,7 +8349,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.4.38"
+                "source": "https://github.com/symfony/cache/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -8369,20 +8369,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-05T08:16:30+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "5d68a57d66910405e5c0b63d6f0af941e66fc868"
+                "reference": "225e8a254166bd3442e370c6f50145465db63831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/5d68a57d66910405e5c0b63d6f0af941e66fc868",
-                "reference": "5d68a57d66910405e5c0b63d6f0af941e66fc868",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/225e8a254166bd3442e370c6f50145465db63831",
+                "reference": "225e8a254166bd3442e370c6f50145465db63831",
                 "shasum": ""
             },
             "require": {
@@ -8396,7 +8396,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -8429,7 +8429,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -8441,11 +8441,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-13T15:25:07+00:00"
+            "time": "2026-05-05T15:33:14+00:00"
         },
         {
             "name": "symfony/clock",
@@ -8606,16 +8610,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.37",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7bbcaf3fdb1e18fa42a7f0b84a10d091c10548f5"
+                "reference": "c132f1215fe4aa45b70173cc00ce9a755dd31ec5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7bbcaf3fdb1e18fa42a7f0b84a10d091c10548f5",
-                "reference": "7bbcaf3fdb1e18fa42a7f0b84a10d091c10548f5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c132f1215fe4aa45b70173cc00ce9a755dd31ec5",
+                "reference": "c132f1215fe4aa45b70173cc00ce9a755dd31ec5",
                 "shasum": ""
             },
             "require": {
@@ -8680,7 +8684,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.37"
+                "source": "https://github.com/symfony/console/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -8700,7 +8704,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:27:04+00:00"
+            "time": "2026-05-12T06:50:03+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -8936,16 +8940,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -8958,7 +8962,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -8983,7 +8987,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -8995,11 +8999,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/doctrine-bridge",
@@ -9191,16 +9199,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v6.4.34",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "ec0d22e1b89d5767a44f7abb63a1f1439bd9c735"
+                "reference": "7e65f76c28f5ed8d933f2c86698a3e2bf0de1b10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/ec0d22e1b89d5767a44f7abb63a1f1439bd9c735",
-                "reference": "ec0d22e1b89d5767a44f7abb63a1f1439bd9c735",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/7e65f76c28f5ed8d933f2c86698a3e2bf0de1b10",
+                "reference": "7e65f76c28f5ed8d933f2c86698a3e2bf0de1b10",
                 "shasum": ""
             },
             "require": {
@@ -9238,7 +9246,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v6.4.34"
+                "source": "https://github.com/symfony/dom-crawler/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -9258,20 +9266,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-16T20:44:03+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "symfony/dotenv",
-            "version": "v6.4.37",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "381ab0832cbc8bc0e927da6bd5116de7b8cae974"
+                "reference": "e25b00497fe75e318c01a72ea24c0a9c2837cd62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/381ab0832cbc8bc0e927da6bd5116de7b8cae974",
-                "reference": "381ab0832cbc8bc0e927da6bd5116de7b8cae974",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/e25b00497fe75e318c01a72ea24c0a9c2837cd62",
+                "reference": "e25b00497fe75e318c01a72ea24c0a9c2837cd62",
                 "shasum": ""
             },
             "require": {
@@ -9316,7 +9324,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v6.4.37"
+                "source": "https://github.com/symfony/dotenv/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -9336,7 +9344,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T06:20:43+00:00"
+            "time": "2026-05-06T14:07:03+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -9503,16 +9511,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -9526,7 +9534,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -9559,7 +9567,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -9571,11 +9579,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/expression-language",
@@ -9647,16 +9659,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.37",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "29f792d7dc30cc670fc4cdd50d7c6653d067ce7b"
+                "reference": "c507b077756b4e3e09adbbe7975fac81cd3722ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/29f792d7dc30cc670fc4cdd50d7c6653d067ce7b",
-                "reference": "29f792d7dc30cc670fc4cdd50d7c6653d067ce7b",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c507b077756b4e3e09adbbe7975fac81cd3722ca",
+                "reference": "c507b077756b4e3e09adbbe7975fac81cd3722ca",
                 "shasum": ""
             },
             "require": {
@@ -9693,7 +9705,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.37"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -9713,7 +9725,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:27:04+00:00"
+            "time": "2026-05-07T13:11:42+00:00"
         },
         {
             "name": "symfony/finder",
@@ -9886,16 +9898,16 @@
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v6.4.37",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "b147918db04b0d823e551b01a7a4f342e415baa5"
+                "reference": "a9cd7d768b9658fb8e9fa505ade58e5211ed7049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/b147918db04b0d823e551b01a7a4f342e415baa5",
-                "reference": "b147918db04b0d823e551b01a7a4f342e415baa5",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/a9cd7d768b9658fb8e9fa505ade58e5211ed7049",
+                "reference": "a9cd7d768b9658fb8e9fa505ade58e5211ed7049",
                 "shasum": ""
             },
             "require": {
@@ -10015,7 +10027,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v6.4.37"
+                "source": "https://github.com/symfony/framework-bundle/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -10035,7 +10047,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T17:11:44+00:00"
+            "time": "2026-05-13T11:43:22+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -10137,16 +10149,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
                 "shasum": ""
             },
             "require": {
@@ -10159,7 +10171,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -10195,7 +10207,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -10207,11 +10219,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T11:18:49+00:00"
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -10296,16 +10312,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.38",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "769c1ee766d6c327176f4e3bdaad58f521193abd"
+                "reference": "41dff5c3d03b3fa20947c552c5f6ba74ca43fa28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/769c1ee766d6c327176f4e3bdaad58f521193abd",
-                "reference": "769c1ee766d6c327176f4e3bdaad58f521193abd",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/41dff5c3d03b3fa20947c552c5f6ba74ca43fa28",
+                "reference": "41dff5c3d03b3fa20947c552c5f6ba74ca43fa28",
                 "shasum": ""
             },
             "require": {
@@ -10390,7 +10406,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.38"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -10410,7 +10426,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-06T13:04:40+00:00"
+            "time": "2026-05-20T08:55:59+00:00"
         },
         {
             "name": "symfony/intl",
@@ -10584,16 +10600,16 @@
         },
         {
             "name": "symfony/mailer",
-            "version": "v6.4.34",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "01b846f48e53ee4096692a383637a1fa4d577301"
+                "reference": "94fd44f3052e02340b0dd4447a7d7a5856e32da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/01b846f48e53ee4096692a383637a1fa4d577301",
-                "reference": "01b846f48e53ee4096692a383637a1fa4d577301",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/94fd44f3052e02340b0dd4447a7d7a5856e32da2",
+                "reference": "94fd44f3052e02340b0dd4447a7d7a5856e32da2",
                 "shasum": ""
             },
             "require": {
@@ -10644,7 +10660,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v6.4.34"
+                "source": "https://github.com/symfony/mailer/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -10664,20 +10680,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-24T09:34:36+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "symfony/messenger",
-            "version": "v6.4.38",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "580a185c5c52f770b00c992e53ee220ca8f06601"
+                "reference": "c96b8feaeedd0b19a104e08e953e6068a35ce553"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/580a185c5c52f770b00c992e53ee220ca8f06601",
-                "reference": "580a185c5c52f770b00c992e53ee220ca8f06601",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/c96b8feaeedd0b19a104e08e953e6068a35ce553",
+                "reference": "c96b8feaeedd0b19a104e08e953e6068a35ce553",
                 "shasum": ""
             },
             "require": {
@@ -10735,7 +10751,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v6.4.38"
+                "source": "https://github.com/symfony/messenger/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -10755,20 +10771,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-04T15:48:23+00:00"
+            "time": "2026-05-11T12:57:53+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.4.37",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "330077bc7fbe314758aff62834b758d06ac6d260"
+                "reference": "7ccfb0cc6ff707ac9ca34b6ddab0bc6187436cbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/330077bc7fbe314758aff62834b758d06ac6d260",
-                "reference": "330077bc7fbe314758aff62834b758d06ac6d260",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/7ccfb0cc6ff707ac9ca34b6ddab0bc6187436cbe",
+                "reference": "7ccfb0cc6ff707ac9ca34b6ddab0bc6187436cbe",
                 "shasum": ""
             },
             "require": {
@@ -10824,7 +10840,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.4.37"
+                "source": "https://github.com/symfony/mime/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -10844,20 +10860,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T09:53:28+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v6.4.37",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "690d3d19bb1855c01a4227c8afc02e7c99de3f34"
+                "reference": "85500da808ce785c6c95fafdbc226cd8af349007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/690d3d19bb1855c01a4227c8afc02e7c99de3f34",
-                "reference": "690d3d19bb1855c01a4227c8afc02e7c99de3f34",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/85500da808ce785c6c95fafdbc226cd8af349007",
+                "reference": "85500da808ce785c6c95fafdbc226cd8af349007",
                 "shasum": ""
             },
             "require": {
@@ -10907,7 +10923,7 @@
             "description": "Provides integration for Monolog with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/monolog-bridge/tree/v6.4.37"
+                "source": "https://github.com/symfony/monolog-bridge/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -10927,7 +10943,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T07:07:43+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -12057,16 +12073,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.33",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
+                "reference": "6c93071cb8c91dce5a41960d125e019e64ef6cb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
-                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6c93071cb8c91dce5a41960d125e019e64ef6cb5",
+                "reference": "6c93071cb8c91dce5a41960d125e019e64ef6cb5",
                 "shasum": ""
             },
             "require": {
@@ -12098,7 +12114,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.33"
+                "source": "https://github.com/symfony/process/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -12118,7 +12134,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-23T16:02:12+00:00"
+            "time": "2026-05-11T16:53:15+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -12451,16 +12467,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.37",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "48035d186798d27d375d95aad37db8fe097e4048"
+                "reference": "0cd0d2fb05382c95dff6b33c51a7c96cbdbc136d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/48035d186798d27d375d95aad37db8fe097e4048",
-                "reference": "48035d186798d27d375d95aad37db8fe097e4048",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/0cd0d2fb05382c95dff6b33c51a7c96cbdbc136d",
+                "reference": "0cd0d2fb05382c95dff6b33c51a7c96cbdbc136d",
                 "shasum": ""
             },
             "require": {
@@ -12514,7 +12530,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.37"
+                "source": "https://github.com/symfony/routing/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -12534,20 +12550,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:45:55+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v6.4.36",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-bundle.git",
-                "reference": "00ce7236da125b39a24784958861678f7d09ce4c"
+                "reference": "435bb0b36c0593506507909e262a0dd9a3996de7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/00ce7236da125b39a24784958861678f7d09ce4c",
-                "reference": "00ce7236da125b39a24784958861678f7d09ce4c",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/435bb0b36c0593506507909e262a0dd9a3996de7",
+                "reference": "435bb0b36c0593506507909e262a0dd9a3996de7",
                 "shasum": ""
             },
             "require": {
@@ -12630,7 +12646,7 @@
             "description": "Provides a tight integration of the Security component into the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-bundle/tree/v6.4.36"
+                "source": "https://github.com/symfony/security-bundle/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -12650,20 +12666,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:20:55+00:00"
+            "time": "2026-05-13T11:44:33+00:00"
         },
         {
             "name": "symfony/security-core",
-            "version": "v6.4.36",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "1b7db28bcc3655543abfe58764025aef563705cd"
+                "reference": "66517b3235ea8ceddc772d9dede40a83c7684a6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/1b7db28bcc3655543abfe58764025aef563705cd",
-                "reference": "1b7db28bcc3655543abfe58764025aef563705cd",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/66517b3235ea8ceddc772d9dede40a83c7684a6b",
+                "reference": "66517b3235ea8ceddc772d9dede40a83c7684a6b",
                 "shasum": ""
             },
             "require": {
@@ -12720,7 +12736,7 @@
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-core/tree/v6.4.36"
+                "source": "https://github.com/symfony/security-core/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -12740,7 +12756,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-31T01:40:43+00:00"
+            "time": "2026-05-13T08:35:02+00:00"
         },
         {
             "name": "symfony/security-csrf",
@@ -12816,16 +12832,16 @@
         },
         {
             "name": "symfony/security-http",
-            "version": "v6.4.34",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-http.git",
-                "reference": "894bb42b39bfb240a1f82c9a46a1ce9402a31a6f"
+                "reference": "816860d96c4fb7ffd7708ae0531ea6e5a1190773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/894bb42b39bfb240a1f82c9a46a1ce9402a31a6f",
-                "reference": "894bb42b39bfb240a1f82c9a46a1ce9402a31a6f",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/816860d96c4fb7ffd7708ae0531ea6e5a1190773",
+                "reference": "816860d96c4fb7ffd7708ae0531ea6e5a1190773",
                 "shasum": ""
             },
             "require": {
@@ -12884,7 +12900,7 @@
             "description": "Symfony Security Component - HTTP Integration",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-http/tree/v6.4.34"
+                "source": "https://github.com/symfony/security-http/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -12904,7 +12920,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-16T20:44:03+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -13010,16 +13026,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -13037,7 +13053,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -13073,7 +13089,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -13093,20 +13109,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.34",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432"
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/2adaf4106f2ef4c67271971bde6d3fe0a6936432",
-                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432",
+                "url": "https://api.github.com/repos/symfony/string/zipball/62e3c927de664edadb5bef260987eb047a17a113",
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113",
                 "shasum": ""
             },
             "require": {
@@ -13162,7 +13178,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.34"
+                "source": "https://github.com/symfony/string/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -13182,7 +13198,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-08T20:44:54+00:00"
+            "time": "2026-05-12T11:44:19+00:00"
         },
         {
             "name": "symfony/templating",
@@ -13355,16 +13371,16 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
                 "shasum": ""
             },
             "require": {
@@ -13377,7 +13393,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -13413,7 +13429,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -13433,20 +13449,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v6.4.36",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "3ae963a108fd6fc14d09a7fe5e41fe64d8ac11ba"
+                "reference": "5a68963b44e9a7089415540908c61de976c1ae34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/3ae963a108fd6fc14d09a7fe5e41fe64d8ac11ba",
-                "reference": "3ae963a108fd6fc14d09a7fe5e41fe64d8ac11ba",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/5a68963b44e9a7089415540908c61de976c1ae34",
+                "reference": "5a68963b44e9a7089415540908c61de976c1ae34",
                 "shasum": ""
             },
             "require": {
@@ -13462,7 +13478,7 @@
                 "symfony/form": "<6.4.32|>7,<7.3.10|>7.4,<7.4.4",
                 "symfony/http-foundation": "<5.4",
                 "symfony/http-kernel": "<6.4",
-                "symfony/mime": "<6.2",
+                "symfony/mime": "<6.4.37|>=7.0,<7.4.9",
                 "symfony/serializer": "<6.4",
                 "symfony/translation": "<5.4",
                 "symfony/workflow": "<5.4"
@@ -13482,7 +13498,7 @@
                 "symfony/http-foundation": "^5.4|^6.0|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
                 "symfony/intl": "^5.4|^6.0|^7.0",
-                "symfony/mime": "^6.2|^7.0",
+                "symfony/mime": "^6.4.37|^7.4.9",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/property-info": "^5.4|^6.0|^7.0",
                 "symfony/routing": "^5.4|^6.0|^7.0",
@@ -13526,7 +13542,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v6.4.36"
+                "source": "https://github.com/symfony/twig-bridge/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -13546,7 +13562,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T09:31:23+00:00"
+            "time": "2026-05-11T09:54:00+00:00"
         },
         {
             "name": "symfony/twig-bundle",
@@ -14177,16 +14193,16 @@
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v6.4.36",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "6f75b4c748886c8e04a3674225d00eaa51f3842d"
+                "reference": "be546fdb34d7a05eb271dfe0bf2370c37472e15c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/6f75b4c748886c8e04a3674225d00eaa51f3842d",
-                "reference": "6f75b4c748886c8e04a3674225d00eaa51f3842d",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/be546fdb34d7a05eb271dfe0bf2370c37472e15c",
+                "reference": "be546fdb34d7a05eb271dfe0bf2370c37472e15c",
                 "shasum": ""
             },
             "require": {
@@ -14239,7 +14255,7 @@
                 "dev"
             ],
             "support": {
-                "source": "https://github.com/symfony/web-profiler-bundle/tree/v6.4.36"
+                "source": "https://github.com/symfony/web-profiler-bundle/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -14259,20 +14275,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-17T09:05:06+00:00"
+            "time": "2026-05-10T17:25:48+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.38",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "f8d2f4af29053842c01b4cae6bd4c2c3191fc63c"
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8d2f4af29053842c01b4cae6bd4c2c3191fc63c",
-                "reference": "f8d2f4af29053842c01b4cae6bd4c2c3191fc63c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/68dcd1f1602dac9d9221e25729683e0ce8733f3b",
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b",
                 "shasum": ""
             },
             "require": {
@@ -14315,7 +14331,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.38"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -14335,7 +14351,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-05T06:55:40+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",
@@ -14522,26 +14538,26 @@
         },
         {
             "name": "twig/extra-bundle",
-            "version": "v3.16.0",
+            "version": "v3.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/twig-extra-bundle.git",
-                "reference": "9746573ca4bc1cd03a767a183faadaf84e0c31fa"
+                "reference": "6a621fcb1f28aa9ea7b34a99047ae0cdf5b834c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/twig-extra-bundle/zipball/9746573ca4bc1cd03a767a183faadaf84e0c31fa",
-                "reference": "9746573ca4bc1cd03a767a183faadaf84e0c31fa",
+                "url": "https://api.github.com/repos/twigphp/twig-extra-bundle/zipball/6a621fcb1f28aa9ea7b34a99047ae0cdf5b834c9",
+                "reference": "6a621fcb1f28aa9ea7b34a99047ae0cdf5b834c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/framework-bundle": "^5.4|^6.4|^7.0",
-                "symfony/twig-bundle": "^5.4|^6.4|^7.0",
+                "php": ">=8.1.0",
+                "symfony/framework-bundle": "^5.4|^6.4|^7.0|^8.0",
+                "symfony/twig-bundle": "^5.4|^6.4|^7.0|^8.0",
                 "twig/twig": "^3.2|^4.0"
             },
             "require-dev": {
-                "league/commonmark": "^1.0|^2.0",
+                "league/commonmark": "^2.7",
                 "symfony/phpunit-bridge": "^6.4|^7.0",
                 "twig/cache-extra": "^3.0",
                 "twig/cssinliner-extra": "^3.0",
@@ -14580,7 +14596,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/twigphp/twig-extra-bundle/tree/v3.16.0"
+                "source": "https://github.com/twigphp/twig-extra-bundle/tree/v3.24.0"
             },
             "funding": [
                 {
@@ -14592,25 +14608,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-26T19:22:23+00:00"
+            "time": "2026-02-07T08:07:38+00:00"
         },
         {
             "name": "twig/string-extra",
-            "version": "v3.16.0",
+            "version": "v3.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/string-extra.git",
-                "reference": "3f90208078a7d55ad4a561301ee3929d3e3840e0"
+                "reference": "6ec8f2e8ca9b2193221a02cb599dc92c36384368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/string-extra/zipball/3f90208078a7d55ad4a561301ee3929d3e3840e0",
-                "reference": "3f90208078a7d55ad4a561301ee3929d3e3840e0",
+                "url": "https://api.github.com/repos/twigphp/string-extra/zipball/6ec8f2e8ca9b2193221a02cb599dc92c36384368",
+                "reference": "6ec8f2e8ca9b2193221a02cb599dc92c36384368",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/string": "^5.4|^6.4|^7.0",
+                "php": ">=8.1.0",
+                "symfony/string": "^5.4|^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^1.1|^2|^3",
                 "twig/twig": "^3.13|^4.0"
             },
@@ -14647,7 +14663,7 @@
                 "unicode"
             ],
             "support": {
-                "source": "https://github.com/twigphp/string-extra/tree/v3.16.0"
+                "source": "https://github.com/twigphp/string-extra/tree/v3.24.0"
             },
             "funding": [
                 {
@@ -14659,20 +14675,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-20T13:10:15+00:00"
+            "time": "2025-12-02T14:45:16+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.20.0",
+            "version": "v3.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3468920399451a384bef53cf7996965f7cd40183"
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3468920399451a384bef53cf7996965f7cd40183",
-                "reference": "3468920399451a384bef53cf7996965f7cd40183",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
                 "shasum": ""
             },
             "require": {
@@ -14682,7 +14698,8 @@
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^2.0",
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
                 "psr/container": "^1.0|^2.0",
                 "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
@@ -14726,7 +14743,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.20.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
             },
             "funding": [
                 {
@@ -14738,7 +14755,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-13T08:34:43+00:00"
+            "time": "2026-05-20T07:31:59+00:00"
         },
         {
             "name": "wikimedia/cssjanus",

--- a/src/Core/Version.php
+++ b/src/Core/Version.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
@@ -12,14 +13,12 @@ namespace PrestaShop\PrestaShop\Core;
  */
 final class Version
 {
-    public const VERSION = '9.1.2';
+    public const VERSION = '9.1.3';
     public const MAJOR_VERSION_STRING = '9';
     public const MAJOR_VERSION = 9;
     public const MINOR_VERSION = 1;
     public const RELEASE_VERSION = 2;
 
     // This class should not be instanciated
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 }

--- a/src/Core/Version.php
+++ b/src/Core/Version.php
@@ -20,5 +20,7 @@ final class Version
     public const RELEASE_VERSION = 2;
 
     // This class should not be instanciated
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/empty_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/empty_row.html.twig
@@ -8,8 +8,8 @@
     {% if grid.attributes.is_empty_state %}
       {{ include([
         '@PrestaShop/Admin/Common/Grid/Blocks/EmptyState/' ~ grid.id ~ '.html.twig',
-        '@PrestaShop/Admin/Common/Grid/Blocks/EmptyState/_default.html.twig'
-        ], {grid: grid}
+        '@PrestaShop/Admin/Common/Grid/Blocks/EmptyState/_default.html.twig',
+        ], {grid: grid},
       ) }}
     {% else %}
       {{ include('@PrestaShop/Admin/Common/Grid/Blocks/EmptyState/_default.html.twig', {grid: grid}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/filter_link_group.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/filter_link_group.html.twig
@@ -10,7 +10,7 @@
 {% set default_value = filter.vars.default_value|default('') %}
 {% set current_value = grid.filters[filter_name]|default(app.request.get(grid.form_prefix) is iterable
   ? app.request.get(grid.form_prefix).filters[filter_name]|default(app.request.get(grid.form_prefix)[filter_name]|default(default_value))
-  : default_value
+  : default_value,
 ) %}
 {% set container_class = container_class|default('filter-link-group') %}
 {% set item_class = item_class|default('filter-link-group__item') %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
@@ -18,7 +18,7 @@
       prefix: grid.form_prefix,
       caller_route: app.request.attributes.get('_route'),
       caller_parameters: route_params,
-      view: grid.view_options.pagination_view|default('full')
+      view: grid.view_options.pagination_view|default('full'),
     })) }}
   {% endif %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
@@ -6,7 +6,7 @@
 {{ renderhook('displayAdminGridTableBefore', {
     grid: grid,
     legacy_controller: app.request.attributes.get('_legacy_controller'),
-    controller: app.request.attributes.get('_controller')
+    controller: app.request.attributes.get('_controller'),
   })
 }}
 
@@ -55,6 +55,6 @@
 {{ renderhook('displayAdminGridTableAfter', {
       grid: grid,
       legacy_controller: app.request.attributes.get('_legacy_controller'),
-      controller: app.request.attributes.get('_controller')
+      controller: app.request.attributes.get('_controller'),
     })
 }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/action.html.twig
@@ -30,7 +30,7 @@
                 column: column,
                 attributes: {class: class|trim, tooltip_name: true},
                 record: record,
-                action: inlineAction
+                action: inlineAction,
               }) }}
           {% endfor %}
         </div>
@@ -54,7 +54,7 @@
                 column: column,
                 attributes: {class: class|trim, tooltip_name: true},
                 record: record,
-                action: action
+                action: action,
               }) }}
 
               {% set isFirstRendered = true %}
@@ -77,7 +77,7 @@
                   column: column,
                   attributes: {class: 'dropdown-item', tooltip_name: false},
                   record: record,
-                  action: action
+                  action: action,
                 }) }}
               {% endfor %}
             </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/api_client_toggle.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/api_client_toggle.html.twig
@@ -8,7 +8,7 @@
   {{ include('@PrestaShop/Admin/Common/Grid/Columns/Content/toggle.html.twig', {
     column: column,
     record: record,
-  }
+  },
   ) }}
 {% else %}
   <div class="text-center">

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/identifier.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/identifier.html.twig
@@ -23,6 +23,6 @@
   {{ include('@PrestaShop/Admin/Common/Grid/Columns/Content/preview.html.twig', {
     column: column.options.preview,
     record: record,
-  }
+  },
   ) }}
 {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/javascript_pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/javascript_pagination.html.twig
@@ -44,7 +44,7 @@
            '%to%': '%to%',
            '%total%': '%total%',
            '%current_page%': '%current_page%',
-           '%page_count%': '%page_count%'
+           '%page_count%': '%page_count%',
          }, 'Admin.Catalog.Feature') }}"
   >
   </label>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig
@@ -27,7 +27,7 @@
         '%to%': min(to + 1, total),
         '%total%': total,
         '%current_page%': current_page,
-        '%page_count%': page_count
+        '%page_count%': page_count,
       }, 'Admin.Catalog.Feature') }}
     </label>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/FormTheme/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/FormTheme/employee_options.html.twig
@@ -29,7 +29,7 @@
       {% endif %}
       <div class="{{ block('form_group_class') }}{% if disabledField %} disabled{% endif %}">
         {{ form_widget(form) }}
-        {# #}
+        {##}
         {{ form_errors(form, {attr: {fieldError: true}}) }}
         {{- block('form_alert') -}}
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/edit.html.twig
@@ -15,7 +15,7 @@
 
   {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig', {
     employeeForm: employeeForm,
-    isRestrictedAccess: isRestrictedAccess
+    isRestrictedAccess: isRestrictedAccess,
   }) }}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/index.html.twig
@@ -7,8 +7,8 @@
   add: {
     href: path('admin_employees_create'),
     desc: 'Add new employee'|trans({}, 'Admin.Advparameters.Feature'),
-    icon: 'add_circle_outline'
-  }
+    icon: 'add_circle_outline',
+  },
 } %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/ImportDataConfiguration/Blocks/import_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/ImportDataConfiguration/Blocks/import_modal.html.twig
@@ -11,7 +11,7 @@
   closable: false,
   progressbar: {
     id: 'import_progress_bar',
-    label: 'Validating data...'|trans
+    label: 'Validating data...'|trans,
   },
   actions: [
     {
@@ -28,7 +28,7 @@
       type: 'button',
       label: 'Close'|trans({}, 'Admin.Actions'),
       class: 'btn btn-outline-secondary btn-lg js-close-modal',
-    }
+    },
   ],
 } %}
   {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Permission/Blocks/profile_tab_contents.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Permission/Blocks/profile_tab_contents.html.twig
@@ -49,7 +49,7 @@
               all: {
                 value: configurablePermissions.isBulkAllConfigurationEnabled(profile.id),
                 label: ('All'|trans({}, 'Admin.Actions')),
-              }
+              },
             }
           %}
           <div class="col-xl-6">
@@ -78,7 +78,7 @@
               uninstall: {
                 value: configurablePermissions.isBulkEditConfigurationEnabled(profile.id),
                 label: ('Uninstall'|trans({}, 'Admin.Actions')),
-              }
+              },
             }
           %}
           <div class="col-xl-6">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
@@ -8,8 +8,8 @@
   add: {
     href: path('admin_webservice_keys_create'),
     desc: 'Add new webservice key'|trans({}, 'Admin.Advparameters.Feature'),
-    icon: 'add_circle_outline'
-  }
+    icon: 'add_circle_outline',
+  },
 } %}
 
 {% block content %}
@@ -46,7 +46,7 @@
           {% endif %}
           <p>
             {{ 'Read the [1]developer documentation[/1].'|trans({
-              '[1]': '<a href="' ~ devdocUrl ~ '" target="_blank">', '[/1]': '</a>'
+              '[1]': '<a href="' ~ devdocUrl ~ '" target="_blank">', '[/1]': '</a>',
             }, 'Admin.Advparameters.Feature')|raw_purified }}
           </p>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/CustomerSettings/Groups/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/CustomerSettings/Groups/index.html.twig
@@ -10,7 +10,7 @@
     href: path('admin_customer_groups_create'),
     desc: 'Add new group'|trans({}, 'Admin.Shopparameters.Feature'),
     icon: 'add_circle_outline',
-  }
+  },
 }
 %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/CustomerSettings/Title/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/CustomerSettings/Title/index.html.twig
@@ -8,7 +8,7 @@
     href: path('admin_title_create'),
     desc: 'Add new title'|trans({}, 'Admin.Shopparameters.Feature'),
     icon: 'add_circle_outline',
-  }
+  },
 }
 %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/index.html.twig
@@ -7,13 +7,13 @@
   add: {
     href: path('admin_order_states_create'),
     desc: 'Add new order status'|trans({}, 'Admin.Shopparameters.Feature'),
-    icon: 'add_circle_outline'
+    icon: 'add_circle_outline',
   },
   add_return_state: {
     href: path('admin_order_return_states_create'),
     desc: 'Add new return status'|trans({}, 'Admin.Shopparameters.Feature'),
-    icon: 'add_circle_outline'
-  }
+    icon: 'add_circle_outline',
+  },
 } %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig
@@ -18,11 +18,11 @@
           attr: {
             class: 'js-meta-page-name',
             'data-toggle': 'select2',
-            'data-minimumResultsForSearch': '7'
-          }
+            'data-minimumResultsForSearch': '7',
+          },
         }, {
           label: 'Page name'|trans({}, 'Admin.Shopparameters.Feature'),
-          help: 'Name of the related page.'|trans({}, 'Admin.Shopparameters.Help')
+          help: 'Name of the related page.'|trans({}, 'Admin.Shopparameters.Help'),
         }) }}
 
         {% set pageTitleHelpLabel %}
@@ -32,7 +32,7 @@
 
         {{ ps.form_group_row(metaForm.page_title, {}, {
           label: 'Page title'|trans({}, 'Admin.Shopparameters.Feature'),
-          help: pageTitleHelpLabel
+          help: pageTitleHelpLabel,
         }) }}
 
         {% set metaDescriptionHelpLabel %}
@@ -42,7 +42,7 @@
 
         {{ ps.form_group_row(metaForm.meta_description, {}, {
           label: 'Meta description'|trans({}, 'Admin.Global'),
-          help: metaDescriptionHelpLabel
+          help: metaDescriptionHelpLabel,
         }) }}
 
         {% set rewriteUrlHelpLabel %}
@@ -52,7 +52,7 @@
 
         {{ ps.form_group_row(metaForm.url_rewrite, {attr: {class: 'js-url-rewrite'}}, {
           label: 'Rewritten URL'|trans({}, 'Admin.Shopparameters.Feature'),
-          help: rewriteUrlHelpLabel
+          help: rewriteUrlHelpLabel,
         }) }}
 
         {% block meta_form_rest %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/index.html.twig
@@ -7,8 +7,8 @@
   add: {
     href: path('admin_search_engines_create'),
     desc: 'Add new search engine'|trans({}, 'Admin.Shopparameters.Feature'),
-    icon: 'add_circle_outline'
-  }
+    icon: 'add_circle_outline',
+  },
 } %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/create_category.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/create_category.html.twig
@@ -7,7 +7,7 @@
 {% block content %}
   {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
       cmsPageCategoryForm: cmsPageCategoryForm,
-      cmsCategoryParentId: app.request.query.get('id_cms_category')
+      cmsCategoryParentId: app.request.query.get('id_cms_category'),
     })
   }}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit_category.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit_category.html.twig
@@ -7,7 +7,7 @@
 {% block content %}
   {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
       cmsPageCategoryForm: cmsPageCategoryForm,
-      cmsCategoryParentId: cmsCategoryParentId
+      cmsCategoryParentId: cmsCategoryParentId,
     })
   }}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig
@@ -17,7 +17,7 @@
       <div class="form-group row">
         {{ ps.label_with_help(
           ('Select your default email theme'|trans({}, 'Admin.Design.Feature')),
-          ('This won\'t regenerate email templates, it only sets the default email theme for future generation (when a language is installed for example).'|trans({}, 'Admin.Design.Help'))
+          ('This won\'t regenerate email templates, it only sets the default email theme for future generation (when a language is installed for example).'|trans({}, 'Admin.Design.Help')),
         ) }}
         <div class="col-sm">
           {{ form_errors(mailThemeConfigurationForm.defaultTheme) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
@@ -39,7 +39,7 @@
         <div class="form-group row">
           {{ ps.label_with_help(
             ('Select the theme you want to overwrite'|trans({}, 'Admin.Design.Feature')),
-            ('PrestaShop\'s email templates are stored in the "mails" folder, but they can be overridden by your current theme\'s own "mails" folder. Using this option enables to overwrite emails from your current theme.'|trans({}, 'Admin.Design.Help'))
+            ('PrestaShop\'s email templates are stored in the "mails" folder, but they can be overridden by your current theme\'s own "mails" folder. Using this option enables to overwrite emails from your current theme.'|trans({}, 'Admin.Design.Help')),
           ) }}
           <div class="col-sm">
             {{ form_errors(generateMailsForm.theme) }}
@@ -53,7 +53,7 @@
         <div class="form-group row">
           {{ ps.label_with_help(
             ('Overwrite templates'|trans({}, 'Admin.Design.Feature')),
-            ('By default, existing email template files are not modified to avoid deleting any modification you may have done. Enable this option to force the overwrite.'|trans({}, 'Admin.Design.Help'))
+            ('By default, existing email template files are not modified to avoid deleting any modification you may have done. Enable this option to force the overwrite.'|trans({}, 'Admin.Design.Help')),
           ) }}
           <div class="col-sm">
             {{ form_errors(generateMailsForm.overwrite) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/index.html.twig
@@ -7,25 +7,25 @@
 {% block content %}
   {{
     include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig', {
-      mailThemeConfigurationForm: mailThemeConfigurationForm
+      mailThemeConfigurationForm: mailThemeConfigurationForm,
     })
   }}
 
   {{
     include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig', {
-      generateMailsForm: generateMailsForm
+      generateMailsForm: generateMailsForm,
     })
   }}
 
   {{
     include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig', {
-      generateMailsForm: generateMailsForm
+      generateMailsForm: generateMailsForm,
     })
   }}
 
   {{
     include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/list_mail_themes.html.twig', {
-      mailThemes: mailThemes
+      mailThemes: mailThemes,
     })
   }}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/preview.html.twig
@@ -7,7 +7,7 @@
 {% block content %}
   {{
     include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig', {
-      mailTheme: mailTheme
+      mailTheme: mailTheme,
     })
   }}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/delete_theme_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/delete_theme_modal.html.twig
@@ -4,7 +4,7 @@
  #}
 
 {% embed '@PrestaShop/Admin/Helpers/bootstrap_popup.html.twig' with {
-  id: 'delete_theme_modal'
+  id: 'delete_theme_modal',
 } %}
   {% block header %}
       <div class="modal-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/rtl_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/rtl_configuration.html.twig
@@ -19,11 +19,11 @@
       </div>
 
       {{ ps.form_group_row(adaptThemeToRtlLanguagesForm.theme_to_adapt, {}, {
-        label: 'Theme to adapt'|trans({}, 'Admin.Design.Feature')
+        label: 'Theme to adapt'|trans({}, 'Admin.Design.Feature'),
       }) }}
 
       {{ ps.form_group_row(adaptThemeToRtlLanguagesForm.generate_rtl_css, {}, {
-        label: 'Generate RTL stylesheet'|trans({}, 'Admin.Design.Feature')
+        label: 'Generate RTL stylesheet'|trans({}, 'Admin.Design.Feature'),
       }) }}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/use_theme_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/use_theme_modal.html.twig
@@ -4,7 +4,7 @@
  #}
 
 {% embed '@PrestaShop/Admin/Helpers/bootstrap_popup.html.twig' with {
-  id: 'use_theme_modal'
+  id: 'use_theme_modal',
 } %}
   {% block header %}
       <div class="modal-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -7,13 +7,13 @@
   add: {
     href: path('admin_themes_import'),
     desc: 'Add new theme'|trans({}, 'Admin.Design.Feature'),
-    icon: 'add_circle_outline'
+    icon: 'add_circle_outline',
   },
   export: {
     href: path('admin_themes_export_current'),
     desc: 'Export current theme'|trans({}, 'Admin.Design.Feature'),
-    icon: 'cloud_download'
-  }
+    icon: 'cloud_download',
+  },
   } %}
 
 {% block content %}
@@ -65,7 +65,7 @@
             themeAuthor: currentlyUsedTheme.get('author.name'),
             themeAuthorUrl: theme.get('author.url'),
             themeFramework: theme.get('meta.compatibility.framework'),
-            isActive: true
+            isActive: true,
           } %}
             {% block image %}
               <img src="{{ baseShopUrl }}{{ currentlyUsedTheme.get('preview') }}" alt="{{ currentlyUsedTheme.get('display_name') }}">
@@ -87,7 +87,7 @@
                 themeAuthor: theme.get('author.name'),
                 themeAuthorUrl: theme.get('author.url'),
                 themeFramework: theme.get('meta.compatibility.framework'),
-                isActive: false
+                isActive: false,
               } %}
                 {% block image %}
                   <img src="{{ baseShopUrl }}{{ theme.get('preview') }}" alt="{{ theme.get('display_name') }}">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/positions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/positions.html.twig
@@ -173,7 +173,7 @@
                                 {% set linkParams = {
                                   id_module: moduleInstance.id,
                                   id_hook: hook['id_hook'],
-                                  editGraft: 1
+                                  editGraft: 1,
                                 } %}
                                 {% if selectedModule %}
                                   {% set linkParams = linkParams|merge({show_modules: selectedModule}) %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -27,9 +27,9 @@
         'modal.restore.title': 'Are you sure you want to restore default settings?'|trans({}, 'Admin.International.Feature'),
         'modal.restore.apply': 'Restore'|trans({}, 'Admin.Actions'),
         'modal.restore.cancel': 'Cancel'|trans({}, 'Admin.Actions'),
-        'modal.restore.body': 'Restoring your currency\'s default settings will delete all the customizations you made before. Parameters will look just the same as when the currency is freshly imported.'|trans({}, 'Admin.International.Feature')
-      }|json_encode
-    }
+        'modal.restore.body': 'Restoring your currency\'s default settings will delete all the customizations you made before. Parameters will look just the same as when the currency is freshly imported.'|trans({}, 'Admin.International.Feature'),
+      }|json_encode,
+    },
     }) }}
 
     <div class="card card-currency">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/index.html.twig
@@ -9,7 +9,7 @@
     href: path('admin_currencies_create'),
     desc: 'Add new currency'|trans({}, 'Admin.International.Feature'),
     icon: 'add_circle_outline',
-  }
+  },
 }
 %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/index.html.twig
@@ -7,8 +7,8 @@
   add: {
     href: path('admin_languages_create'),
     desc: 'Add new language'|trans({}, 'Admin.International.Feature'),
-    icon: 'add_circle_outline'
-  }
+    icon: 'add_circle_outline',
+  },
 } %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Locations/State/Blocks/change_states_zone_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Locations/State/Blocks/change_states_zone_modal.html.twig
@@ -18,8 +18,8 @@
       {{ form_start(changeStatesZoneForm, {
         action: path('admin_states_bulk_update_zone'),
         attr: {
-          'data-bulk-inputs-id': changeStatesZoneForm.state_ids.vars.id
-        }
+          'data-bulk-inputs-id': changeStatesZoneForm.state_ids.vars.id,
+        },
       }) }}
 
       <div class="form-group mb-0">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/index.html.twig
@@ -7,8 +7,8 @@
     add: {
     href: path('admin_taxes_create'),
     desc: 'Add new tax'|trans({}, 'Admin.International.Feature'),
-    icon: 'add_circle_outline'
-  }
+    icon: 'add_circle_outline',
+  },
 } %}
 
 {% trans_default_domain 'Admin.International.Feature' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/overview.html.twig
@@ -21,7 +21,7 @@
       domainsTreeUrl: '{{ url('api_translation_domains_tree', {
         lang: app.request.query.get('lang'),
         type: app.request.query.get('type'),
-        selected: app.request.query.get('selected')
+        selected: app.request.query.get('selected'),
       }) }}',
       translationUrl: '{{ url('api_i18n_translations_list', {page: 'international'}) }}',
       internationalUrl: '{{ getAdminLink('AdminLocalization')|raw_purified }}',

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -9,7 +9,7 @@
   {% block translations_kpis_row %}
     {{ render(controller(
       'PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction',
-      {kpiRow: kpiRow}
+      {kpiRow: kpiRow},
     )) }}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -12,7 +12,7 @@
         url: module.attributes.urls[module.attributes.url_active],
         action: module.attributes.url_active,
         label: module.attributes.urls_labels[module.attributes.url_active],
-        upload_url: module.attributes.upload_url|default(null)}
+        upload_url: module.attributes.upload_url|default(null)},
     ) }}
     {% if (module.attributes.urls|length > 1) %}
         <input type="hidden" class="btn" />
@@ -30,7 +30,7 @@
                         url: module_url,
                         action: module_action,
                         label: module.attributes.urls_labels[module_action],
-                        upload_url: module.attributes.upload_url|default(null)}
+                        upload_url: module.attributes.upload_url|default(null)},
                     ) }}
                 </li>
             {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_notification_configure.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_notification_configure.html.twig
@@ -9,7 +9,7 @@
         , {
             module: module,
             display_type: display_type,
-            origin: origin|default('none')
-        }
+            origin: origin|default('none'),
+        },
     ) }}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_notification_update.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_notification_update.html.twig
@@ -9,7 +9,7 @@
         , {
             module: module,
             display_type: display_type,
-            origin: origin|default('none')
-        }
+            origin: origin|default('none'),
+        },
     ) }}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/required_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/required_fields.html.twig
@@ -18,7 +18,7 @@
             {{ 'Required fields apply to the customer\'s registration form, you should check the address formats in [1]International > Locations > Countries[/1] before.'|trans(
               {
                 '[1]': '<a href="' ~ getAdminLink('AdminCountries', true) ~ '">',
-                '[/1]': '</a>'
+                '[/1]': '</a>',
               },
               'Admin.Orderscustomers.Help')|raw
             }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attribute/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attribute/edit.html.twig
@@ -8,7 +8,7 @@
 {% block content %}
   {{ include('@PrestaShop/Admin/Sell/Catalog/Attribute/Blocks/form.html.twig', {
     attributeGroupId: attributeGroupId,
-    attributeForm: attributeForm
+    attributeForm: attributeForm,
   }) }}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attribute/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attribute/index.html.twig
@@ -8,7 +8,7 @@
     href: path('admin_attributes_create', {attributeGroupId: attributeGroupId}),
     desc: 'Add new value'|trans({}, 'Admin.Catalog.Feature'),
     icon: 'add_circle_outline',
-  }
+  },
 }
 %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/AttributeGroup/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/AttributeGroup/create.html.twig
@@ -7,7 +7,7 @@
 
 {% block content %}
     {{ include('@PrestaShop/Admin/Sell/Catalog/AttributeGroup/Blocks/form.html.twig', {
-      attributeForm: attributeGroupForm
+      attributeForm: attributeGroupForm,
     }) }}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/AttributeGroup/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/AttributeGroup/edit.html.twig
@@ -7,7 +7,7 @@
 
 {% block content %}
   {{ include('@PrestaShop/Admin/Sell/Catalog/AttributeGroup/Blocks/form.html.twig', {
-    attributeForm: attributeGroupForm
+    attributeForm: attributeGroupForm,
   }) }}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/AttributeGroup/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/AttributeGroup/index.html.twig
@@ -13,7 +13,7 @@
     href: path('admin_attributes_create'),
     desc: 'Add new value'|trans({}, 'Admin.Catalog.Feature'),
     icon: 'add_circle_outline',
-  }
+  },
 }
 %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig
@@ -21,7 +21,7 @@
 
       {% if catalogPriceRuleForm.id_shop is defined %}
         {{ ps.form_group_row(catalogPriceRuleForm.id_shop, {}, {
-          label: 'Store'|trans({}, 'Admin.Global')
+          label: 'Store'|trans({}, 'Admin.Global'),
         }) }}
       {% endif %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/index.html.twig
@@ -9,7 +9,7 @@
     href: path('admin_catalog_price_rules_create'),
     desc: 'Add new catalog price rule'|trans({}, 'Admin.Catalog.Feature'),
     icon: 'add_circle_outline',
-  }
+  },
 }
 %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/index.html.twig
@@ -12,7 +12,7 @@
   {% block categories_kpis %}
     {{ render(controller(
       'PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction',
-      {kpiRow: categoriesKpi}
+      {kpiRow: categoriesKpi},
     )) }}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig
@@ -9,7 +9,7 @@
 <div class="alert alert-warning" role="alert">
   <p>
     {{ 'This feature has been disabled. You can activate it here: %url%.'|trans({
-      '%url%': "<a href=\"#{href}\">#{linkText}</a>"
+      '%url%': "<a href=\"#{href}\">#{linkText}</a>",
     }, 'Admin.Catalog.Notification')|raw_purified }}
   </p>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/FeatureValue/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/FeatureValue/create.html.twig
@@ -6,7 +6,7 @@
 
 {% block content %}
   {{ include('@PrestaShop/Admin/Sell/Catalog/Features/FeatureValue/Blocks/form.html.twig', {
-    featureForm: featureValueForm
+    featureForm: featureValueForm,
   }) }}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/FeatureValue/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/FeatureValue/edit.html.twig
@@ -6,7 +6,7 @@
 
 {% block content %}
     {{ include('@PrestaShop/Admin/Sell/Catalog/Features/FeatureValue/Blocks/form.html.twig', {
-      featureValueForm: featureValueForm
+      featureValueForm: featureValueForm,
     }) }}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/create.html.twig
@@ -10,7 +10,7 @@
   {% else %}
     {{ include('@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig', {
       featureId: null,
-      featureForm: featureForm
+      featureForm: featureForm,
     }) }}
   {% endif %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/edit.html.twig
@@ -10,7 +10,7 @@
   {% else %}
     {{ include('@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig', {
       featureId: editableFeature.featureId.getValue,
-      featureForm: featureForm
+      featureForm: featureForm,
     }) }}
   {% endif %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Monitoring/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Monitoring/index.html.twig
@@ -27,7 +27,7 @@
 
       {% block grid_panel_extra_content %}
         {{ include('@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig'
-              , {deleteCategoriesForm: deleteCategoryForm}
+              , {deleteCategoriesForm: deleteCategoryForm},
             ) }}
       {% endblock %}
     {% endembed %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/bulk.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/bulk.html.twig
@@ -27,7 +27,7 @@
       'data-download-error-log': 'Download error log'|trans({}, 'Admin.Catalog.Feature'),
       'data-view-error-log': 'View %error_count% error logs'|trans({}, 'Admin.Catalog.Feature'),
       'data-view-error-title': 'Error log'|trans({}, 'Admin.Catalog.Feature'),
-    }}
+    }},
   ) }}
   {{ form_row(bulkCombinationForm) }}
   {{ form_end(bulkCombinationForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
@@ -15,7 +15,7 @@
     'data-shop-id': shop_id,
     'data-is-multi-store-active': is_multi_store_active,
     'data-form-name': update_form_name,
-    'data-token': csrf_token(update_form_name)
+    'data-token': csrf_token(update_form_name),
   }) %}
 
   {% if form.shop_images is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -31,7 +31,7 @@
     'data-product-id': productId,
     'data-shop-id': shopId,
     'data-product-type': productType,
-    'data-force-default-active': forceDefaultActive
+    'data-force-default-active': forceDefaultActive,
   }}) }}
 
   {# Header form child is rendered separately because it's not one of the tabs so it needs to be rendered before #}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/index.html.twig
@@ -12,7 +12,7 @@
   {% block customers_kpis %}
     {{ render(controller(
       'PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction',
-      {kpiRow: customersKpi}
+      {kpiRow: customersKpi},
     )) }}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/customer_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/customer_information.html.twig
@@ -48,7 +48,7 @@
         '[1]': '<span class="badge badge-primary rounded">',
         '[/1]': '</span>',
         '[2]': '<span class="badge badge-success rounded">',
-        '[/2]': '</span>'
+        '[/2]': '</span>',
       }, 'Admin.Orderscustomers.Feature')|raw_purified }}
     {% else %}
       {{ 'No order validated for the moment. By default, an order is considered validated when its payment is accepted.'|trans({}, 'Admin.Orderscustomers.Feature') }}
@@ -57,7 +57,7 @@
     <p class="text-muted">
       {{ 'Customer since: %s'|trans(
         {'%s': customerThreadView.customerInformation.customerSinceDate},
-        'Admin.Orderscustomers.Feature'
+        'Admin.Orderscustomers.Feature',
       ) }}
     </p>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/forward_thread_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/forward_thread_modal.html.twig
@@ -12,9 +12,9 @@
   <div class="modal-dialog" role="document">
     {{ form_start(forwardCustomerThreadForm, {
       action: path('admin_customer_threads_forward', {
-        customerThreadId: customerThreadView.customerThreadId.value
+        customerThreadId: customerThreadView.customerThreadId.value,
       }),
-      attr: {class: 'form-horizontal'}
+      attr: {class: 'form-horizontal'},
     }) }}
       <div class="modal-content">
         <div class="modal-header">
@@ -54,7 +54,7 @@
             </label>
             <div class="col-sm">
               {{ form_widget(forwardCustomerThreadForm.comment, {
-                attr: {placeholder: 'You can add a comment here.'|trans({}, 'Admin.Orderscustomers.Help')}
+                attr: {placeholder: 'You can add a comment here.'|trans({}, 'Admin.Orderscustomers.Help')},
               }) }}
             </div>
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/thread_actions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/thread_actions.html.twig
@@ -7,7 +7,7 @@
   <div class="card-body">
     {% for action in customerThreadView.actions %}
       <form action="{{ path('admin_customer_threads_view_update_status', {
-        customerThreadId: customerThreadView.customerThreadId.value
+        customerThreadId: customerThreadView.customerThreadId.value,
       }) }}" method="post" class="d-inline">
         <input type="hidden" name="newStatus" value="{{ action.value }}"/>
         <button class="btn btn-outline-secondary">{{ action.label }}</button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/your_answer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/your_answer.html.twig
@@ -4,7 +4,7 @@
  #}
 
 {{ form_start(replyToCustomerThreadForm, {
-  action: path('admin_customer_threads_reply', {customerThreadId: customerThreadView.customerThreadId.value})
+  action: path('admin_customer_threads_reply', {customerThreadId: customerThreadView.customerThreadId.value}),
 }) }}
   <div class="card" data-role="employee-answer">
     <h3 class="card-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/options.html.twig
@@ -7,7 +7,7 @@
 
 {{ form_start(merchandiseReturnsOptionsForm, {
   attr: {class: 'form'},
-  action: path('admin_merchandise_returns_save_options')
+  action: path('admin_merchandise_returns_save_options'),
 }) }}
   <div class="card">
     <h3 class="card-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
@@ -161,7 +161,7 @@
               <td>
                 <a href="{{ getAdminLink('AdminCartRules', true, {
                   id_cart_rule: cartRule.id,
-                  updatecart_rule: 1
+                  updatecart_rule: 1,
                 }) }}">
                   {{ cartRule.name }}
                 </a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/index.html.twig
@@ -8,7 +8,7 @@
   {% block carts_kpis %}
     {{ render(controller(
       'PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction',
-      {kpiRow: cartsKpi}
+      {kpiRow: cartsKpi},
     )) }}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/view.html.twig
@@ -8,7 +8,7 @@
   {% block cart_kpis %}
     {{ render(controller(
       'PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction',
-      {kpiRow: cartKpi}
+      {kpiRow: cartKpi},
     )) }}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
@@ -57,7 +57,7 @@
                 {{ 'Invoice'|trans({}, 'Admin.Global') }}
               </label>
               {{ form_widget(addOrderCartRuleForm.invoice_id, {attr: {
-                disabled: not orderForViewing.hasInvoice
+                disabled: not orderForViewing.hasInvoice,
               }}) }}
             </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
@@ -6,7 +6,7 @@
 <div class="modal fade" id="updateOrderShippingModal" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
     {{ form_start(updateOrderShippingForm, {
-      action: path('admin_orders_update_shipping', {orderId: orderForViewing.id})
+      action: path('admin_orders_update_shipping', {orderId: orderForViewing.id}),
     }) }}
       <div class="modal-content">
         <div class="modal-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -163,8 +163,8 @@
             {{ form_start(privateNoteForm, {
               action: path('admin_customers_set_private_note', {
                 customerId: orderForViewing.customer.id,
-                back: path('admin_orders_view', {orderId: orderForViewing.id})
-              })
+                back: path('admin_orders_view', {orderId: orderForViewing.id}),
+              }),
               }) }}
 
               {{ form_widget(privateNoteForm.note) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
@@ -95,7 +95,7 @@
           <td colspan="5">
             <form action="{{ path('admin_orders_update_invoice_note', {
               orderId: orderForViewing.id,
-              orderInvoiceId: document.id
+              orderInvoiceId: document.id,
             }) }}" method="post">
               <div class="input-group">
                 <input type="text" class="form-control invoice-note" name="invoice_note" value="{{ document.note }}">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/edit_shipment_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/edit_shipment_form.html.twig
@@ -6,11 +6,11 @@
  {{ form_start(editShipmentForm, {
   action: path('admin_orders_edit_shipment', {
     orderId: orderId,
-    shipmentId: shipmentId
+    shipmentId: shipmentId,
   }),
   attr: {
     id: 'edit_shipment',
-    class: 'shipment-form'
+    class: 'shipment-form',
   },
 }) }}
   <div class="form-group">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/internal_note.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/internal_note.html.twig
@@ -22,7 +22,7 @@
 
     <div class="col-md-12 mt-3 js-order-notes-block{% if not isNoteOpen %} d-none{% endif %}">
       {{ form_start(internalNoteForm, {
-        action: path('admin_orders_set_internal_note', {orderId: orderForViewing.getId()})
+        action: path('admin_orders_set_internal_note', {orderId: orderForViewing.getId()}),
       }) }}
       {{ form_widget(internalNoteForm.note) }}
       <div class="d-none">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merge_shipment_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merge_shipment_form.html.twig
@@ -6,7 +6,7 @@
 {{ form_start(mergeShipmentForm, {
   action: path('admin_orders_merge_shipment', {
     orderId: orderId,
-    shipmentId: shipmentId
+    shipmentId: shipmentId,
   }),
   attr: {
     id: 'merge_shipment',
@@ -93,7 +93,7 @@
     attr: {
       class: 'form-control',
       id: 'merge_shipment_merge_to_shipment',
-    }
+    },
   }) }}
 </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/messages.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/messages.html.twig
@@ -40,13 +40,13 @@
 
   <div class="card-body d-print-none">
     {{ form_start(orderMessageForm, {
-      action: path('admin_orders_send_message', {orderId: orderForViewing.id})
+      action: path('admin_orders_send_message', {orderId: orderForViewing.id}),
     }) }}
 
     {{ ps.form_group_row(orderMessageForm.order_message, {}, {
       label: 'Choose your order message'|trans({}, 'Admin.Orderscustomers.Feature'),
       label_on_top: true,
-      class: 'mb-0'
+      class: 'mb-0',
     }) }}
 
     <div class="js-order-messages-container d-none">
@@ -72,7 +72,7 @@
     {{ ps.form_group_row(orderMessageForm.message, {attr: {cols: 30, rows: 3}}, {
       label: 'Message'|trans({}, 'Admin.Global'),
       label_on_top: true,
-      class: 'js-text-with-length-counter'
+      class: 'js-text-with-length-counter',
     }) }}
 
     {% block order_message_form_rest %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
@@ -6,8 +6,8 @@
   {{ form_start(updateOrderStatusActionBarForm, {
     action: path('admin_orders_update_status', {orderId: orderForViewing.id}),
     attr: {
-      id: 'update_order_status_action_form'
-    }
+      id: 'update_order_status_action_form',
+    },
   }) }}
 
   <div class="input-group">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig
@@ -13,7 +13,7 @@
   <div class="card-body">
     {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/payments_alert.html.twig', {
         payments: orderForViewing.payments,
-        linkedOrders: orderForViewing.linkedOrders
+        linkedOrders: orderForViewing.linkedOrders,
     }) }}
 
     <table class="table mb-0" data-role="payments-grid-table">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -34,7 +34,7 @@
       {% if isImprovedShipmentFeatureFlagEnabled and product.shipmentIds is not empty %}
         <p class="mb-0 productShipmentNumber">
           {{ 'Shipment number: %shipment_id%'|trans({
-              '%shipment_id%': product.shipmentIds|join(', ')
+              '%shipment_id%': product.shipmentIds|join(', '),
           }, 'Admin.Orderscustomers.Feature') }}
         </p>
       {% endif %}
@@ -118,7 +118,7 @@
                 'data-product-price-tax-excl': product.unitPriceTaxExclRaw,
                 'data-amount-refundable': product.amountRefundableRaw,
                 'data-quantity-refundable': product.quantityRefundable,
-              }
+              },
             } %}
             {{ form_widget(cancelProductForm['quantity_' ~ product.orderDetailId], quantityInputOptions) }}
           </div>
@@ -131,7 +131,7 @@
             <small class="max-refund text-left">
               {{ '(Max %amount_refundable% %tax_method%)'|trans({
                 '%amount_refundable%': product.amountRefundable,
-                '%tax_method%': orderForViewing.taxMethod
+                '%tax_method%': orderForViewing.taxMethod,
               }, 'Admin.Orderscustomers.Help')|raw_purified }}.
             </small>
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product_list.html.twig
@@ -9,6 +9,6 @@
         paginationNum: paginationNum,
         isColumnLocationDisplayed: isColumnLocationDisplayed,
         isColumnRefundedDisplayed: isColumnRefundedDisplayed,
-        isAvailableQuantityDisplayed: isAvailableQuantityDisplayed
+        isAvailableQuantityDisplayed: isAvailableQuantityDisplayed,
     }) }}
 {% endfor %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -32,8 +32,8 @@
             'data-is-delivered': orderForViewing.isDelivered,
             'data-is-tax-included': orderForViewing.isTaxIncluded,
             'data-discounts-amount': orderForViewing.prices.discountsAmountRaw,
-            'data-price-specification': priceSpecification|json_encode
-          }
+            'data-price-specification': priceSpecification|json_encode,
+          },
         } %}
     {{ form_start(cancelProductForm, formOptions) }}
 
@@ -144,7 +144,7 @@
     {# DISCOUNT LIST #}
     {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig', {
         discounts: orderForViewing.discounts.discounts,
-        orderId: orderForViewing.id
+        orderId: orderForViewing.id,
     }) }}
 
     {# ORDER TOTALS #}
@@ -218,7 +218,7 @@
         {{ 'For this customer group, prices are displayed as: [1]%tax_method%[/1]'|trans({
           '%tax_method%': orderForViewing.taxMethod,
           '[1]': '<strong>',
-          '[/1]': '</strong>'
+          '[/1]': '</strong>',
         }, 'Admin.Orderscustomers.Notification')|raw_purified }}.
 
         {% if not configuration('PS_ORDER_RETURN') %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/split_shipment_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/split_shipment_form.html.twig
@@ -9,7 +9,7 @@
     id: 'split_shipment',
     class: 'shipment-form',
     'data-is-valid': formIsValid and not isShipped,
-  }
+  },
 }) }}
   <div class="shipment-form__loader"></div>
   <p class="shipment-form__tooltip-wrapper">
@@ -94,8 +94,8 @@
     {{ form_widget(splitShipmentForm.carrier, {
       attr: {
         class: 'form-control',
-        id: 'split_shipment_carriers'
-      }
+        id: 'split_shipment_carriers',
+      },
     }) }}
 
     <a href="{{ path('admin_carriers_index') }}" class="shipment-form__carriers-link" target="_blank">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/change_orders_status_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/change_orders_status_modal.html.twig
@@ -18,8 +18,8 @@
       {{ form_start(changeOrderStatusesForm, {
         action: path('admin_orders_change_orders_status'),
         attr: {
-          'data-bulk-inputs-id': changeOrderStatusesForm.order_ids.vars.id
-        }
+          'data-bulk-inputs-id': changeOrderStatusesForm.order_ids.vars.id,
+        },
       }) }}
 
       <div class="form-group mb-0">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
@@ -15,7 +15,7 @@
   {% block orders_kpi %}
     {{ render(controller(
       'PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction',
-      {kpiRow: orderKpi}
+      {kpiRow: orderKpi},
     )) }}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
@@ -143,7 +143,7 @@
                 <a href="#" class="js-preview-more-products-btn text-dark">
                   <i class="material-icons">more_horiz</i>
                   {{ '(%count% more)'|trans({
-                    '%count%': orderPreview.productDetails|length - productsPreviewLimit
+                    '%count%': orderPreview.productDetails|length - productsPreviewLimit,
                   }, 'Admin.Global') }}
                 </a>
               </td>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -713,12 +713,12 @@
     {% set attr = attr|merge({
       class: (attr.class|default('') ~ ' custom-file-input')|trim,
       'data-multiple-files-text': '%count% file(s)'|trans({}, 'Admin.Global'),
-      'data-locale': get_context_iso_code()
+      'data-locale': get_context_iso_code(),
     }) -%}
 
     {% if attr.disabled is defined and attr.disabled %}
       {% set attr = attr|merge({
-        class: attr.class ~ ' disabled'
+        class: attr.class ~ ' disabled',
       }) %}
     {% endif %}
 
@@ -766,7 +766,7 @@
 {% block text_with_recommended_length_widget %}
   {% set attr = attr|merge({
     'data-recommended-length-counter': '#' ~ id ~ '_recommended_length_counter',
-    class: 'js-recommended-length-input'
+    class: 'js-recommended-length-input',
   }) -%}
 
   {% if input_type == 'textarea' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
@@ -16,7 +16,7 @@
     'data-data-limit': limit,
     'data-min-length': min_length,
     'data-allow-delete': form.vars.allow_delete ? 1 : 0,
-    'data-suggestion-field': form.vars.suggestion_field
+    'data-suggestion-field': form.vars.suggestion_field,
   }) -%}
   {%- set attr = attr|merge({class: (attr.class|default('') ~ ' entity-search-widget')|trim}) -%}
 
@@ -29,7 +29,7 @@
           class: (search_attr.class|default('') ~ ' entity-search-input form-control')|trim,
           autocomplete: 'off',
           placeholder: placeholder,
-          type: 'text'
+          type: 'text',
         }) -%}
         {%- set id = form.vars.id ~ '_search_input' -%}
         <input {{ block('widget_container_attributes') }} />

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
@@ -328,7 +328,7 @@
   {% for child in form -%}
     {% if not child.rendered %}
       {{- ps.form_group_row(child, {attr: child.vars.attr}, {
-        label: child.vars.label
+        label: child.vars.label,
       }) -}}
     {% endif %}
   {%- endfor %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -975,12 +975,12 @@
     {% set attr = attr|merge({
       class: (attr.class|default('') ~ ' custom-file-input')|trim,
       'data-multiple-files-text': '%count% file(s)'|trans({}, 'Admin.Global'),
-      'data-locale': get_context_iso_code()
+      'data-locale': get_context_iso_code(),
     }) -%}
 
     {% if attr.disabled is defined and attr.disabled %}
       {% set attr = attr|merge({
-        class: attr.class ~ ' disabled'
+        class: attr.class ~ ' disabled',
       }) %}
     {% endif %}
     {{- block('form_widget_simple') -}}
@@ -1038,7 +1038,7 @@
 {% block text_with_recommended_length_widget %}
   {% set attr = attr|merge({
     'data-recommended-length-counter': '#' ~ id ~ '_recommended_length_counter',
-    class: 'js-recommended-length-input'
+    class: 'js-recommended-length-input',
   }) -%}
 
   {% if input_type == 'textarea' %}
@@ -1547,7 +1547,7 @@
   {%- set attr = attr|merge({
     class: (attr.class|default('') ~ ' form-group btn-collection btn-toolbar')|trim,
     role: 'group',
-    style: 'justify-content: ' ~ justify_content
+    style: 'justify-content: ' ~ justify_content,
   }) -%}
   <div {{ block('widget_attributes') }}>
     {% for group, buttons in button_groups %}
@@ -1580,7 +1580,7 @@
             {% for button in remainingButtons %}
               {% set action = attribute(form, button) %}
               {{ form_widget(action, {attr: {
-                class: 'dropdown-item ' ~ action.vars.attr.class|default('')|trim
+                class: 'dropdown-item ' ~ action.vars.attr.class|default('')|trim,
               }}) }}
             {% endfor %}
           </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | build/9.1.3
| Description?      | Security update of Symfony from **v6.4.38 → v6.4.40** and Twig from **v3.20.0 → v3.26.0**, addressing **26 CVEs** published on 2026-05-20.<br><br>**Symfony 6.4.40** (16 CVEs) — packages concerned: `symfony/cache`, `symfony/dom-crawler`, `symfony/http-kernel`, `symfony/mailer`, `symfony/mime`, `symfony/monolog-bridge`, `symfony/routing`, `symfony/security-http`, `symfony/twig-bridge`, `symfony/yaml` (+ transitive dependencies).<br><br>**Twig 3.26.0** (10 CVEs) — CVE-2026-46640 (arbitrary PHP code execution), CVE-2026-46633 (PHP code injection via `{% use %}`), CVE-2026-46638 (sandbox bypass), CVE-2026-46635 (sandbox property allowlist bypass), CVE-2026-46628 (`spaceless` filter XSS), CVE-2026-47730 (XSS in profiler), CVE-2026-46627 (resource exhaustion), CVE-2026-46634 (SourcePolicy sandbox escape), CVE-2026-24425 (sandbox bypass), CVE-2026-47732 (`__toString()` sandbox bypass).
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Checkout the branch and run `composer install`<br>2. Run `composer audit` → should return **"No security vulnerability advisories found"**<br>3. Run `composer unit-tests` and `composer integration-tests`<br>4. Verify that the back-office and front-office load correctly
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/26167111911
| Fixed issue or discussion?     | <!-- To be filled if a related issue exists -->
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA
