### PR TITLE
Fix states grid not refreshing after toggle when filters are active

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/state/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/state/index.ts
@@ -16,7 +16,7 @@ class StatePage {
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
-    stateGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.ModalFormSubmitExtension());
   }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/StateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/StateController.php
@@ -270,32 +270,25 @@ class StateController extends PrestaShopAdminController
      *
      * @param int $stateId
      *
-     * @return JsonResponse
+     * @return RedirectResponse
      */
     #[DemoRestricted(redirectRoute: 'admin_states_index')]
     #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_states_index')]
-    public function toggleStatusAction(int $stateId): JsonResponse
+    public function toggleStatusAction(int $stateId): RedirectResponse
     {
         try {
             $this->dispatchCommand(
                 new ToggleStateStatusCommand((int) $stateId)
             );
-            $response = [
-                'status' => true,
-                'message' => $this->trans(
-                    'The status has been successfully updated.',
-                    [],
-                    'Admin.Notifications.Success'
-                ),
-            ];
+            $this->addFlash(
+                'success',
+                $this->trans('The status has been successfully updated.', [], 'Admin.Notifications.Success')
+            );
         } catch (StateException $e) {
-            $response = [
-                'status' => false,
-                'message' => $this->getErrorMessageForException($e, $this->getErrorMessages()),
-            ];
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
-        return $this->json($response);
+        return $this->redirectToRoute('admin_states_index');
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Same bug as #41615 (Countries): the States listing page does not refresh after toggling a row's status when filters are active. `StateController::toggleStatusAction` was returning a `JsonResponse` consumed via AJAX by `AsyncToggleColumnExtension`, without reloading the page. Fix: align with the Zone grid pattern — return a `RedirectResponse` with a flash message from the controller, and replace `AsyncToggleColumnExtension` with `ColumnTogglingExtension` in `state/index.ts` so the toggle submits a POST form, follows the redirect, and the grid reloads with active filters re-applied.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **International > Locations > Tab States**. 2. Filter by **Enabled = Yes** and click Search. 3. Toggle any state's status switch to **No**. 4. The page should reload, the row should disappear from the list, and a success flash message should appear. 5. Verify the same behavior on the Zone grid (`International > Zones`) as a reference.
| UI Tests          | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27403541307 :green_circle:
| Fixed issue or discussion?     | Fixes #41619
| Related PRs       | #41617, PrestaShop/ui-testing-library#1004
| Sponsor company   | PrestaShop SA

---

> [!IMPORTANT]
> This change makes the states toggle reload the page (flash message) instead of showing a growl message, so the `setStateStatus` page object in the UI testing library must be adapted: **PrestaShop/ui-testing-library#1004**.
>
> Since `tests/UI/package.json` points the library to `…/ui-testing-library#main` (not a tagged release — no library release is planned), once #1004 is merged into `main`, **`tests/UI/package-lock.json` must be regenerated** in this PR to pick up the new `main` commit, otherwise the UI tests will keep using the old page object.