### PR TITLE
Cart rule compatibility search does not filter results for new cart rule

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1935,6 +1935,7 @@ class CartRuleCore extends ObjectModel
 			' . ($active_only ? 'AND t.active = 1' : '') . '
 			' . (in_array($type, ['carrier', 'shop']) ? ' AND t.deleted = 0' : '') . '
 			' . ($type == 'cart_rule' ? 'AND t.id_cart_rule != ' . (int) $this->id : '') .
+            ($type == 'cart_rule' && $i18n && $search_cart_rule_name ? ' AND tl.name LIKE "%' . pSQL($search_cart_rule_name) . '%"' : '') .
                 $shop_list .
                 (in_array($type, ['carrier', 'shop']) ? ' ORDER BY t.name ASC ' : '') .
                 (in_array($type, ['country', 'group', 'cart_rule']) && $i18n ? ' ORDER BY tl.name ASC ' : '') .


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When editing the "Compatibility with other cart rules" autocomplete (Catalog → Discounts → Cart Rules → tab *Conditions* → "Compatible with other cart rules"), the search field does not filter the list of cart rules. Typing a search term still returns all cart rules instead of those matching the term. This happens whenever the cart rule has no compatibility restriction set yet - i.e. when **creating a new cart rule** (`id_cart_rule=0`) or editing an existing one whose `cart_rule_restriction = 0`.<br><br>Root cause: in `CartRule::getAssociatedRestrictions()`, when `!Validate::isLoadedObject($this) \|\| $this->cart_rule_restriction == 0`, the method runs an SQL query that **never applies** the `$search_cart_rule_name` argument. The `LIKE` filter only exists in the other branch, through `getCartRuleCombinations()`, which is reached only for an already-saved rule with `cart_rule_restriction = 1`.<br><br>Fix: apply the missing `AND tl.name LIKE "%...%"` filter (escaped via `pSQL()`) in that branch, only for the `cart_rule` type and only when a search term is provided.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **Catalog → Discounts** and create a few cart rules with distinct names (e.g. `10% off`, `-50% summer`, `Free shipping`).<br>2. Create a **new** cart rule, open the **Conditions** tab, and use the "Compatible with other cart rules" search field.<br>3. Type part of a name (e.g. `10`).<br>**Before:** the list ignores the term and shows all cart rules.<br>**After:** the list is filtered to cart rules whose name matches the term.<br>4. Repeat while editing an existing cart rule that has its compatibility restriction disabled - same result.
| UI Tests          |  https://github.com/LaBisquerie/ga.tests.ui.pr/actions/runs/26877209625
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41610
| Related PRs       | N/A
| Sponsor company   | Creabilis
