### PR TITLE
Filter payment module group restrictions by current shop

### DIFF
--- a/src/Core/Form/ChoiceProvider/GroupByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/GroupByIdChoiceProvider.php
@@ -26,15 +26,23 @@ final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
     private $langId;
 
     /**
+     * @var bool whether choices must be restricted to the groups of the current shop context
+     */
+    private $filterByShop;
+
+    /**
      * @param GroupDataProvider $groupDataProvider
      * @param int $langId
+     * @param bool $filterByShop
      */
     public function __construct(
         GroupDataProvider $groupDataProvider,
-        $langId
+        $langId,
+        bool $filterByShop = false
     ) {
         $this->groupDataProvider = $groupDataProvider;
         $this->langId = $langId;
+        $this->filterByShop = $filterByShop;
     }
 
     /**
@@ -43,7 +51,7 @@ final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
     public function getChoices()
     {
         return FormChoiceFormatter::formatFormChoices(
-            $this->groupDataProvider->getGroups($this->langId),
+            $this->groupDataProvider->getGroups($this->langId, $this->filterByShop),
             'id_group',
             'name',
             false

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -145,7 +145,7 @@ services:
     arguments:
       $paymentModules: '@=service("prestashop.adapter.module.payment_module_provider").getPaymentModuleList()'
       $countryChoices: '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
-      $groupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
+      $groupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id_shop_filtered").getChoices()'
       $carrierChoices: '@=service("prestashop.core.form.choice_provider.carrier_by_reference_id").getChoices()'
       $countryDataProvider: '@prestashop.adapter.data_provider.country'
 

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -47,6 +47,13 @@ services:
     arguments:
       - '@prestashop.adapter.data_provider.group'
 
+  # Same provider but restricted to the customer groups of the current shop context (e.g. payment restrictions)
+  prestashop.core.form.choice_provider.group_by_id_shop_filtered:
+    class: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider
+    arguments:
+      $groupDataProvider: '@prestashop.adapter.data_provider.group'
+      $filterByShop: true
+
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CarrierByReferenceChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.carrier'

--- a/tests/UI/campaigns/functional/BO/10_payment/02_preferences/03_groupRestrictionsMultistore.ts
+++ b/tests/UI/campaigns/functional/BO/10_payment/02_preferences/03_groupRestrictionsMultistore.ts
@@ -1,0 +1,329 @@
+import testContext from '@utils/testContext';
+import setMultiStoreStatus from '@commonTests/BO/advancedParameters/multistore';
+import {expect} from 'chai';
+
+import {
+  boCustomerGroupsPage,
+  boCustomerGroupsCreatePage,
+  boCustomerSettingsPage,
+  boDashboardPage,
+  boLoginPage,
+  boMultistorePage,
+  boMultistoreShopPage,
+  boMultistoreShopCreatePage,
+  boMultistoreShopUrlCreatePage,
+  boPaymentPreferencesPage,
+  type BrowserContext,
+  FakerGroup,
+  FakerShop,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_payment_preferences_groupRestrictionsMultistore';
+
+/*
+Issue #9858: In a multishop context, the "Payment > Preferences" group restrictions table must only list the
+customer groups of the currently selected shop, not the groups of every shop.
+
+Scenario:
+- Enable multistore and create a second shop
+- Create a customer group while the second shop is the active context (so the group belongs to that shop only)
+- Check that the group is listed in the group restrictions table when the second shop is selected
+- Check that the group is NOT listed when the default shop is selected (regression of #9858)
+ */
+describe('BO - Payment - Preferences : Group restrictions are filtered by shop', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+  let shopID: number = 0;
+  let groupsInNewShop: string[] = [];
+
+  const createShopData: FakerShop = new FakerShop({name: 'newShop', shopGroup: 'Default', categoryRoot: 'Home'});
+  const groupData: FakerGroup = new FakerGroup();
+
+  // Pre-condition: Enable multistore
+  setMultiStoreStatus(true, `${baseContext}_preTest`);
+
+  // before and after functions
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  describe('Create a second shop', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
+    it('should go to \'Advanced Parameters > Multistore\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToMultiStorePage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.multistoreLink,
+      );
+      await boMultistorePage.closeSfToolBar(page);
+
+      const pageTitle = await boMultistorePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistorePage.pageTitle);
+    });
+
+    it('should go to add new shop page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewShopPage', baseContext);
+
+      await boMultistorePage.goToNewShopPage(page);
+
+      const pageTitle = await boMultistoreShopCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistoreShopCreatePage.pageTitleCreate);
+    });
+
+    it('should create shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createShop', baseContext);
+
+      const textResult = await boMultistoreShopCreatePage.setShop(page, createShopData);
+      expect(textResult).to.contains(boMultistorePage.successfulCreationMessage);
+    });
+
+    it('should get the id of the new shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'getShopID', baseContext);
+
+      const numberOfShops = await boMultistoreShopPage.getNumberOfElementInGrid(page);
+      expect(numberOfShops).to.be.above(0);
+
+      shopID = parseInt(await boMultistoreShopPage.getTextColumn(page, 1, 'id_shop'), 10);
+    });
+
+    it('should go to add URL', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToAddURL', baseContext);
+
+      await boMultistoreShopPage.filterTable(page, 'a!name', createShopData.name);
+      await boMultistoreShopPage.goToSetURL(page, 1);
+
+      const pageTitle = await boMultistoreShopUrlCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistoreShopUrlCreatePage.pageTitleCreate);
+    });
+
+    it('should set URL', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addURL', baseContext);
+
+      const textResult = await boMultistoreShopUrlCreatePage.setVirtualUrl(page, createShopData.name);
+      expect(textResult).to.contains(boMultistoreShopUrlCreatePage.successfulCreationMessage);
+    });
+  });
+
+  describe('Create a customer group that belongs to the new shop only', async () => {
+    it('should select the new shop in the multistore header', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'selectNewShop', baseContext);
+
+      await boMultistoreShopUrlCreatePage.clickOnMultiStoreHeader(page);
+      await boMultistoreShopUrlCreatePage.chooseShop(page, 2);
+
+      const shopName = await boMultistoreShopUrlCreatePage.getShopName(page);
+      expect(shopName).to.eq(createShopData.name);
+    });
+
+    it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPage', baseContext);
+
+      await boMultistoreShopUrlCreatePage.goToSubMenu(
+        page,
+        boDashboardPage.shopParametersParentLink,
+        boDashboardPage.customerSettingsLink,
+      );
+      await boCustomerSettingsPage.closeSfToolBar(page);
+
+      const pageTitle = await boCustomerSettingsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerSettingsPage.pageTitle);
+    });
+
+    it('should go to \'Groups\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToGroupsPage', baseContext);
+
+      await boCustomerSettingsPage.goToGroupsPage(page);
+
+      const pageTitle = await boCustomerGroupsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsPage.pageTitle);
+    });
+
+    it('should go to add new group page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewGroup', baseContext);
+
+      await boCustomerGroupsPage.goToNewGroupPage(page);
+
+      const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleCreate);
+    });
+
+    it('should create the group', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createGroup', baseContext);
+
+      const textResult = await boCustomerGroupsCreatePage.createEditGroup(page, groupData);
+      expect(textResult).to.contains(boCustomerGroupsPage.successfulCreationMessage);
+    });
+  });
+
+  describe('Check that the group restrictions table is filtered by shop', async () => {
+    it('should go to \'Payment > Preferences\' page (new shop selected)', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToPreferencesPageNewShop', baseContext);
+
+      await boCustomerGroupsPage.goToSubMenu(
+        page,
+        boCustomerGroupsPage.paymentParentLink,
+        boCustomerGroupsPage.preferencesLink,
+      );
+
+      const pageTitle = await boPaymentPreferencesPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boPaymentPreferencesPage.pageTitle);
+    });
+
+    it('should check that the created group is listed for the new shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkGroupVisibleNewShop', baseContext);
+
+      groupsInNewShop = await boPaymentPreferencesPage.getGroupRestrictionNames(page);
+      expect(groupsInNewShop).to.include(groupData.name);
+    });
+
+    it('should select the default shop in the multistore header', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'selectDefaultShop', baseContext);
+
+      await boPaymentPreferencesPage.clickOnMultiStoreHeader(page);
+      await boPaymentPreferencesPage.chooseShop(page, 1);
+
+      const shopName = await boPaymentPreferencesPage.getShopName(page);
+      expect(shopName).to.eq(global.INSTALL.SHOP_NAME);
+    });
+
+    it('should go to \'Payment > Preferences\' page (default shop selected)', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToPreferencesPageDefaultShop', baseContext);
+
+      await boPaymentPreferencesPage.goToSubMenu(
+        page,
+        boPaymentPreferencesPage.paymentParentLink,
+        boPaymentPreferencesPage.preferencesLink,
+      );
+
+      const pageTitle = await boPaymentPreferencesPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boPaymentPreferencesPage.pageTitle);
+    });
+
+    it('should check that the created group is NOT listed for the default shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkGroupHiddenDefaultShop', baseContext);
+
+      const groupsInDefaultShop = await boPaymentPreferencesPage.getGroupRestrictionNames(page);
+      // The group belongs to the new shop only, so it must not appear in the default shop context (issue #9858)
+      expect(groupsInDefaultShop).to.not.include(groupData.name);
+      // Sanity check: the default shop still has its own groups, but fewer than the new shop
+      expect(groupsInDefaultShop.length).to.be.above(0);
+      expect(groupsInDefaultShop.length).to.be.below(groupsInNewShop.length);
+    });
+  });
+
+  describe('Delete the created group', async () => {
+    it('should select the new shop in the multistore header', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'selectNewShopToDelete', baseContext);
+
+      await boPaymentPreferencesPage.clickOnMultiStoreHeader(page);
+      await boPaymentPreferencesPage.chooseShop(page, 2);
+
+      const shopName = await boPaymentPreferencesPage.getShopName(page);
+      expect(shopName).to.eq(createShopData.name);
+    });
+
+    it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPageToDelete', baseContext);
+
+      await boPaymentPreferencesPage.goToSubMenu(
+        page,
+        boDashboardPage.shopParametersParentLink,
+        boDashboardPage.customerSettingsLink,
+      );
+
+      const pageTitle = await boCustomerSettingsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerSettingsPage.pageTitle);
+    });
+
+    it('should go to \'Groups\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToGroupsPageToDelete', baseContext);
+
+      await boCustomerSettingsPage.goToGroupsPage(page);
+
+      const pageTitle = await boCustomerGroupsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsPage.pageTitle);
+    });
+
+    it('should filter the list by the created group name', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterToDelete', baseContext);
+
+      await boCustomerGroupsPage.resetFilter(page);
+      await boCustomerGroupsPage.filterTable(page, 'input', 'b!name', groupData.name);
+
+      const textColumn = await boCustomerGroupsPage.getTextColumn(page, 1, 'b!name');
+      expect(textColumn).to.contains(groupData.name);
+    });
+
+    it('should delete the group', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteGroup', baseContext);
+
+      const textResult = await boCustomerGroupsPage.deleteGroup(page, 1);
+      expect(textResult).to.contains(boCustomerGroupsPage.successfulDeleteMessage);
+    });
+  });
+
+  describe('Delete the created shop', async () => {
+    it('should select the default shop in the multistore header', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'selectDefaultShopBeforeDeleteShop', baseContext);
+
+      await boCustomerGroupsPage.clickOnMultiStoreHeader(page);
+      await boCustomerGroupsPage.chooseShop(page, 1);
+
+      const shopName = await boCustomerGroupsPage.getShopName(page);
+      expect(shopName).to.eq(global.INSTALL.SHOP_NAME);
+    });
+
+    it('should go to \'Advanced Parameters > Multistore\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToMultiStorePage', baseContext);
+
+      await boCustomerGroupsPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.multistoreLink,
+      );
+      await boMultistorePage.closeSfToolBar(page);
+
+      const pageTitle = await boMultistorePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistorePage.pageTitle);
+    });
+
+    it('should go to the created shop page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCreatedShopPage', baseContext);
+
+      await boMultistorePage.goToShopPage(page, shopID);
+
+      const pageTitle = await boMultistoreShopPage.getPageTitle(page);
+      expect(pageTitle).to.contains(createShopData.name);
+    });
+
+    it('should delete the shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteShop', baseContext);
+
+      await boMultistoreShopPage.filterTable(page, 'a!name', createShopData.name);
+
+      const textResult = await boMultistoreShopPage.deleteShop(page, 1);
+      expect(textResult).to.contains(boMultistoreShopPage.successfulDeleteMessage);
+    });
+  });
+
+  // Post-condition: Disable multistore
+  setMultiStoreStatus(false, `${baseContext}_postTest`);
+});

