### PR TITLE
Fix Discount V2 end date validation when period never expires is checked

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
@@ -121,6 +121,14 @@ $(() => {
     toggleType: ToggleType.visibility,
   });
 
+  new FormFieldToggler({
+    disablingInputSelector: DiscountMap.periodNeverExpiresCheckbox,
+    matchingValue: '1',
+    disableOnMatch: true,
+    targetSelector: DiscountMap.periodExpiryDateFormGroup,
+    toggleType: ToggleType.availability,
+  });
+
   $(DiscountMap.countriesSelect).select2({
     templateResult: formatOption,
     templateSelection: formatOption,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountPeriodType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountPeriodType.php
@@ -12,8 +12,10 @@ use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopBundle\Form\Admin\Type\CardType;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Event\PreSubmitEvent;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DiscountPeriodType extends TranslatorAwareType
@@ -47,6 +49,14 @@ class DiscountPeriodType extends TranslatorAwareType
                 ],
             ])
         ;
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (PreSubmitEvent $event): void {
+            $data = $event->getData();
+            if (!empty($data['period_never_expires'])) {
+                $data['valid_date_range']['to'] = null;
+                $event->setData($data);
+            }
+        });
     }
 
     public function configureOptions(OptionsResolver $resolver): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When creating a discount in Discount V2, if an end date earlier than the start date was entered and then "Period never expires" was checked, the form still raised a validation error on the end date field. <br><br> **Root cause (two layers):** <br> 1. **JS**: the `FormFieldToggler` used `ToggleType.visibility` which only hides the field visually (`d-none`) but does not add `disabled` on the inputs — the browser still submits the previous end date value. <br> 2. **PHP**: the `DateRange` constraint in `DiscountPeriodType` is applied unconditionally; there was no `PRE_SUBMIT` listener to clear the end date before Symfony validation when `period_never_expires` is checked. <br><br> **Fix:** <br> - Added a second `FormFieldToggler` with `ToggleType.availability` to disable the end date inputs when "never expires" is checked, preventing submission. <br> - Added a `PRE_SUBMIT` event listener in `DiscountPeriodType` that sets `valid_date_range.to` to `null` when `period_never_expires` is checked, so the server-side `DateRange` constraint is bypassed even if JS is disabled or bypassed.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to BO > Catalog > Discounts > Create a discount <br> 2. Set a name <br> 3. In the Period section, set an end date **earlier** than the start date (e.g. start: tomorrow, end: today) <br> 4. Check **"Period never expires"** <br> 5. Fill in a discount value and save <br> **Expected:** form saves successfully, no date range error. <br> **Before fix:** form still showed "The expiration date must be after start date".
| UI Tests          | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/26577015957 :green_circle: 
| Fixed issue or discussion?     | Fixes #41091
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA