### PR TITLE
Fix highlight option missing in Discount V2 form

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
@@ -114,6 +114,7 @@ class DiscountFormDataHandler implements FormDataHandlerInterface
 
         // Set description
         $command->setDescription($data['information']['description'] ?? '');
+        $command->setHighlightInCart((bool) ($data['information']['highlight_in_cart'] ?? false));
 
         // Set code
         if ($data['usability']['mode']['children_selector'] === DiscountUsabilityModeType::CODE_MODE) {

--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -69,6 +69,9 @@ class DiscountFormDataProvider implements FormDataProviderInterface
         $endDate = (clone $now)->modify('+1 month')->setTime(23, 59);
 
         return [
+            'information' => [
+                'highlight_in_cart' => false,
+            ],
             'period' => [
                 'valid_date_range' => [
                     'from' => $startDate->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
@@ -159,6 +162,7 @@ class DiscountFormDataProvider implements FormDataProviderInterface
             'id' => $id,
             'information' => [
                 'active' => $discountForEditing->isActive(),
+                'highlight_in_cart' => $discountForEditing->isHighlightInCart(),
                 'discount_type' => $discountForEditing->getType()->getValue(),
                 'names' => $discountForEditing->getLocalizedNames(),
                 'description' => $discountForEditing->getDescription(),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountInformationType.php
@@ -97,6 +97,17 @@ class DiscountInformationType extends TranslatorAwareType
                 ],
                 'required' => false,
             ])
+            ->add('highlight_in_cart', SwitchType::class, [
+                'label' => $this->trans('Highlight', 'Admin.Catalog.Feature'),
+                'label_attr' => [
+                    'class' => 'font-weight-bold',
+                ],
+                'label_help_box' => $this->trans(
+                    'If the voucher is not yet in the cart, it will be displayed in the cart summary.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
         ;
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | The **Highlight** option (which displays the voucher in the cart summary when not yet applied) was already fully implemented at the Domain and Adapter layers for Discount V2, but was never wired up in the Symfony form layer.<br/>This PR adds the missing `highlight_in_cart` field in `DiscountInformationType`, exposes it in `DiscountFormDataProvider`, and handles it in `DiscountFormDataHandler`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable Discount V2.<br/>2. BO > Catalog > Discounts > Create a new discount.<br/>3. The **Highlight** toggle should be visible in the Discount information card.<br/>4. Toggle it on, save, reopen — the value should be persisted correctly.<br/>5. Verify on the FO that the voucher appears in the cart summary when highlight is enabled and the code is not yet applied.
| UI Tests          | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/26641214717 :green_circle: 
| Fixed issue or discussion?     | Fixes #41197
| Related PRs       | 
| Sponsor company   | PrestaShop SA