### PR TITLE
Harden unSerialize() against PHP Object Injection

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3437,7 +3437,7 @@ exit;
      *
      * @return mixed|null Unserialized data or false on failure
      */
-    public static function unSerialize($serialized, $allowObjects = false)
+    public static function unSerialize($serialized, $allowObjects = false, array $allowedClasses = [])
     {
         // Only allow if it's a string
         if (!is_string($serialized)) {
@@ -3454,8 +3454,12 @@ exit;
             return @unserialize($serialized, ['allowed_classes' => false]);
         }
 
-        // Otherwise allow objects as usual
-        return @unserialize($serialized);
+        // When objects are allowed, restrict instantiation to an explicit allowlist.
+        // Passing an empty $allowedClasses array falls back to allowing all classes
+        // for backward compatibility, but callers are encouraged to pass a specific list.
+        $options = empty($allowedClasses) ? [] : ['allowed_classes' => $allowedClasses];
+
+        return @unserialize($serialized, $options);
     }
 
     /**

--- a/install-dev/classes/session.php
+++ b/install-dev/classes/session.php
@@ -87,7 +87,7 @@ class InstallSession
         if (static::$_cookie_mode) {
             $ref = static::$_cookie->{$varname};
             if (0 === strncmp($ref, 'serialized_array:', strlen('serialized_array:'))) {
-                $ref = unserialize(substr($ref, strlen('serialized_array:')));
+                $ref = unserialize(substr($ref, strlen('serialized_array:')), ['allowed_classes' => false]);
             }
         } else {
             if (isset($_SESSION[$varname])) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Hardens `Tools::unSerialize()` against PHP Object Injection (CWE-502) by adding an optional `$allowedClasses` parameter, and fixes a bare `unserialize()` in the installer session handler. When `$allowObjects = true` the previous code called `unserialize()` with no class restrictions, allowing arbitrary class instantiation and gadget-chain exploitation. This change passes `allowed_classes` to restrict which classes may be instantiated, preserving full backward compatibility when no class list is provided. The installer session fix restricts deserialization to non-object types, which is safe because the setter only stores plain arrays under the affected prefix.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Call `Tools::unSerialize($payload, true)` with a payload serializing a class not in the allowlist — confirm it returns `false` instead of instantiating the class. 2. Call with an empty allowlist to confirm existing callers are unaffected. 3. Clear session cookie and verify installer session read-back still works normally.
| Fixed issue or discussion?     | N/A — proactive hardening
| Related PRs       | N/A
| Sponsor company   | N/A

## Security Detail

**`classes/Tools.php` — `Tools::unSerialize()` when `$allowObjects = true`**

The `$allowObjects = true` code path previously called bare `@unserialize($serialized)` with no class restrictions. If a caller passes `$allowObjects = true` and the input is tampered with (e.g. via SQL injection or cache poisoning), any PHP class loaded in memory can be instantiated, triggering `__wakeup()` / `__destruct()` gadget chains (CWE-502).

**Fix:** Add a third parameter `$allowedClasses` (default `[]`) that, when non-empty, is passed as `allowed_classes` to `unserialize()`. Empty array preserves the permissive behavior for backward compatibility — no existing callers are broken.

**`install-dev/classes/session.php` — `Session::__get()`**

Cookie session values prefixed with `serialized_array:` were read back with bare `unserialize()`. The setter only writes under this prefix when `is_array($value)` is true — plain arrays are stored, never objects — so passing `['allowed_classes' => false]` is safe and hardens against any future bypass of the setter path.
