### PR TITLE
Fix size filter on the Files (attachments) BO grid

### DIFF
--- a/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
@@ -171,6 +171,16 @@ final class AttachmentGridDefinitionFactory extends AbstractFilterableGridDefini
                 (new Filter('file_size', IntegerMinMaxFilterType::class))
                     ->setTypeOptions([
                         'required' => false,
+                        'min_field_options' => [
+                            'attr' => [
+                                'placeholder' => $this->trans('Min (bytes)', [], 'Admin.Actions'),
+                            ],
+                        ],
+                        'max_field_options' => [
+                            'attr' => [
+                                'placeholder' => $this->trans('Max (bytes)', [], 'Admin.Actions'),
+                            ],
+                        ],
                     ])
                     ->setAssociatedColumn('file_size')
             )

--- a/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
@@ -18,6 +18,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShopBundle\Form\Admin\Type\IntegerMinMaxFilterType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -167,11 +168,8 @@ final class AttachmentGridDefinitionFactory extends AbstractFilterableGridDefini
                     ->setAssociatedColumn('name')
             )
             ->add(
-                (new Filter('file_size', NumberType::class))
+                (new Filter('file_size', IntegerMinMaxFilterType::class))
                     ->setTypeOptions([
-                        'attr' => [
-                            'placeholder' => $this->trans('Search file size', [], 'Admin.Actions'),
-                        ],
                         'required' => false,
                     ])
                     ->setAssociatedColumn('file_size')

--- a/src/Core/Grid/Query/AttachmentQueryBuilder.php
+++ b/src/Core/Grid/Query/AttachmentQueryBuilder.php
@@ -143,6 +143,26 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
                 continue;
             }
 
+            // File size is stored in bytes but displayed in a human-readable unit (kB, MB...),
+            // so it is filtered through a min/max range (expressed in bytes) instead of a LIKE.
+            if ('file_size' === $filterName) {
+                if (!is_array($value)) {
+                    continue;
+                }
+
+                if (isset($value['min_field']) && '' !== $value['min_field']) {
+                    $qb->andWhere($allowedFiltersMap[$filterName] . ' >= :file_size_min')
+                        ->setParameter('file_size_min', $value['min_field']);
+                }
+
+                if (isset($value['max_field']) && '' !== $value['max_field']) {
+                    $qb->andWhere($allowedFiltersMap[$filterName] . ' <= :file_size_max')
+                        ->setParameter('file_size_max', $value['max_field']);
+                }
+
+                continue;
+            }
+
             $qb->andWhere($allowedFiltersMap[$filterName] . ' LIKE :' . $filterName)
                 ->setParameter($filterName, '%' . $value . '%');
         }

--- a/tests/UI/campaigns/functional/BO/03_catalog/06_files/03_filterSortPaginationAndBulkActions.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/06_files/03_filterSortPaginationAndBulkActions.ts
@@ -108,11 +108,6 @@ describe('BO - Catalog - Files : Filter, sort, pagination and bulk actions files
       },
       {
         args: {
-          testIdentifier: 'filterSize', filterType: 'input', filterBy: 'file_size', filterValue: '64',
-        },
-      },
-      {
-        args: {
           testIdentifier: 'filterProducts', filterType: 'input', filterBy: 'products', filterValue: '1',
         },
       },
@@ -136,6 +131,39 @@ describe('BO - Catalog - Files : Filter, sort, pagination and bulk actions files
         const numberOfFilesAfterReset = await boFilesPage.resetAndGetNumberOfLines(page);
         expect(numberOfFilesAfterReset).to.be.equal(numberOfFiles + 11);
       });
+    });
+
+    // File size is filtered through a min/max range (in bytes), not a single text input
+    it('should filter list by file size range matching all files', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterSizeRange', baseContext);
+
+      await boFilesPage.filterByFileSize(page, 0, 1000000);
+
+      const numberOfFilesAfterFilter = await boFilesPage.getNumberOfElementInGrid(page);
+      expect(numberOfFilesAfterFilter).to.be.equal(numberOfFiles + 11);
+    });
+
+    it('should reset all filters', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterSizeRangeReset', baseContext);
+
+      const numberOfFilesAfterReset = await boFilesPage.resetAndGetNumberOfLines(page);
+      expect(numberOfFilesAfterReset).to.be.equal(numberOfFiles + 11);
+    });
+
+    it('should filter list by file size range matching no file', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterSizeRangeEmpty', baseContext);
+
+      await boFilesPage.filterByFileSize(page, 1000000, '');
+
+      const numberOfFilesAfterFilter = await boFilesPage.getNumberOfElementInGrid(page);
+      expect(numberOfFilesAfterFilter).to.be.equal(0);
+    });
+
+    it('should reset all filters', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterSizeRangeEmptyReset', baseContext);
+
+      const numberOfFilesAfterReset = await boFilesPage.resetAndGetNumberOfLines(page);
+      expect(numberOfFilesAfterReset).to.be.equal(numberOfFiles + 11);
     });
   });
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | In **Catalog > Files**, filtering by **Size** always returned *No records found*. The `file_size` column is stored in raw bytes but displayed in human-readable units (kB, MB…), while the filter ran a `LIKE '%value%'` on the byte value. Typing the value shown in the column (e.g. `12.5`) could never match the stored byte count (e.g. `12800`). This PR replaces the single-value `LIKE` filter with a min/max byte **range** (`IntegerMinMaxFilterType` + `>=`/`<=`), the same pattern the Product grid already uses for quantity and price.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **BO > Catalog > Files** and add at least two attachments of clearly different sizes (e.g. a few bytes vs a few kB).<br>2. In the **Size** filter, enter a **min**/**max** range (in **bytes**) that brackets one of the files and search → only the matching file(s) are listed.<br>3. Leave both fields empty (or use a wide range like 0–1000000) → all files are listed.<br>4. Enter a min larger than every file (e.g. 1000000) → no records, as expected.<br>5. Before this fix, typing the displayed size in the old single field returned *No records found*.
| UI Tests          | The `03_catalog/06_files/03_filterSortPaginationAndBulkActions` campaign is updated to drive the new min/max range filter. It depends on a new `boFilesPage.filterByFileSize(min, max)` helper — see **Related PRs**.
| Fixed issue or discussion?     | Fixes #11054
| Related PRs       | Requires a companion PR on [PrestaShop/ui-testing-library](https://github.com/PrestaShop/ui-testing-library) adding `filterByFileSize()` (min/max inputs `#attachment_file_size_min_field` / `#attachment_file_size_max_field`) to the Files page object. UI tests will stay red until that helper is released and bumped here.
| Sponsor company   |

### Notes

The `file_size` value is filtered in **bytes** (matching how the Product grid filters `quantity`), since the column is stored in bytes while displayed in a variable human-readable unit. An empty range returns all records.