### PR TITLE
Align MySQL session time zone with the shop time zone on each connection

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -878,4 +878,25 @@ abstract class DbCore
     {
         return $this->link;
     }
+
+    /**
+     * Aligns the MySQL session time zone with PHP's current time zone offset.
+     *
+     * Without this, SQL directives such as NOW() or CURRENT_TIMESTAMP evaluate
+     * in the MySQL server time zone (UTC by default) instead of the shop time
+     * zone configured in PHP, producing timestamps that disagree with PHP's
+     * date() (see issue #30828). A numeric offset (e.g. "+02:00") is used on
+     * purpose: it needs no MySQL time zone tables and is recomputed on each
+     * call, so DST is always correct at connection time.
+     */
+    public function setTimeZone(): void
+    {
+        $offset = (new DateTime())->format('P');
+        // Defensive: only ever inject a well-formed offset into the statement.
+        if (!preg_match('/^[+-]\d{2}:\d{2}$/', $offset)) {
+            return;
+        }
+
+        $this->_query("SET SESSION time_zone = '" . $offset . "'");
+    }
 }

--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -69,6 +69,7 @@ class DbMySQLiCore extends Db
         }
 
         $this->link->query('SET SESSION sql_mode = \'\'');
+        $this->setTimeZone();
 
         return $this->link;
     }

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -118,6 +118,7 @@ class DbPDOCore extends Db
         }
 
         $this->link->exec('SET SESSION sql_mode = \'\'');
+        $this->setTimeZone();
 
         return $this->link;
     }

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -138,6 +138,13 @@ $context->country = $default_country;
 /* It is not safe to rely on the system's timezone settings, and this would generate a PHP Strict Standards notice. */
 @date_default_timezone_set(Configuration::get('PS_TIMEZONE'));
 
+/*
+ * The first DB connection was opened (during Shop::initialize() above) before the shop
+ * timezone was known, so its MySQL session is still on the default offset. Re-align it now
+ * that PHP's timezone is set, so NOW()/CURRENT_TIMESTAMP match PHP date() (see issue #30828).
+ */
+Db::getInstance()->setTimeZone();
+
 /* Set locales */
 $locale = strtolower(Configuration::get('PS_LOCALE_LANGUAGE')) . '_' . strtoupper(Configuration::get('PS_LOCALE_COUNTRY'));
 /* Please do not use LC_ALL here http://www.php.net/manual/fr/function.setlocale.php#25041 */

