### PR TITLE
Fix "Array to string conversion" in RenderedHook::outputContent()

### DIFF
--- a/src/Core/Hook/RenderedHook.php
+++ b/src/Core/Hook/RenderedHook.php
@@ -52,6 +52,27 @@ final class RenderedHook implements RenderedHookInterface
      */
     public function outputContent()
     {
-        return implode('', $this->content);
+        return $this->flattenContent($this->content);
+    }
+
+    /**
+     * Concatenates the rendered content into a single string.
+     *
+     * The content is expected to hold strings (['module_name' => 'rendered_content', ...]),
+     * but a legacy module may return an array from a rendering hook. Such values are
+     * concatenated recursively so they never trigger an "Array to string conversion" warning.
+     *
+     * @param array $content
+     *
+     * @return string
+     */
+    private function flattenContent(array $content)
+    {
+        $output = '';
+        foreach ($content as $partialContent) {
+            $output .= is_array($partialContent) ? $this->flattenContent($partialContent) : (string) $partialContent;
+        }
+
+        return $output;
     }
 }

--- a/tests/Unit/Core/Hook/RenderedHookTest.php
+++ b/tests/Unit/Core/Hook/RenderedHookTest.php
@@ -55,6 +55,29 @@ class RenderedHookTest extends TestCase
     }
 
     /**
+     * A legacy module may return an array instead of a string from a rendering hook.
+     * Such a value reaches RenderedHook as a (possibly nested) array and must be
+     * concatenated to a string without triggering an "Array to string conversion" warning.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/41609
+     */
+    public function testOutputContentFlattensArrayContent()
+    {
+        $renderedHook = new RenderedHook($this->hookStub, [
+            'module_1' => '<h1>Hello World</h1>',
+            'module_2' => ['<p>How are you?</p>'], // single-element array (subscriber wrap)
+            'module_3' => ['<span>a</span>', '<span>b</span>'], // multi-element array
+            'module_4' => [], // empty array
+        ]);
+
+        $this->assertIsString($renderedHook->outputContent());
+        $this->assertSame(
+            '<h1>Hello World</h1><p>How are you?</p><span>a</span><span>b</span>',
+            $renderedHook->outputContent()
+        );
+    }
+
+    /**
      * This will return the expected content for the rendered Hook.
      *
      * @return array


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A legacy module that returns an **array** instead of a string from a rendering hook causes a PHP `E_WARNING: Array to string conversion` in `RenderedHook::outputContent()`. `Hook::exec(..., $array_return=true)` stores the module output as-is (unlike the non-array path, which discards arrays with a dev notice). After `LegacyHookSubscriber` wraps it once more and the dispatcher's one-level `current()` flatten, a nested array survives down to `implode('', $this->content)`. The warning is silent under PHP's default handler (renders `Array` in the HTML), but crashes the whole admin page under a strict error handler (e.g. a Sentry monitoring module). `outputContent()` now concatenates content recursively, honoring its documented string-output contract regardless of nesting.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Have a legacy module hooked on a back-office rendering hook return an array (instead of a string) from its hook method. 2. With the previous code, loading an admin page (e.g. **Modules > Module Manager**) emits `E_WARNING: Array to string conversion` in `src/Core/Hook/RenderedHook.php` (visible via the PHP error log, or as a hard crash if a strict error handler promotes warnings to exceptions). 3. With this fix, the page renders without any warning and the string parts of the content are concatenated correctly. Automated coverage: `php vendor/bin/phpunit tests/Unit/Core/Hook/RenderedHookTest.php`.
| UI Tests          |
| Fixed issue or discussion?     | Fixes #41609
| Related PRs       |