### PR TITLE
Fix multilang fallback for fields using isRequiredWhenActive and defaultLanguageRequiredWhenActive validators

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -355,7 +355,10 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
             if ($type == self::FORMAT_LANG && $id_lang && is_array($value)) {
                 if (!empty($value[$id_lang])) {
                     $value = $value[$id_lang];
-                } elseif (!empty($data['required'])) {
+                } elseif (!empty($data['required']) || in_array(
+                    Tools::strtolower($data['validate'] ?? ''),
+                    ['isrequiredwhenactive', 'defaultlanguagerequiredwhenactive']
+                )) {
                     $value = $value[Configuration::get('PS_LANG_DEFAULT')];
                 } else {
                     $value = '';

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/BO/add_cart_level_discount.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/BO/add_cart_level_discount.feature
@@ -106,3 +106,14 @@ Feature: Add discount
       | reduction_currency     | usd                 |
       | reduction_tax_included | false               |
     Then I should get error that discount field reduction_amount is invalid
+
+  Scenario: Create a discount with name only in default language, non-default languages should fallback to default language name
+    When I create a "cart_level" discount "fallback_name_discount" with following properties:
+      | name[en-US]       | Promotion fallback  |
+      | active            | true                |
+      | valid_from        | 2019-01-01 11:05:00 |
+      | valid_to          | 2019-12-01 00:00:00 |
+      | reduction_percent | 10.0                |
+    And discount "fallback_name_discount" should have the following properties:
+      | name[en-US]       | Promotion fallback  |
+      | name[fr-FR]       | Promotion fallback  |

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/BO/add_discount_with_single_customer_eligibility.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/BO/add_discount_with_single_customer_eligibility.feature
@@ -122,7 +122,7 @@ Feature: Add discount with single customer eligibility
       | minimum_product_quantity | 0                      |
     Then discount "free_shipping_for_jane" should have the following properties:
       | name[en-US] | Free Shipping for Jane |
-      | name[fr-FR] |                        |
+      | name[fr-FR] | Free Shipping for Jane |
       | type        | free_shipping          |
       | customer    | jane_smith             |
 


### PR DESCRIPTION
> Re-based version of #40985, correctly targeting `9.1.x` (the original branch was inadvertently based on `develop`, polluting the diff). This PR supersedes #40985.

| Questions         | Answers
| ----------------- | -------
| Branch?           | 9.1.x
| Description?      | When a multilang field uses the `isRequiredWhenActive` or `defaultLanguageRequiredWhenActive` validator instead of `required => true`, the fallback mechanism in `ObjectModel::formatFields()` was skipped. This caused non-default languages to be saved as empty strings in the database instead of inheriting the default language value. The CartRule `name` field was changed from `required => true` to `required => false` with `validate => defaultLanguageRequiredWhenActive` in a previous commit (8d3da9f5d6). This broke the fallback, causing blank promo names in FO, exceptions at checkout, and missing order statuses when using a non-default language. The fix extends the fallback condition in `ObjectModel::formatFields()` to also trigger for these two validators, which are semantically equivalent to `required` for the default language value. A Behat regression test is also added to cover this scenario.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| UI        | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/27351393710
| Deprecations?     | no
| How to test?      | 1. Install PrestaShop with two languages (e.g. EN as default + FR). 2. Go to BO > Catalog > Discounts > Add new cart rule. 3. Fill the name **only** in the default language (EN), set a code, enable the rule and add a reduction. 4. Save. 5. Check the `ps_cart_rule_lang` table: the `name` column for FR must contain the EN value, not an empty string. 6. In FO, add a product to cart, switch to FR, apply the promo code → the discount name must appear correctly and checkout must complete without exception. Alternatively, run the Behat test: `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s discount --tags add-cart-level-discount`
| Fixed issue or discussion? | Fixes #40101
| Sponsor company   | PrestaShop
