### PR TITLE
Harden module configuration route against malformed module_name (BO tokens disabled)

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -103,20 +103,32 @@ class ModuleController extends ModuleAbstractController
         string $module_name,
         LegacyContext $legacyContext,
     ): Response {
+        // When the back office security tokens are disabled, generated admin links no longer
+        // contain a query string. Modules that build their configuration form action by
+        // concatenating extra query parameters (e.g. the official GDPR module appends
+        // "&page=...") then glue those parameters onto the {module_name} route placeholder
+        // instead of the query string, leading to a "module not found" 500 error.
+        // We extract the real module name so the configuration page keeps working. See #41314.
+        $module_name = preg_replace('/[^a-zA-Z0-9_-].*$/s', '', $module_name);
+
         // Get accessed module object
         /** @var ModuleAdapter $module */
         $module = $this->getModuleRepository()->getModule($module_name);
         if (!$module->getInstance()) {
+            // The configure page relies on the module instance (getContent, translation links,
+            // toolbar buttons, ...) so it cannot be rendered for a missing module. We redirect
+            // back to the module manager with an explicit error instead of failing with a 500.
             $this->addFlash('error', $this->trans(
                 'The module "%modulename%" cannot be found',
                 ['%modulename%' => $module_name],
                 'Admin.Modules.Notification'
             ));
-            $layoutSubTitle = null;
-        } else {
-            $this->saveModuleHistory($module);
-            $layoutSubTitle = $module->getInstance()->displayName;
+
+            return $this->redirectToRoute('admin_module_manage');
         }
+
+        $this->saveModuleHistory($module);
+        $layoutSubTitle = $module->getInstance()->displayName;
 
         // This controller is not purely migrated, in the sense that it still relies on the legacy layout because module implementing
         // getContent need the default theme to be working as expected

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -102,14 +102,25 @@ class ModuleController extends ModuleAbstractController
     public function configureModuleAction(
         string $module_name,
         LegacyContext $legacyContext,
+        Request $request,
     ): Response {
         // When the back office security tokens are disabled, generated admin links no longer
         // contain a query string. Modules that build their configuration form action by
         // concatenating extra query parameters (e.g. the official GDPR module appends
         // "&page=...") then glue those parameters onto the {module_name} route placeholder
         // instead of the query string, leading to a "module not found" 500 error.
-        // We extract the real module name so the configuration page keeps working. See #41314.
-        $module_name = preg_replace('/[^a-zA-Z0-9_-].*$/s', '', $module_name);
+        // We extract the real module name so the configuration page keeps working, and re-inject
+        // the glued parameters into the request query so the module's own getContent() sees them
+        // via Tools::getValue(). See #41314.
+        if (preg_match('/^(?P<name>[a-zA-Z0-9_-]+)(?P<tail>.*)$/s', $module_name, $matches)) {
+            $module_name = $matches['name'];
+            parse_str(ltrim($matches['tail'], '&?'), $gluedParameters);
+            if (!empty($gluedParameters)) {
+                $request->query->add($gluedParameters);
+            }
+        } else {
+            $module_name = '';
+        }
 
         // Get accessed module object
         /** @var ModuleAdapter $module */

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/ModuleControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/ModuleControllerTest.php
@@ -168,6 +168,11 @@ class ModuleControllerTest extends WebTestCase
             // The glued suffix must be stripped before the repository is queried.
             $this->assertSame('ps_emailalerts', $this->capturedConfiguredModuleName);
 
+            // The glued parameters must be re-injected into the request query so the module's own
+            // getContent() sees them via Tools::getValue(), otherwise the link points at the
+            // module's default configuration page rather than the sub-page it was meant to reach.
+            $this->assertSame('dataConsent', $this->client->getRequest()->query->get('page'));
+
             // A missing module must redirect to the module manager instead of triggering a 500.
             $response = $this->client->getResponse();
             $this->assertTrue(

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/ModuleControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/ModuleControllerTest.php
@@ -12,18 +12,18 @@ use Context;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
+use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Translation\Translator;
 use Tests\Integration\Utility\LoginTrait;
-use Tests\Unit\Core\Configuration\MockConfigurationTrait;
 
 class ModuleControllerTest extends WebTestCase
 {
-    use MockConfigurationTrait;
     use LoginTrait;
 
     /**
@@ -43,6 +43,13 @@ class ModuleControllerTest extends WebTestCase
      */
     protected $context;
 
+    /**
+     * Records the module name received by ModuleRepository::getModule() during a request.
+     *
+     * @var string|null
+     */
+    protected $capturedConfiguredModuleName;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -54,8 +61,10 @@ class ModuleControllerTest extends WebTestCase
 
         Context::setInstanceForTesting($this->context->getContext());
 
-        // Enable debug mode
-        $configurationMock = $this->mockConfiguration([
+        // Mock the configuration so that unknown keys fall back to the provided default instead of
+        // throwing, allowing the full admin request lifecycle - which reads many configuration
+        // entries - to run without having to list every single one here.
+        $configurationValues = [
             '_PS_MODE_DEMO_' => true,
             '_PS_ROOT_DIR_' => _PS_ROOT_DIR_,
             '_PS_MODULE_DIR_' => _PS_ROOT_DIR_ . '/tests/Resources/modules/',
@@ -66,14 +75,30 @@ class ModuleControllerTest extends WebTestCase
             'PS_SSL_ENABLED' => '0',
             'PS_CURRENCY_DEFAULT' => '1',
             'PS_COUNTRY_DEFAULT' => '1',
-        ], null, Configuration::class);
+        ];
+        $configurationMock = $this->createMock(Configuration::class);
+        $configurationMock
+            ->method('get')
+            ->willReturnCallback(static function ($name, $default = null) use ($configurationValues) {
+                return $configurationValues[$name] ?? $default;
+            });
 
         self::$kernel->getContainer()->set('prestashop.adapter.legacy.configuration', $configurationMock);
         self::$kernel->getContainer()->set(ConfigurationInterface::class, $configurationMock);
         self::$kernel->getContainer()->set(Configuration::class, $configurationMock);
 
+        $instancelessModule = $this->createMock(ModuleInterface::class);
+        $instancelessModule->method('getInstance')->willReturn(null);
+
         $moduleRepository = $this->createMock(ModuleRepository::class);
         $moduleRepository->method('getList')->willReturn(new ModuleCollection());
+        $moduleRepository->method('getModule')->willReturnCallback(
+            function (string $moduleName) use ($instancelessModule): ModuleInterface {
+                $this->capturedConfiguredModuleName = $moduleName;
+
+                return $instancelessModule;
+            }
+        );
         self::$kernel->getContainer()->set(ModuleRepository::class, $moduleRepository);
     }
 
@@ -114,5 +139,44 @@ class ModuleControllerTest extends WebTestCase
 
         $this->assertArrayHasKey('msg', $decodedContent);
         $this->assertEquals('This functionality has been disabled.', $decodedContent['msg']);
+    }
+
+    /**
+     * When the back office security tokens are disabled, admin links are generated without any
+     * query string. Modules building their configuration form action by concatenating extra query
+     * parameters (e.g. the official GDPR module appends "&page=...") then glue those parameters
+     * onto the {module_name} route placeholder instead of the query string. The controller must
+     * recover the real module name and must not fail with a 500 error.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/41314
+     */
+    public function testConfigureModuleActionRecoversModuleNameWithGluedQueryParameters(): void
+    {
+        // Disable the back office security tokens so that generated admin links no longer carry a
+        // "?_token=..." query string, which is the condition that triggers the bug.
+        $previousTokenEnv = getenv(TokenInUrls::ENV_VAR);
+        putenv(TokenInUrls::ENV_VAR . '=' . TokenInUrls::DISABLED);
+
+        try {
+            // Without a query string on the admin link, a module appending "&page=..." to its form
+            // action glues the parameter onto the module_name path segment (no "?" separator).
+            $configureUrl = strtok($this->router->generate('admin_module_configure_action', [
+                'module_name' => 'ps_emailalerts',
+            ]), '?');
+            $this->client->request('POST', $configureUrl . '&page=dataConsent');
+
+            // The glued suffix must be stripped before the repository is queried.
+            $this->assertSame('ps_emailalerts', $this->capturedConfiguredModuleName);
+
+            // A missing module must redirect to the module manager instead of triggering a 500.
+            $response = $this->client->getResponse();
+            $this->assertTrue(
+                $response->isRedirect(),
+                'Expected a redirect response, got HTTP ' . $response->getStatusCode()
+            );
+            $this->assertStringContainsString('manage', (string) $response->headers->get('Location'));
+        } finally {
+            putenv(TokenInUrls::ENV_VAR . ($previousTokenEnv === false ? '' : '=' . $previousTokenEnv));
+        }
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | **Core hardening, complementary to the module-side fix [psgdpr#242](https://github.com/PrestaShop/psgdpr/pull/242).**<br><br>When the back office security tokens are disabled, generated admin links no longer contain a query string (no `_token` to introduce the `?`). Modules that build their configuration link by concatenating extra parameters onto `getAdminLink('AdminModules', …)` — e.g. `… . '&configure=' . $name . '&page=…'` — then glue those parameters onto the `{module_name}` route placeholder instead of the query string. The `admin_module_configure_action` route placeholder (`[^/]+`) swallows the whole tail, so `module_name` becomes e.g. `psgdpr&page=dataConsent`; the module cannot be resolved and the page crashes with a **fatal 500** (null instance dereference).<br><br>This is not psgdpr-specific: ~14 bundled native modules use the same `getAdminLink('AdminModules', …) . '&configure=…'` concatenation (ps_imageslider, ps_banner, contactform, blockreassurance, ps_emailalerts, ps_bestsellers…). Regardless of module-side fixes, core should not fatally error on a malformed `module_name`.<br><br>This PR makes `ModuleController::configureModuleAction()`:<br>1. recover the real module name (keep only valid module-name characters, matching `Validate::isModuleName`);<br>2. redirect to the module manager with an explicit error when a module cannot be found, instead of crashing while building the page.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With BO tokens disabled (Advanced Parameters > Security), POST to `…/improve/modules/manage/action/configure/<module>&page=foo` (a `module_name` polluted by a glued query parameter). Before: a fatal 500. After: the glued suffix is stripped, the real module is resolved, and an unknown module redirects to the module manager. A regression test is added in `ModuleControllerTest::testConfigureModuleActionRecoversModuleNameWithGluedQueryParameters`. The full end-user GDPR scenario from #41314 is fixed module-side by psgdpr#242.
| Fixed issue or discussion?     | Related to #41314 (module-side fix: psgdpr#242)
| Related PRs       | https://github.com/PrestaShop/psgdpr/pull/242
| Sponsor company   | PrestaEdit
