### PR TITLE
Fix countries grid total count always showing 1

### DIFF
--- a/src/Core/Grid/Query/CountryQueryBuilder.php
+++ b/src/Core/Grid/Query/CountryQueryBuilder.php
@@ -57,7 +57,8 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         $qb = $this->getQueryBuilder($searchCriteria)
-            ->select('c.id_country, c.iso_code, c.call_prefix, c.active, cl.name, z.name as zone_name');
+            ->select('c.id_country, c.iso_code, c.call_prefix, c.active, cl.name, z.name as zone_name')
+            ->groupBy('c.id_country');
 
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
@@ -103,7 +104,6 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
             )
             ->setParameter('contextLangId', $this->contextLangId)
             ->setParameter('contextShopIds', $this->contextShopIds, Connection::PARAM_INT_ARRAY)
-            ->groupBy('c.id_country')
         ;
 
         $this->applyFilters($qb, $searchCriteria);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The Countries listing page always displays **Countries (1)** in the card header, regardless of the actual number of countries. The root cause is that `CountryQueryBuilder::getQueryBuilder()` applied `GROUP BY c.id_country` (needed in search queries to deduplicate rows when a country belongs to multiple shops). This clause was inherited by `getCountQueryBuilder()`, causing `COUNT(DISTINCT c.id_country) GROUP BY c.id_country` to return one row per country — each with value `1`. `DoctrineGridDataFactory::fetchOne()` then only picked the first row. Fix: move `GROUP BY` to `getSearchQueryBuilder()` only; `COUNT(DISTINCT ...)` already handles deduplication in the count query.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **International > Locations > Tab Countries** in the back office. 2. Check the card header — it should display the actual total number of countries (e.g. **Countries (244)**) instead of **Countries (1)**. 3. Apply a filter (e.g. filter by zone) and verify the counter updates correctly to reflect the filtered count.
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes #41613
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA

Closes #41613