### PR TITLE
Sort hook selector options alphabetically by name

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/improve/design_positions/hook-module-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/improve/design_positions/hook-module-handler.ts
@@ -105,8 +105,12 @@ export default class HookModuleHandler {
     const currentValue = this.hookSelector.value;
     this.clearHookSelector();
 
-    const available = hooks.filter((hook) => !hook.registered);
-    const registered = hooks.filter((hook) => hook.registered);
+    // Sort by technical name (case-insensitive) so each group is alphabetical,
+    // matching the order the option label leads with.
+    const byName = (a: HookableInfo, b: HookableInfo): number => a.name.localeCompare(b.name, undefined, {sensitivity: 'base'});
+
+    const available = hooks.filter((hook) => !hook.registered).sort(byName);
+    const registered = hooks.filter((hook) => hook.registered).sort(byName);
 
     const buildOption = (hook: HookableInfo): HTMLOptionElement => {
       const option = document.createElement('option');

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -501,6 +501,7 @@ class PositionsController extends PrestaShopAdminController
                     $entries[] = sprintf('module-%s-%s', $module, $controller);
                 }
             }
+            sort($entries);
 
             return $entries;
         };


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Sort hook selector options alphabetically by name, related to @Hlavtox comment in https://github.com/PrestaShop/PrestaShop/pull/41407
| Type?             | improvement 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | Open the "hook a module" page and the hook list in the select should be sorted alphabetically
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/26758150490
| Fixed issue or discussion?     | N/A
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41407
| Sponsor company   | PrestaShop SA 

### Before 

<img width="905" height="284" alt="Capture d’écran 2026-06-01 à 15 24 57" src="https://github.com/user-attachments/assets/7fd71bff-bcfa-415b-8acb-04d8f7bdde6d" />



### After

<img width="942" height="383" alt="Capture d’écran 2026-06-01 à 15 26 52" src="https://github.com/user-attachments/assets/3fc35142-a0c2-4026-ab6b-77b2847e2bb6" />

