### PR TITLE
TEST – [DO NOT MERGE] Validate ui-testing-library PR #992 (quick access modal) on 9.1.x

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OSL-3.0",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
-        "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+        "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#a5e228ef6414b150c49b4cbae65e1fa8fcf4a6d0",
         "chai": "^4.5.0",
         "chai-string": "^1.6.0",
         "dotenv": "^17.2.3",
@@ -547,7 +547,8 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#36caa6561fecd84c412c8bcaab00b7196de74a56",
+      "resolved": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#a5e228ef6414b150c49b4cbae65e1fa8fcf4a6d0",
+      "integrity": "sha512-mH/E3TsoFrouXDXPNEQDYP12njoRwzb+bi4C87uMR5kryPcumDtg44vE6at+dBVZdML/jrv6e56W4bo/wpoD/g==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8975,8 +8976,9 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#36caa6561fecd84c412c8bcaab00b7196de74a56",
-      "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
+      "version": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#a5e228ef6414b150c49b4cbae65e1fa8fcf4a6d0",
+      "integrity": "sha512-mH/E3TsoFrouXDXPNEQDYP12njoRwzb+bi4C87uMR5kryPcumDtg44vE6at+dBVZdML/jrv6e56W4bo/wpoD/g==",
+      "from": "@prestashop-core/ui-testing@https://github.com/mattgoud/ui-testing-library#a5e228ef6414b150c49b4cbae65e1fa8fcf4a6d0",
       "requires": {
         "@faker-js/faker": "^10.1.0",
         "@playwright/test": "^1.48.1",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -111,7 +111,7 @@
   "homepage": "https://github.com/PrestaShop/PrestaShop/tree/develop/tests/UI#readme",
   "dependencies": {
     "@faker-js/faker": "^10.1.0",
-    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+    "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#a5e228ef6414b150c49b4cbae65e1fa8fcf4a6d0",
     "chai": "^4.5.0",
     "chai-string": "^1.6.0",
     "dotenv": "^17.2.3",


### PR DESCRIPTION
> ⚠️ **Test PR — DO NOT MERGE.** Created only to run UI tests against ui-testing-library PR [PrestaShop/ui-testing-library#992](https://github.com/PrestaShop/ui-testing-library/pull/992) on the 9.1.x branch. Will be closed and its branch deleted once the run is validated.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Temporarily pins `tests/UI/package.json` (and `package-lock.json`) to the ui-testing-library PR PrestaShop/ui-testing-library#992 fork commit `a5e228e` (branch `fix/quick-access-add-modal-interaction`). That PR makes `addCurrentPageToQuickAccess` backward-compatible: it interacts with the new quick-access modal on `develop`+, and falls back to the legacy `window.prompt()` dialog listener on ≤ 9.1.x. This PR validates the ≤ 9.1.x (no-modal) code path on the 9.1.x branch, as requested by @Progi1984 before merging the library PR.
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the `functional:BO:header` campaign via [ga.tests.ui.pr](https://github.com/PrestaShop/ga.tests.ui.pr/) against this PR with `base_branch: 9.1.x`. The relevant test is `campaigns/functional/BO/15_header/02_quickAccess.ts`, step `addCurrentPageToQuickAccess`: on 9.1.x no modal appears, so the method must fall back to the `dialogListener` (`window.prompt()`) and the success growl message must be returned.
| UI Tests          | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/26981329734 :hourglass: 
| Fixed issue or discussion?     | Validates PrestaShop/ui-testing-library#992
| Related PRs       | PrestaShop/ui-testing-library#992
| Sponsor company   | PrestaShop SA
