### PR TITLE
Always list all customer groups in the group choice provider (remove never-executed skip)

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/GroupByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/GroupByIdChoiceProvider.php
@@ -6,8 +6,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 
-use Group;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 /**
@@ -16,9 +15,9 @@ use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
 {
     /**
-     * @var ConfigurationInterface
+     * @var GroupDataProvider
      */
-    private $configuration;
+    private $groupDataProvider;
 
     /**
      * @var int
@@ -26,12 +25,12 @@ final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
     private $contextLangId;
 
     /**
-     * @param ConfigurationInterface $configuration
+     * @param GroupDataProvider $groupDataProvider
      * @param int $contextLangId
      */
-    public function __construct(ConfigurationInterface $configuration, int $contextLangId)
+    public function __construct(GroupDataProvider $groupDataProvider, int $contextLangId)
     {
-        $this->configuration = $configuration;
+        $this->groupDataProvider = $groupDataProvider;
         $this->contextLangId = $contextLangId;
     }
 
@@ -41,21 +40,9 @@ final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
     public function getChoices(): array
     {
         $choices = [];
-        $groups = Group::getGroups($this->contextLangId, true);
 
-        $groupsToSkip = [
-            (int) $this->configuration->get('PS_UNIDENTIFIED_GROUP'),
-            (int) $this->configuration->get('PS_GUEST_GROUP'),
-        ];
-
-        foreach ($groups as $group) {
-            $groupId = $group['id_group'];
-
-            if (in_array($groups, $groupsToSkip)) {
-                continue;
-            }
-
-            $choices[$group['name']] = (int) $groupId;
+        foreach ($this->groupDataProvider->getGroups($this->contextLangId, true) as $group) {
+            $choices[$group['name']] = (int) $group['id_group'];
         }
 
         return $choices;

--- a/tests/Unit/Adapter/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php
+++ b/tests/Unit/Adapter/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Form\ChoiceProvider;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\GroupByIdChoiceProvider;
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+
+class GroupByIdChoiceProviderTest extends TestCase
+{
+    private const LANG_ID = 1;
+
+    /**
+     * Groups as returned by the data provider (ids are strings, like the DB returns them).
+     * The first two are the special "unidentified" (Visitor) and "guest" groups.
+     *
+     * @var array<int, array<string, string>>
+     */
+    private $groups = [
+        ['id_group' => '1', 'name' => 'Visitor'],
+        ['id_group' => '2', 'name' => 'Guest'],
+        ['id_group' => '3', 'name' => 'Customer'],
+    ];
+
+    /**
+     * Every group must be selectable, including the unidentified (Visitor) and guest
+     * groups: they are needed e.g. when editing a guest customer.
+     */
+    public function testItProvidesAllGroupsIncludingUnidentifiedAndGuest(): void
+    {
+        $choiceProvider = new GroupByIdChoiceProvider(
+            $this->mockGroupDataProvider(),
+            self::LANG_ID
+        );
+
+        $this->assertSame(
+            ['Visitor' => 1, 'Guest' => 2, 'Customer' => 3],
+            $choiceProvider->getChoices()
+        );
+    }
+
+    private function mockGroupDataProvider(): GroupDataProvider
+    {
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider
+            ->expects($this->once())
+            ->method('getGroups')
+            ->with(self::LANG_ID, true)
+            ->willReturn($this->groups);
+
+        return $groupDataProvider;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------- |
| Branch?           | develop |
| Description?      | The Adapter `GroupByIdChoiceProvider` built a "groups to skip" list (`PS_UNIDENTIFIED_GROUP`, `PS_GUEST_GROUP`) but, because of an `in_array($groups, …)` typo, it **never actually skipped anything** — so all groups have always been listed. Activating the skip would be wrong here: these groups are needed in the customer form (e.g. when editing a guest customer), unlike the payment-restriction provider. This PR therefore **removes the dead skip logic** instead of fixing the typo, drops the now-unused `Configuration` dependency, injects `GroupDataProvider` for testability (consistent with the Core provider), and adds a unit test asserting every group is returned. No behaviour change. |
| Type?             | improvement |
| Category?         | BO |
| BC breaks?        | no |
| Deprecations?     | no |
| Fixed ticket?     | N/A (unrelated to #9858, which fixes the Core provider used by payment restrictions) |
| How to test?      | BO > Customers (add/edit a customer): the "Group access" list and the default group must keep listing **all** groups, including "Visitor" (unidentified) and "Guest". Covered by `tests/Unit/Adapter/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php`. |
| Possible impacts? | The constructor signature of the Adapter `GroupByIdChoiceProvider` changes (the `Configuration` dependency is removed and `GroupDataProvider` is injected); the service is autowired from the container. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)