### PR TITLE
Make HookRegistry stateless and name-keyed

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -910,13 +910,7 @@ class HookCore extends ObjectModel
         $isRegistryEnabled = null !== $hookRegistry;
 
         if ($isRegistryEnabled) {
-            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
-            $hookRegistry->selectHook(
-                $hook_name,
-                $hook_args,
-                $backtrace[0]['file'],
-                $backtrace[0]['line']
-            );
+            $hookRegistry->hookDispatched($hook_name, $hook_args);
         }
 
         // $chain & $array_return are incompatible so if chained is set to true, we disable the array_return option
@@ -943,19 +937,11 @@ class HookCore extends ObjectModel
         // We retrieve a list of modules to be executed for the given hook.
         // If no modules associated to hook_name or recompatible hook name, we stop the function.
         if (!($module_list = Hook::getHookModuleExecList($hook_name))) {
-            if ($isRegistryEnabled) {
-                $hookRegistry->collect();
-            }
-
             return $array_return ? [] : '';
         }
 
         // Check if hook exists
         if (!($id_hook = Hook::getIdByName($hook_name, false))) {
-            if ($isRegistryEnabled) {
-                $hookRegistry->collect();
-            }
-
             return $array_return ? [] : null;
         }
 
@@ -1109,10 +1095,6 @@ class HookCore extends ObjectModel
                 continue;
             }
 
-            if ($isRegistryEnabled) {
-                $hookRegistry->hookedByModule($moduleInstance);
-            }
-
             if (Hook::isHookCallableOn($moduleInstance, $registeredHookName)) {
                 $hook_args['altern'] = ++$altern;
 
@@ -1157,7 +1139,8 @@ class HookCore extends ObjectModel
                 if ($isRegistryEnabled) {
                     $hookRegistry->hookedByCallback(
                         $moduleInstance,
-                        $hook_args
+                        $hook_args,
+                        $hook_name
                     );
                 }
             } elseif (Hook::isDisplayHookName($registeredHookName)) {
@@ -1202,7 +1185,7 @@ class HookCore extends ObjectModel
                 }
 
                 if ($isRegistryEnabled) {
-                    $hookRegistry->hookedByWidget($moduleInstance, $hook_args);
+                    $hookRegistry->hookedByWidget($moduleInstance, $hook_args, $hook_name);
                 }
             }
         }
@@ -1219,11 +1202,6 @@ class HookCore extends ObjectModel
             if (isset($output['cart'])) {
                 unset($output['cart']);
             }
-        }
-
-        if ($isRegistryEnabled) {
-            $hookRegistry->hookWasCalled();
-            $hookRegistry->collect();
         }
 
         return $output;

--- a/src/Adapter/Hook/HookDispatcher.php
+++ b/src/Adapter/Hook/HookDispatcher.php
@@ -89,24 +89,10 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
         if ($listeners = $this->getListeners(strtolower($eventName ?? ''))) {
             $this->doDispatch($listeners, $eventName, $event);
         } elseif ($this->isDebug && null !== $this->hookRegistry) {
-            // When a hook has no listeners it means it's not even in the database or no modules were attached, in the current case
-            // Hook::exec will never be called meaning no stats will be registered for this hook So we handle the registry data collection
-            // here so that we can still get some info in the Debug toolbar
-            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5);
-
-            // Try to find the initial backtrace that was not called from the dispatcher services
-            $initialBackTrace = [];
-            for ($i = 0; $i < count($backtrace); ++$i) {
-                $initialBackTrace = $backtrace[$i];
-                $isCodeFromDispatcher = (bool) strpos($initialBackTrace['file'], 'HookDispatcher');
-                if (!$isCodeFromDispatcher) {
-                    break;
-                }
-            }
-
-            $this->hookRegistry->selectHook($eventName, $event->getHookParameters(), $initialBackTrace['file'] ?? 'unknown file', $initialBackTrace['line'] ?? 'unknown line');
-            $this->hookRegistry->hookWasNotRegistered();
-            $this->hookRegistry->collect();
+            // When a hook has no listeners it means it's not even in the database or no modules were attached.
+            // Hook::exec will never be called, so we record the dispatch directly here for the toolbar.
+            $this->hookRegistry->hookDispatched($eventName ?? '', $event->getHookParameters());
+            $this->hookRegistry->hookWasNotRegistered($eventName ?? '');
         }
 
         return $event;

--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -107,19 +107,17 @@ final class HookDataCollector extends DataCollector
      */
     private function stringifyHookArguments(array &$hooksList)
     {
-        foreach ($hooksList as &$hookList) {
-            foreach ($hookList as &$hook) {
-                $hook['args'] = $this->cloneVar($hook['args']);
+        foreach ($hooksList as &$hook) {
+            $hook['args'] = $this->cloneVar($hook['args']);
 
-                foreach ($hook['modules'] as &$modulesByType) {
-                    foreach ($modulesByType as $type => &$module) {
-                        if (empty($module)) {
-                            unset($modulesByType[$type]);
-                        }
+            foreach ($hook['modules'] as &$modulesByType) {
+                foreach ($modulesByType as $type => &$module) {
+                    if (empty($module)) {
+                        unset($modulesByType[$type]);
+                    }
 
-                        if (array_key_exists('args', $module)) {
-                            $module['args'] = $this->cloneVar($module['args']);
-                        }
+                    if (array_key_exists('args', $module)) {
+                        $module['args'] = $this->cloneVar($module['args']);
                     }
                 }
             }

--- a/src/PrestaShopBundle/DataCollector/HookRegistry.php
+++ b/src/PrestaShopBundle/DataCollector/HookRegistry.php
@@ -4,13 +4,19 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace PrestaShopBundle\DataCollector;
 
 use ModuleCore;
 use PrestaShop\PrestaShop\Core\Module\Legacy\ModuleInterface;
+use Twig\Template;
 
 /**
  * Collect all hooks information dispatched during a request.
+ *
+ * One entry per hook name, addressed by name on every mutator.
+ * Status promotion is asymmetric: CALLED is sticky and cannot be downgraded.
  */
 final class HookRegistry
 {
@@ -19,143 +25,217 @@ final class HookRegistry
     public const HOOK_CALLED = 'called';
 
     /**
-     * @var array the current selected hook during the request
+     * Frames whose class is — or inherits from — one of these are part of the
+     * dispatch machinery and skipped when resolving the originator. Inheritance
+     * matters because legacy classes are typically extended by an empty `Xxx`
+     * subclass of `XxxCore`, and modules may override dispatcher classes.
      */
-    private $currentHook = null;
+    private const MACHINERY_CLASSES = [
+        'HookCore', // legacy Hook class (Hook extends HookCore via override pattern)
+        'PrestaShopBundle\\DataCollector\\HookRegistry',
+        'PrestaShopBundle\\Twig\\HookExtension',
+        'PrestaShop\\PrestaShop\\Adapter\\Hook\\HookDispatcher',
+        'PrestaShop\\PrestaShop\\Adapter\\LegacyHookSubscriber',
+        'PrestaShop\\PrestaShop\\Core\\Hook\\HookDispatcher',
+    ];
 
     /**
-     * @var array<string, array<string, array{args: array, name:string, location: string, modules: array}>> the list of hooks data
+     * Namespace prefixes for vendor code we treat as machinery as a whole.
+     * Used where inheritance matching is impractical (the SF event dispatcher
+     * has many concrete classes scattered across the namespace).
      */
-    private $hooks;
+    private const MACHINERY_NAMESPACE_PREFIXES = [
+        'Symfony\\Component\\EventDispatcher\\',
+    ];
 
-    public function __construct()
+    /**
+     * @var array<string, array{name: string, status: string, dispatch_count: int, calls_count: int, args: array, location: string, modules: array<string, array{callback?: array{args: array}, widget?: array{args: array}}>}>
+     */
+    private array $hooks = [];
+
+    /**
+     * Record that a hook was dispatched. Creates the entry on first dispatch,
+     * increments `dispatch_count` and refreshes `args`/`location` on subsequent ones.
+     */
+    public function hookDispatched(string $hookName, array $hookArguments): void
     {
-        $this->hooks = [
-            self::HOOK_CALLED => [],
-            self::HOOK_NOT_CALLED => [],
-            self::HOOK_NOT_REGISTERED => [],
-        ];
+        $frame = $this->resolveOriginatorFrame();
+        $location = sprintf('%s:%s', $frame['file'], $frame['line']);
+
+        if (!isset($this->hooks[$hookName])) {
+            $this->hooks[$hookName] = [
+                'name' => $hookName,
+                'status' => self::HOOK_NOT_CALLED,
+                'dispatch_count' => 0,
+                'calls_count' => 0,
+                'args' => $hookArguments,
+                'location' => $location,
+                'modules' => [],
+            ];
+        }
+
+        ++$this->hooks[$hookName]['dispatch_count'];
+        $this->hooks[$hookName]['args'] = $hookArguments;
+        $this->hooks[$hookName]['location'] = $location;
     }
 
     /**
-     * @param string $hookName
-     * @param array $hookArguments
-     * @param string $file filepath where the "Hook::exec" call have been done
-     * @param int $line position in file where the "Hook::exec" call have been done
+     * Mark a hook as not registered (no listeners / not in DB). Asymmetric:
+     * never downgrades from CALLED. Silently no-ops if the hook was never dispatched.
      */
-    public function selectHook($hookName, $hookArguments, $file, $line)
+    public function hookWasNotRegistered(string $hookName): void
     {
-        $this->currentHook = [
-            'name' => $hookName,
-            'args' => $hookArguments,
-            'location' => "$file:$line",
-            'status' => self::HOOK_NOT_CALLED,
-            'modules' => [],
-        ];
+        if (!isset($this->hooks[$hookName])) {
+            return;
+        }
+        if (self::HOOK_NOT_CALLED === $this->hooks[$hookName]['status']) {
+            $this->hooks[$hookName]['status'] = self::HOOK_NOT_REGISTERED;
+        }
     }
 
     /**
-     * Notify the registry that the selected hook have been called.
-     */
-    public function hookWasCalled()
-    {
-        $this->currentHook['status'] = self::HOOK_CALLED;
-    }
-
-    /**
-     * Notify the registry that the selected hook have been called.
-     */
-    public function hookWasNotRegistered()
-    {
-        $this->currentHook['status'] = self::HOOK_NOT_REGISTERED;
-    }
-
-    /**
-     * @param ModuleCore $module
-     */
-    public function hookedByModule(ModuleInterface $module)
-    {
-        $this->currentHook['modules'][$module->name] = [
-            'callback' => [],
-            'widget' => [],
-        ];
-    }
-
-    /**
-     * A callback have been executed by the module during the Hook dispatch.
+     * A module callback was executed. Promotes status to CALLED and increments
+     * `calls_count`. Silently no-ops if the hook was never dispatched.
      *
      * @param ModuleCore $module
-     * @param array $args All arguments passed to the Module callback
      */
-    public function hookedByCallback(ModuleInterface $module, $args)
+    public function hookedByCallback(ModuleInterface $module, array $args, string $hookName): void
     {
-        $this->currentHook['modules'][$module->name]['callback'] = [
-            'args' => $args,
-        ];
+        if (!isset($this->hooks[$hookName])) {
+            return;
+        }
+        $this->hooks[$hookName]['status'] = self::HOOK_CALLED;
+        ++$this->hooks[$hookName]['calls_count'];
+        $this->hooks[$hookName]['modules'][$module->name]['callback'] = ['args' => $args];
     }
 
     /**
-     * A widget have been rendered by the module during the Hook dispatch.
+     * A module widget was rendered. Promotes status to CALLED and increments
+     * `calls_count`. Silently no-ops if the hook was never dispatched.
      *
      * @param ModuleCore $module
-     * @param array $args All arguments passed to the Module callback
      */
-    public function hookedByWidget(ModuleInterface $module, $args)
+    public function hookedByWidget(ModuleInterface $module, array $args, string $hookName): void
     {
-        $this->currentHook['modules'][$module->name]['widget'] = [
-            'args' => $args,
-        ];
+        if (!isset($this->hooks[$hookName])) {
+            return;
+        }
+        $this->hooks[$hookName]['status'] = self::HOOK_CALLED;
+        ++$this->hooks[$hookName]['calls_count'];
+        $this->hooks[$hookName]['modules'][$module->name]['widget'] = ['args' => $args];
     }
 
     /**
-     * @return array the list of called hooks
+     * @return array<string, array> hooks whose code actually ran
      */
-    public function getCalledHooks()
+    public function getCalledHooks(): array
     {
-        return $this->hooks[self::HOOK_CALLED];
+        return array_filter($this->hooks, fn (array $hook): bool => self::HOOK_CALLED === $hook['status']);
     }
 
     /**
-     * @return array the list of uncalled hooks
+     * @return array<string, array> hooks dispatched but without any module producing output
      */
-    public function getNotCalledHooks()
+    public function getNotCalledHooks(): array
     {
-        return $this->hooks[self::HOOK_NOT_CALLED];
+        return array_filter($this->hooks, fn (array $hook): bool => self::HOOK_NOT_CALLED === $hook['status']);
     }
 
     /**
-     * @return array the list of unregistered hooks
+     * @return array<string, array> hooks dispatched without listeners (Symfony events not in DB)
      */
-    public function getNotRegisteredHooks()
+    public function getNotRegisteredHooks(): array
     {
-        return $this->hooks[self::HOOK_NOT_REGISTERED];
+        return array_filter($this->hooks, fn (array $hook): bool => self::HOOK_NOT_REGISTERED === $hook['status']);
     }
 
     /**
-     * @return array the list of dispatched hooks
+     * @return array<string, array> all dispatched hooks, regardless of status
      */
-    public function getHooks()
+    public function getHooks(): array
     {
-        return $this->hooks[self::HOOK_CALLED] + $this->hooks[self::HOOK_NOT_CALLED] + $this->hooks[self::HOOK_NOT_REGISTERED];
+        return $this->hooks;
     }
 
     /**
-     * Persist the selected hook into the list.
+     * Walk the backtrace and return the first frame outside the dispatch machinery.
      *
-     * Theses hooks will be used by the HookDataCollector
+     * For frames that originate from a compiled Twig template, the source `.twig`
+     * file path and source line are returned instead of the compiled cache path.
+     *
+     * @return array{file: string, line: int}
      */
-    public function collect()
+    private function resolveOriginatorFrame(): array
     {
-        $name = $this->currentHook['name'];
-        $status = $this->currentHook['status'];
+        // PROVIDE_OBJECT is required because IGNORE_ARGS alone strips the `object`
+        // key from the backtrace frames — and we need that key for Twig template
+        // resolution and inheritance-aware machinery detection.
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 15);
+        foreach ($backtrace as $frame) {
+            if (!isset($frame['file'])) {
+                continue;
+            }
 
-        $hook = [
-            'args' => $this->currentHook['args'],
-            'name' => $name,
-            'location' => $this->currentHook['location'],
-            'modules' => $this->currentHook['modules'],
+            $twigFrame = $this->resolveTwigTemplateFrame($frame);
+            if (null !== $twigFrame) {
+                return $twigFrame;
+            }
+
+            if ($this->isMachineryFrame($frame)) {
+                continue;
+            }
+
+            return [
+                'file' => $frame['file'],
+                'line' => (int) ($frame['line'] ?? 0),
+            ];
+        }
+
+        return ['file' => 'unknown', 'line' => 0];
+    }
+
+    /**
+     * If the frame belongs to a compiled Twig template, return the source
+     * `.twig` path and the corresponding source line. Returns null otherwise.
+     *
+     * @return array{file: string, line: int}|null
+     */
+    private function resolveTwigTemplateFrame(array $frame): ?array
+    {
+        if (!isset($frame['object']) || !$frame['object'] instanceof Template) {
+            return null;
+        }
+
+        $template = $frame['object'];
+        $compiledLine = (int) ($frame['line'] ?? 0);
+        $debugInfo = $template->getDebugInfo();
+
+        return [
+            'file' => $template->getSourceContext()->getName(),
+            'line' => (int) ($debugInfo[$compiledLine] ?? 0),
         ];
+    }
 
-        $this->hooks[$status][$name][] = $hook;
+    private function isMachineryFrame(array $frame): bool
+    {
+        $class = $frame['class'] ?? '';
+        if ('' === $class) {
+            return false;
+        }
+        foreach (self::MACHINERY_NAMESPACE_PREFIXES as $prefix) {
+            if (str_starts_with($class, $prefix)) {
+                return true;
+            }
+        }
+        foreach (self::MACHINERY_CLASSES as $machineryClass) {
+            // is_a() with $allow_string=true accepts a class name and walks
+            // the inheritance chain — so subclasses of machinery classes
+            // (e.g. `Hook extends HookCore`) are recognised as machinery too.
+            if (is_a($class, $machineryClass, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/hooks_collector.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/hooks_collector.html.twig
@@ -24,15 +24,30 @@
                     <thead>
                     <tr>
                         <th>Hook name</th>
-                        <th>Call(s)</th>
+                        <th>Dispatches</th>
+                        <th>Calls</th>
                     </tr>
                     </thead>
                     <tbody class="sf-toolbar-ajax-request-list">
-                        {% for hookName, hooks in collector.calledHooks %}
-                            <tr><td>{{ hookName }}</td><td>{{ hooks|length }}</td></tr>
+                        {% for hookName, hook in collector.calledHooks %}
+                            <tr><td>{{ hookName }}</td><td>{{ hook.dispatch_count }}</td><td>{{ hook.calls_count }}</td></tr>
                         {% else %}
-                            <tr><td colspan="2">No hook dispatched.</td></tr>
+                            <tr><td colspan="3">No hook dispatched.</td></tr>
                         {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <table class="sf-toolbar-ajax-requests">
+                    <tbody>
+                        <tr>
+                            <td>Dispatched without active modules</td>
+                            <td>{{ collector.notCalledHooks|length }}</td>
+                        </tr>
+                        <tr>
+                            <td>Dispatched without listeners</td>
+                            <td>{{ collector.notRegisteredHooks|length }}</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -129,7 +144,7 @@
 {% endblock %}
 
 {% macro render_table(hookList, hookModules) %}
-    {% for hookName, hooks in hookList %}
+    {% for hookName, hook in hookList %}
         <h3>{{ hookName }}</h3>
 
         <table>
@@ -137,13 +152,14 @@
                 <tr>
                     <th>Arguments</th>
                     <th>Location</th>
+                    <th>Dispatches</th>
+                    <th>Calls</th>
                     {% if hookModules %}
                         <th>Hooked modules</th>
                     {% endif %}
                 </tr>
             </thead>
             <tbody>
-            {% for position, hook in hooks %}
             <tr>
                 <td>
                     {{ profiler_dump(hook.args) }}
@@ -151,6 +167,8 @@
                 <td>
                     <span class="text-muted">{{ hook.location }}</span>
                 </td>
+                <td>{{ hook.dispatch_count }}</td>
+                <td>{{ hook.calls_count }}</td>
                 {% if hookModules %}
                     <td>
                         {% set modules = hook.modules %}
@@ -177,7 +195,6 @@
                     </td>
                 {% endif %}
             </tr>
-            {% endfor %}
             </tbody>
         </table>
     {% endfor %}


### PR DESCRIPTION
| Questions         | Answers      |
|-------------------|--------------|
| Branch?           | develop      
| Description?      | See below    
| Type?             | bug fix      
| Category?         | BO           
| BC breaks?        | yes           
| Deprecations?     | no           
| How to test?      | In dev environment, open any back-office page and inspect the Hooks tab in the Symfony toolbar. Verify dispatch/call counts populate, the Location column points at user-code frames (controllers, services, .twig templates) rather than `HookDispatcher.php`/`Hook.php`/`Template.php`, and that nested dispatches no longer misattribute modules. 

## Incorrect behaviour in debug toolbar

The `HookRegistry` data collector relied on a stateful `currentHook` pointer set by `selectHook` and read by every other mutator. On nested dispatches (e.g. Smarty render inside a hook callback triggering another `Hook::exec`), the inner call overwrote `currentHook`, so the outer hook's later mutations landed on the inner entry — the outer was wrongly marked NOT_CALLED with no modules, the inner got duplicate-collected.

Mutators now take an explicit `$hookName` and address a single entry per hook in `$this->hooks`. `selectHook`/`collect`/`hookWasCalled`/`hookedByModule` are gone; `selectHook` is renamed `hookDispatched`. Each entry carries `dispatch_count` and `calls_count`; status promotion is asymmetric (CALLED is sticky).

`Hook::exec` and `HookDispatcher::dispatch` no longer capture backtraces themselves — the registry resolves the originator internally with inheritance-aware skipping of dispatch machinery (`HookCore`, `HookDispatcher`, `LegacyHookSubscriber`, `HookExtension`, SF `EventDispatcher`). Compiled Twig templates are detected and reported as their source `.twig` path + source line instead of the cache file.

`HookDataCollector` and the Twig profiler template are adapted to the new flat shape, with Dispatches/Calls columns and summary lines for not-called / not-registered hooks.

## About BC

The `HookRegistry` service is dev-environment-only and only consumed internally; no external BC surface.

Before:
<img width="307" height="203" alt="Capture d’écran 2026-05-26 à 19 21 00" src="https://github.com/user-attachments/assets/99089ea7-e55f-4c6b-8d46-e12925d672e8" />

After:
<img width="352" height="297" alt="Capture d’écran 2026-05-26 à 19 21 56" src="https://github.com/user-attachments/assets/ca1f0e7e-1268-42f2-a3c5-0687cf184a1b" />