--- a/tests/Unit/Core/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php
+++ b/tests/Unit/Core/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\ChoiceProvider;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider;
+
+class GroupByIdChoiceProviderTest extends TestCase
+{
+    private const LANG_ID = 1;
+
+    /**
+     * @var array<int, array<string, int|string>>
+     */
+    private $groups = [
+        ['id_group' => 1, 'name' => 'Visitor'],
+        ['id_group' => 2, 'name' => 'Guest'],
+        ['id_group' => 3, 'name' => 'Customer'],
+    ];
+
+    public function testItProvidesAllGroupsWithoutShopFilteringByDefault(): void
+    {
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider
+            ->expects($this->once())
+            ->method('getGroups')
+            ->with(self::LANG_ID, false)
+            ->willReturn($this->groups);
+
+        $choiceProvider = new GroupByIdChoiceProvider($groupDataProvider, self::LANG_ID);
+
+        $this->assertSame(
+            ['Visitor' => 1, 'Guest' => 2, 'Customer' => 3],
+            $choiceProvider->getChoices()
+        );
+    }
+
+    public function testItFiltersGroupsByCurrentShopWhenEnabled(): void
+    {
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider
+            ->expects($this->once())
+            ->method('getGroups')
+            ->with(self::LANG_ID, true)
+            ->willReturn($this->groups);
+
+        $choiceProvider = new GroupByIdChoiceProvider($groupDataProvider, self::LANG_ID, true);
+
+        $this->assertSame(
+            ['Visitor' => 1, 'Guest' => 2, 'Customer' => 3],
+            $choiceProvider->getChoices()
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | On the **Improve > Payment > Preferences** page, the "Group restrictions" table listed **every** customer group regardless of the shop selected in the multistore header, while the *checked* restrictions were already filtered per shop. As a result, shop administrators could see (and change) restrictions for customer groups that do not belong to the shop they manage.<br><br>Root cause: the group **choices** were built by the shared `Core\Form\ChoiceProvider\GroupByIdChoiceProvider`, which called `Group::getGroups()` without the shop filter, so all groups of all shops were returned.<br><br>Fix (scoped to the payment page): an optional `bool $filterByShop = false` flag is added to `GroupByIdChoiceProvider` and passed to `Group::getGroups()`. A dedicated shop-filtered service (`prestashop.core.form.choice_provider.group_by_id_shop_filtered`) is wired **only** to `PaymentModulePreferencesType`. The four other consumers of the provider (catalog price rules, discounts, product applicable groups, customer/category forms) keep the default unfiltered service, so their behaviour is unchanged. In an "all shops" context every group is still listed, as before.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable multistore and create a second shop. Create a customer group while the second shop is the active context (so the group belongs to that shop only). Go to **Payment > Preferences**: with the second shop selected, the new group appears in the Group restrictions table; with the default shop selected, it must **not** appear. This is covered by the new functional test `tests/UI/.../02_preferences/03_groupRestrictionsMultistore.ts` and the unit test `tests/Unit/Core/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php`.
| UI Tests          | N/A (to be run on CI)
| Fixed issue or discussion?     | Fixes #9858
| Related PRs       | Requires PrestaShop/ui-testing-library#990 (adds `getGroupRestrictionNames` used by the new UI test) <br> Scenario: PrestaShop/test-scenarios#697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

