### PR TITLE
Use position as default sorting for feature grid

### DIFF
--- a/src/Core/Search/Filters/FeatureFilters.php
+++ b/src/Core/Search/Filters/FeatureFilters.php
@@ -25,7 +25,7 @@ final class FeatureFilters extends ShopFilters
         return [
             'limit' => self::LIST_LIMIT,
             'offset' => 0,
-            'orderBy' => 'name',
+            'orderBy' => 'position',
             'sortOrder' => 'asc',
             'filters' => [],
         ];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR updates the default sorting of the **Feature** grid from `name` to `position`.<br/><br/>This aligns the Feature grid behavior with other sortable grids such as **Attribute**, **Attribute Group**, and **Feature Value** grids, which already use `position` as the default `orderBy` value.<br/><br/>The change ensures that features are displayed by default according to their configured position instead of alphabetically by name.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Empty the `admin_filter` database table.<br/>2. Go to **Catalog > Attributes & Features > Features**.<br/>3. Make sure the grid is sorted by the `Position` column by default.
| UI Tests          | OLD: https://github.com/Codencode/ga.tests.ui.pr/actions/runs/26620334864<br/>NEW: https://github.com/Codencode/ga.tests.ui.pr/actions/runs/26641497108
| Fixed issue or discussion?     | Fixes #41553 
| Related PRs       | 
| Sponsor company   | Codencode snc
