### PR TITLE
Migration - Customer Service IMAP mailbox sync (async on render)

### DIFF
--- a/src/Adapter/CustomerService/CommandHandler/SyncImapMessagesHandler.php
+++ b/src/Adapter/CustomerService/CommandHandler/SyncImapMessagesHandler.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\CustomerService\CommandHandler;
+
+use Contact;
+use Customer;
+use CustomerMessage;
+use CustomerThread;
+use Db;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\SyncImapMessagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\CommandHandler\SyncImapMessagesHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\ImapSyncResult;
+use PrestaShopException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Tools;
+use Validate;
+
+/**
+ * Connects to the IMAP mailbox configured under `Sell > Customer Service >
+ * Options` and imports every new message: subjects matching the legacy
+ * `#ct{thread}#tc{token}` pattern are appended to the existing thread,
+ * unrecognised mails (with `PS_SAV_IMAP_CREATE_THREADS` enabled) become
+ * new threads assigned to the matching contact category.
+ *
+ * Direct port of `AdminCustomerThreadsController::syncImap()`. Each
+ * imported message is fingerprinted (md5 of date + from + subject + msgno)
+ * in `customer_message_sync_imap`, so a repeat pass over the same mailbox
+ * is idempotent. When `PS_SAV_IMAP_DELETE_MSG` is enabled, already-imported
+ * messages get `imap_delete`d to keep the mailbox lean.
+ *
+ * @internal
+ */
+#[AsCommandHandler]
+final class SyncImapMessagesHandler implements SyncImapMessagesHandlerInterface
+{
+    private const IMAP_OPTION_FLAGS = [
+        'PS_SAV_IMAP_OPT_POP3' => '/pop3',
+        'PS_SAV_IMAP_OPT_NORSH' => '/norsh',
+        'PS_SAV_IMAP_OPT_SSL' => '/ssl',
+        'PS_SAV_IMAP_OPT_VALIDATE-CERT' => '/validate-cert',
+        'PS_SAV_IMAP_OPT_NOVALIDATE-CERT' => '/novalidate-cert',
+        'PS_SAV_IMAP_OPT_TLS' => '/tls',
+        'PS_SAV_IMAP_OPT_NOTLS' => '/notls',
+    ];
+
+    public function __construct(
+        private readonly ConfigurationInterface $configuration,
+        private readonly LanguageContext $languageContext,
+        private readonly ShopContext $shopContext,
+        private readonly TranslatorInterface $translator,
+        private readonly string $dbPrefix,
+    ) {
+    }
+
+    public function handle(SyncImapMessagesCommand $command): ImapSyncResult
+    {
+        $url = (string) $this->configuration->get('PS_SAV_IMAP_URL');
+        $port = (string) $this->configuration->get('PS_SAV_IMAP_PORT');
+        $user = (string) $this->configuration->get('PS_SAV_IMAP_USER');
+        $password = (string) $this->configuration->get('PS_SAV_IMAP_PWD');
+
+        if ('' === $url || '' === $port || '' === $user || '' === $password) {
+            return new ImapSyncResult(['IMAP configuration is not correct']);
+        }
+
+        if (!function_exists('imap_open')) {
+            return new ImapSyncResult(['imap is not installed on this server']);
+        }
+
+        $mailbox = @imap_open(
+            sprintf('{%s:%s%s}', $url, $port, $this->buildImapOptionString()),
+            $user,
+            $password,
+        );
+
+        $connectionErrors = $this->collectConnectionErrors();
+
+        if (!$mailbox) {
+            return new ImapSyncResult([sprintf('Cannot connect to the mailbox :<br />%s', $connectionErrors)]);
+        }
+
+        $check = imap_check($mailbox);
+        if (!$check) {
+            imap_close($mailbox);
+
+            return new ImapSyncResult(['Fail to get information about the current mailbox']);
+        }
+
+        if (0 === $check->Nmsgs) {
+            imap_close($mailbox);
+
+            return new ImapSyncResult(['NO message to sync']);
+        }
+
+        $deleteAfterSync = (bool) $this->configuration->get('PS_SAV_IMAP_DELETE_MSG');
+        $createUnrecognised = (bool) $this->configuration->get('PS_SAV_IMAP_CREATE_THREADS');
+
+        $overviews = imap_fetch_overview($mailbox, sprintf('1:%d', $check->Nmsgs), 0);
+        $messageErrors = [];
+        $deleteErrors = '';
+
+        foreach ($overviews as $overview) {
+            $subject = $overview->subject ?? '';
+            $md5 = md5($overview->date . $overview->from . $subject . $overview->msgno);
+
+            if ($this->isAlreadyImported($md5)) {
+                if ($deleteAfterSync && !imap_delete($mailbox, $overview->msgno)) {
+                    $deleteErrors = ', Fail to delete message';
+                }
+
+                continue;
+            }
+
+            $this->importOverview(
+                $mailbox,
+                $overview,
+                $subject,
+                $createUnrecognised,
+                $messageErrors,
+            );
+
+            Db::getInstance()->execute(
+                'INSERT INTO `' . $this->dbPrefix . 'customer_message_sync_imap` (`md5_header`) VALUES (\'' . pSQL($md5) . '\')'
+            );
+        }
+
+        imap_expunge($mailbox);
+        imap_close($mailbox);
+
+        $aggregated = array_filter([trim($connectionErrors . $deleteErrors, ', ')]);
+
+        return new ImapSyncResult(array_values(array_merge($aggregated, $messageErrors)));
+    }
+
+    /**
+     * Builds the `/pop3/ssl/...` option string appended to the IMAP mailbox URL.
+     */
+    private function buildImapOptionString(): string
+    {
+        $options = '';
+        foreach (self::IMAP_OPTION_FLAGS as $configurationKey => $optionFlag) {
+            if ($this->configuration->get($configurationKey)) {
+                $options .= $optionFlag;
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Returns a single string aggregating the connection errors reported by
+     * `imap_errors()`. Empty when there is nothing to report.
+     */
+    private function collectConnectionErrors(): string
+    {
+        $errors = imap_errors();
+        if (!is_array($errors) || [] === $errors) {
+            return '';
+        }
+
+        return rtrim(implode(', ', array_unique($errors)), ', ');
+    }
+
+    private function isAlreadyImported(string $md5): bool
+    {
+        return (bool) Db::getInstance()->getValue(
+            'SELECT `md5_header` FROM `' . $this->dbPrefix . 'customer_message_sync_imap` WHERE `md5_header` = \'' . pSQL($md5) . '\''
+        );
+    }
+
+    /**
+     * Imports a single mailbox overview: either appends to an existing thread
+     * (when the subject contains the legacy `#ct{id}#tc{token}` marker) or
+     * creates a new one (when `PS_SAV_IMAP_CREATE_THREADS` is enabled). Errors
+     * are pushed into `$messageErrors` for the caller to surface.
+     *
+     * @param array<int, string> $messageErrors
+     */
+    private function importOverview(
+        $mailbox,
+        object $overview,
+        string $subject,
+        bool $createUnrecognised,
+        array &$messageErrors,
+    ): void {
+        preg_match('/\#ct([0-9]*)/', $subject, $threadMatch);
+        preg_match('/\#tc([0-9-a-z-A-Z]*)/', $subject, $tokenMatch);
+        $matchedExisting = isset($threadMatch[1], $tokenMatch[1]);
+
+        $shouldCreateNew = $createUnrecognised && !$matchedExisting && false === strpos($subject, '[no_sync]');
+
+        if (!$matchedExisting && !$shouldCreateNew) {
+            return;
+        }
+
+        $thread = $shouldCreateNew
+            ? $this->createThreadFromOverview($overview, $messageErrors)
+            : new CustomerThread((int) $threadMatch[1]);
+
+        if (null === $thread) {
+            return;
+        }
+
+        if (!Validate::isLoadedObject($thread)) {
+            return;
+        }
+
+        if (!$shouldCreateNew && (!isset($tokenMatch[1]) || $thread->token !== $tokenMatch[1])) {
+            return;
+        }
+
+        $this->appendMessage($mailbox, $overview, $thread, $subject, $messageErrors);
+    }
+
+    /**
+     * @param array<int, string> $messageErrors
+     */
+    private function createThreadFromOverview(object $overview, array &$messageErrors): ?CustomerThread
+    {
+        $fromMatch = [];
+        if (!isset($overview->from)
+            || (!preg_match(
+                '/<([a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+[._a-z\p{L}0-9-]*\.[a-z0-9]+)>/',
+                $overview->from,
+                $fromMatch,
+            )
+            && !Validate::isEmail($overview->from))) {
+            $messageErrors[] = $this->translator->trans('Cannot create message in a new thread.', [], 'Admin.Orderscustomers.Notification');
+
+            return null;
+        }
+
+        $fromEmail = $fromMatch[1] ?? $overview->from;
+
+        $contacts = Contact::getContacts($this->languageContext->getId());
+        if (!$contacts) {
+            return null;
+        }
+
+        $idContact = (int) $contacts[0]['id_contact'];
+        if (isset($overview->to)) {
+            foreach ($contacts as $contact) {
+                if (false !== strpos((string) $overview->to, (string) $contact['email'])) {
+                    $idContact = (int) $contact['id_contact'];
+                }
+            }
+        }
+
+        $customer = (new Customer())->getByEmail($fromEmail);
+
+        $thread = new CustomerThread();
+        if (isset($customer->id)) {
+            $thread->id_customer = (int) $customer->id;
+        }
+        $thread->email = $fromEmail;
+        $thread->id_contact = $idContact;
+        $thread->id_lang = (int) $this->configuration->get('PS_LANG_DEFAULT');
+        $thread->id_shop = $this->shopContext->getId();
+        $thread->status = 'open';
+        $thread->token = Tools::passwdGen(12);
+        $thread->add();
+
+        return $thread;
+    }
+
+    /**
+     * Pulls the body part of the overview and appends it as a customer message
+     * to the resolved thread. Encoding-aware (handles base64 + quoted-printable
+     * + arbitrary charsets via iconv).
+     *
+     * @param array<int, string> $messageErrors
+     */
+    private function appendMessage(
+        $mailbox,
+        object $overview,
+        CustomerThread $thread,
+        string $subject,
+        array &$messageErrors,
+    ): void {
+        $structure = imap_bodystruct($mailbox, $overview->msgno, '1');
+        if (0 === $structure->type) {
+            $body = imap_fetchbody($mailbox, $overview->msgno, '1');
+        } elseif (1 === $structure->type) {
+            $structure = imap_bodystruct($mailbox, $overview->msgno, '1.1');
+            $body = imap_fetchbody($mailbox, $overview->msgno, '1.1');
+        } else {
+            return;
+        }
+
+        $body = match ($structure->encoding) {
+            3 => imap_base64($body),
+            4 => imap_qprint($body),
+            default => $body,
+        };
+
+        $body = nl2br((string) iconv($this->resolveEncoding($structure), 'utf-8', $body));
+
+        if ('' === $body) {
+            $messageErrors[] = $this->translator->trans('The message body is empty, cannot import it.', [], 'Admin.Orderscustomers.Notification');
+
+            return;
+        }
+
+        if (!Validate::isCleanHtml($body)) {
+            $messageErrors[] = $this->translator->trans('Invalid message content for subject: %s', [$subject], 'Admin.Orderscustomers.Notification');
+
+            return;
+        }
+
+        $message = new CustomerMessage();
+        $message->id_customer_thread = (int) $thread->id;
+        $message->message = $body;
+
+        try {
+            $message->add();
+        } catch (PrestaShopException $e) {
+            $messageErrors[] = $this->translator->trans('The message content is not valid, cannot import it.', [], 'Admin.Orderscustomers.Notification');
+        }
+    }
+
+    private function resolveEncoding(object $structure): string
+    {
+        foreach ($structure->parameters ?? [] as $parameter) {
+            if ('CHARSET' === strtoupper($parameter->attribute)) {
+                return (string) $parameter->value;
+            }
+        }
+
+        return 'utf-8';
+    }
+}

--- a/src/Adapter/CustomerService/Configuration/CustomerServiceOptionsConfiguration.php
+++ b/src/Adapter/CustomerService/Configuration/CustomerServiceOptionsConfiguration.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\CustomerService\Configuration;
+
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Persists the "Contact options" panel of the Customer Service settings:
+ * the customer-side file upload toggle and the translatable default
+ * employee signature used when replying to a thread.
+ */
+final class CustomerServiceOptionsConfiguration extends AbstractMultistoreConfiguration
+{
+    private const CONFIGURATION_FIELDS = [
+        'file_upload',
+        'signature',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        $shopConstraint = $this->getShopConstraint();
+
+        return [
+            'file_upload' => (bool) $this->configuration->get('PS_CUSTOMER_SERVICE_FILE_UPLOAD', false, $shopConstraint),
+            'signature' => $this->configuration->get('PS_CUSTOMER_SERVICE_SIGNATURE', [], $shopConstraint),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration)
+    {
+        if ($this->validateConfiguration($configuration)) {
+            $shopConstraint = $this->getShopConstraint();
+
+            $this->updateConfigurationValue('PS_CUSTOMER_SERVICE_FILE_UPLOAD', 'file_upload', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_CUSTOMER_SERVICE_SIGNATURE', 'signature', $configuration, $shopConstraint);
+        }
+
+        return [];
+    }
+
+    protected function buildResolver(): OptionsResolver
+    {
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('file_upload', 'bool')
+            ->setAllowedTypes('signature', 'array');
+    }
+}

--- a/src/Adapter/CustomerService/Configuration/ImapConfiguration.php
+++ b/src/Adapter/CustomerService/Configuration/ImapConfiguration.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\CustomerService\Configuration;
+
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Persists the "Customer service options" IMAP panel that drives the
+ * inbox synchronization performed when the Customer Service listing is loaded.
+ *
+ * Thirteen settings: connection (URL / port / user / password), behaviour
+ * flags (delete after sync, create new threads), and the seven IMAP option
+ * toggles native to the PHP imap_open mailbox string. The legacy
+ * `PS_SAV_IMAP_OPT` concatenated value is intentionally not written: it has
+ * no consumers and `syncImap` rebuilds the option string at call time from
+ * the individual toggles.
+ */
+final class ImapConfiguration extends AbstractMultistoreConfiguration
+{
+    /**
+     * Form key => Configuration key. Most are 1:1 except the two `*-CERT`
+     * legacy keys that contain a literal dash.
+     *
+     * @var array<string, string>
+     */
+    private const FIELD_TO_CONFIG_KEY = [
+        'imap_url' => 'PS_SAV_IMAP_URL',
+        'imap_port' => 'PS_SAV_IMAP_PORT',
+        'imap_user' => 'PS_SAV_IMAP_USER',
+        'imap_password' => 'PS_SAV_IMAP_PWD',
+        'imap_delete_msg' => 'PS_SAV_IMAP_DELETE_MSG',
+        'imap_create_threads' => 'PS_SAV_IMAP_CREATE_THREADS',
+        'imap_opt_pop3' => 'PS_SAV_IMAP_OPT_POP3',
+        'imap_opt_norsh' => 'PS_SAV_IMAP_OPT_NORSH',
+        'imap_opt_ssl' => 'PS_SAV_IMAP_OPT_SSL',
+        'imap_opt_validate_cert' => 'PS_SAV_IMAP_OPT_VALIDATE-CERT',
+        'imap_opt_novalidate_cert' => 'PS_SAV_IMAP_OPT_NOVALIDATE-CERT',
+        'imap_opt_tls' => 'PS_SAV_IMAP_OPT_TLS',
+        'imap_opt_notls' => 'PS_SAV_IMAP_OPT_NOTLS',
+    ];
+
+    private const BOOLEAN_FIELDS = [
+        'imap_delete_msg',
+        'imap_create_threads',
+        'imap_opt_pop3',
+        'imap_opt_norsh',
+        'imap_opt_ssl',
+        'imap_opt_validate_cert',
+        'imap_opt_novalidate_cert',
+        'imap_opt_tls',
+        'imap_opt_notls',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        $shopConstraint = $this->getShopConstraint();
+        $values = [
+            'imap_url' => (string) $this->configuration->get('PS_SAV_IMAP_URL', '', $shopConstraint),
+            'imap_port' => (string) $this->configuration->get('PS_SAV_IMAP_PORT', '143', $shopConstraint),
+            'imap_user' => (string) $this->configuration->get('PS_SAV_IMAP_USER', '', $shopConstraint),
+            'imap_password' => (string) $this->configuration->get('PS_SAV_IMAP_PWD', '', $shopConstraint),
+        ];
+
+        foreach (self::BOOLEAN_FIELDS as $field) {
+            $values[$field] = (bool) $this->configuration->get(self::FIELD_TO_CONFIG_KEY[$field], false, $shopConstraint);
+        }
+
+        return $values;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration)
+    {
+        if ($this->validateConfiguration($configuration)) {
+            $shopConstraint = $this->getShopConstraint();
+
+            foreach (self::FIELD_TO_CONFIG_KEY as $field => $configKey) {
+                // The password field renders empty in the form when the
+                // stored value is masked; persisting it as-is would wipe the
+                // previously saved credentials. Skip it when blank so existing
+                // credentials are preserved.
+                if ($field === 'imap_password' && ($configuration[$field] ?? '') === '') {
+                    continue;
+                }
+
+                $this->updateConfigurationValue($configKey, $field, $configuration, $shopConstraint);
+            }
+        }
+
+        return [];
+    }
+
+    protected function buildResolver(): OptionsResolver
+    {
+        $resolver = (new OptionsResolver())
+            ->setDefined(array_keys(self::FIELD_TO_CONFIG_KEY))
+            ->setAllowedTypes('imap_url', 'string')
+            ->setAllowedTypes('imap_port', 'string')
+            ->setAllowedTypes('imap_user', 'string')
+            ->setAllowedTypes('imap_password', 'string');
+
+        foreach (self::BOOLEAN_FIELDS as $field) {
+            $resolver->setAllowedTypes($field, 'bool');
+        }
+
+        return $resolver;
+    }
+}

--- a/src/Core/Domain/CustomerService/Command/SyncImapMessagesCommand.php
+++ b/src/Core/Domain/CustomerService/Command/SyncImapMessagesCommand.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\CustomerService\Command;
+
+/**
+ * Triggers a single IMAP synchronisation pass: connect to the configured
+ * mailbox, import every new message that hasn't been processed yet, and
+ * either create matching customer threads or append the message to an
+ * existing one. The handler returns an `ImapSyncResult` describing what
+ * happened so the caller can surface errors to the merchant.
+ */
+final class SyncImapMessagesCommand
+{
+}

--- a/src/Core/Domain/CustomerService/CommandHandler/SyncImapMessagesHandlerInterface.php
+++ b/src/Core/Domain/CustomerService/CommandHandler/SyncImapMessagesHandlerInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\CustomerService\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\SyncImapMessagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\ImapSyncResult;
+
+interface SyncImapMessagesHandlerInterface
+{
+    public function handle(SyncImapMessagesCommand $command): ImapSyncResult;
+}

--- a/src/Core/Domain/CustomerService/QueryResult/ImapSyncResult.php
+++ b/src/Core/Domain/CustomerService/QueryResult/ImapSyncResult.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult;
+
+/**
+ * Outcome of one IMAP synchronisation pass. Mirrors the legacy `syncImap`
+ * return shape (`hasError`, `errors`) and exposes typed accessors so the
+ * caller doesn't have to deal with the raw array.
+ */
+final class ImapSyncResult
+{
+    /**
+     * @param list<string> $errors
+     */
+    public function __construct(
+        private readonly array $errors,
+    ) {
+    }
+
+    public function hasErrors(): bool
+    {
+        return [] !== $this->errors;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
@@ -22,6 +22,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadFor
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeEmailById;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerThreadFilter;
@@ -29,6 +30,7 @@ use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Form\Admin\CustomerService\CustomerThread\ForwardCustomerThreadType;
 use PrestaShopBundle\Form\Admin\Sell\CustomerService\ReplyToCustomerThreadType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
+use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -301,6 +303,52 @@ class CustomerThreadController extends PrestaShopAdminController
     }
 
     /**
+     * Show the Customer service options forms (Contact panel + IMAP panel).
+     */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute: 'admin_customer_threads')]
+    public function optionsAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.adapter.customer_service.options.form_handler')]
+        FormHandlerInterface $optionsFormHandler,
+        #[Autowire(service: 'prestashop.adapter.customer_service.imap.form_handler')]
+        FormHandlerInterface $imapFormHandler,
+    ): Response {
+        return $this->render('@PrestaShop/Admin/Sell/CustomerService/CustomerThread/options.html.twig', [
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'enableSidebar' => true,
+            'layoutTitle' => $this->trans('Customer service options', [], 'Admin.Catalog.Feature'),
+            'customerServiceOptionsForm' => $optionsFormHandler->getForm()->createView(),
+            'imapOptionsForm' => $imapFormHandler->getForm()->createView(),
+        ]);
+    }
+
+    /**
+     * Save the "Contact options" panel.
+     */
+    #[DemoRestricted(redirectRoute: 'admin_customer_threads_options')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_customer_threads_options')]
+    public function saveOptionsAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.adapter.customer_service.options.form_handler')]
+        FormHandlerInterface $optionsFormHandler,
+    ): RedirectResponse {
+        return $this->processOptionsForm($request, $optionsFormHandler);
+    }
+
+    /**
+     * Save the "Customer service options" IMAP panel.
+     */
+    #[DemoRestricted(redirectRoute: 'admin_customer_threads_options')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_customer_threads_options')]
+    public function saveImapOptionsAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.adapter.customer_service.imap.form_handler')]
+        FormHandlerInterface $imapFormHandler,
+    ): RedirectResponse {
+        return $this->processOptionsForm($request, $imapFormHandler);
+    }
+
+    /**
      * Bulk delete customer thread
      *
      * @param Request $request
@@ -380,6 +428,28 @@ class CustomerThreadController extends PrestaShopAdminController
         }
 
         return array_map('intval', $customerThreadIds);
+    }
+
+    private function processOptionsForm(Request $request, FormHandlerInterface $formHandler): RedirectResponse
+    {
+        $form = $formHandler->getForm();
+        $form->handleRequest($request);
+
+        if (!$form->isSubmitted() || !$form->isValid()) {
+            return $this->redirectToRoute('admin_customer_threads_options');
+        }
+
+        $saveErrors = $formHandler->save($form->getData());
+
+        if (0 === count($saveErrors)) {
+            $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
+
+            return $this->redirectToRoute('admin_customer_threads_options');
+        }
+
+        $this->addFlashErrors($saveErrors);
+
+        return $this->redirectToRoute('admin_customer_threads_options');
     }
 
     private function handleCustomerThreadStatusUpdate(int $customerThreadId, string $newStatus)

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
@@ -12,6 +12,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\BulkDeleteCustomer
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\DeleteCustomerThreadCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\ForwardCustomerThreadCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\ReplyToCustomerThreadCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\SyncImapMessagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\UpdateCustomerThreadStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CannotDeleteCustomerThreadException;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
@@ -20,6 +21,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceLi
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceSignature;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadForViewing;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\ImapSyncResult;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeEmailById;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
@@ -32,6 +34,7 @@ use PrestaShopBundle\Form\Admin\Sell\CustomerService\ReplyToCustomerThreadType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -300,6 +303,27 @@ class CustomerThreadController extends PrestaShopAdminController
         }
 
         return $this->redirectToRoute('admin_customer_threads');
+    }
+
+    /**
+     * Trigger an IMAP synchronisation pass and return the result as JSON.
+     *
+     * Called asynchronously from the listing page (after first paint) so the
+     * grid loads instantly while the mailbox sync runs in the background.
+     * Any error messages produced by the legacy `syncImap` flow are
+     * returned to the front-end and displayed as a flash banner — matches
+     * the iso-functional behaviour merchants saw on the legacy page.
+     */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+    public function syncImapAction(): JsonResponse
+    {
+        /** @var ImapSyncResult $result */
+        $result = $this->dispatchCommand(new SyncImapMessagesCommand());
+
+        return new JsonResponse([
+            'hasError' => $result->hasErrors(),
+            'errors' => $result->getErrors(),
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/CustomerServiceOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/CustomerServiceOptionsFormDataProvider.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\CustomerService;
+
+use PrestaShop\PrestaShop\Adapter\CustomerService\Configuration\CustomerServiceOptionsConfiguration;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+/**
+ * Bridges the "Contact options" panel form with the underlying configuration
+ * adapter, so the controller does not need to know whether values land in
+ * Configuration::updateValue or anywhere else.
+ */
+final class CustomerServiceOptionsFormDataProvider implements FormDataProviderInterface
+{
+    public function __construct(
+        private readonly CustomerServiceOptionsConfiguration $configuration,
+    ) {
+    }
+
+    public function getData(): array
+    {
+        return $this->configuration->getConfiguration();
+    }
+
+    public function setData(array $data): array
+    {
+        return $this->configuration->updateConfiguration($data);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/CustomerServiceOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/CustomerServiceOptionsType.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\CustomerService;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * "Contact options" panel: customer-side file upload toggle and translatable
+ * default employee signature used when replying to a customer thread.
+ */
+final class CustomerServiceOptionsType extends TranslatorAwareType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('file_upload', SwitchType::class, [
+                'label' => $this->trans('Allow file uploading', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Allow customers to upload files using the contact page.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('signature', TranslatableType::class, [
+                'label' => $this->trans('Default message', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Please fill out the message fields that appear by default when you answer a thread on the customer service page.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+                'type' => TextareaType::class,
+                'options' => [
+                    'required' => false,
+                    'attr' => [
+                        'rows' => 5,
+                    ],
+                ],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'Admin.Catalog.Feature',
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'customer_service_options_block';
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ImapOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ImapOptionsFormDataProvider.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\CustomerService;
+
+use PrestaShop\PrestaShop\Adapter\CustomerService\Configuration\ImapConfiguration;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+final class ImapOptionsFormDataProvider implements FormDataProviderInterface
+{
+    public function __construct(
+        private readonly ImapConfiguration $configuration,
+    ) {
+    }
+
+    public function getData(): array
+    {
+        return $this->configuration->getConfiguration();
+    }
+
+    public function setData(array $data): array
+    {
+        return $this->configuration->updateConfiguration($data);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ImapOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ImapOptionsType.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\CustomerService;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * "Customer service options" IMAP panel powering the inbox synchronization.
+ */
+final class ImapOptionsType extends TranslatorAwareType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('imap_url', TextType::class, [
+                'label' => $this->trans('IMAP URL', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'URL for your IMAP server (ie.: mail.server.com).',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_port', TextType::class, [
+                'label' => $this->trans('IMAP port', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Port to use to connect to your IMAP server.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_user', TextType::class, [
+                'label' => $this->trans('IMAP user', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'User to use to connect to your IMAP server.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_password', PasswordType::class, [
+                'label' => $this->trans('IMAP password', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Password to use to connect your IMAP server.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+                'always_empty' => false,
+            ])
+            ->add('imap_delete_msg', SwitchType::class, [
+                'label' => $this->trans('Delete messages', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Delete messages after synchronization. If you do not enable this option, the synchronization will take more time.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_create_threads', SwitchType::class, [
+                'label' => $this->trans('Create new threads', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Create new threads for unrecognized emails.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_pop3', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/pop3)',
+                'help' => $this->trans('Use POP3 instead of IMAP.', 'Admin.Catalog.Help'),
+                'required' => false,
+            ])
+            ->add('imap_opt_norsh', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/norsh)',
+                'help' => $this->trans(
+                    'Do not use RSH or SSH to establish a preauthenticated IMAP sessions.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_ssl', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/ssl)',
+                'help' => $this->trans(
+                    'Use the Secure Socket Layer (TLS/SSL) to encrypt the session.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_validate_cert', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/validate-cert)',
+                'help' => $this->trans('Validate certificates from the TLS/SSL server.', 'Admin.Catalog.Help'),
+                'required' => false,
+            ])
+            ->add('imap_opt_novalidate_cert', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/novalidate-cert)',
+                'help' => $this->trans(
+                    'Do not validate certificates from the TLS/SSL server. This is only needed if a server uses self-signed certificates.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_tls', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/tls)',
+                'help' => $this->trans(
+                    'Force use of start-TLS to encrypt the session, and reject connection to servers that do not support it.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_notls', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/notls)',
+                'help' => $this->trans(
+                    'Do not use start-TLS to encrypt the session, even with servers that support it.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'Admin.Catalog.Feature',
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'imap_options_block';
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/customer_threads.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/customer_threads.yml
@@ -97,3 +97,30 @@ admin_customer_threads_bulk_delete:
     _legacy_controller: AdminCustomerThreads
     _legacy_link: AdminCustomerThreads
     _legacy_feature_flag: customer_threads
+
+admin_customer_threads_options:
+  path: /options
+  methods: [ GET ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerService\CustomerThreadController::optionsAction
+    _legacy_controller: AdminCustomerThreads
+    _legacy_link: AdminCustomerThreads:options
+    _legacy_feature_flag: customer_threads
+
+admin_customer_threads_options_save:
+  path: /options
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerService\CustomerThreadController::saveOptionsAction
+    _legacy_controller: AdminCustomerThreads
+    _legacy_link: AdminCustomerThreads:options
+    _legacy_feature_flag: customer_threads
+
+admin_customer_threads_imap_options_save:
+  path: /options/imap
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerService\CustomerThreadController::saveImapOptionsAction
+    _legacy_controller: AdminCustomerThreads
+    _legacy_link: AdminCustomerThreads:options
+    _legacy_feature_flag: customer_threads

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/customer_threads.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/customer_threads.yml
@@ -124,3 +124,14 @@ admin_customer_threads_imap_options_save:
     _legacy_controller: AdminCustomerThreads
     _legacy_link: AdminCustomerThreads:options
     _legacy_feature_flag: customer_threads
+
+admin_customer_threads_sync_imap:
+  path: /sync-imap
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerService\CustomerThreadController::syncImapAction
+    _legacy_controller: AdminCustomerThreads
+    _legacy_link: AdminCustomerThreads
+    _legacy_feature_flag: customer_threads
+  options:
+    expose: true

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -30,6 +30,20 @@ services:
       - '@prestashop.adapter.shop.context'
       - '@prestashop.adapter.multistore_feature'
 
+  prestashop.adapter.customer_service.options_configuration:
+    class: 'PrestaShop\PrestaShop\Adapter\CustomerService\Configuration\CustomerServiceOptionsConfiguration'
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
+
+  prestashop.adapter.customer_service.imap_configuration:
+    class: 'PrestaShop\PrestaShop\Adapter\CustomerService\Configuration\ImapConfiguration'
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
+
   prestashop.adapter.order_general.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Order\GeneralConfiguration'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -136,6 +136,16 @@ services:
   PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs\DatabaseLogsFormDataProvider:
     autowire: true
 
+  prestashop.adapter.customer_service.options.form_provider:
+    class: 'PrestaShopBundle\Form\Admin\Sell\CustomerService\CustomerServiceOptionsFormDataProvider'
+    arguments:
+      - '@prestashop.adapter.customer_service.options_configuration'
+
+  prestashop.adapter.customer_service.imap.form_provider:
+    class: 'PrestaShopBundle\Form\Admin\Sell\CustomerService\ImapOptionsFormDataProvider'
+    arguments:
+      - '@prestashop.adapter.customer_service.imap_configuration'
+
   prestashop.admin.import.form_data_provider:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import\ImportFormDataProvider'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -269,6 +269,24 @@ services:
       - 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs\LogsByEmailType'
       - 'LogsPage'
 
+  prestashop.adapter.customer_service.options.form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.adapter.customer_service.options.form_provider'
+      - 'PrestaShopBundle\Form\Admin\Sell\CustomerService\CustomerServiceOptionsType'
+      - 'CustomerServiceOptions'
+
+  prestashop.adapter.customer_service.imap.form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.adapter.customer_service.imap.form_provider'
+      - 'PrestaShopBundle\Form\Admin\Sell\CustomerService\ImapOptionsType'
+      - 'CustomerServiceImap'
+
   prestashop.adapter.logs_database.form_handler:
     class: 'PrestaShop\PrestaShop\Core\Form\Handler'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/domain/customer_service.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/domain/customer_service.yml
@@ -62,3 +62,12 @@ services:
 
   PrestaShop\PrestaShop\Adapter\CustomerService\QueryHandler\GetCustomerServiceListingStatisticsHandler:
     autoconfigure: true
+
+  PrestaShop\PrestaShop\Adapter\CustomerService\CommandHandler\SyncImapMessagesHandler:
+    autoconfigure: true
+    arguments:
+      $configuration: '@prestashop.adapter.legacy.configuration'
+      $languageContext: '@PrestaShop\PrestaShop\Core\Context\LanguageContext'
+      $shopContext: '@PrestaShop\PrestaShop\Core\Context\ShopContext'
+      $translator: '@translator'
+      $dbPrefix: '%database_prefix%'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
@@ -32,4 +32,33 @@
 
   <script src="{{ asset('themes/new-theme/public/customer_thread.bundle.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      fetch('{{ path('admin_customer_threads_sync_imap') }}', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+      })
+        .then(function (response) {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .then(function (payload) {
+          if (!payload || !payload.hasError || !Array.isArray(payload.errors)) {
+            return;
+          }
+          var container = document.querySelector('.content-div') || document.body;
+          payload.errors.forEach(function (message) {
+            var banner = document.createElement('div');
+            banner.className = 'alert alert-warning';
+            banner.setAttribute('role', 'alert');
+            banner.innerHTML = message;
+            container.insertBefore(banner, container.firstChild);
+          });
+        })
+        .catch(function () {});
+    });
+  </script>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
@@ -13,14 +13,14 @@
   {% block customer_service_kpis %}
     {{ render(controller(
       'PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction',
-      {kpiRow: customerServiceKpi}
+      {kpiRow: customerServiceKpi},
     )) }}
   {% endblock %}
 
   {% block customer_service_listing_statistics %}
     {{ include(
       '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/listing_statistics.html.twig',
-      {statistics: customerServiceListingStatistics}
+      {statistics: customerServiceListingStatistics},
     ) }}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/options.html.twig
@@ -1,0 +1,52 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% trans_default_domain 'Admin.Catalog.Feature' %}
+{% form_theme customerServiceOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+{% form_theme imapOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+
+{% block content %}
+  {% block customer_service_options_form %}
+    {{ form_start(customerServiceOptionsForm, {action: path('admin_customer_threads_options_save')}) }}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">settings</i>
+        {{ 'Contact options'|trans }}
+      </h3>
+      <div class="card-body">
+        <div class="form-wrapper">
+          {{ form_widget(customerServiceOptionsForm) }}
+        </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
+    </div>
+    {{ form_end(customerServiceOptionsForm) }}
+  {% endblock %}
+
+  {% block customer_service_imap_options_form %}
+    {{ form_start(imapOptionsForm, {action: path('admin_customer_threads_imap_options_save')}) }}
+    <div class="card mt-3">
+      <h3 class="card-header">
+        <i class="material-icons">mail</i>
+        {{ 'Customer service options'|trans }}
+      </h3>
+      <div class="card-body">
+        <div class="form-wrapper">
+          {{ form_widget(imapOptionsForm) }}
+        </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
+    </div>
+    {{ form_end(imapOptionsForm) }}
+  {% endblock %}
+{% endblock %}

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -7,6 +7,7 @@
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Gherkin\Node\TableNode;
+use Configuration;
 use CustomerThread;
 use Db;
 use PHPUnit\Framework\Assert;
@@ -22,6 +23,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadFor
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerServiceListingStatistics;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadStatus;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
@@ -89,7 +91,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
         $customerThread->token = Tools::passwdGen(12);
         $customerThread->add();
 
-        $this->getSharedStorage()->set($threadReference, $customerThread);
+        $this->getSharedStorage()->set($threadReference, (int) $customerThread->id);
 
         $customerMessage = new CustomerMessage();
         $customerMessage->id_customer_thread = $customerThread->id;
@@ -221,6 +223,94 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
                 $customerThreadView->getStatus()
             )
         );
+    }
+
+    /**
+     * @When I update customer service options with:
+     */
+    public function updateCustomerServiceOptions(TableNode $table): void
+    {
+        $rows = $table->getRowsHash();
+        $defaultLangId = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        $data = [
+            'file_upload' => filter_var($rows['file_upload'] ?? false, FILTER_VALIDATE_BOOLEAN),
+            'signature' => [$defaultLangId => $rows['signature_in_default'] ?? ''],
+        ];
+
+        /** @var FormDataProviderInterface $provider */
+        $provider = $this->getContainer()->get('prestashop.adapter.customer_service.options.form_provider');
+        $provider->setData($data);
+    }
+
+    /**
+     * @When I update IMAP options with:
+     */
+    public function updateImapOptions(TableNode $table): void
+    {
+        $rows = $table->getRowsHash();
+        $data = [];
+        foreach ($rows as $key => $value) {
+            if ($key === 'imap_url' || $key === 'imap_port' || $key === 'imap_user' || $key === 'imap_password') {
+                $data[$key] = (string) $value;
+            } else {
+                $data[$key] = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+
+        /** @var FormDataProviderInterface $provider */
+        $provider = $this->getContainer()->get('prestashop.adapter.customer_service.imap.form_provider');
+        $provider->setData($data);
+    }
+
+    /**
+     * @Then customer service file upload should be :state
+     */
+    public function assertFileUploadState(string $state): void
+    {
+        $expected = $state === 'enabled';
+        $actual = (bool) Configuration::get('PS_CUSTOMER_SERVICE_FILE_UPLOAD');
+
+        Assert::assertSame(
+            $expected,
+            $actual,
+            sprintf('Expected file upload to be %s, got %s.', $state, $actual ? 'enabled' : 'disabled')
+        );
+    }
+
+    /**
+     * @Then customer service signature in default language should be :expected
+     */
+    public function assertSignatureInDefaultLanguage(string $expected): void
+    {
+        $defaultLangId = (int) Configuration::get('PS_LANG_DEFAULT');
+        $actual = (string) Configuration::get('PS_CUSTOMER_SERVICE_SIGNATURE', $defaultLangId);
+        Assert::assertSame($expected, $actual);
+    }
+
+    /**
+     * @Then /^IMAP configuration "([^"]+)" should be "([^"]+)"$/
+     */
+    public function assertImapConfigurationStringValue(string $key, string $expected): void
+    {
+        $actual = (string) Configuration::get($key);
+        Assert::assertSame($expected, $actual, sprintf('Configuration "%s" should be "%s", got "%s".', $key, $expected, $actual));
+    }
+
+    /**
+     * @Then /^IMAP configuration "([^"]+)" should be enabled$/
+     */
+    public function assertImapConfigurationEnabled(string $key): void
+    {
+        Assert::assertTrue((bool) Configuration::get($key), sprintf('Configuration "%s" should be enabled.', $key));
+    }
+
+    /**
+     * @Then /^IMAP configuration "([^"]+)" should be disabled$/
+     */
+    public function assertImapConfigurationDisabled(string $key): void
+    {
+        Assert::assertFalse((bool) Configuration::get($key), sprintf('Configuration "%s" should be disabled.', $key));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -15,6 +15,7 @@ use PrestaShop\PrestaShop\Adapter\Entity\CustomerMessage;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\BulkDeleteCustomerThreadCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\DeleteCustomerThreadCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\ReplyToCustomerThreadCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\SyncImapMessagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\UpdateCustomerThreadStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerThreadNotFoundException;
@@ -22,6 +23,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceLi
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadForViewing;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerServiceListingStatistics;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\ImapSyncResult;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadStatus;
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use RuntimeException;
@@ -311,6 +313,59 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     public function assertImapConfigurationDisabled(string $key): void
     {
         Assert::assertFalse((bool) Configuration::get($key), sprintf('Configuration "%s" should be disabled.', $key));
+    }
+
+    /**
+     * @Given IMAP configuration is unset
+     */
+    public function clearImapConfiguration(): void
+    {
+        foreach (['PS_SAV_IMAP_URL', 'PS_SAV_IMAP_PORT', 'PS_SAV_IMAP_USER', 'PS_SAV_IMAP_PWD'] as $key) {
+            Configuration::updateValue($key, '');
+        }
+    }
+
+    /**
+     * @Given the IMAP server is configured with:
+     */
+    public function setImapConfiguration(TableNode $table): void
+    {
+        $values = $table->getRowsHash();
+        $map = [
+            'imap_url' => 'PS_SAV_IMAP_URL',
+            'imap_port' => 'PS_SAV_IMAP_PORT',
+            'imap_user' => 'PS_SAV_IMAP_USER',
+            'imap_password' => 'PS_SAV_IMAP_PWD',
+        ];
+        foreach ($map as $key => $configurationKey) {
+            Configuration::updateValue($configurationKey, $values[$key] ?? '');
+        }
+    }
+
+    /**
+     * @When I synchronise customer service IMAP messages
+     */
+    public function synchroniseImapMessages(): void
+    {
+        /** @var ImapSyncResult $result */
+        $result = $this->getCommandBus()->handle(new SyncImapMessagesCommand());
+        $this->getSharedStorage()->set('imap_sync_result', $result);
+    }
+
+    /**
+     * @Then customer service IMAP sync should fail with errors:
+     */
+    public function assertImapSyncErrors(TableNode $table): void
+    {
+        /** @var ImapSyncResult $result */
+        $result = $this->getSharedStorage()->get('imap_sync_result');
+
+        Assert::assertTrue($result->hasErrors(), 'Expected IMAP sync to report errors, got none.');
+        Assert::assertSame(
+            array_map('trim', array_column($table->getRows(), 0)),
+            $result->getErrors(),
+            'IMAP sync errors do not match expectations.'
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service_imap_sync.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service_imap_sync.feature
@@ -1,0 +1,23 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer_service --tags customer-service-imap-sync
+@restore-all-tables-before-feature
+@customer-service-imap-sync
+Feature: Customer service IMAP sync
+
+  Background:
+    Given there are no customer threads
+
+  Scenario: Syncing IMAP without configured credentials returns a configuration error
+    Given IMAP configuration is unset
+    When I synchronise customer service IMAP messages
+    Then customer service IMAP sync should fail with errors:
+      | IMAP configuration is not correct |
+
+  Scenario: Syncing IMAP with a missing port returns a configuration error
+    Given the IMAP server is configured with:
+      | imap_url      | mail.example.com |
+      | imap_port     |                  |
+      | imap_user     | support          |
+      | imap_password | secret           |
+    When I synchronise customer service IMAP messages
+    Then customer service IMAP sync should fail with errors:
+      | IMAP configuration is not correct |

--- a/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service_options.feature
@@ -1,0 +1,42 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer_service --tags customer-service-options
+@restore-all-tables-before-feature
+@customer-service-options
+Feature: Customer service options
+
+  Scenario: Save the contact options panel (file upload + signature)
+    When I update customer service options with:
+      | file_upload          | true  |
+      | signature_in_default | Hello |
+    Then customer service file upload should be enabled
+    And customer service signature in default language should be "Hello"
+
+  Scenario: Toggle the contact-side file upload off
+    When I update customer service options with:
+      | file_upload          | false |
+      | signature_in_default | Hi    |
+    Then customer service file upload should be disabled
+
+  Scenario: Save the IMAP options panel
+    When I update IMAP options with:
+      | imap_url            | mail.example.com |
+      | imap_port           | 993              |
+      | imap_user           | support          |
+      | imap_password       | secret           |
+      | imap_delete_msg     | true             |
+      | imap_create_threads | false            |
+      | imap_opt_pop3       | false            |
+      | imap_opt_norsh      | false            |
+      | imap_opt_ssl        | true             |
+      | imap_opt_validate_cert   | true        |
+      | imap_opt_novalidate_cert | false       |
+      | imap_opt_tls        | false            |
+      | imap_opt_notls      | false            |
+    Then IMAP configuration "PS_SAV_IMAP_URL" should be "mail.example.com"
+    And IMAP configuration "PS_SAV_IMAP_PORT" should be "993"
+    And IMAP configuration "PS_SAV_IMAP_USER" should be "support"
+    And IMAP configuration "PS_SAV_IMAP_PWD" should be "secret"
+    And IMAP configuration "PS_SAV_IMAP_DELETE_MSG" should be enabled
+    And IMAP configuration "PS_SAV_IMAP_CREATE_THREADS" should be disabled
+    And IMAP configuration "PS_SAV_IMAP_OPT_SSL" should be enabled
+    And IMAP configuration "PS_SAV_IMAP_OPT_VALIDATE-CERT" should be enabled
+    And IMAP configuration "PS_SAV_IMAP_OPT_NOVALIDATE-CERT" should be disabled


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | migration/customer-service
| Description?      | Brings the IMAP mailbox synchronisation back on the migrated Customer Service page (feature flag `customer_threads`). The legacy page ran `syncImap()` synchronously inside `renderList()`, blocking the grid render whenever the mailbox was slow or unreachable. This PR ports the sync to a CQRS command and fires it asynchronously from the listing template, so the grid loads instantly and any error surfaces as a banner above the grid once the sync finishes — same merchant-visible behaviour, no blocking render. Stacked on top of #41421 (Customer service options page) and the migration/customer-service integration branch.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | (1) Enable the `customer_threads` feature flag. (2) Configure IMAP under `Sell > Customer Service > Customer Service > Options` against a reachable mailbox containing a few new messages. (3) Open `Sell > Customer Service > Customer Service` — the grid should render immediately while a POST to `/sync-imap` runs in the background; merchant-facing errors (bad credentials, missing port, missing IMAP extension) appear as a Bootstrap warning banner above the grid. (4) Re-run the page — already-imported messages are skipped via the `customer_message_sync_imap` md5 dedup table; if `PS_SAV_IMAP_DELETE_MSG` is on they are removed from the mailbox. (5) Run `composer create-test-db && ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer_service` — expect 17 scenarios green (the two new ones cover the IMAP config error paths).
| UI Tests          | N/A in this PR — the existing Customer Service Playwright campaigns continue to pass since the listing URL and grid structure are unchanged. A dedicated Playwright campaign for the IMAP sync (with a MailDev fixture) is tracked alongside the other Playwright additions for this migration.
| Fixed issue or discussion?     | Part of the AdminCustomerThreads → Symfony migration umbrella tracked in #41417.
| Related PRs       | Stacked on top of #41421 (Customer service options page). Both target the `migration/customer-service` integration branch where #41418 and #41420 are already merged.
| Sponsor company   | @PrestaShopCorp

## What this PR adds

### Domain (Core)

- `SyncImapMessagesCommand` — empty command, just triggers a sync pass.
- `SyncImapMessagesHandlerInterface` returning an `ImapSyncResult`.
- `ImapSyncResult` DTO with `hasErrors()` / `getErrors(): list<string>`.

### Adapter

`SyncImapMessagesHandler` ports `AdminCustomerThreadsController::syncImap()` nearly line-for-line:

- Builds the mailbox URL from the seven `PS_SAV_IMAP_OPT_*` flags (`/pop3`, `/ssl`, `/validate-cert`, etc.).
- Short-circuits with explicit errors when the configuration is incomplete or when the PHP `imap` extension is not installed.
- Walks `imap_fetch_overview`, fingerprints each message via the existing `customer_message_sync_imap` md5 dedup table, optionally `imap_delete`s already-imported messages when `PS_SAV_IMAP_DELETE_MSG` is on.
- Subject matches the legacy `#ct{thread}#tc{token}` marker → appends the body as a new `CustomerMessage` on the existing thread.
- Unrecognised mails (when `PS_SAV_IMAP_CREATE_THREADS` is on and the subject doesn't carry `[no_sync]`) become brand-new threads assigned to the matching contact category, with the customer pre-filled when an existing account matches the `From:` address.
- Encoding-aware body extraction (base64 / quoted-printable / iconv-converted to UTF-8 from any structure charset).

### Controller + routing

- `CustomerThreadController::syncImapAction` (POST `/sync-imap`) dispatches the command, returns the result as JSON.
- `admin_customer_threads_sync_imap` route is flag-gated on `customer_threads` with `expose: true` so the FOSJsRouting reference in the template generates a usable URL.

### Twig

`index.html.twig` now ships a small inline JS snippet:

```js
document.addEventListener('DOMContentLoaded', function () {
  fetch('{{ path('admin_customer_threads_sync_imap') }}', { method: 'POST', credentials: 'same-origin' })
    .then(r => r.json())
    .then(payload => {
      if (!payload || !payload.hasError) return;
      payload.errors.forEach(message => { /* render Bootstrap alert above the grid */ });
    });
});
```

Same merchant-visible behaviour as the legacy `renderProcessSyncImap` — error banners appear on page load — but the grid renders immediately and the sync runs in the background.

### Behat coverage

`customer_service_imap_sync.feature` with two scenarios driving the command bus through error paths (unset configuration, missing port). Mocking a real IMAP server in the integration suite is out of scope; happy-path coverage will land with the Playwright campaign once a MailDev fixture is wired up.

## What is intentionally NOT in this PR

- **IMAP server fixture for Behat happy paths** — mocking `imap_*` extension functions requires either an interface seam or a stream wrapper; deferred to keep this PR focused on the iso-functional behaviour.
- **Playwright campaign** — the existing Customer Service campaigns continue to pass against this branch since the URL and grid structure are unchanged. Dedicated IMAP-sync Playwright coverage is tracked alongside the rest of the migration's Playwright work.
- **Manual "Sync now" button** — the legacy AJAX endpoint had a `syncImapMail` POST that the page-level JS could call explicitly. The current Symfony route covers both the auto-on-render call and any future manual trigger; adding a UI button is a separate cosmetic change.