### PR TITLE
Reject form fields filled only with whitespace

### DIFF
--- a/classes/form/AbstractForm.php
+++ b/classes/form/AbstractForm.php
@@ -132,7 +132,8 @@ abstract class AbstractFormCore implements FormInterface
     {
         foreach ($this->formFields as $field) {
             if ($field->isRequired()) {
-                if (!$field->getValue()) {
+                // A required field filled only with whitespace must be considered empty (see issue #9871)
+                if (!$field->getValue() || (is_string($field->getValue()) && empty(trim($field->getValue())))) {
                     $field->addError(
                         $this->constraintTranslator->translate('required')
                     );

--- a/tests/Unit/Classes/form/AbstractFormTest.php
+++ b/tests/Unit/Classes/form/AbstractFormTest.php
@@ -47,6 +47,16 @@ class AbstractFormTest extends TestCase
                     'field' => ['Required field'],
                 ],
             ],
+            // Required field but whitespace-only (issue #9871)
+            [
+                ['field' => (new FormField())->setName('field')->setRequired(true)],
+                ['field' => '   '],
+                false,
+                [
+                    '' => [],
+                    'field' => ['Required field'],
+                ],
+            ],
             // Required field (min length)
             [
                 ['field' => (new FormField())->setName('field')->setRequired(true)->setMinLength(5)],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When a field is set as **required** (for instance the address phone number, via BO > Customers > Addresses > *Set required fields*), the Front Office form still accepted a value made only of whitespace (e.g. a single space). `AbstractForm::validate()` relied on `if (!$field->getValue())`, and a `" "` string is truthy, so the *required* constraint was never triggered. The value also passes `Validate::isPhoneNumber()` (the regex allows spaces) and `Tools::isEmpty()` (which only treats `''`/`null` as empty), so the address was saved with a blank phone. This PR normalizes whitespace-only string values to an empty string before validation, so the *required* constraint is correctly enforced.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. BO > **Customers** > **Addresses** > **Set required fields**, check **Phone**, save.<br>2. FO > customer account > **Addresses** > **Add new address**.<br>3. Enter only a space (or several spaces) in the **phone** field and save.<br>**Expected:** the form is rejected with a *required field* error instead of saving the address. A valid phone number (with or without spaces between digits) is still accepted. The change is covered by a unit test in `tests/Unit/Classes/form/AbstractFormTest.php`.
| Fixed issue or discussion?     | Fixes #9871