### PR TITLE
One-page Checkout beta version setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "^0.3.0",
+        "prestashop/ps_onepagecheckout": "^0.4.0",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "^0.6.2",
+        "prestashop/ps_onepagecheckout": "0.6.2",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "^0.1",
+        "prestashop/ps_onepagecheckout": "^0.2.0",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "^0.4.0",
+        "prestashop/ps_onepagecheckout": "^0.6.0",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "^0.6.3",
+        "prestashop/ps_onepagecheckout": "^0.6.2",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
+        "prestashop/ps_onepagecheckout": "^0.1",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "^0.2.0",
+        "prestashop/ps_onepagecheckout": "^0.3.0",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "^0.6.2",
+        "prestashop/ps_onepagecheckout": "^0.6.3",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "^0.6.0",
+        "prestashop/ps_onepagecheckout": "^0.6.2",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -6421,6 +6421,56 @@
             "time": "2026-06-07T18:46:03+00:00"
         },
         {
+            "name": "prestashop/ps_onepagecheckout",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
+                "reference": "d542543ceb93f35f408ce86ad529b8eec4db9d72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/d542543ceb93f35f408ce86ad529b8eec4db9d72",
+                "reference": "d542543ceb93f35f408ce86ad529b8eec4db9d72",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "segmentio/analytics-php": "^3.0"
+            },
+            "require-dev": {
+                "prestashop/php-dev-tools": "^4.3"
+            },
+            "type": "prestashop-module",
+            "autoload": {
+                "psr-4": {
+                    "PrestaShop\\Module\\PsOnePageCheckout\\": "src/"
+                },
+                "classmap": [
+                    "ps_onepagecheckout.php",
+                    "controllers/",
+                    "src/Checkout/Ajax/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "AFL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "PrestaShop SA",
+                    "email": "contact@prestashop.com"
+                }
+            ],
+            "description": "PrestaShop module ps_onepagecheckout",
+            "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
+            "support": {
+                "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.1.0"
+            },
+            "time": "2026-06-01T09:35:25+00:00"
+        },
+        {
             "name": "prestashop/ps_searchbar",
             "version": "v2.1.4",
             "source": {
@@ -8076,6 +8126,70 @@
                 "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/8.4.0"
             },
             "time": "2021-12-11T13:40:54+00:00"
+        },
+        {
+            "name": "segmentio/analytics-php",
+            "version": "3.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/segmentio/analytics-php.git",
+                "reference": "6199b9887e53e11dfdfb590beba79577c120efed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/segmentio/analytics-php/zipball/6199b9887e53e11dfdfb590beba79577c120efed",
+                "reference": "6199b9887e53e11dfdfb590beba79577c120efed",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "overtrue/phplint": "^3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpunit/phpunit": "~9.5",
+                "roave/security-advisories": "dev-latest",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "suggest": {
+                "ext-curl": "For using the curl HTTP client",
+                "ext-zlib": "For using compression"
+            },
+            "bin": [
+                "bin/analytics"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Segment\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Segment.io <friends@segment.com>",
+                    "homepage": "https://segment.com/"
+                }
+            ],
+            "description": "Segment Analytics PHP Library",
+            "homepage": "https://segment.com/libraries/php",
+            "keywords": [
+                "analytics",
+                "analytics.js",
+                "segment",
+                "segmentio"
+            ],
+            "support": {
+                "issues": "https://github.com/segmentio/analytics-php/issues",
+                "source": "https://github.com/segmentio/analytics-php/tree/3.8.2"
+            },
+            "time": "2026-03-11T18:19:46+00:00"
         },
         {
             "name": "smarty/smarty",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5bd08ebf7e2cb4220e2247741666c1a",
+    "content-hash": "a5af1d2c527ee6dd8e43b300513b31d3",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6422,16 +6422,16 @@
         },
         {
             "name": "prestashop/ps_onepagecheckout",
-            "version": "v0.6.0",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
-                "reference": "376576dad2583669b55b1c7d033dbdc97a12a419"
+                "reference": "521db0a4d459069b367b7be5292e5520632d2a09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/376576dad2583669b55b1c7d033dbdc97a12a419",
-                "reference": "376576dad2583669b55b1c7d033dbdc97a12a419",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/521db0a4d459069b367b7be5292e5520632d2a09",
+                "reference": "521db0a4d459069b367b7be5292e5520632d2a09",
                 "shasum": ""
             },
             "require": {
@@ -6465,9 +6465,9 @@
             "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
-                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.0"
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.2"
             },
