### PR TITLE
Merchandise Returns : Cancel returns if the order return state is cancellable

### DIFF
--- a/classes/Customization.php
+++ b/classes/Customization.php
@@ -107,7 +107,7 @@ class CustomizationCore extends ObjectModel
         if (($result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 			SELECT ore.`id_order_return`, ord.`id_order_detail`, ord.`id_customization`, ord.`product_quantity`
 			FROM `' . _DB_PREFIX_ . 'order_return` ore
-			INNER JOIN `' . _DB_PREFIX_ . 'order_return_detail` ord ON (ord.`id_order_return` = ore.`id_order_return`)
+			INNER JOIN `' . _DB_PREFIX_ . 'order_return_detail` ord ON (ord.`id_order_return` = ore.`id_order_return` AND ord.`cancelled` = 0)
 			WHERE ore.`id_order` = ' . (int) $idOrder . ' AND ord.`id_customization` != 0')) === false) {
             return false;
         }

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -931,9 +931,10 @@ class OrderCore extends ObjectModel
             SELECT IFNULL(SUM(ord.product_quantity), SUM(product_quantity_return))
             FROM `' . _DB_PREFIX_ . 'orders` o
             INNER JOIN `' . _DB_PREFIX_ . 'order_detail` od
-            ON od.id_order = o.id_order
+                ON od.id_order = o.id_order
             LEFT JOIN `' . _DB_PREFIX_ . 'order_return_detail` ord
-            ON ord.id_order_detail = od.id_order_detail
+                ON ord.id_order_detail = od.id_order_detail
+                    AND ord.cancelled = 0 
             WHERE o.id_order = ' . (int) $this->id);
     }
 

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -59,7 +59,16 @@ class OrderReturnCore extends ObjectModel
                 if ($qty = (int) $product_qty_list[$key]) {
                     $orderdetail = new OrderDetail((int) $order_detail);
                     $id_customization = $orderdetail->id_customization;
-                    Db::getInstance()->insert('order_return_detail', ['id_order_return' => (int) $this->id, 'id_order_detail' => (int) $order_detail, 'product_quantity' => $qty, 'id_customization' => (int) $id_customization]);
+                    Db::getInstance()->insert(
+                        'order_return_detail',
+                        [
+                            'id_order_return' => (int) $this->id,
+                            'id_order_detail' => (int) $order_detail,
+                            'product_quantity' => $qty,
+                            'id_customization' => (int) $id_customization,
+                            'cancelled' => '0',
+                        ]
+                    );
                 }
             }
         }
