### PR TITLE
Fix: SQL queries using NOW() rely on MySQL timezone instead of shop timezone

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -429,7 +429,7 @@ class CartRuleCore extends ObjectModel
         $sql .= ')';
 
         // Then, conditions for date, voucher active property and total amount of vouchers in stock
-        $sql .= ' AND NOW() BETWEEN cr.date_from AND cr.date_to
+        $sql .= ' AND \'' . date('Y-m-d H:i:s') . '\' BETWEEN cr.date_from AND cr.date_to
             ' . ($active ? 'AND cr.`active` = 1' : '') . '
             ' . ($inStock ? 'AND (cr.`quantity` > 0 OR cr.`quantity` is null)' : '');
 
@@ -1992,7 +1992,7 @@ class CartRuleCore extends ObjectModel
 		WHERE cr.active = 1
 		AND cr.code = ""
 		AND (cr.quantity > 0 OR cr.quantity is null)
-		AND NOW() BETWEEN cr.date_from AND cr.date_to
+		AND \'' . date('Y-m-d H:i:s') . '\' BETWEEN cr.date_from AND cr.date_to
 		AND (
 			cr.id_customer = 0
 			' . (Validate::isLoadedObject($context->customer) ? 'OR cr.id_customer = ' . (int) $context->cart->id_customer : '') . '

--- a/classes/Connection.php
+++ b/classes/Connection.php
@@ -221,7 +221,7 @@ class ConnectionCore extends ObjectModel
             // Records of connections details older than the beginning of the  specified interval are deleted
             Db::getInstance()->execute('
 			DELETE FROM `' . _DB_PREFIX_ . 'connections_page`
-			WHERE time_start < LAST_DAY(DATE_SUB(NOW(), INTERVAL ' . $interval . '))');
+			WHERE time_start < LAST_DAY(DATE_SUB(\'' . date('Y-m-d H:i:s') . '\', INTERVAL ' . $interval . '))');
         }
     }
 }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6434,7 +6434,7 @@ class ProductCore extends ObjectModel
      */
     public static function getOldTempProducts()
     {
-        $sql = 'SELECT id_product FROM `' . _DB_PREFIX_ . 'product` WHERE state=' . Product::STATE_TEMP . ' AND date_upd < NOW() - INTERVAL 1 DAY';
+        $sql = 'SELECT id_product FROM `' . _DB_PREFIX_ . 'product` WHERE state=' . Product::STATE_TEMP . ' AND date_upd < \'' . date('Y-m-d H:i:s', strtotime('-1 day')) . '\'';
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql, true, false);
     }

--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -18,7 +18,7 @@ class ProductSaleCore
     {
         $sql = 'REPLACE INTO ' . _DB_PREFIX_ . 'product_sale
 				(`id_product`, `quantity`, `sale_nbr`, `date_upd`)
-				SELECT od.product_id, SUM(od.product_quantity), COUNT(od.product_id), NOW()
+				SELECT od.product_id, SUM(od.product_quantity), COUNT(od.product_id), \'' . date('Y-m-d H:i:s') . '\'
 							FROM ' . _DB_PREFIX_ . 'order_detail od GROUP BY od.product_id';
 
         return Db::getInstance()->execute($sql);
@@ -222,8 +222,8 @@ class ProductSaleCore
         return Db::getInstance()->execute('
 			INSERT INTO ' . _DB_PREFIX_ . 'product_sale
 			(`id_product`, `quantity`, `sale_nbr`, `date_upd`)
-			VALUES (' . (int) $productId . ', ' . (int) $qty . ', 1, NOW())
-			ON DUPLICATE KEY UPDATE `quantity` = `quantity` + ' . (int) $qty . ', `sale_nbr` = `sale_nbr` + 1, `date_upd` = NOW()');
+			VALUES (' . (int) $productId . ', ' . (int) $qty . ', 1, \'' . date('Y-m-d H:i:s') . '\')
+			ON DUPLICATE KEY UPDATE `quantity` = `quantity` + ' . (int) $qty . ', `sale_nbr` = `sale_nbr` + 1, `date_upd` = \'' . date('Y-m-d H:i:s') . '\'');
     }
 
     /**
@@ -258,7 +258,7 @@ class ProductSaleCore
             return Db::getInstance()->execute(
                 '
 				UPDATE ' . _DB_PREFIX_ . 'product_sale
-				SET `quantity` = CAST(`quantity` AS SIGNED) - ' . (int) $qty . ', `sale_nbr` = CAST(`sale_nbr` AS SIGNED) - 1, `date_upd` = NOW()
+				SET `quantity` = CAST(`quantity` AS SIGNED) - ' . (int) $qty . ', `sale_nbr` = CAST(`sale_nbr` AS SIGNED) - 1, `date_upd` = \'' . date('Y-m-d H:i:s') . '\'
 				WHERE `id_product` = ' . (int) $idProduct
             );
         } elseif ($totalSales == 1) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Several SQL queries used `NOW()` to compare or store the current date, which relies on the MySQL server timezone (UTC by default). This caused issues when the shop's configured timezone differs from the MySQL server's timezone — for example, a cart rule valid from a given hour would not appear to customers until MySQL's UTC clock reached that hour.<br/><br/>This PR replaces all core occurrences of `NOW()` in raw SQL queries with PHP's `date('Y-m-d H:i:s')`, which always uses the shop's configured timezone (set via `date_default_timezone_set`). The affected files are `CartRule.php` (2 occurrences — the primary bug), `ProductSale.php` (3 occurrences), `Connection.php` (1 occurrence) and `Product.php` (1 occurrence).
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Set your shop timezone to `Europe/Paris` (or any timezone different from UTC).<br/>2. Ensure your MySQL server runs in UTC (default).<br/>3. Create a cart rule for a specific customer with a `date_from` set to the current time.<br/>4. Log in on the FO with that customer and go to **My account > My vouchers**.<br/>5. The cart rule should appear immediately (before the fix it would only appear 1–2 hours later depending on DST).
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #30828
| Related PRs       | This is the **surgical, low-risk** fix targeting the maintained stable branch `9.1.x` (merges up into `develop`). The broader **connection-level** approach for `develop`/9.2 — which aligns the MySQL session time zone with the shop time zone on every connection and covers all `NOW()` at once — is #41628. The two do not conflict (idempotent, no file overlap); see #41628 for the full comparison. Native module PRs from the same effort: PrestaShop/ps_googleanalytics#177, PrestaShop/blockwishlist#451, PrestaShop/ps_emailsubscription#127, PrestaShop/ps_facetedsearch#1234, PrestaShop/pagesnotfound#42, PrestaShop/statssearch#30, PrestaShop/statsbestproducts#28
| Sponsor company   | PrestaShop SA
