### PR TITLE
Replace window.prompt() with a modal when adding a page to Quick Access

### DIFF
--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -202,7 +202,18 @@ $(() => {
       },
     });
   });
-  const doQuickLinkAjax = ($link, method, name, newWindow) => {
+  const doQuickLinkAjax = ($link, method, name, newWindow, callbacks = {}) => {
+    const reportErrors = (messages) => {
+      if (callbacks.onError) {
+        callbacks.onError(messages);
+        return;
+      }
+
+      messages.forEach((message) => {
+        $.growl.error({title: '', message});
+      });
+    };
+
     $.ajax({
       type: 'POST',
       headers: {'cache-control': 'no-cache'},
@@ -219,11 +230,13 @@ $(() => {
       dataType: 'json',
       success: (data) => {
         if (typeof data.has_errors !== 'undefined' && data.has_errors) {
+          const messages = [];
           $.each(data, (index) => {
             if (typeof data[index] === 'string') {
-              $.growl.error({title: '', message: data[index]});
+              messages.push(data[index]);
             }
           });
+          reportErrors(messages);
         } else if (Array.isArray(data)) {
           let quicklinkList = '';
           $.each(data, (index, item) => {
@@ -238,17 +251,24 @@ $(() => {
             $('#header_quick ul.dropdown-menu .divider').prevAll().remove();
             $('#header_quick ul.dropdown-menu').prepend(quicklinkList);
             $link.closest('li').remove();
+            if (callbacks.onSuccess) {
+              callbacks.onSuccess();
+            }
             window.showSuccessMessage(window.update_success_msg);
           }
         }
       },
       error: (xhr, textStatus) => {
-        $.growl.error({
-          title: 'Quick access error',
-          message: textStatus === 'parsererror'
-            ? `Server returned non-JSON (status ${xhr.status})`
-            : `${xhr.status} ${xhr.statusText}`,
-        });
+        const message = textStatus === 'parsererror'
+          ? `Server returned non-JSON (status ${xhr.status})`
+          : `${xhr.status} ${xhr.statusText}`;
+
+        if (callbacks.onError) {
+          callbacks.onError([message]);
+          return;
+        }
+
+        $.growl.error({title: 'Quick access error', message});
       },
     });
   };
@@ -282,14 +302,39 @@ $(() => {
         }
       });
 
-      $modal.find('#quick-access-save-btn').off('click').on('click', () => {
-        const name = String($modal.find('#quick-access-name').val()).trim();
+      const $nameInput = $modal.find('#quick-access-name');
+      const $nameGroup = $modal.find('#quick-access-name-group');
+      const $nameError = $modal.find('#quick-access-name-error');
+      const $modalError = $modal.find('#quick-access-add-error');
 
-        if (!name) return;
+      const resetErrors = () => {
+        $nameGroup.removeClass('has-error');
+        $nameError.addClass('hidden').text('');
+        $modalError.addClass('hidden').text('');
+      };
+
+      $modal.one('hidden.bs.modal', resetErrors);
+      $nameInput.off('input').on('input', resetErrors);
+
+      $modal.find('#quick-access-save-btn').off('click').on('click', () => {
+        resetErrors();
+
+        const name = String($nameInput.val()).trim();
+
+        if (!name) {
+          $nameGroup.addClass('has-error');
+          $nameError.text($nameInput.data('required-message')).removeClass('hidden');
+          $nameInput.trigger('focus');
+          return;
+        }
 
         const newWindow = $modal.find('input[name="quick_access_new_window"]:checked').val() === '1';
-        $modal.modal('hide');
-        doQuickLinkAjax($link, method, name, newWindow);
+        doQuickLinkAjax($link, method, name, newWindow, {
+          onSuccess: () => $modal.modal('hide'),
+          onError: (messages) => {
+            $modalError.text(messages.join(' ')).removeClass('hidden');
+          },
+        });
       });
 
       $modal.modal('show');

--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -284,7 +284,9 @@ $(() => {
 
       $modal.find('#quick-access-save-btn').off('click').on('click', () => {
         const name = String($modal.find('#quick-access-name').val()).trim();
+
         if (!name) return;
+
         const newWindow = $modal.find('input[name="quick_access_new_window"]:checked').val() === '1';
         $modal.modal('hide');
         doQuickLinkAjax($link, method, name, newWindow);

--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -310,7 +310,7 @@ $(() => {
       const resetErrors = () => {
         $nameGroup.removeClass('has-error');
         $nameError.addClass('hidden').text('');
-        $modalError.addClass('hidden').text('');
+        $modalError.removeClass('alert alert-danger').addClass('hidden').text('');
       };
 
       $modal.one('hidden.bs.modal', resetErrors);
@@ -332,7 +332,7 @@ $(() => {
         doQuickLinkAjax($link, method, name, newWindow, {
           onSuccess: () => $modal.modal('hide'),
           onError: (messages) => {
-            $modalError.text(messages.join(' ')).removeClass('hidden');
+            $modalError.addClass('alert alert-danger').text(messages.join(' ')).removeClass('hidden');
           },
         });
       });

--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -202,65 +202,95 @@ $(() => {
       },
     });
   });
+  const doQuickLinkAjax = ($link, method, name, newWindow) => {
+    $.ajax({
+      type: 'POST',
+      headers: {'cache-control': 'no-cache'},
+      async: true,
+      url: $link.data('post-link'),
+      data: {
+        method,
+        url: $link.data('url'),
+        name,
+        icon: $link.data('icon'),
+        id_quick_access: $link.data('quicklink-id'),
+        new_window: newWindow ? 1 : 0,
+      },
+      dataType: 'json',
+      success: (data) => {
+        if (typeof data.has_errors !== 'undefined' && data.has_errors) {
+          $.each(data, (index) => {
+            if (typeof data[index] === 'string') {
+              $.growl.error({title: '', message: data[index]});
+            }
+          });
+        } else if (Array.isArray(data)) {
+          let quicklinkList = '';
+          $.each(data, (index, item) => {
+            if (typeof item.name !== 'undefined') {
+              const activeClass = item.active ? ' active' : '';
+              const classAttr = item.class ? ` class="${item.class}"` : '';
+              quicklinkList += `<li class="quick-row-link${activeClass}">`
+                + `<a${classAttr} href="${item.link}" data-item="${item.name}">${item.name}</a></li>`;
+            }
+          });
+          if (quicklinkList) {
+            $('#header_quick ul.dropdown-menu .divider').prevAll().remove();
+            $('#header_quick ul.dropdown-menu').prepend(quicklinkList);
+            $link.closest('li').remove();
+            window.showSuccessMessage(window.update_success_msg);
+          }
+        }
+      },
+      error: (xhr, textStatus) => {
+        $.growl.error({
+          title: 'Quick access error',
+          message: textStatus === 'parsererror'
+            ? `Server returned non-JSON (status ${xhr.status})`
+            : `${xhr.status} ${xhr.statusText}`,
+        });
+      },
+    });
+  };
+
   $(document).on('click', '.js-quick-link', (e) => {
     e.preventDefault();
 
     const $link = $(e.target).closest('.js-quick-link');
     const method = $link.data('method');
-    let name = null;
 
-    if (method === 'add') {
-      name = prompt($link.data('prompt-text'), $link.data('link'));
+    if (method === 'remove') {
+      doQuickLinkAjax($link, method, null, false);
+      return;
     }
 
-    if ((method === 'add' && name) || method === 'remove') {
-      $.ajax({
-        type: 'POST',
-        headers: {'cache-control': 'no-cache'},
-        async: true,
-        url: $link.data('post-link'),
-        data: {
-          method,
-          url: $link.data('url'),
-          name,
-          icon: $link.data('icon'),
-          id_quick_access: $link.data('quicklink-id'),
-        },
-        dataType: 'json',
-        success: (data) => {
-          if (typeof data.has_errors !== 'undefined' && data.has_errors) {
-            $.each(data, (index) => {
-              if (typeof data[index] === 'string') {
-                $.growl.error({title: '', message: data[index]});
-              }
-            });
-          } else if (Array.isArray(data)) {
-            let quicklinkList = '';
-            $.each(data, (index, item) => {
-              if (typeof item.name !== 'undefined') {
-                const activeClass = item.active ? ' active' : '';
-                const classAttr = item.class ? ` class="${item.class}"` : '';
-                quicklinkList += `<li class="quick-row-link${activeClass}">`
-                  + `<a${classAttr} href="${item.link}" data-item="${item.name}">${item.name}</a></li>`;
-              }
-            });
-            if (quicklinkList) {
-              $('#header_quick ul.dropdown-menu .divider').prevAll().remove();
-              $('#header_quick ul.dropdown-menu').prepend(quicklinkList);
-              $link.closest('li').remove();
-              window.showSuccessMessage(window.update_success_msg);
-            }
-          }
-        },
-        error: (xhr, textStatus) => {
-          $.growl.error({
-            title: 'Quick access error',
-            message: textStatus === 'parsererror'
-              ? `Server returned non-JSON (status ${xhr.status})`
-              : `${xhr.status} ${xhr.statusText}`,
-          });
-        },
+    if (method === 'add') {
+      const $modal = $('#quick-access-add-modal');
+      document.body.appendChild($modal[0]);
+      const defaultName = ($link.data('link') || '').substring(0, 32);
+
+      $modal.find('#quick-access-name').val(defaultName);
+      $modal.find('input[name="quick_access_new_window"][value="0"]').prop('checked', true);
+
+      $modal.one('shown.bs.modal', () => {
+        $modal.find('#quick-access-name').trigger('focus');
       });
+
+      $modal.find('#quick-access-name').off('keypress').on('keypress', (keyEvent) => {
+        if (keyEvent.key === 'Enter') {
+          $modal.find('#quick-access-save-btn').trigger('click');
+        }
+      });
+
+      $modal.find('#quick-access-save-btn').off('click').on('click', () => {
+        const name = String($modal.find('#quick-access-name').val()).trim();
+        if (!name) return;
+        const newWindow = $modal.find('input[name="quick_access_new_window"]:checked').val() === '1';
+        $modal.modal('hide');
+        doQuickLinkAjax($link, method, name, newWindow);
+      });
+
+      $modal.modal('show');
     }
   });
 

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -179,7 +179,7 @@
               </h4>
             </div>
             <div class="modal-body">
-              <div class="alert alert-danger hidden" role="alert" id="quick-access-add-error"></div>
+              <div class="hidden" role="alert" id="quick-access-add-error"></div>
               <div class="form-group" id="quick-access-name-group">
                 <label for="quick-access-name">
                   {l s='Shortcut name' d='Admin.Navigation.Header'}

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -147,8 +147,7 @@
                    data-method="add"
                    data-url="{$link->getQuickLink($smarty.server.REQUEST_URI)|escape:'html':'UTF-8'}"
                    data-post-link="{$quick_access_ajax_add_url|escape:'html':'UTF-8'}"
-                   data-prompt-text="{l s='Please name this shortcut:' d='Admin.Navigation.Header'}"
-                   data-link="{$quick_access_current_link_short_name|escape:'html':'UTF-8'|truncate:32}"
+                   data-link="{$quick_access_current_link_short_name|escape:'html':'UTF-8'}"
                    data-icon="{$quick_access_current_link_icon|escape:'html':'UTF-8'}"
                 >
                   <i class="material-icons">add_circle</i>
@@ -163,6 +162,51 @@
               </a>
             </li>
           </ul>
+        </div>
+      </div>
+
+      <div class="modal fade" id="quick-access-add-modal" tabindex="-1" role="dialog"
+           aria-labelledby="quick-access-add-modal-title" aria-modal="true">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal"
+                      aria-label="{l s='Close' d='Admin.Actions'}">
+                <span aria-hidden="true">&times;</span>
+              </button>
+              <h4 class="modal-title" id="quick-access-add-modal-title">
+                {l s='Add to Quick Access' d='Admin.Navigation.Header'}
+              </h4>
+            </div>
+            <div class="modal-body">
+              <div class="form-group">
+                <label for="quick-access-name">
+                  {l s='Shortcut name' d='Admin.Navigation.Header'}
+                </label>
+                <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
+              </div>
+              <div class="form-group">
+                <label class="d-block">
+                  {l s='Open in new window' d='Admin.Navigation.Header'}
+                </label>
+                <span class="ps-switch">
+                  <input id="quick-access-new-window-off" name="quick_access_new_window" value="0" checked type="radio">
+                  <label for="quick-access-new-window-off">{l s='No' d='Admin.Global'}</label>
+                  <input id="quick-access-new-window-on" name="quick_access_new_window" value="1" type="radio">
+                  <label for="quick-access-new-window-on">{l s='Yes' d='Admin.Global'}</label>
+                  <span class="slide-button"></span>
+                </span>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-default btn-lg" data-dismiss="modal">
+                {l s='Cancel' d='Admin.Actions'}
+              </button>
+              <button type="button" class="btn btn-primary btn-lg" id="quick-access-save-btn">
+                {l s='Save' d='Admin.Actions'}
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -179,11 +179,14 @@
               </h4>
             </div>
             <div class="modal-body">
-              <div class="form-group">
+              <div class="alert alert-danger hidden" role="alert" id="quick-access-add-error"></div>
+              <div class="form-group" id="quick-access-name-group">
                 <label for="quick-access-name">
                   {l s='Shortcut name' d='Admin.Navigation.Header'}
                 </label>
-                <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
+                <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32"
+                       data-required-message="{l s='Shortcut name is required' d='Admin.Navigation.Header'}">
+                <span class="help-block hidden" id="quick-access-name-error"></span>
               </div>
               <div class="form-group">
                 <label class="d-block">

--- a/admin-dev/themes/new-theme/js/header.ts
+++ b/admin-dev/themes/new-theme/js/header.ts
@@ -50,7 +50,7 @@ export default class Header {
 
         const resetErrors = (): void => {
           $nameGroup.removeClass('has-error');
-          $nameError.addClass('d-none').find('.js-error-text').text('');
+          $nameError.removeClass('d-inline-block').addClass('d-none').find('.js-error-text').text('');
           $modalError.addClass('d-none').find('.alert-text').text('');
         };
 
@@ -64,7 +64,8 @@ export default class Header {
 
           if (!name) {
             $nameGroup.addClass('has-error');
-            $nameError.removeClass('d-none').find('.js-error-text').text($nameInput.data('required-message') as string);
+            $nameError.removeClass('d-none').addClass('d-inline-block');
+            $nameError.find('.js-error-text').text($nameInput.data('required-message') as string);
             $nameInput.trigger('focus');
 
             return;

--- a/admin-dev/themes/new-theme/js/header.ts
+++ b/admin-dev/themes/new-theme/js/header.ts
@@ -43,16 +43,40 @@ export default class Header {
           }
         });
 
+        const $nameInput = $modal.find('#quick-access-name');
+        const $nameGroup = $modal.find('#quick-access-name-group');
+        const $nameError = $modal.find('#quick-access-name-error');
+        const $modalError = $modal.find('#quick-access-add-error');
+
+        const resetErrors = (): void => {
+          $nameGroup.removeClass('has-error');
+          $nameError.addClass('d-none').find('.js-error-text').text('');
+          $modalError.addClass('d-none').find('.alert-text').text('');
+        };
+
+        $modal.one('hidden.bs.modal', resetErrors);
+        $nameInput.off('input').on('input', resetErrors);
+
         $modal.find('#quick-access-save-btn').off('click').on('click', () => {
-          const name = ($modal.find('#quick-access-name').val() as string).trim();
+          resetErrors();
+
+          const name = ($nameInput.val() as string).trim();
 
           if (!name) {
+            $nameGroup.addClass('has-error');
+            $nameError.removeClass('d-none').find('.js-error-text').text($nameInput.data('required-message') as string);
+            $nameInput.trigger('focus');
+
             return;
           }
 
           const newWindow = $modal.find('input[name="quick_access_new_window"]:checked').val() === '1';
-          $modal.modal('hide');
-          this.doQuickLinkAction($link, method, name, newWindow);
+          this.doQuickLinkAction($link, method, name, newWindow, {
+            onSuccess: () => $modal.modal('hide'),
+            onError: (messages: string[]) => {
+              $modalError.removeClass('d-none').find('.alert-text').text(messages.join(' '));
+            },
+          });
         });
 
         $modal.modal('show');
@@ -77,11 +101,32 @@ export default class Header {
     });
   }
 
-  private doQuickLinkAction($link: JQuery, method: string, name: string | null, newWindow: boolean = false): void {
+  private doQuickLinkAction(
+    $link: JQuery,
+    method: string,
+    name: string | null,
+    newWindow: boolean = false,
+    callbacks: {onSuccess?: () => void; onError?: (messages: string[]) => void} = {},
+  ): void {
     const postLink = $link.data('post-link');
     const quickLinkId = $link.data('quicklink-id');
     const url = $link.data('url');
     const icon = $link.data('icon');
+
+    const reportErrors = (messages: string[]): void => {
+      if (callbacks.onError) {
+        callbacks.onError(messages);
+
+        return;
+      }
+
+      messages.forEach((message) => {
+        $.growl.error({
+          title: '',
+          message,
+        });
+      });
+    };
 
     $.ajax({
       type: 'POST',
@@ -101,14 +146,13 @@ export default class Header {
       dataType: 'json',
       success: (data) => {
         if (typeof data.has_errors !== 'undefined' && data.has_errors) {
+          const messages: string[] = [];
           $.each(data, (index) => {
             if (typeof data[index] === 'string') {
-              $.growl.error({
-                title: '',
-                message: data[index],
-              });
+              messages.push(data[index]);
             }
           });
+          reportErrors(messages);
         } else if (Array.isArray(data)) {
           let quicklinkList = '';
           data.forEach((item) => {
@@ -122,15 +166,26 @@ export default class Header {
           $menu.find('.dropdown-divider').prevAll('a.quick-row-link').remove();
           $menu.prepend(quicklinkList);
           $link.remove();
+          if (callbacks.onSuccess) {
+            callbacks.onSuccess();
+          }
           window.showSuccessMessage(window.update_success_msg);
         }
       },
       error: (xhr, textStatus) => {
+        const message = textStatus === 'parsererror'
+          ? `Server returned non-JSON (status ${xhr.status})`
+          : `${xhr.status} ${xhr.statusText}`;
+
+        if (callbacks.onError) {
+          callbacks.onError([message]);
+
+          return;
+        }
+
         $.growl.error({
           title: 'Quick access error',
-          message: textStatus === 'parsererror'
-            ? `Server returned non-JSON (status ${xhr.status})`
-            : `${xhr.status} ${xhr.statusText}`,
+          message,
         });
       },
     });

--- a/admin-dev/themes/new-theme/js/header.ts
+++ b/admin-dev/themes/new-theme/js/header.ts
@@ -51,7 +51,7 @@ export default class Header {
         const resetErrors = (): void => {
           $nameGroup.removeClass('has-error');
           $nameError.removeClass('d-inline-block').addClass('d-none').find('.js-error-text').text('');
-          $modalError.addClass('d-none').find('.alert-text').text('');
+          $modalError.removeClass('alert alert-danger').addClass('d-none').find('.alert-text').text('');
         };
 
         $modal.one('hidden.bs.modal', resetErrors);
@@ -75,7 +75,7 @@ export default class Header {
           this.doQuickLinkAction($link, method, name, newWindow, {
             onSuccess: () => $modal.modal('hide'),
             onError: (messages: string[]) => {
-              $modalError.removeClass('d-none').find('.alert-text').text(messages.join(' '));
+              $modalError.addClass('alert alert-danger').removeClass('d-none').find('.alert-text').text(messages.join(' '));
             },
           });
         });

--- a/admin-dev/themes/new-theme/js/header.ts
+++ b/admin-dev/themes/new-theme/js/header.ts
@@ -24,13 +24,40 @@ export default class Header {
 
       const $link = $(e.target).closest('.js-quick-link');
       const method = $link.data('method');
-      let name = null;
 
       if (method === 'add') {
-        const text = $link.data('prompt-text');
-        const link = $link.data('link');
+        const $modal = $('#quick-access-add-modal');
+        document.body.appendChild($modal[0]);
+        const defaultName = (($link.data('link') as string) ?? '').substring(0, 32);
 
-        name = prompt(text, link);
+        $modal.find('#quick-access-name').val(defaultName);
+        $modal.find('input[name="quick_access_new_window"][value="0"]').prop('checked', true);
+
+        $modal.one('shown.bs.modal', () => {
+          $modal.find('#quick-access-name').trigger('focus');
+        });
+
+        $modal.find('#quick-access-name').off('keypress').on('keypress', (keyEvent) => {
+          if (keyEvent.key === 'Enter') {
+            $modal.find('#quick-access-save-btn').trigger('click');
+          }
+        });
+
+        $modal.find('#quick-access-save-btn').off('click').on('click', () => {
+          const name = ($modal.find('#quick-access-name').val() as string).trim();
+
+          if (!name) {
+            return;
+          }
+
+          const newWindow = $modal.find('input[name="quick_access_new_window"]:checked').val() === '1';
+          $modal.modal('hide');
+          this.doQuickLinkAction($link, method, name, newWindow);
+        });
+
+        $modal.modal('show');
+
+        return;
       }
 
       if (method === 'remove') {
@@ -46,17 +73,11 @@ export default class Header {
           () => this.doQuickLinkAction($link, method, null),
         );
         confirmModal.show();
-
-        return;
-      }
-
-      if (method === 'add' && name) {
-        this.doQuickLinkAction($link, method, name);
       }
     });
   }
 
-  private doQuickLinkAction($link: JQuery, method: string, name: string | null): void {
+  private doQuickLinkAction($link: JQuery, method: string, name: string | null, newWindow: boolean = false): void {
     const postLink = $link.data('post-link');
     const quickLinkId = $link.data('quicklink-id');
     const url = $link.data('url');
@@ -75,6 +96,7 @@ export default class Header {
         name,
         icon,
         id_quick_access: quickLinkId,
+        new_window: newWindow ? 1 : 0,
       },
       dataType: 'json',
       success: (data) => {

--- a/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
@@ -70,11 +70,19 @@
         </button>
       </div>
       <div class="modal-body">
-        <div class="form-group">
+        <div class="alert alert-danger d-print-none d-none" role="alert" id="quick-access-add-error">
+          <div class="alert-text"></div>
+        </div>
+        <div class="form-group" id="quick-access-name-group">
           <label class="form-control-label" for="quick-access-name">
             {l s='Shortcut name' d='Admin.Navigation.Header'}
           </label>
-          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
+          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32"
+                 data-required-message="{l s='Shortcut name is required' d='Admin.Navigation.Header'}">
+          <div class="d-inline-block align-baseline text-danger mt-1 d-none" role="alert" id="quick-access-name-error">
+            <i class="material-icons form-error-icon">error_outline</i>
+            <span class="js-error-text"></span>
+          </div>
         </div>
         <div class="form-group">
           <label class="form-control-label d-block">

--- a/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
@@ -43,8 +43,7 @@
         data-method="add"
         data-url="{$link->getQuickLink($smarty.server['REQUEST_URI']|escape:'javascript')}"
         data-post-link="{$link->getAdminLink('AdminQuickAccesses')|escape:'html':'UTF-8'}"
-        data-prompt-text="{l s='Please name this shortcut:' js=1  d='Admin.Navigation.Header'}"
-        data-link="{$quick_access_current_link_name|truncate:32|escape:'html':'UTF-8'}"
+        data-link="{$quick_access_current_link_name|escape:'html':'UTF-8'}"
       >
         <i class="material-icons">add_circle</i>
         {l s='Add current page to Quick Access'  d='Admin.Actions'}
@@ -54,5 +53,50 @@
       <i class="material-icons">settings</i>
       {l s='Manage your quick accesses' d='Admin.Navigation.Header'}
     </a>
+  </div>
+</div>
+
+<div class="modal fade" id="quick-access-add-modal" tabindex="-1" role="dialog"
+     aria-labelledby="quick-access-add-modal-title" aria-modal="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="quick-access-add-modal-title">
+          {l s='Add to Quick Access' d='Admin.Navigation.Header'}
+        </h4>
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="{l s='Close' d='Admin.Actions'}">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-control-label" for="quick-access-name">
+            {l s='Shortcut name' d='Admin.Navigation.Header'}
+          </label>
+          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
+        </div>
+        <div class="form-group">
+          <label class="form-control-label d-block">
+            {l s='Open in new window' d='Admin.Navigation.Header'}
+          </label>
+          <span class="ps-switch">
+            <input id="quick-access-new-window-off" name="quick_access_new_window" value="0" checked type="radio">
+            <label for="quick-access-new-window-off">{l s='No' d='Admin.Global'}</label>
+            <input id="quick-access-new-window-on" name="quick_access_new_window" value="1" type="radio">
+            <label for="quick-access-new-window-on">{l s='Yes' d='Admin.Global'}</label>
+            <span class="slide-button"></span>
+          </span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary btn-lg" data-dismiss="modal">
+          {l s='Cancel' d='Admin.Actions'}
+        </button>
+        <button type="button" class="btn btn-primary btn-lg" id="quick-access-save-btn">
+          {l s='Save' d='Admin.Actions'}
+        </button>
+      </div>
+    </div>
   </div>
 </div>

--- a/controllers/admin/AdminQuickAccessesController.php
+++ b/controllers/admin/AdminQuickAccessesController.php
@@ -191,7 +191,7 @@ class AdminQuickAccessesControllerCore extends AdminController
     public function ajaxProcessGetUrl()
     {
         if (Tools::strtolower(Tools::getValue('method')) === 'add') {
-            $params['new_window'] = 0;
+            $params['new_window'] = (int) Tools::getValue('new_window', 0);
             $params['name_' . (int) Configuration::get('PS_LANG_DEFAULT')] = Tools::getValue('name');
             $params['link'] = Tools::getValue('url');
             $params['submitAddquick_access'] = 1;

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/QuickAccessController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/QuickAccessController.php
@@ -186,7 +186,7 @@ class QuickAccessController extends PrestaShopAdminController
             $createdId = $this->dispatchCommand(new AddQuickAccessCommand(
                 [$languageContext->getId() => $request->request->getString('name')],
                 $request->request->getString('url'),
-                false,
+                $request->request->getBoolean('new_window'),
             ));
         } catch (QuickAccessException $e) {
             return new JsonResponse([

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/quick_access.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/quick_access.html.twig
@@ -47,7 +47,6 @@
            data-icon="{{ this.currentPageIcon }}"
            data-url="{{ this.currentPageQuickAccessLink }}"
            data-post-link="{{ this.ajaxAddUrl }}"
-           data-prompt-text="{{ 'Please name this shortcut:'|trans({}, 'Admin.Navigation.Header') }}"
            data-link="{{ this.currentPageTitle }}"
         >
           <i class="material-icons">add_circle</i>
@@ -58,6 +57,51 @@
       <i class="material-icons">settings</i>
       {{ 'Manage your quick accesses'|trans({}, 'Admin.Navigation.Header') }}
       </a>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="quick-access-add-modal" tabindex="-1" role="dialog"
+     aria-labelledby="quick-access-add-modal-title" aria-modal="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="quick-access-add-modal-title">
+          {{ 'Add to Quick Access'|trans({}, 'Admin.Navigation.Header') }}
+        </h4>
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-control-label" for="quick-access-name">
+            {{ 'Shortcut name'|trans({}, 'Admin.Navigation.Header') }}
+          </label>
+          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
+        </div>
+        <div class="form-group">
+          <label class="form-control-label d-block">
+            {{ 'Open in new window'|trans({}, 'Admin.Navigation.Header') }}
+          </label>
+          <span class="ps-switch">
+            <input id="quick-access-new-window-off" name="quick_access_new_window" value="0" checked type="radio">
+            <label for="quick-access-new-window-off">{{ 'No'|trans({}, 'Admin.Global') }}</label>
+            <input id="quick-access-new-window-on" name="quick_access_new_window" value="1" type="radio">
+            <label for="quick-access-new-window-on">{{ 'Yes'|trans({}, 'Admin.Global') }}</label>
+            <span class="slide-button"></span>
+          </span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary btn-lg" data-dismiss="modal">
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </button>
+        <button type="button" class="btn btn-primary btn-lg" id="quick-access-save-btn">
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/quick_access.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/quick_access.html.twig
@@ -61,47 +61,4 @@
   </div>
 </div>
 
-<div class="modal fade" id="quick-access-add-modal" tabindex="-1" role="dialog"
-     aria-labelledby="quick-access-add-modal-title" aria-modal="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h4 class="modal-title" id="quick-access-add-modal-title">
-          {{ 'Add to Quick Access'|trans({}, 'Admin.Navigation.Header') }}
-        </h4>
-        <button type="button" class="close" data-dismiss="modal"
-                aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        <div class="form-group">
-          <label class="form-control-label" for="quick-access-name">
-            {{ 'Shortcut name'|trans({}, 'Admin.Navigation.Header') }}
-          </label>
-          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
-        </div>
-        <div class="form-group">
-          <label class="form-control-label d-block">
-            {{ 'Open in new window'|trans({}, 'Admin.Navigation.Header') }}
-          </label>
-          <span class="ps-switch">
-            <input id="quick-access-new-window-off" name="quick_access_new_window" value="0" checked type="radio">
-            <label for="quick-access-new-window-off">{{ 'No'|trans({}, 'Admin.Global') }}</label>
-            <input id="quick-access-new-window-on" name="quick_access_new_window" value="1" type="radio">
-            <label for="quick-access-new-window-on">{{ 'Yes'|trans({}, 'Admin.Global') }}</label>
-            <span class="slide-button"></span>
-          </span>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-outline-secondary btn-lg" data-dismiss="modal">
-          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-        </button>
-        <button type="button" class="btn btn-primary btn-lg" id="quick-access-save-btn">
-          {{ 'Save'|trans({}, 'Admin.Actions') }}
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+{{ include('@PrestaShop/Admin/Component/quick_access_add_modal.html.twig') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/quick_access.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/quick_access.html.twig
@@ -49,7 +49,6 @@
            data-icon="{{ this.currentPageIcon }}"
            data-url="{{ this.currentPageQuickAccessLink }}"
            data-post-link="{{ this.ajaxAddUrl }}"
-           data-prompt-text="{{ 'Please name this shortcut:'|trans({}, 'Admin.Navigation.Header') }}"
            data-link="{{ this.currentPageTitle }}"
         >
           <i class="material-icons">add_circle</i>
@@ -64,5 +63,50 @@
         </a>
       </li>
     </ul>
+  </div>
+</div>
+
+<div class="modal fade" id="quick-access-add-modal" tabindex="-1" role="dialog"
+     aria-labelledby="quick-access-add-modal-title" aria-modal="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title" id="quick-access-add-modal-title">
+          {{ 'Add to Quick Access'|trans({}, 'Admin.Navigation.Header') }}
+        </h4>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-control-label" for="quick-access-name">
+            {{ 'Shortcut name'|trans({}, 'Admin.Navigation.Header') }}
+          </label>
+          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
+        </div>
+        <div class="form-group">
+          <label class="form-control-label d-block">
+            {{ 'Open in new window'|trans({}, 'Admin.Navigation.Header') }}
+          </label>
+          <span class="ps-switch">
+            <input id="quick-access-new-window-off" name="quick_access_new_window" value="0" checked type="radio">
+            <label for="quick-access-new-window-off">{{ 'No'|trans({}, 'Admin.Global') }}</label>
+            <input id="quick-access-new-window-on" name="quick_access_new_window" value="1" type="radio">
+            <label for="quick-access-new-window-on">{{ 'Yes'|trans({}, 'Admin.Global') }}</label>
+            <span class="slide-button"></span>
+          </span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default btn-lg" data-dismiss="modal">
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </button>
+        <button type="button" class="btn btn-primary btn-lg" id="quick-access-save-btn">
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/quick_access.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/quick_access.html.twig
@@ -66,47 +66,4 @@
   </div>
 </div>
 
-<div class="modal fade" id="quick-access-add-modal" tabindex="-1" role="dialog"
-     aria-labelledby="quick-access-add-modal-title" aria-modal="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal"
-                aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
-          <span aria-hidden="true">&times;</span>
-        </button>
-        <h4 class="modal-title" id="quick-access-add-modal-title">
-          {{ 'Add to Quick Access'|trans({}, 'Admin.Navigation.Header') }}
-        </h4>
-      </div>
-      <div class="modal-body">
-        <div class="form-group">
-          <label class="form-control-label" for="quick-access-name">
-            {{ 'Shortcut name'|trans({}, 'Admin.Navigation.Header') }}
-          </label>
-          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
-        </div>
-        <div class="form-group">
-          <label class="form-control-label d-block">
-            {{ 'Open in new window'|trans({}, 'Admin.Navigation.Header') }}
-          </label>
-          <span class="ps-switch">
-            <input id="quick-access-new-window-off" name="quick_access_new_window" value="0" checked type="radio">
-            <label for="quick-access-new-window-off">{{ 'No'|trans({}, 'Admin.Global') }}</label>
-            <input id="quick-access-new-window-on" name="quick_access_new_window" value="1" type="radio">
-            <label for="quick-access-new-window-on">{{ 'Yes'|trans({}, 'Admin.Global') }}</label>
-            <span class="slide-button"></span>
-          </span>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default btn-lg" data-dismiss="modal">
-          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-        </button>
-        <button type="button" class="btn btn-primary btn-lg" id="quick-access-save-btn">
-          {{ 'Save'|trans({}, 'Admin.Actions') }}
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+{{ include('@PrestaShop/Admin/Component/quick_access_add_modal.html.twig', {legacyLayout: true}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/quick_access_add_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/quick_access_add_modal.html.twig
@@ -37,7 +37,7 @@
           </label>
           <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32"
                  data-required-message="{{ 'Shortcut name is required'|trans({}, 'Admin.Navigation.Header') }}">
-          <div class="d-inline-block align-baseline text-danger mt-1 d-none" role="alert" id="quick-access-name-error">
+          <div class="align-baseline text-danger mt-1 d-none" role="alert" id="quick-access-name-error">
             <i class="material-icons form-error-icon">error_outline</i>
             <span class="js-error-text"></span>
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/quick_access_add_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/quick_access_add_modal.html.twig
@@ -28,11 +28,19 @@
         {% endif %}
       </div>
       <div class="modal-body">
-        <div class="form-group">
+        <div class="alert alert-danger d-print-none d-none" role="alert" id="quick-access-add-error">
+          <div class="alert-text"></div>
+        </div>
+        <div class="form-group" id="quick-access-name-group">
           <label class="form-control-label" for="quick-access-name">
             {{ 'Shortcut name'|trans({}, 'Admin.Navigation.Header') }}
           </label>
-          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
+          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32"
+                 data-required-message="{{ 'Shortcut name is required'|trans({}, 'Admin.Navigation.Header') }}">
+          <div class="d-inline-block align-baseline text-danger mt-1 d-none" role="alert" id="quick-access-name-error">
+            <i class="material-icons form-error-icon">error_outline</i>
+            <span class="js-error-text"></span>
+          </div>
         </div>
         <div class="form-group">
           <label class="form-control-label d-block">

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/quick_access_add_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/quick_access_add_modal.html.twig
@@ -1,0 +1,60 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+{% set legacyLayout = legacyLayout|default(false) %}
+<div class="modal fade" id="quick-access-add-modal" tabindex="-1" role="dialog"
+     aria-labelledby="quick-access-add-modal-title" aria-modal="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        {% set modalTitle %}
+          <h4 class="modal-title" id="quick-access-add-modal-title">
+            {{ 'Add to Quick Access'|trans({}, 'Admin.Navigation.Header') }}
+          </h4>
+        {% endset %}
+        {% set closeButton %}
+          <button type="button" class="close" data-dismiss="modal"
+                  aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        {% endset %}
+        {% if legacyLayout %}
+          {{ closeButton }}
+          {{ modalTitle }}
+        {% else %}
+          {{ modalTitle }}
+          {{ closeButton }}
+        {% endif %}
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-control-label" for="quick-access-name">
+            {{ 'Shortcut name'|trans({}, 'Admin.Navigation.Header') }}
+          </label>
+          <input type="text" id="quick-access-name" class="form-control" required aria-required="true" maxlength="32">
+        </div>
+        <div class="form-group">
+          <label class="form-control-label d-block">
+            {{ 'Open in new window'|trans({}, 'Admin.Navigation.Header') }}
+          </label>
+          <span class="ps-switch">
+            <input id="quick-access-new-window-off" name="quick_access_new_window" value="0" checked type="radio">
+            <label for="quick-access-new-window-off">{{ 'No'|trans({}, 'Admin.Global') }}</label>
+            <input id="quick-access-new-window-on" name="quick_access_new_window" value="1" type="radio">
+            <label for="quick-access-new-window-on">{{ 'Yes'|trans({}, 'Admin.Global') }}</label>
+            <span class="slide-button"></span>
+          </span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn {{ legacyLayout ? 'btn-default' : 'btn-outline-secondary' }} btn-lg" data-dismiss="modal">
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </button>
+        <button type="button" class="btn btn-primary btn-lg" id="quick-access-save-btn">
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/quick_access_add_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/quick_access_add_modal.html.twig
@@ -28,7 +28,7 @@
         {% endif %}
       </div>
       <div class="modal-body">
-        <div class="alert alert-danger d-print-none d-none" role="alert" id="quick-access-add-error">
+        <div class="d-print-none d-none" role="alert" id="quick-access-add-error">
           <div class="alert-text"></div>
         </div>
         <div class="form-group" id="quick-access-name-group">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Replace the native `window.prompt()` dialog triggered when clicking "Add current page to Quick Access" in the BO header with a PrestaShop modal. The modal contains a pre-filled name input (truncated to 32 chars) and an "Open in new window" toggle switch (defaulting to off), and performs inline validation (an empty shortcut name keeps the modal open and shows an inline error). The AJAX endpoints are extended to accept the `new_window` parameter on both the legacy and Symfony paths. The change applies to all three header rendering contexts: the new-theme Smarty template, the Twig components (migrated layout and legacy layout), and the legacy default theme header.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to any BO page. 2. Open the Quick Access dropdown in the top header. 3. Click "Add current page to Quick Access". 4. A PrestaShop modal opens — no native browser prompt. 5. The name input is pre-filled with the current page title (max 32 chars). 6. Clear the name and click Save — the modal stays open and shows an inline error. 7. Set a name, toggle "Open in new window" to Yes, click Save. 8. The link appears in the dropdown and opens in a new tab. 9. Verify "Remove from Quick Access" still works without regression. 10. Test on a migrated Symfony page and on a legacy page.
| UI Tests          |https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27364693775 :green_circle: 
| Fixed issue?      | Fixes #41608
| Related PRs       | [PrestaShop/ui-testing-library#1010](https://github.com/PrestaShop/ui-testing-library/pull/1010) — adds the `addCurrentPageToQuickAccessWithEmptyName` page object. Once it is merged to `main`, the UI test covering the empty-name inline validation and the matching `tests/UI/package-lock.json` bump will be added to this PR. (The modal page object from #992 is already on `develop`.)
| Sponsor company   |