@@ -108,7 +117,7 @@ class OrderReturnCore extends ObjectModel
         if (!$data = Db::getInstance()->getRow('
 		SELECT COUNT(`id_order_return`) AS total
 		FROM `' . _DB_PREFIX_ . 'order_return_detail`
-		WHERE `id_order_return` = ' . (int) $this->id)) {
+		WHERE `id_order_return` = ' . (int) $this->id . ' AND `cancelled` = 0')) {
             return false;
         }
 
@@ -142,10 +151,11 @@ class OrderReturnCore extends ObjectModel
 
     public static function getOrdersReturnDetail($id_order_return)
     {
-        return Db::getInstance()->executeS('
-		SELECT *
-		FROM `' . _DB_PREFIX_ . 'order_return_detail`
-		WHERE `id_order_return` = ' . (int) $id_order_return);
+        return Db::getInstance()->executeS(
+            'SELECT *
+		    FROM `' . _DB_PREFIX_ . 'order_return_detail`
+		    WHERE `id_order_return` = ' . (int) $id_order_return
+        );
     }
 
     /**
@@ -229,8 +239,7 @@ class OrderReturnCore extends ObjectModel
         $details = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
             'SELECT od.id_order_detail, GREATEST(od.product_quantity_return, IFNULL(SUM(ord.product_quantity),0)) as qty_returned
 			FROM ' . _DB_PREFIX_ . 'order_detail od
-			LEFT JOIN ' . _DB_PREFIX_ . 'order_return_detail ord
-			ON ord.id_order_detail = od.id_order_detail
+			LEFT JOIN ' . _DB_PREFIX_ . 'order_return_detail ord ON ord.id_order_detail = od.id_order_detail AND ord.cancelled = 0
 			WHERE od.id_order = ' . (int) $id_order . '
 			GROUP BY od.id_order_detail'
         );
@@ -248,5 +257,14 @@ class OrderReturnCore extends ObjectModel
                 $product['qty_returned'] = $detail_list[$product['id_order_detail']]['qty_returned'];
             }
         }
+    }
+
+    public static function setCancelledStatus(int $idOrderReturn, bool $cancelled): void
+    {
+        Db::getInstance()->execute(
+            'UPDATE ' . _DB_PREFIX_ . 'order_return_detail ord '
+            . 'SET cancelled = ' . ($cancelled ? '1' : '0') . ' '
+            . 'WHERE id_order_return = ' . (string) $idOrderReturn
+        );
     }
 }

--- a/classes/order/OrderReturnState.php
+++ b/classes/order/OrderReturnState.php
@@ -14,6 +14,9 @@ class OrderReturnStateCore extends ObjectModel
     /** @var string Display state in the specified color */
     public $color;
 
+    /** Cancel return products */
+    public bool $is_cancelling_return = false;
+
     /**
      * @see ObjectModel::$definition
      */
@@ -23,6 +26,7 @@ class OrderReturnStateCore extends ObjectModel
         'multilang' => true,
         'fields' => [
             'color' => ['type' => self::TYPE_STRING, 'validate' => 'isColor', 'size' => 32],
+            'is_cancelling_return' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
 
             /* Lang fields */
             'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => OrderReturnStateSettings::NAME_MAX_LENGTH],

--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -206,6 +206,7 @@ class AdminReturnControllerCore extends AdminController
     public function postProcess()
     {
         $this->context = Context::getContext();
+        // Delete
         if (Tools::isSubmit('deleteorder_return_detail')) {
             if ($this->access('delete')) {
                 if (($id_order_detail = (int) Tools::getValue('id_order_detail')) && Validate::isUnsignedId($id_order_detail)) {
@@ -242,6 +243,12 @@ class AdminReturnControllerCore extends AdminController
                     $orderReturn->state = (int) Tools::getValue('state');
                     if ($orderReturn->save()) {
                         $orderReturnState = new OrderReturnState($orderReturn->state);
+                        // Cancel Returns if cancellable
+                        if ($orderReturnState->is_cancelling_return === true) {
+                            OrderReturn::setCancelledStatus((int) $id_order_return, true);
+                        }
+
+                        // Send email
                         $vars = [
                             '{lastname}' => $customer->lastname,
                             '{firstname}' => $customer->firstname,

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1460,6 +1460,7 @@ CREATE TABLE `PREFIX_order_return_detail` (
   `id_order_detail` int(10) unsigned NOT NULL,
   `id_customization` int(10) unsigned NOT NULL DEFAULT '0',
   `product_quantity` int(10) unsigned NOT NULL DEFAULT '0',
+  `cancelled` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (
     `id_order_return`, `id_order_detail`,
     `id_customization`
@@ -1470,6 +1471,7 @@ CREATE TABLE `PREFIX_order_return_detail` (
 CREATE TABLE `PREFIX_order_return_state` (
   `id_order_return_state` int(10) unsigned NOT NULL auto_increment,
   `color` varchar(32) DEFAULT NULL,
+  `is_cancelling_return` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_order_return_state`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 

--- a/install-dev/data/xml/order_return_state.xml
+++ b/install-dev/data/xml/order_return_state.xml
@@ -4,10 +4,10 @@
     <field name="color"/>
   </fields>
   <entities>
-    <order_return_state id="Waiting_for_confirmation" color="#4169E1"/>
-    <order_return_state id="Waiting_for_package" color="#8A2BE2"/>
-    <order_return_state id="Package_received" color="#32CD32"/>
-    <order_return_state id="Return_denied" color="#DC143C"/>
-    <order_return_state id="Return_completed" color="#108510"/>
+    <order_return_state id="Waiting_for_confirmation" color="#4169E1" is_cancelling_return="0"/>
+    <order_return_state id="Waiting_for_package" color="#8A2BE2" is_cancelling_return="0"/>
+    <order_return_state id="Package_received" color="#32CD32" is_cancelling_return="0"/>
+    <order_return_state id="Return_denied" color="#DC143C" is_cancelling_return="1"/>
+    <order_return_state id="Return_completed" color="#108510" is_cancelling_return="0"/>
   </entities>
 </entity_order_return_state>

--- a/src/Adapter/OrderReturnState/CommandHandler/AddOrderReturnStateHandler.php
+++ b/src/Adapter/OrderReturnState/CommandHandler/AddOrderReturnStateHandler.php
@@ -45,5 +45,6 @@ final class AddOrderReturnStateHandler extends AbstractOrderReturnStateHandler i
     {
         $orderReturnState->name = $command->getLocalizedNames();
         $orderReturnState->color = $command->getColor();
+        $orderReturnState->is_cancelling_return = $command->isCancellingReturn();
     }
 }

--- a/src/Adapter/OrderReturnState/CommandHandler/EditOrderReturnStateHandler.php
+++ b/src/Adapter/OrderReturnState/CommandHandler/EditOrderReturnStateHandler.php
@@ -53,5 +53,9 @@ final class EditOrderReturnStateHandler extends AbstractOrderReturnStateHandler 
         if (null !== $command->getColor()) {
             $orderReturnState->color = $command->getColor();
         }
+
+        if (null !== $command->isCancellingReturn()) {
+            $orderReturnState->is_cancelling_return = $command->isCancellingReturn();
+        }
     }
 }

--- a/src/Adapter/OrderReturnState/QueryHandler/GetOrderReturnStateForEditingHandler.php
+++ b/src/Adapter/OrderReturnState/QueryHandler/GetOrderReturnStateForEditingHandler.php
@@ -37,7 +37,8 @@ final class GetOrderReturnStateForEditingHandler implements GetOrderReturnStateF
         return new EditableOrderReturnState(
             $orderReturnStateId,
             $orderReturnState->name,
-            $orderReturnState->color
+            $orderReturnState->color,
+            $orderReturnState->is_cancelling_return
         );
     }
 }

--- a/src/Core/Domain/OrderReturnState/Command/AddOrderReturnStateCommand.php
+++ b/src/Core/Domain/OrderReturnState/Command/AddOrderReturnStateCommand.php
@@ -18,17 +18,13 @@ class AddOrderReturnStateCommand
      * @var string[]
      */
     private $localizedNames;
-    /**
-     * @var string
-     */
-    private $color;
 
     public function __construct(
         array $localizedNames,
-        string $color
+        private string $color,
+        private bool $isCancellingReturn = false
     ) {
         $this->setLocalizedNames($localizedNames);
-        $this->color = $color;
     }
 
     /**
@@ -63,5 +59,17 @@ class AddOrderReturnStateCommand
     public function getColor()
     {
         return $this->color;
+    }
+
+    public function setCancellingReturn(bool $isCancellingReturn): self
+    {
+        $this->isCancellingReturn = $isCancellingReturn;
+
+        return $this;
+    }
+
+    public function isCancellingReturn(): bool
+    {
+        return $this->isCancellingReturn;
     }
 }

--- a/src/Core/Domain/OrderReturnState/Command/EditOrderReturnStateCommand.php
+++ b/src/Core/Domain/OrderReturnState/Command/EditOrderReturnStateCommand.php
@@ -35,6 +35,8 @@ class EditOrderReturnStateCommand
      */
     private $color;
 
+    private ?bool $isCancellingReturn = null;
+
     /**
      * @param int $orderReturnStateId
      */
@@ -87,5 +89,17 @@ class EditOrderReturnStateCommand
         $this->color = $color;
 
         return $this;
+    }
+
+    public function setCancellingReturn(?bool $isCancellingReturn): self
+    {
+        $this->isCancellingReturn = $isCancellingReturn;
+
+        return $this;
+    }
+
+    public function isCancellingReturn(): ?bool
+    {
+        return $this->isCancellingReturn;
     }
 }

--- a/src/Core/Domain/OrderReturnState/QueryResult/EditableOrderReturnState.php
+++ b/src/Core/Domain/OrderReturnState/QueryResult/EditableOrderReturnState.php
@@ -15,26 +15,20 @@ use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\ValueObject\OrderReturnSt
 class EditableOrderReturnState
 {
     /**
-     * @var OrderReturnStateId
-     */
-    private $orderReturnStateId;
-    /**
-     * @var array
+     * @var array<string, string>
      */
     private $localizedNames;
-    /**
-     * @var string
-     */
-    private $color;
+
+    private OrderReturnStateId $orderReturnStateId;
 
     public function __construct(
         OrderReturnStateId $orderStateId,
         array $name,
-        string $color
+        private string $color,
+        private bool $isCancellingReturn,
     ) {
         $this->orderReturnStateId = $orderStateId;
         $this->localizedNames = $name;
-        $this->color = $color;
     }
 
     /**
@@ -59,5 +53,10 @@ class EditableOrderReturnState
     public function getColor()
     {
         return $this->color;
+    }
+
+    public function isCancellingReturn(): bool
+    {
+        return $this->isCancellingReturn;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/OrderReturnStateFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/OrderReturnStateFormDataHandler.php
@@ -58,7 +58,8 @@ final class OrderReturnStateFormDataHandler implements FormDataHandlerInterface
     {
         $command = new AddOrderReturnStateCommand(
             $data['name'],
-            $data['color']
+            $data['color'],
+            $data['is_cancelling_return']
         );
 
         return $command;
@@ -74,6 +75,7 @@ final class OrderReturnStateFormDataHandler implements FormDataHandlerInterface
         $command = (new EditOrderReturnStateCommand($orderReturnStateId))
             ->setName($data['name'])
             ->setColor($data['color'])
+            ->setCancellingReturn($data['is_cancelling_return'])
         ;
 
         return $command;

--- a/src/Core/Form/IdentifiableObject/DataProvider/OrderReturnStateFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/OrderReturnStateFormDataProvider.php
@@ -38,6 +38,7 @@ final class OrderReturnStateFormDataProvider implements FormDataProviderInterfac
         return [
             'name' => $editableOrderReturnState->getLocalizedNames(),
             'color' => $editableOrderReturnState->getColor(),
+            'is_cancelling_return' => $editableOrderReturnState->isCancellingReturn(),
         ];
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
@@ -13,6 +13,7 @@ use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\OrderReturnStateSettings;
 use PrestaShopBundle\Form\Admin\Type\ColorPickerType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -65,6 +66,13 @@ class OrderReturnStateType extends TranslatorAwareType
                 'label' => $this->trans('Color', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Status will be highlighted in this color. HTML colors only.', 'Admin.Shopparameters.Help'),
                 'required' => false,
+            ])
+            ->add('is_cancelling_return', CheckboxType::class, [
+                'required' => false,
+                'label' => $this->trans('Cancelling order returns.', 'Admin.Shopparameters.Feature'),
+                'attr' => [
+                    'material_design' => true,
+                ],
             ])
         ;
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderReturnStateFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderReturnStateFeatureContext.php
@@ -41,7 +41,8 @@ class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
                 [
                     $this->getDefaultLangId() => $data['name'],
                 ],
-                $data['color']
+                $data['color'],
+                $data['is_cancelling_return'] === '1' ? true : false
             ));
 
             SharedStorage::getStorage()->set($orderReturnStateReference, $orderReturnStateId->getValue());
@@ -70,6 +71,9 @@ class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
         }
         if (isset($data['color'])) {
             $editableOrderReturnState->setColor($data['color']);
+        }
+        if (isset($data['is_cancelling_return'])) {
+            $editableOrderReturnState->setCancellingReturn($data['is_cancelling_return'] === '1' ? true : false);
         }
 
         try {
@@ -134,6 +138,10 @@ class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
         Assert::assertArrayHasKey($this->getDefaultLangId(), $localizedNames);
         Assert::assertEquals($data['name'], $localizedNames[$this->getDefaultLangId()]);
         Assert::assertEquals($data['color'], $editableOrderReturnState->getColor());
+        Assert::assertEquals(
+            $data['is_cancelling_return'] === '1' ? true : false,
+            $editableOrderReturnState->isCancellingReturn()
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/OrderReturnState/order_return_state.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/OrderReturnState/order_return_state.feature
@@ -4,21 +4,25 @@ Feature: OrderState
   Background:
     Given shop "shop1" with name "test_shop" exists
     And I add a new order return state "order_return_state_1st" with the following details:
-      | name            | The 1st Order Return State |
-      | color           | #123456                    |
+      | name               | The 1st Order Return State |
+      | color              | #123456                  |
+      | is_cancelling_return | 0                          |
     And the order return state "order_return_state_1st" should exist
     And I add a new order return state "order_return_state_2nd" with the following details:
-      | name            | The 2nd Order Return State |
-      | color           | #7890AB                    |
+      | name               | The 2nd Order Return State |
+      | color              | #7890AB                  |
+      | is_cancelling_return | 1                          |
     And the order return state "order_return_state_2nd" should exist
 
   Scenario: Add new order return state
     When I add a new order return state "order_return_state_3rd" with the following details:
-      | name            | The 3rd Order Return State |
-      | color           | #CDEF12                    |
+      | name               | The 3rd Order Return State |
+      | color              | #CDEF12                  |
+      | is_cancelling_return | 0                          |
     And the order return state "order_return_state_3rd" should have the following details:
-      | name            | The 3rd Order Return State |
-      | color           | #CDEF12                    |
+      | name               | The 3rd Order Return State |
+      | color              | #CDEF12                  |
+      | is_cancelling_return | 0                          |
     ## Reset
     When I delete the order return state "order_return_state_3rd"
 
@@ -26,8 +30,15 @@ Feature: OrderState
     When I update the order return state "order_return_state_1st" with the following details:
       | color           | #345678                    |
     And the order return state "order_return_state_1st" should have the following details:
-      | name            | The 1st Order Return State |
-      | color           | #345678                    |
+      | name               | The 1st Order Return State |
+      | color              | #345678                  |
+      | is_cancelling_return | 0                          |
+    When I update the order return state "order_return_state_1st" with the following details:
+      | is_cancelling_return | 1                          |
+    And the order return state "order_return_state_1st" should have the following details:
+      | name               | The 1st Order Return State |
+      | color              | #345678                  |
+      | is_cancelling_return | 1                          |
 
   Scenario: Delete order return state
     When I delete the order return state "order_return_state_1st"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Added the ability to mark an order return status as "cancelling returns", which automatically cancels the associated return detail lines when that status is applied
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **BO** > **SELL** > **Customer Service** > **Merchandise Returns** <br>2. Enable returns<br>3. Go to **FO** & Connect > **Your account** >  **Order history** page<br>4. Click on **Details** of an Order with status **Shipped**<br>5. Choose a product to return then click on **Request Return** button<br>6. Go to **BO** > **SELL** > **Customer Service** > **Merchandise Returns**<br>7. Change the return status to **Return denied**<br>8. Go to **FO** > **Your account** > **Merchandise Return** > check your return's status, it's denied <br>9. **Your account** >  **Order history** > click on Details<br/>10. **BEFORE** The quantity of returned product is still 1<br/>10. **AFTER** The quantity of returned product is 0
| UI Tests          | :dolphin: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/26457585279 :green_circle: <br/>:seal: : 
| Fixed issue or discussion?     | Fixes #10029 
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## Description
This improvement addresses issue [#10029](https://github.com/PrestaShop/PrestaShop/issues/10029) (BOOM-1069), which reported a bug in returned quantity calculation. 

### What changes
* New `isCancellingReturn` field on `OrderReturnState`
> A boolean is added to the `OrderReturnState` model (class, database, installation XML). It allows configuring whether a return status should trigger the cancellation of its return lines. By default, only the "Return denied" status has this flag set to true in the installation data.
* New `cancelled` field on order_return_detail
> A `cancelled` column (tinyint) is added to the `order_return_detail` table. It allows marking individual return lines as cancelled without deleting them.
* Logic in AdminReturnController
> When a return's `status` is changed, if the new status has `isCancellingReturn` = true, all return detail lines are marked as cancelled via the new static method `OrderReturn::setCancelledStatus()`.
* SQL query fixes
> Several queries in `OrderReturn`, Order and Customization are updated to exclude rows where cancelled = 1: returned quantity calculation, product count, retrieval of returned customizations, etc. This is the core fix for the calculation bug.
* Propagation through the CQRS layer
> The `AddOrderReturnStateCommand` and `EditOrderReturnStateCommand` commands, their handlers, the `EditableOrderReturnState` (query result), the Symfony form type and the data handlers/providers are all updated to handle this new field.
* Tests
> The Behat context OrderReturnStateFeatureContext and the corresponding .feature scenario are extended to cover the creation, update and assertion of the new field.