### PR TITLE
Fix countries grid not refreshing after toggle when filters are active

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/country/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/country/index.ts
@@ -15,6 +15,6 @@ $(() => {
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
-  countryGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.ModalFormSubmitExtension());
 });

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -34,7 +34,6 @@ use PrestaShopBundle\Form\Admin\Improve\International\Locations\ChangeCountriesZ
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -208,26 +207,19 @@ class CountryController extends PrestaShopAdminController
 
     #[DemoRestricted(redirectRoute: 'admin_countries_index')]
     #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_countries_index')]
-    public function toggleStatusAction(int $countryId): JsonResponse
+    public function toggleStatusAction(int $countryId): RedirectResponse
     {
         try {
             $this->dispatchCommand(new ToggleCountryStatusCommand($countryId));
-            $response = [
-                'status' => true,
-                'message' => $this->trans(
-                    'The status has been successfully updated.',
-                    [],
-                    'Admin.Notifications.Success'
-                ),
-            ];
+            $this->addFlash(
+                'success',
+                $this->trans('The status has been successfully updated.', [], 'Admin.Notifications.Success')
+            );
         } catch (CountryException $e) {
-            $response = [
-                'status' => false,
-                'message' => $this->getErrorMessageForException($e, $this->getErrorMessages($e)),
-            ];
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
-        return $this->json($response);
+        return $this->redirectToRoute('admin_countries_index');
     }
 
     #[DemoRestricted(redirectRoute: 'admin_countries_index')]


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | On the Countries listing page, when a filter is active (e.g. Enabled = Yes) and the user toggles a row's status via the switch column, the row stays visible instead of disappearing. The root cause: `CountryController::toggleStatusAction` was returning a `JsonResponse` (consumed by `AsyncToggleColumnExtension` via AJAX) while `ZoneController::toggleStatusAction` returns a `RedirectResponse` with a flash message. Fix: align the Country toggle controller with Zone (return `RedirectResponse` + flash, remove unused `JsonResponse` import), and replace `AsyncToggleColumnExtension` with `ColumnTogglingExtension` in `country/index.ts` so the toggle submits a standard form POST, follows the redirect, and the grid reloads with active filters re-applied.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **International > Locations > Tab Countries** in the back office. 2. Filter by **Enabled = Yes** and click Search. 3. Toggle any country's status switch to **No**. 4. The page should reload and the row should disappear from the list. 5. A success flash message should appear at the top of the page. 6. Verify the same behavior on the Zones grid (**International > Locations > Tab Zones**) as a reference.
| UI Tests          | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27011607861 :green_circle: 
| Fixed issue or discussion?     | Fixes #41615
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA

Closes #41615