### PR TITLE
TE: add automation test for BO > International > Locations > Countries > Help button

### DIFF
--- a/tests/UI/campaigns/functional/BO/11_international/02_locations/02_countries/06_helpButton.ts
+++ b/tests/UI/campaigns/functional/BO/11_international/02_locations/02_countries/06_helpButton.ts
@@ -18,7 +18,6 @@ describe('BO - International - Countries : Help button', async () => {
   let browserContext: BrowserContext;
   let page: Page;
 
-  // before and after functions
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
     page = await utilsPlaywright.newTab(browserContext);

--- a/tests/UI/campaigns/functional/BO/11_international/02_locations/02_countries/06_helpButton.ts
+++ b/tests/UI/campaigns/functional/BO/11_international/02_locations/02_countries/06_helpButton.ts
@@ -14,7 +14,6 @@ import {
 
 const baseContext: string = 'functional_BO_international_locations_countries_helpButton';
 
-// Check that help card is in english in countries page
 describe('BO - International - Countries : Help button', async () => {
   let browserContext: BrowserContext;
   let page: Page;

--- a/tests/UI/campaigns/functional/BO/11_international/02_locations/02_countries/06_helpButton.ts
+++ b/tests/UI/campaigns/functional/BO/11_international/02_locations/02_countries/06_helpButton.ts
@@ -73,7 +73,7 @@ describe('BO - International - Countries : Help button', async () => {
   it('should close the help side bar', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'closeHelpSidebar', baseContext);
 
-    const isHelpSidebarVisible = await boCountriesPage.closeHelpSideBar(page);
-    expect(isHelpSidebarVisible).to.eq(true);
+    const isHelpSidebarHidden = await boCountriesPage.closeHelpSideBar(page);
+    expect(isHelpSidebarHidden).to.eq(true);
   });
 });

--- a/tests/UI/campaigns/functional/BO/11_international/02_locations/02_countries/06_helpButton.ts
+++ b/tests/UI/campaigns/functional/BO/11_international/02_locations/02_countries/06_helpButton.ts
@@ -1,0 +1,81 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {expect} from 'chai';
+import {
+  boCountriesPage,
+  boDashboardPage,
+  boLoginPage,
+  boZonesPage,
+  type BrowserContext,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_international_locations_countries_helpButton';
+
+// Check that help card is in english in countries page
+describe('BO - International - Countries : Help button', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  // before and after functions
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should go to \'International > Locations\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToLocationsPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.internationalParentLink,
+      boDashboardPage.locationsLink,
+    );
+    await boZonesPage.closeSfToolBar(page);
+
+    const pageTitle = await boZonesPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boZonesPage.pageTitle);
+  });
+
+  it('should go to \'Countries\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToCountriesPage', baseContext);
+
+    await boZonesPage.goToSubTabCountries(page);
+
+    const pageTitle = await boCountriesPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boCountriesPage.pageTitle);
+  });
+
+  it('should open the help side bar and check the document language', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'openHelpSidebar', baseContext);
+
+    const isHelpSidebarVisible = await boCountriesPage.openHelpSideBar(page);
+    expect(isHelpSidebarVisible).to.eq(true);
+
+    const documentURL = await boCountriesPage.getHelpDocumentURL(page);
+    expect(documentURL).to.contains('country=en');
+  });
+
+  it('should close the help side bar', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeHelpSidebar', baseContext);
+
+    const isHelpSidebarVisible = await boCountriesPage.closeHelpSideBar(page);
+    expect(isHelpSidebarVisible).to.eq(true);
+  });
+});


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add Playwright automation test for the Help button on the BO International > Locations > Countries listing page. The test opens the help sidebar, checks the document language is in English, and closes the sidebar.
| Type?             | new feature
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to BO > International > Locations > Countries (legacy page, `country` feature flag disabled)<br>2. Click the Help button<br>3. Verify the help sidebar opens and the document URL contains `country=en`<br>4. Close the sidebar and verify it is hidden
| UI Tests          | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/26450979557 :green_circle: 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/test-scenarios/issues/589
| Related PRs       | **PrestaShop/ui-testing-library#980** — fix `BOBasePage` help sidebar methods to support legacy pages (**merged ✅**)
| Sponsor company   | PrestaShop