### PR TITLE
Fix get-file friendly URL for virtual product downloads

### DIFF
--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -5,6 +5,8 @@
  */
 class GetFileControllerCore extends FrontController
 {
+    public $php_self = 'get-file';
+
     protected const MIME_TYPES = [
         'ez' => 'application/andrew-inset',
         'hqx' => 'application/mac-binhex40',

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -7,6 +7,18 @@ class GetFileControllerCore extends FrontController
 {
     public $php_self = 'get-file';
 
+    /**
+     * A download is identified by its `key` query parameter, not by a canonical page URL.
+     * The canonical built from $php_self in FrontController::init() carries no key, so
+     * redirecting to it would turn an existing download link (e.g. from an order email)
+     * into a keyless request once a friendly URL is configured for the get-file page.
+     * $php_self must stay set for Meta::getPages() to register the friendly URL under
+     * the same name used by ProductDownload::getTextLink(), hence the no-op override here.
+     */
+    protected function canonicalRedirection(string $canonical_url = '')
+    {
+    }
+
     protected const MIME_TYPES = [
         'ez' => 'application/andrew-inset',
         'hqx' => 'application/mac-binhex40',

--- a/controllers/front/UploadController.php
+++ b/controllers/front/UploadController.php
@@ -8,6 +8,10 @@ declare(strict_types=1);
 
 class UploadControllerCore extends GetFileController
 {
+    // Reset the "get-file" value inherited from GetFileController. This controller has its own "upload" route and
+    // must keep an empty php_self so FrontController::init() does not attempt a canonical redirection on download.
+    public $php_self = null;
+
     private $filename;
 
     /**

--- a/tests/Unit/Classes/controller/GetFileControllerTest.php
+++ b/tests/Unit/Classes/controller/GetFileControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Controller;
+
+use GetFileControllerCore;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use UploadControllerCore;
+
+class GetFileControllerTest extends TestCase
+{
+    /**
+     * The download links are generated with the "get-file" controller name
+     * (see ProductDownload::getTextLink()). Meta::getPages() builds the list of
+     * pages available in BO > SEO & URLs from the php_self property, so php_self
+     * must match "get-file" for the friendly URL to be applied to download links.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/34339
+     */
+    public function testGetFileControllerExposesHyphenatedPhpSelf(): void
+    {
+        $properties = (new ReflectionClass(GetFileControllerCore::class))->getDefaultProperties();
+
+        $this->assertSame('get-file', $properties['php_self']);
+    }
+
+    /**
+     * UploadController extends GetFileController but is reached through its own
+     * "upload" route. It must not inherit the "get-file" php_self, otherwise it
+     * would collide with get-file in the SEO list and trigger a canonical
+     * redirection in FrontController::init().
+     */
+    public function testUploadControllerDoesNotInheritGetFilePhpSelf(): void
+    {
+        $properties = (new ReflectionClass(UploadControllerCore::class))->getDefaultProperties();
+
+        $this->assertEmpty($properties['php_self']);
+    }
+}

--- a/tests/Unit/Classes/controller/GetFileControllerTest.php
+++ b/tests/Unit/Classes/controller/GetFileControllerTest.php
@@ -8,26 +8,60 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Classes\Controller;
 
+use Context;
 use GetFileControllerCore;
+use Link;
 use PHPUnit\Framework\TestCase;
+use ProductDownload;
 use ReflectionClass;
 use UploadControllerCore;
 
 class GetFileControllerTest extends TestCase
 {
     /**
-     * The download links are generated with the "get-file" controller name
-     * (see ProductDownload::getTextLink()). Meta::getPages() builds the list of
-     * pages available in BO > SEO & URLs from the php_self property, so php_self
-     * must match "get-file" for the friendly URL to be applied to download links.
+     * Virtual product download links are generated for the "get-file" controller
+     * (ProductDownload::getTextLink), while the friendly URL configured in
+     * BO > SEO & URLs is registered under the controller php_self (Meta::getPages).
+     * If those two names drift apart, the friendly URL stops being applied and the
+     * link falls back to index.php?controller=get-file.
+     *
+     * This test pins the download link to GetFileController::$php_self so both sides
+     * cannot diverge again.
      *
      * @see https://github.com/PrestaShop/PrestaShop/issues/34339
      */
-    public function testGetFileControllerExposesHyphenatedPhpSelf(): void
+    public function testDownloadLinkTargetsGetFileControllerPhpSelf(): void
     {
-        $properties = (new ReflectionClass(GetFileControllerCore::class))->getDefaultProperties();
+        $capturedController = null;
+        $link = $this->getMockBuilder(Link::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getPageLink'])
+            ->getMock();
+        $link
+            ->method('getPageLink')
+            ->willReturnCallback(function ($controller) use (&$capturedController) {
+                $capturedController = $controller;
 
-        $this->assertSame('get-file', $properties['php_self']);
+                return '';
+            });
+
+        $context = Context::getContext();
+        $previousLink = $context->link;
+        $context->link = $link;
+
+        try {
+            $productDownload = new ProductDownload();
+            $productDownload->filename = 'a1b2c3';
+            $productDownload->getTextLink('orderhash');
+        } finally {
+            $context->link = $previousLink;
+        }
+
+        // getPageLink() receives "<controller>&key=..." so we only compare the controller part.
+        $linkController = explode('&', (string) $capturedController)[0];
+        $phpSelf = (new ReflectionClass(GetFileControllerCore::class))->getDefaultProperties()['php_self'];
+
+        $this->assertSame($phpSelf, $linkController);
     }
 
     /**

--- a/tests/Unit/Classes/controller/GetFileControllerTest.php
+++ b/tests/Unit/Classes/controller/GetFileControllerTest.php
@@ -14,6 +14,7 @@ use Link;
 use PHPUnit\Framework\TestCase;
 use ProductDownload;
 use ReflectionClass;
+use ReflectionMethod;
 use UploadControllerCore;
 
 class GetFileControllerTest extends TestCase
@@ -75,5 +76,43 @@ class GetFileControllerTest extends TestCase
         $properties = (new ReflectionClass(UploadControllerCore::class))->getDefaultProperties();
 
         $this->assertEmpty($properties['php_self']);
+    }
+
+    /**
+     * Setting $php_self enables FrontController::init() to call canonicalRedirection()
+     * with a URL built from getPageLink($php_self, ...) - which carries no `key` query
+     * parameter. Once a friendly URL is configured for the get-file page, that canonical
+     * no longer matches an incoming `index.php?controller=get-file&key=...` request, so
+     * the request would be 301'd to the keyless canonical, breaking every download link
+     * already sent in past order emails.
+     *
+     * GetFileController must therefore override canonicalRedirection() as a no-op.
+     * This test pins the override so it cannot be silently removed.
+     *
+     * @see FrontController::init()
+     * @see https://github.com/PrestaShop/PrestaShop/pull/41642#issuecomment-5115542084
+     */
+    public function testGetFileControllerOverridesCanonicalRedirectionAsNoop(): void
+    {
+        $method = new ReflectionMethod(GetFileControllerCore::class, 'canonicalRedirection');
+
+        $this->assertSame(
+            GetFileControllerCore::class,
+            $method->getDeclaringClass()->getName(),
+            'GetFileController must override canonicalRedirection() to prevent a keyless canonical redirect on download requests.'
+        );
+
+        $source = file($method->getFileName());
+        $body = implode('', array_slice(
+            $source,
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1
+        ));
+
+        $this->assertSame(
+            '',
+            trim(preg_replace('/^.*?\{|}\s*$/s', '', $body)),
+            'GetFileController::canonicalRedirection() must stay a no-op; a body would strip the `key` from download URLs.'
+        );
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The friendly URL for the virtual-product download page (`get-file`) was never applied: after adding the page in **BO → SEO & URLs** and setting a rewritten URL, download links still rendered as `index.php?controller=get-file`. <br><br> The download link is generated with the `get-file` controller name (`ProductDownload::getTextLink()` → `Link::getPageLink('get-file&key=…')`), but `GetFileController` had no `php_self` property. As a result `Meta::getPages()` listed the page using the filename fallback, i.e. `getfile` (no dash). The route saved from SEO & URLs was therefore registered under the name `getfile` and never matched the `get-file` name used to build links, so `Dispatcher::createUrl()` fell back to the non-friendly URL. <br><br> This PR declares `public $php_self = 'get-file';` on `GetFileController`, following the existing convention for hyphenated front controllers (`my-account`, `order-follow`, `guest-tracking`). `UploadController` extends `GetFileController` and is reached through its own `upload` route, so it resets `php_self` to `null` to avoid inheriting `get-file` (which would also trigger an unwanted canonical redirection in `FrontController::init()`).
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable Friendly URLs (**Shop Parameters → Traffic & SEO**). <br> 2. In **BO → SEO & URLs**, click **Add a new page**, choose the `get-file` page, set a Rewritten URL and save. <br> 3. Create/own an order containing a virtual product with an attached download file (in a paid state). <br> 4. On the FO, open the customer's order history / download area and check the download link: it must now use the configured friendly URL instead of `index.php?controller=get-file`, and downloading the file must work. <br> 5. Customization file downloads served by `UploadController` must keep working unchanged. <br><br> Automated: `php ./vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Classes/controller/GetFileControllerTest.php`
| UI Tests          |
| Fixed issue or discussion?     | Fixes #34339
| Related PRs       |
| Sponsor company   |

> Note for existing shops: stores that already added the page before this fix have a `getfile` row stored in the `meta` table. They still need the one-time manual rename of `meta.page` from `getfile` to `get-file` (as described in the issue). New additions made after this fix are stored correctly as `get-file`.