--- a/src/PrestaShopBundle/Doctrine/Middleware/SetSessionTimeZoneMiddleware.php
+++ b/src/PrestaShopBundle/Doctrine/Middleware/SetSessionTimeZoneMiddleware.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Doctrine\Middleware;
+
+use DateTime;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use SensitiveParameter;
+
+/**
+ * Aligns the MySQL session time zone with PHP's current time zone offset on every
+ * Doctrine DBAL connection, so that SQL directives such as NOW() or CURRENT_TIMESTAMP
+ * evaluate in the shop time zone configured in PHP rather than the MySQL server time
+ * zone (UTC by default). See issue #30828.
+ *
+ * A numeric offset (e.g. "+02:00") is used on purpose: it requires no MySQL time zone
+ * tables and is recomputed on each connection, so DST is always correct at connect time.
+ *
+ * This mirrors the legacy Db::setTimeZone() behaviour for the Symfony/CQRS connection.
+ */
+final class SetSessionTimeZoneMiddleware implements Middleware
+{
+    public function wrap(Driver $driver): Driver
+    {
+        return new class($driver) extends AbstractDriverMiddleware {
+            public function connect(
+                #[SensitiveParameter]
+                array $params
+            ): Connection {
+                $connection = parent::connect($params);
+
+                $offset = (new DateTime())->format('P');
+                // Defensive: only ever inject a well-formed offset into the statement.
+                if (preg_match('/^[+-]\d{2}:\d{2}$/', $offset)) {
+                    $connection->exec("SET SESSION time_zone = '" . $offset . "'");
+                }
+
+                return $connection;
+            }
+        };
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -47,6 +47,11 @@ services:
     arguments:
       $prefix: "%database_prefix%"
 
+  # Aligns the MySQL session time zone with PHP's time zone on each DBAL connection (issue #30828)
+  PrestaShopBundle\Doctrine\Middleware\SetSessionTimeZoneMiddleware:
+    tags:
+      - { name: doctrine.middleware }
+
   prestashop.service.translation:
     class: PrestaShopBundle\Service\TranslationService
     properties:

--- a/tests/Integration/Classes/db/DbSetTimeZoneTest.php
+++ b/tests/Integration/Classes/db/DbSetTimeZoneTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\db;
+
+use DateTime;
+use Db;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Ensures both database connection layers (legacy Db and Doctrine DBAL) align the
+ * MySQL session time zone with PHP's current offset, so that NOW() / CURRENT_TIMESTAMP
+ * match PHP date() regardless of the MySQL server time zone (see issue #30828).
+ */
+class DbSetTimeZoneTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+    }
+
+    public function testLegacyConnectionUsesThePhpTimeZoneOffset(): void
+    {
+        $db = Db::getInstance();
+        // Re-apply explicitly so the test does not depend on bootstrap ordering.
+        $db->setTimeZone();
+
+        $this->assertSame(
+            (new DateTime())->format('P'),
+            $db->getValue('SELECT @@session.time_zone')
+        );
+    }
+
+    public function testLegacyNowMatchesPhpDate(): void
+    {
+        $db = Db::getInstance();
+        $db->setTimeZone();
+
+        $this->assertLessThanOrEqual(
+            2,
+            abs(strtotime((string) $db->getValue('SELECT NOW()')) - time()),
+            'MySQL NOW() should match the PHP wall-clock time within 2 seconds'
+        );
+    }
+
+    public function testDoctrineConnectionUsesThePhpTimeZoneOffset(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+
+        $this->assertSame(
+            (new DateTime())->format('P'),
+            $connection->fetchOne('SELECT @@session.time_zone')
+        );
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Doctrine/Middleware/SetSessionTimeZoneMiddlewareTest.php
+++ b/tests/Unit/PrestaShopBundle/Doctrine/Middleware/SetSessionTimeZoneMiddlewareTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Doctrine\Middleware;
+
+use DateTime;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Doctrine\Middleware\SetSessionTimeZoneMiddleware;
+
+class SetSessionTimeZoneMiddlewareTest extends TestCase
+{
+    public function testItSetsTheSessionTimeZoneToTheCurrentPhpOffsetOnConnect(): void
+    {
+        $expectedStatement = "SET SESSION time_zone = '" . (new DateTime())->format('P') . "'";
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('exec')
+            ->with($expectedStatement);
+
+        $wrappedDriver = $this->createMock(Driver::class);
+        $wrappedDriver
+            ->expects($this->once())
+            ->method('connect')
+            ->willReturn($connection);
+
+        $driver = (new SetSessionTimeZoneMiddleware())->wrap($wrappedDriver);
+        $result = $driver->connect([]);
+
+        // The middleware must return the very connection produced by the wrapped driver.
+        $this->assertSame($connection, $result);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | SQL directives such as `NOW()`, `CURRENT_TIMESTAMP` or `CURDATE()` evaluate in the **MySQL server time zone** (UTC by default), not the shop time zone configured in PHP. When the two differ, timestamps written/compared via SQL disagree with PHP `date()` — e.g. a cart rule valid "from now" only becomes visible to customers 1–2h later depending on the offset/DST.<br><br>Rather than replacing `NOW()` call by call (incomplete by nature — it can never cover third-party modules or future code), this PR sets the MySQL **SESSION** `time_zone` to PHP's current offset on **every connection**, covering core, native modules and third-party code at once.<br><br>Changes:<br>• `Db::setTimeZone()` (legacy) runs `SET SESSION time_zone = '<offset>'`, called from `DbPDO::connect()` and `DbMySQLi::connect()` next to the existing `sql_mode` statement.<br>• Re-applied in `config/config.inc.php` right after `date_default_timezone_set()`: the first/master legacy connection opens during `Shop::initialize()` **before** the shop time zone is known, and is reused for the whole request.<br>• New Doctrine DBAL middleware `SetSessionTimeZoneMiddleware` does the same for the Symfony/CQRS connection (connects lazily, after the time zone is set, so no re-apply needed there).<br><br>A **numeric offset** (e.g. `+02:00`) is used on purpose: it needs no MySQL time zone tables (`mysql.time_zone_*`, often empty on shared hosting) and is recomputed per connection, so DST is correct at connect time.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | **Reproduce the bug** (without this PR): set the MySQL server to UTC (`SELECT @@global.time_zone`) and the shop `PS_TIMEZONE` to a different zone (e.g. `Europe/Paris`). Run `SELECT NOW();` in **Advanced Parameters > Database > SQL Manager** → it returns UTC time, ~1–2h behind the shop clock.<br><br>**With this PR:**<br>1. Same setup (server UTC, shop `Europe/Paris`).<br>2. `SELECT NOW(), @@session.time_zone;` → `@@session.time_zone` is `+02:00` (or `+01:00` in winter) and `NOW()` matches the shop wall-clock time / PHP `date('Y-m-d H:i:s')`.<br>3. Functional check: create a cart rule for a specific customer with *Valid from = now*; log in on the FO as that customer → **My account > My vouchers** → the voucher appears **immediately** (before the fix it appeared 1–2h later).<br>4. Both connection layers verified: legacy (`Db::getInstance()`) and Doctrine (`php bin/console doctrine:query:sql \"SELECT @@session.time_zone\"`) both return the shop offset.
| UI Tests          | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27225889770 :green_circle:
| Fixed issue or discussion?     | Fixes #30828
| Related PRs       | This is the **single, definitive fix** for #30828, based on the connection-level approach suggested in the issue ([comment](https://github.com/PrestaShop/PrestaShop/issues/30828#issuecomment-2296880150)). It **supersedes** the earlier proposals, now closed: the file-by-file `NOW()` → PHP `date()` PR (#41596) and the per-module `NOW()` → `date()` PRs (PrestaShop/ps_googleanalytics#177, PrestaShop/blockwishlist#451, PrestaShop/ps_emailsubscription#127, PrestaShop/ps_facetedsearch#1234, PrestaShop/pagesnotfound#42, PrestaShop/statssearch#30, PrestaShop/statsbestproducts#28). Those only patched specific occurrences; the connection-level fix here corrects **every** `NOW()` / `CURRENT_TIMESTAMP` / `CURDATE()` at once (core, native modules, third-party, future code, and comparisons such as `WHERE date_end > NOW()`).
| Sponsor company   | PrestaShop SA

## Behaviour across deployment topologies

The offset is always derived from `(new \DateTime())->format('P')` **after** `date_default_timezone_set(Configuration::get('PS_TIMEZONE'))` has run, and applied per connection. Analysis of every topology:

| Topology | Result |
|----------|--------|
| Single server / single shop | ✅ `NOW()`, `CURRENT_TIMESTAMP`, `UNIX_TIMESTAMP()` and PHP `date()` all agree. |
| Single DB, multistore (many shops) | ✅ `PS_TIMEZONE` is a **global** configuration (single `ps_configuration` row, no per-shop `ShopConstraint` override) → all shops share one offset. |
| Separate installs (separate DBs) | ✅ Each PHP process derives its own offset from its own `PS_TIMEZONE` and applies it to its own connection — fully isolated. |
| Multiple PHP/web servers, shared MySQL (load-balanced) | ✅ `SET SESSION time_zone` is **per physical connection**, so servers never interfere. The offset comes from `date_default_timezone_set(PS_TIMEZONE)`, identical across servers regardless of each server's `php.ini` default. |
| Read replicas / slave servers | ✅ `Db::getInstance(false)` goes through the same patched `connect()`. Slave connections open after the time zone is set, so they get the correct offset directly. |
| CLI (`bin/console`) | ✅ `config.inc.php` runs in CLI; both the legacy re-apply and the Doctrine middleware fire. |

## Known limitations / caveats

**No topology that was correct before this PR becomes incorrect after it.** Each caveat below is tagged as either a **pre-existing** condition (this PR rides the same mechanism PrestaShop already uses) or a **new behaviour** (introduced by this PR), with the before/after comparison made explicit.

- **Connection poolers in *transaction* mode** (ProxySQL `transaction_mode`, AWS RDS Proxy with pinning off) — **PRE-EXISTING, not a regression.** PrestaShop already issues `SET NAMES utf8mb4` and `SET SESSION sql_mode = ''` on every connect (legacy drivers + `doctrine.yml`). Those session variables suffer the *exact* same per-transaction routing problem; if it broke them, charset corruption and altered query semantics would already make this topology unusable — far worse than a timestamp. This PR adds `time_zone` to that same connect-time sequence: **no new failure mechanism**, only a new *symptom* on a topology already unsupported for charset/sql_mode. *Recommendation:* use **session-mode** (connection) pooling, or have the pooler track the `time_zone` variable.
- **Persistent connections** (`PDO::ATTR_PERSISTENT` / `mysql.allow_persistent`) — **PRE-EXISTING, not a regression (slightly more robust).** Not used by core. The `Db` singleton is rebuilt every request (PHP statics reset per request), so `connect()` — and its `SET SESSION sql_mode` — already re-runs each request even on a reused physical connection. `setTimeZone()` follows the identical path **plus** the `config.inc.php` re-apply, so `time_zone` is re-asserted exactly like `sql_mode`. No cross-request staleness in practice.
- **Long-lived CLI/daemons across a DST boundary** — **NEW behaviour, but a net improvement.** This is the only genuinely new behaviour. *Before:* `NOW()` used the server time zone (UTC) → **always** off by 1–2h, but stable (UTC has no DST). *After:* the numeric offset is fixed at connect time, so a connection held for hours across the spring/autumn switch keeps the pre-transition offset until it reconnects → correct ~99.99% of the time, off by 1h only inside the brief transition window. So it replaces an *always-wrong* value with an *almost-always-correct* one; the degraded case (single-connection daemon spanning a DST change, twice a year) is still better than the prior state. Negligible for web requests (sub-second). *Mitigation:* cycle the DB connection periodically (most queue frameworks already do). A named zone (`Europe/Paris`) would be DST-aware but requires the MySQL time zone tables to be populated — deliberately avoided.
- **Runtime change of `PS_TIMEZONE`** — **PRE-EXISTING, not a regression.** Connections already open keep the old offset; the next request recomputes correctly. With per-request connections this affects at most one in-flight request — the same window that already applied to PHP's own `date_default_timezone_set()`.
- **Mid-request shop-context switch** (a multishop CLI/webservice loop calling `Shop::setContext()` across shops) — **not a regression; moot today.** `PS_TIMEZONE` is **global** today (single `ps_configuration` row, no per-shop `ShopConstraint` override), so every shop resolves to the same offset and no divergence is possible. The caveat is purely hypothetical (would require a per-shop `PS_TIMEZONE` **and** code relying on `NOW()` rather than PHP `date()`). Even then it is **never worse** than before, where `NOW()` was UTC — wrong for every shop. Such flows can call `Db::getInstance()->setTimeZone()` after switching context.

## Verification performed

Verified end-to-end on a Docker stack reproducing the bug (MySQL server in UTC, shop `Europe/Paris`):

- **Legacy** (`Db::getInstance()`): `@@session.time_zone = +02:00`, `NOW()` == PHP `date()` (e.g. `11:19:12` instead of UTC `09:19:12`).
- **Doctrine** (`doctrine:query:sql`, via the middleware): `@@session.time_zone = +02:00`, `NOW()` in shop time.
- `php -l`, PHPStan and php-cs-fixer pass on all touched files.
