### PR TITLE
Invoice : If no payments, display the payment method

### DIFF
--- a/pdf/invoice.payment-tab.tpl
+++ b/pdf/invoice.payment-tab.tpl
@@ -6,6 +6,7 @@
 	<tr>
 		<td class="payment center small grey bold" width="44%">{l s='Payment Method' d='Shop.Pdf' pdf='true'}</td>
 		<td class="payment left white" width="56%">
+			{if $order->hasPayments()}
 			<table width="100%" border="0">
 				{foreach from=$order_invoice->getOrderPaymentCollection() item=payment}
 					<tr>
@@ -14,6 +15,9 @@
 					</tr>
 				{/foreach}
 			</table>
+			{else}
+				{$order->payment}
+			{/if}
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Invoice : If no payments, display the payment method
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | :dolphin: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/26229207193<br/>:seal: : 
| Fixed issue or discussion?     | Fixes #20448
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?
* Go to FO and make an order
* Go to BO => order => order => and select the previously created order
* Click on the document tab and click on "generate invoice" button
* Open the invoice
* **BEFORE** : the payment method is not printed on the invoice
* **AFTER** : the payment method is printed on the invoice
* In BO, add a payment to the order
* Open the invoice
* The payment is displayed