-            "time": "2026-06-19T13:07:42+00:00"
+            "time": "2026-07-02T14:45:01+00:00"
         },
         {
             "name": "prestashop/ps_searchbar",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "549cec46630642906f036da7741fa481",
+    "content-hash": "a5af1d2c527ee6dd8e43b300513b31d3",
     "packages": [
         {
             "name": "api-platform/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5af1d2c527ee6dd8e43b300513b31d3",
+    "content-hash": "549cec46630642906f036da7741fa481",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6422,16 +6422,16 @@
         },
         {
             "name": "prestashop/ps_onepagecheckout",
-            "version": "v0.6.2",
+            "version": "v0.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
-                "reference": "521db0a4d459069b367b7be5292e5520632d2a09"
+                "reference": "d268146959f06f768fc09fdb92d15be4277bbefc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/521db0a4d459069b367b7be5292e5520632d2a09",
-                "reference": "521db0a4d459069b367b7be5292e5520632d2a09",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/d268146959f06f768fc09fdb92d15be4277bbefc",
+                "reference": "d268146959f06f768fc09fdb92d15be4277bbefc",
                 "shasum": ""
             },
             "require": {
@@ -6465,9 +6465,9 @@
             "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
-                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.2"
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.3"
             },
-            "time": "2026-07-02T14:45:01+00:00"
+            "time": "2026-07-06T18:03:10+00:00"
         },
         {
             "name": "prestashop/ps_searchbar",

--- a/composer.lock
+++ b/composer.lock
@@ -6422,16 +6422,16 @@
         },
         {
             "name": "prestashop/ps_onepagecheckout",
-            "version": "v0.6.3",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
-                "reference": "d268146959f06f768fc09fdb92d15be4277bbefc"
+                "reference": "521db0a4d459069b367b7be5292e5520632d2a09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/d268146959f06f768fc09fdb92d15be4277bbefc",
-                "reference": "d268146959f06f768fc09fdb92d15be4277bbefc",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/521db0a4d459069b367b7be5292e5520632d2a09",
+                "reference": "521db0a4d459069b367b7be5292e5520632d2a09",
                 "shasum": ""
             },
             "require": {
@@ -6465,9 +6465,9 @@
             "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
-                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.3"
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.2"
             },
-            "time": "2026-07-06T18:03:10+00:00"
+            "time": "2026-07-02T14:45:01+00:00"
         },
         {
             "name": "prestashop/ps_searchbar",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5d62828525418928a488d734abef22d",
+    "content-hash": "4a30ce77447f27bf49b8a2a8090041ee",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6422,16 +6422,16 @@
         },
         {
             "name": "prestashop/ps_onepagecheckout",
-            "version": "v0.3.0",
+            "version": "v0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
-                "reference": "e7b07742e52ce1c1c7253921095ff6d78e3317d6"
+                "reference": "393f7093614ff5a23a0922c8991ff996eb4ad35c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/e7b07742e52ce1c1c7253921095ff6d78e3317d6",
-                "reference": "e7b07742e52ce1c1c7253921095ff6d78e3317d6",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/393f7093614ff5a23a0922c8991ff996eb4ad35c",
+                "reference": "393f7093614ff5a23a0922c8991ff996eb4ad35c",
                 "shasum": ""
             },
             "require": {
@@ -6466,9 +6466,9 @@
             "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
-                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.3.0"
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.4.0"
             },
-            "time": "2026-06-09T13:04:52+00:00"
+            "time": "2026-06-10T12:27:28+00:00"
         },
         {
             "name": "prestashop/ps_searchbar",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bb880f931623d4f9c9814c8def12082",
+    "content-hash": "c5d62828525418928a488d734abef22d",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6422,16 +6422,16 @@
         },
         {
             "name": "prestashop/ps_onepagecheckout",
-            "version": "v0.2.0",
+            "version": "v0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
-                "reference": "272f85a147ee40c089e41d5f8e229f55eaf923ba"
+                "reference": "e7b07742e52ce1c1c7253921095ff6d78e3317d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/272f85a147ee40c089e41d5f8e229f55eaf923ba",
-                "reference": "272f85a147ee40c089e41d5f8e229f55eaf923ba",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/e7b07742e52ce1c1c7253921095ff6d78e3317d6",
+                "reference": "e7b07742e52ce1c1c7253921095ff6d78e3317d6",
                 "shasum": ""
             },
             "require": {
@@ -6466,9 +6466,9 @@
             "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
-                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.2.0"
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.3.0"
             },
