### PR TITLE
Add missing breadcrumb link to CartController

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -710,4 +710,16 @@ class CartControllerCore extends FrontController
             }
         }
     }
+
+    public function getBreadcrumbLinks(): array
+    {
+      $breadcrumb = parent::getBreadcrumbLinks();
+
+      $breadcrumb['links'][] = [
+          'title' => $this->trans('Cart', [], 'Shop.Theme.Checkout'),
+          'url' => $this->context->link->getPageLink('cart', null, null, ['action' => 'show']),
+      ];
+
+      return $breadcrumb;
+    }
 }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -713,13 +713,13 @@ class CartControllerCore extends FrontController
 
     public function getBreadcrumbLinks(): array
     {
-      $breadcrumb = parent::getBreadcrumbLinks();
+        $breadcrumb = parent::getBreadcrumbLinks();
 
-      $breadcrumb['links'][] = [
-          'title' => $this->trans('Cart', [], 'Shop.Theme.Checkout'),
-          'url' => $this->context->link->getPageLink('cart', null, null, ['action' => 'show']),
-      ];
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('Cart', [], 'Shop.Theme.Checkout'),
+            'url' => $this->context->link->getPageLink('cart', null, null, ['action' => 'show']),
+        ];
 
-      return $breadcrumb;
+        return $breadcrumb;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR adds the missing breadcrumb link to the cart page.<br/>The `CartController` now defines `getBreadcrumbLinks()` and appends the `Cart` breadcrumb entry, consistently with other front controllers.<br/>**This also improves accessibility by providing a clearer navigation structure for users and assistive technologies.**
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to the FO cart page and verify that the displayed breadcrumb is `Home > Cart`
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/26877586964
| Fixed issue or discussion?     |
| Related PRs       | 
| Sponsor company   | @Codencode 

# With fix
<img width="1418" height="418" alt="With fix" src="https://github.com/user-attachments/assets/4a8f256a-dcf8-42d8-a851-f7beede49c99" />


# Without fix
<img width="1428" height="426" alt="Without fix" src="https://github.com/user-attachments/assets/bd735384-7eca-46b9-b279-cf5f74e5ac82" />

