### PR TITLE
Fix shop selector lists overflowing their container

### DIFF
--- a/admin-dev/themes/default/scss/partials/_multistore.scss
+++ b/admin-dev/themes/default/scss/partials/_multistore.scss
@@ -79,6 +79,8 @@
   .dropdown-menu {
     min-width: var(--#{$cdk}size-240);
     max-width: var(--#{$cdk}size-320);
+    max-height: 70vh;
+    overflow-y: auto;
 
     li {
       &.active {

--- a/admin-dev/themes/new-theme/scss/components/_multishop-modal.scss
+++ b/admin-dev/themes/new-theme/scss/components/_multishop-modal.scss
@@ -242,6 +242,7 @@ $component-name: multishop-modal;
     max-height: 500px;
     padding-right: var(--#{$cdk}size-16);
     margin: 0;
+    overflow: auto;
   }
 
   &-shop-view {

--- a/admin-dev/themes/new-theme/scss/components/_multishop-selector.scss
+++ b/admin-dev/themes/new-theme/scss/components/_multishop-selector.scss
@@ -11,6 +11,7 @@ $component-name: shop-selector;
     max-height: 500px;
     padding: 0 var(--#{$cdk}size-16) 0 0;
     margin-left: 0;
+    overflow: auto;
     list-style-type: none;
   }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Several multishop UI lists overflow their container when many shops exist. This PR caps each and enables scrolling:<br>**1.** Shop selector list (`.shop-selector ul.shop-selector-group-list`) — used in the product 'Shops' association — exceeds its `max-height: 500px` and overflows instead of scrolling. Added `overflow: auto`.<br>**2.** Header multistore dropdown (`#header_shop .dropdown-menu`) had no height limit, overflowing off the bottom of the viewport. Added `max-height: 70vh` + `overflow-y: auto`.<br>**3.** Multishop modal shop list (`.multishop-modal` shop list, `_multishop-modal.scss`) exceeds its `max-height: 500px` without scrolling. Added `overflow: auto`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set up a PrestaShop instance with multistore enabled and ~20 shops.<br>**Shop selector list:** Open the product 'Shops' association → list is capped and scrollable instead of overflowing.<br>**Header dropdown:** Click the store selector in the top header → dropdown caps at 70% viewport height and scrolls instead of running off-screen.<br>**Multishop modal:** Open the multishop modal → its shop list scrolls within the modal instead of overflowing.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/28004302187
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | N/A