-            "time": "2026-06-02T11:06:56+00:00"
+            "time": "2026-06-09T13:04:52+00:00"
         },
         {
             "name": "prestashop/ps_searchbar",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5af1d2c527ee6dd8e43b300513b31d3",
+    "content-hash": "4548743a74fa7b7ea459f665203aa4ee",
     "packages": [
         {
             "name": "api-platform/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a30ce77447f27bf49b8a2a8090041ee",
+    "content-hash": "b5bd08ebf7e2cb4220e2247741666c1a",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6422,21 +6422,20 @@
         },
         {
             "name": "prestashop/ps_onepagecheckout",
-            "version": "v0.4.0",
+            "version": "v0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
-                "reference": "393f7093614ff5a23a0922c8991ff996eb4ad35c"
+                "reference": "376576dad2583669b55b1c7d033dbdc97a12a419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/393f7093614ff5a23a0922c8991ff996eb4ad35c",
-                "reference": "393f7093614ff5a23a0922c8991ff996eb4ad35c",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/376576dad2583669b55b1c7d033dbdc97a12a419",
+                "reference": "376576dad2583669b55b1c7d033dbdc97a12a419",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "segmentio/analytics-php": "^3.0"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "prestashop/php-dev-tools": "^4.3"
@@ -6466,9 +6465,9 @@
             "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
-                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.4.0"
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.0"
             },
-            "time": "2026-06-10T12:27:28+00:00"
+            "time": "2026-06-19T13:07:42+00:00"
         },
         {
             "name": "prestashop/ps_searchbar",
@@ -8126,70 +8125,6 @@
                 "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/8.4.0"
             },
             "time": "2021-12-11T13:40:54+00:00"
-        },
-        {
-            "name": "segmentio/analytics-php",
-            "version": "3.8.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/segmentio/analytics-php.git",
-                "reference": "6199b9887e53e11dfdfb590beba79577c120efed"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/segmentio/analytics-php/zipball/6199b9887e53e11dfdfb590beba79577c120efed",
-                "reference": "6199b9887e53e11dfdfb590beba79577c120efed",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-                "overtrue/phplint": "^3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3",
-                "phpunit/phpunit": "~9.5",
-                "roave/security-advisories": "dev-latest",
-                "slevomat/coding-standard": "^7.0",
-                "squizlabs/php_codesniffer": "^3.6"
-            },
-            "suggest": {
-                "ext-curl": "For using the curl HTTP client",
-                "ext-zlib": "For using compression"
-            },
-            "bin": [
-                "bin/analytics"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Segment\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Segment.io <friends@segment.com>",
-                    "homepage": "https://segment.com/"
-                }
-            ],
-            "description": "Segment Analytics PHP Library",
-            "homepage": "https://segment.com/libraries/php",
-            "keywords": [
-                "analytics",
-                "analytics.js",
-                "segment",
-                "segmentio"
-            ],
-            "support": {
-                "issues": "https://github.com/segmentio/analytics-php/issues",
-                "source": "https://github.com/segmentio/analytics-php/tree/3.8.2"
-            },
-            "time": "2026-03-11T18:19:46+00:00"
         },
         {
             "name": "smarty/smarty",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95a71dd97e02f35f52a3724f5717db52",
+    "content-hash": "6bb880f931623d4f9c9814c8def12082",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6422,16 +6422,16 @@
         },
         {
             "name": "prestashop/ps_onepagecheckout",
-            "version": "v0.1.0",
+            "version": "v0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
-                "reference": "d542543ceb93f35f408ce86ad529b8eec4db9d72"
+                "reference": "272f85a147ee40c089e41d5f8e229f55eaf923ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/d542543ceb93f35f408ce86ad529b8eec4db9d72",
-                "reference": "d542543ceb93f35f408ce86ad529b8eec4db9d72",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/272f85a147ee40c089e41d5f8e229f55eaf923ba",
+                "reference": "272f85a147ee40c089e41d5f8e229f55eaf923ba",
                 "shasum": ""
             },
             "require": {
@@ -6466,9 +6466,9 @@
             "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
-                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.1.0"
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.2.0"
             },
-            "time": "2026-06-01T09:35:25+00:00"
+            "time": "2026-06-02T11:06:56+00:00"
         },
         {
             "name": "prestashop/ps_searchbar",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | ------------------------------------------------------- 
| Branch?           | develop
| Description?      | Adds the native `ps_onepagecheckout` module as a Core Composer dependency. This makes the beta OPC module available while keeping activation controlled by the module configuration flag.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `composer install` and verify that `modules/ps_onepagecheckout/ps_onepagecheckout.php` is installed and reports version `0.1.0`. Install the module with `php bin/console prestashop:module install ps_onepagecheckout --no-interaction`, enable `PS_ONE_PAGE_CHECKOUT_ENABLED`, add a product to cart, go to `/order`, and verify that the OPC is displayed without errors. Also verify that the module can be disabled/uninstalled cleanly.
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/28880256101 https://github.com/ThbPS/ga.tests.ui.pr/actions/runs/27338135228  https://github.com/PrestaShopCorp/opc.e2e.tests/actions/runs/28813401509
| Fixed issue or discussion? | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop