### PR TITLE
Fix stale product thumbnails after cover update

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -348,6 +348,14 @@ class ImageCore extends ObjectModel
             unlink(_PS_TMP_IMG_DIR_ . 'product_' . $idProduct . '.jpg');
         }
 
+        // Clear order/cart page thumbnails keyed by attribute id or shop id.
+        $oldThumbnails = glob(_PS_TMP_IMG_DIR_ . 'product_mini_' . (int) $idProduct . '_*.jpg');
+        if (!empty($oldThumbnails)) {
+            foreach ($oldThumbnails as $file) {
+                @unlink($file);
+            }
+        }
+
         return Db::getInstance()->execute(
             '
 			UPDATE `' . _DB_PREFIX_ . 'image`

--- a/src/Adapter/Product/Image/Update/ProductImageUpdater.php
+++ b/src/Adapter/Product/Image/Update/ProductImageUpdater.php
@@ -107,6 +107,7 @@ class ProductImageUpdater
         }
 
         $productId = new ProductId((int) $newCover->id_product);
+        $coverUpdated = false;
         foreach ($shopIds as $shopId) {
             $currentCover = $this->productImageRepository->findCoverImageId($productId, $shopId);
 
@@ -120,6 +121,13 @@ class ProductImageUpdater
             }
 
             $this->updateCover($newCover, true, $shopId);
+            $coverUpdated = true;
+        }
+
+        if ($coverUpdated) {
+            // Cover changes do not go through Image::deleteCover(); clear temporary
+            // order/cart thumbnails so the new cover is reflected immediately.
+            $this->productImageUploader->clearCachedImages((int) $newCover->id_product);
         }
     }
 

--- a/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
+++ b/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
@@ -147,6 +147,18 @@ class ProductImageUploader extends AbstractImageUploader
     }
 
     /**
+     * Clears temporary product thumbnails used by back-office listings and order/cart views.
+     *
+     * @param int $productId
+     *
+     * @throws CannotUnlinkImageException
+     */
+    public function clearCachedImages(int $productId): void
+    {
+        $this->deleteCachedImages($productId);
+    }
+
+    /**
      * @param int $productId
      *
      * @throws CannotUnlinkImageException
@@ -157,6 +169,18 @@ class ProductImageUploader extends AbstractImageUploader
             $this->productImagePathFactory->getHelperThumbnail($productId, $this->contextShopId),
             $this->productImagePathFactory->getCachedCover($productId),
         ];
+
+        // Order/cart pages also cache product_mini_{productId}_{attributeId}.jpg variants.
+        $temporaryMiniThumbnails = glob(
+            dirname($this->productImagePathFactory->getCachedCover($productId))
+            . DIRECTORY_SEPARATOR
+            . 'product_mini_'
+            . $productId
+            . '_*.jpg'
+        );
+        if (!empty($temporaryMiniThumbnails)) {
+            $cachedImages = array_unique(array_merge($cachedImages, $temporaryMiniThumbnails));
+        }
 
         foreach ($cachedImages as $cachedImage) {
             if (!file_exists($cachedImage)) {

--- a/tests/Integration/Classes/ImageDeleteCoverTest.php
+++ b/tests/Integration/Classes/ImageDeleteCoverTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Image;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ImageDeleteCoverTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        self::bootKernel();
+    }
+
+    /**
+     * Deleting a product cover must also clear the temporary product_mini_{id}_{attributeId}.jpg
+     * thumbnails, otherwise BO order/cart views keep showing the previous image.
+     */
+    public function testDeleteCoverRemovesTheTemporaryProductMiniThumbnails(): void
+    {
+        $idProduct = 999999;
+        $thumbnails = [
+            _PS_TMP_IMG_DIR_ . 'product_mini_' . $idProduct . '_1.jpg',
+            _PS_TMP_IMG_DIR_ . 'product_mini_' . $idProduct . '_5.jpg',
+        ];
+
+        foreach ($thumbnails as $thumbnail) {
+            file_put_contents($thumbnail, 'fake-thumbnail');
+        }
+
+        try {
+            Image::deleteCover($idProduct);
+
+            foreach ($thumbnails as $thumbnail) {
+                $this->assertFileDoesNotExist($thumbnail);
+            }
+        } finally {
+            foreach ($thumbnails as $thumbnail) {
+                @unlink($thumbnail);
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When a product cover is changed, the temporary `product_mini_{id}_{attributeId}.jpg` thumbnails used by back-office order and cart views are not cleared. This can make order detail pages keep showing the previous product image after the cover is updated.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create a product with image A and place an order containing it. <br> 2. Open the order in the back office so the product thumbnail is generated. <br> 3. Change the product cover to image B. <br> 4. Re-open the order detail page and check that the product row shows image B instead of the old cached image A.
| UI Tests          |  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/29188319636
| Fixed issue or discussion?     | Fixes #32788
| Related PRs       | N/A
| Sponsor company   | N/A

## Additional information

`Image::deleteImage()` already removes the `product_mini_{id}_*.jpg` variants when deleting an image. This applies the same cache invalidation when clearing a product cover, so back-office order and cart thumbnails are regenerated after the cover changes.