### PR TITLE
Make category visibility configurable per shop

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -101,7 +101,7 @@ class CategoryCore extends ObjectModel
             'nleft' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'],
             'nright' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'],
             'level_depth' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'],
-            'active' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => true],
+            'active' => ['type' => self::TYPE_BOOL, 'shop' => 'both', 'validate' => 'isBool', 'required' => true],
             'id_parent' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'],
             'id_shop_default' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'is_root_category' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
@@ -641,7 +641,7 @@ class CategoryCore extends ObjectModel
 			' . Shop::addSqlAssociation('category', 'c') . '
 			LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl ON c.`id_category` = cl.`id_category`' . Shop::addSqlRestrictionOnLang('cl') . '
 			WHERE 1 ' . $sqlFilter . ' ' . ($idLang ? 'AND `id_lang` = ' . (int) $idLang : '') . '
-			' . ($active ? 'AND `active` = 1' : '') . '
+			' . ($active ? 'AND category_shop.`active` = 1' : '') . '
 			' . (!$idLang ? 'GROUP BY c.id_category' : '') . '
 			' . ($orderBy != '' ? $orderBy : 'ORDER BY c.`level_depth` ASC, category_shop.`position` ASC') . '
 			' . ($limit != '' ? $limit : '')
@@ -730,7 +730,7 @@ class CategoryCore extends ObjectModel
 				' . (isset($groups) && Group::isFeatureActive() ? 'LEFT JOIN `' . _DB_PREFIX_ . 'category_group` cg ON c.`id_category` = cg.`id_category`' : '') . '
 				' . (isset($idRootCategory) ? 'RIGHT JOIN `' . _DB_PREFIX_ . 'category` c2 ON c2.`id_category` = ' . (int) $idRootCategory . ' AND c.`nleft` >= c2.`nleft` AND c.`nright` <= c2.`nright`' : '') . '
 				WHERE 1 ' . $sqlFilter . ' ' . ($idLang ? 'AND `id_lang` = ' . (int) $idLang : '') . '
-				' . ($active ? ' AND c.`active` = 1' : '') . '
+				' . ($active ? ($useShopRestriction ? ' AND category_shop.`active` = 1' : ' AND c.`active` = 1') : '') . '
 				' . (isset($groups) && Group::isFeatureActive() ? ' AND cg.`id_group` IN (' . implode(',', array_map('intval', $groups)) . ')' : '') . '
 				' . (!$idLang || (isset($groups) && Group::isFeatureActive()) ? ' GROUP BY c.`id_category`' : '') . '
 				' . ($orderBy != '' ? $orderBy : ' ORDER BY c.`level_depth` ASC') . '
@@ -794,14 +794,14 @@ class CategoryCore extends ObjectModel
         if (!Cache::isStored($cacheId)) {
             $result = Db::getInstance()->executeS(
                 '
-				SELECT c.*, cl.*
+				SELECT c.*, cl.*' . ($useShopRestriction ? ', category_shop.`active`' : '') . '
 				FROM `' . _DB_PREFIX_ . 'category` c
 				' . ($useShopRestriction ? Shop::addSqlAssociation('category', 'c') : '') . '
 				LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl ON c.`id_category` = cl.`id_category`' . Shop::addSqlRestrictionOnLang('cl') . '
 				' . (isset($groups) && Group::isFeatureActive() ? 'LEFT JOIN `' . _DB_PREFIX_ . 'category_group` cg ON c.`id_category` = cg.`id_category`' : '') . '
 				' . (isset($idRootCategory) ? 'RIGHT JOIN `' . _DB_PREFIX_ . 'category` c2 ON c2.`id_category` = ' . (int) $idRootCategory . ' AND c.`nleft` >= c2.`nleft` AND c.`nright` <= c2.`nright`' : '') . '
 				WHERE 1 ' . $sqlFilter . ' ' . ($idLang ? 'AND `id_lang` = ' . (int) $idLang : '') . '
-				' . ($active ? ' AND c.`active` = 1' : '') . '
+				' . ($active ? ($useShopRestriction ? ' AND category_shop.`active` = 1' : ' AND c.`active` = 1') : '') . '
 				' . (isset($groups) && Group::isFeatureActive() ? ' AND cg.`id_group` IN (' . implode(',', array_map('intval', $groups)) . ')' : '') . '
 				' . (!$idLang || (isset($groups) && Group::isFeatureActive()) ? ' GROUP BY c.`id_category`' : '') . '
 				' . ($orderBy != '' ? $orderBy : ' ORDER BY c.`level_depth` ASC') . '
@@ -930,7 +930,7 @@ class CategoryCore extends ObjectModel
 		LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl ON (c.`id_category` = cl.`id_category` AND `id_lang` = ' . (int) $idLang . ' ' . Shop::addSqlRestrictionOnLang('cl') . ')
 		' . $sqlGroupsJoin . '
 		WHERE `id_parent` = ' . (int) $this->id . '
-		' . ($active ? 'AND `active` = 1' : '') . '
+		' . ($active ? 'AND category_shop.`active` = 1' : '') . '
 		' . $sqlGroupsWhere . '
 		GROUP BY c.`id_category`
 		ORDER BY `level_depth` ASC, category_shop.`position` ASC');
@@ -1152,7 +1152,7 @@ class CategoryCore extends ObjectModel
 			' . Shop::addSqlAssociation('category', 'c') . '
 			WHERE `id_lang` = ' . (int) $idLang . '
 			AND c.`id_parent` = ' . (int) $idParent . '
-			' . ($active ? 'AND `active` = 1' : '') . '
+			' . ($active ? 'AND category_shop.`active` = 1' : '') . '
 			GROUP BY c.`id_category`
 			ORDER BY category_shop.`position` ASC';
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
@@ -1184,7 +1184,7 @@ class CategoryCore extends ObjectModel
 			' . Shop::addSqlAssociation('category', 'c') . '
 			WHERE `id_lang` = ' . (int) $idLang . '
 			AND c.`id_parent` = ' . (int) $idParent . '
-			' . ($active ? 'AND `active` = 1' : '') . ' LIMIT 1';
+			' . ($active ? 'AND category_shop.`active` = 1' : '') . ' LIMIT 1';
             $result = (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
             Cache::store($cacheId, $result);
 
@@ -2032,7 +2032,7 @@ class CategoryCore extends ObjectModel
 		FROM `' . _DB_PREFIX_ . 'category` c
 		' . Shop::addSqlAssociation('category', 'c') . '
 		WHERE c.`id_parent` = ' . (int) $this->id . '
-		AND c.`active` = 1
+		AND category_shop.`active` = 1
 		ORDER BY category_shop.`position` ASC');
     }
 
@@ -2101,7 +2101,7 @@ class CategoryCore extends ObjectModel
 				WHERE `' . _DB_PREFIX_ . 'category_product`.id_category = c2.id_category
 					AND c2.nleft > ' . (int) $this->nleft . '
 					AND c2.nright < ' . (int) $this->nright . '
-					AND c2.active = 1
+					AND category_shop.active = 1
 			)
 		');
         if (!$nbProductRecursive) {
@@ -2210,9 +2210,10 @@ class CategoryCore extends ObjectModel
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 		SELECT DISTINCT(c.`id_category`), cl.`name`
 		FROM `' . _DB_PREFIX_ . 'category` c
+		' . Shop::addSqlAssociation('category', 'c') . '
 		LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl ON (cl.`id_category` = c.`id_category` AND cl.`id_lang`=' . (int) $idLang . ')
 		WHERE `is_root_category` = 1
-		' . ($active ? 'AND `active` = 1' : ''));
+		' . ($active ? 'AND category_shop.`active` = 1' : ''));
     }
 
     /**

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -397,7 +397,7 @@ class ManufacturerCore extends ObjectModel
 					SELECT 1
 					FROM `' . _DB_PREFIX_ . 'category_group` cg
 					LEFT JOIN `' . _DB_PREFIX_ . 'category_product` cp ON (cp.`id_category` = cg.`id_category`)' .
-                    ($activeCategory ? ' INNER JOIN `' . _DB_PREFIX_ . 'category` ca ON cp.`id_category` = ca.`id_category` AND ca.`active` = 1' : '') . '
+                    ($activeCategory ? ' INNER JOIN `' . _DB_PREFIX_ . 'category_shop` ca ON cp.`id_category` = ca.`id_category` AND ca.`id_shop` = ' . (int) $context->shop->id . ' AND ca.`active` = 1' : '') . '
 					WHERE p.`id_product` = cp.`id_product` AND cg.`id_group` ' . $sqlGroups . '
 				)';
 
@@ -458,7 +458,7 @@ class ManufacturerCore extends ObjectModel
                 $sql .= 'JOIN `' . _DB_PREFIX_ . 'category_group` cg ON (cp.`id_category` = cg.`id_category` AND cg.`id_group` ' . $sqlGroups . ')';
             }
             if ($activeCategory) {
-                $sql .= 'JOIN `' . _DB_PREFIX_ . 'category` ca ON cp.`id_category` = ca.`id_category` AND ca.`active` = 1';
+                $sql .= 'JOIN `' . _DB_PREFIX_ . 'category_shop` ca ON cp.`id_category` = ca.`id_category` AND ca.`id_shop` = ' . (int) $context->shop->id . ' AND ca.`active` = 1';
             }
         }
 

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -472,9 +472,10 @@ class SearchCore
             'FROM `' . _DB_PREFIX_ . 'category_product` cp ' .
             (Group::isFeatureActive() ? 'INNER JOIN `' . _DB_PREFIX_ . 'category_group` cg ON cp.`id_category` = cg.`id_category`' : '') . ' ' .
             'INNER JOIN `' . _DB_PREFIX_ . 'category` c ON cp.`id_category` = c.`id_category` ' .
+            Shop::addSqlAssociation('category', 'c') . ' ' .
             'INNER JOIN `' . _DB_PREFIX_ . 'product` p ON cp.`id_product` = p.`id_product` ' .
             Shop::addSqlAssociation('product', 'p', false) . ' ' .
-            'WHERE c.`active` = 1 ' .
+            'WHERE category_shop.`active` = 1 ' .
             'AND product_shop.`active` = 1 ' .
             'AND product_shop.`visibility` IN ("both", "search") ' .
             'AND product_shop.indexed = 1 ' .

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -303,7 +303,7 @@ class SupplierCore extends ObjectModel
 				SELECT cp.`id_product`
 				FROM `' . _DB_PREFIX_ . 'category_product` cp
 				' . (Group::isFeatureActive() ? 'LEFT JOIN `' . _DB_PREFIX_ . 'category_group` cg ON (cp.`id_category` = cg.`id_category`)' : '') . '
-				' . ($activeCategory ? ' INNER JOIN `' . _DB_PREFIX_ . 'category` ca ON cp.`id_category` = ca.`id_category` AND ca.`active` = 1' : '') . '
+				' . ($activeCategory ? ' INNER JOIN `' . _DB_PREFIX_ . 'category_shop` ca ON cp.`id_category` = ca.`id_category` AND ca.`id_shop` = ' . (int) $context->shop->id . ' AND ca.`active` = 1' : '') . '
 				' . $sqlGroups . '
 			)');
         }
@@ -358,7 +358,7 @@ class SupplierCore extends ObjectModel
                 $sql .= 'JOIN `' . _DB_PREFIX_ . 'category_group` cg ON (cp.`id_category` = cg.`id_category` AND cg.`id_group` ' . (count($groups) ? 'IN (' . implode(',', $groups) . ')' : '= 1') . ')';
             }
             if ($activeCategory) {
-                $sql .= 'JOIN `' . _DB_PREFIX_ . 'category` ca ON cp.`id_category` = ca.`id_category` AND ca.`active` = 1';
+                $sql .= 'JOIN `' . _DB_PREFIX_ . 'category_shop` ca ON cp.`id_category` = ca.`id_category` AND ca.`id_shop` = ' . (int) $context->shop->id . ' AND ca.`active` = 1';
             }
         }
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2692,6 +2692,7 @@ CREATE TABLE `PREFIX_category_shop` (
   `id_category` int(11) NOT NULL,
   `id_shop` int(11) NOT NULL,
   `position` int(10) unsigned NOT NULL DEFAULT '0',
+  `active` tinyint(1) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`id_category`, `id_shop`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 

--- a/src/Core/Grid/Query/CategoryQueryBuilder.php
+++ b/src/Core/Grid/Query/CategoryQueryBuilder.php
@@ -85,7 +85,7 @@ final class CategoryQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('COUNT(cp.`id_product`) AS `products_count`, c.id_category, c.id_parent, c.active, cl.name, cl.description, cs.position');
+        $qb->select('COUNT(cp.`id_product`) AS `products_count`, c.id_category, c.id_parent, cs.active, cl.name, cl.description, cs.position');
         $qb->leftJoin(
             'c',
             $this->dbPrefix . 'category_product',
@@ -193,7 +193,7 @@ final class CategoryQueryBuilder extends AbstractDoctrineQueryBuilder
             }
 
             if ('active' === $filterName) {
-                $qb->andWhere("c.active = :$filterName");
+                $qb->andWhere("cs.active = :$filterName");
                 $qb->setParameter($filterName, $filterValue);
 
                 continue;

--- a/src/Core/Grid/Query/Monitoring/EmptyCategoryQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/EmptyCategoryQueryBuilder.php
@@ -75,7 +75,7 @@ final class EmptyCategoryQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('c.id_category, c.active, cl.name, cl.description');
+        $qb->select('c.id_category, cs.active, cl.name, cl.description');
 
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
@@ -153,7 +153,7 @@ final class EmptyCategoryQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $allowedFiltersAliasMap = [
             'id_category' => 'c.id_category',
-            'active' => 'c.active',
+            'active' => 'cs.active',
             'name' => 'cl.name',
             'description' => 'cl.description',
         ];

--- a/src/PrestaShopBundle/Entity/Repository/CategoryRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/CategoryRepository.php
@@ -92,7 +92,7 @@ class CategoryRepository
             '{table_prefix}',
             $this->tablePrefix,
             'SELECT
-            c.id_category, c.id_parent, c.active, c.position, cl.name
+            c.id_category, c.id_parent, cs.active, c.position, cl.name
             FROM {table_prefix}category c
             INNER JOIN {table_prefix}category_lang cl ON (cl.id_category = c.id_category AND cl.id_lang = :language_id AND cl.id_shop = :shop_id)
             INNER JOIN {table_prefix}category_shop cs ON (cs.id_category = c.id_category AND cs.id_shop = :shop_id)

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_visibility_per_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_visibility_per_shop.feature
@@ -1,0 +1,46 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s category --tags category-visibility-per-shop
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@category-visibility-per-shop
+Feature: Category visibility per shop
+  PrestaShop allows BO users to manage categories for products
+  As a BO user
+  I must be able to enable or disable a category independently for each shop
+  in a multistore installation
+
+  Background:
+    Given language "en" with locale "en-US" exists
+    And language with iso code "en" is the default one
+    And shop "shop1" with name "test_shop" exists
+    And category "home" in default language named "Home" exists
+    And category "root" in default language named "Root" exists
+    And category "root" is the root category and it cannot be edited
+    And I enable multishop feature
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "test_shop_2" and color "red" for the group "default_shop_group"
+    And single shop context is loaded
+    And category "home" is set as the home category for shop "shop1"
+
+  Scenario: Disabling a category for one shop keeps it enabled for the other shop
+    Given I add new category "perShopCategory" with following details:
+      | name[en-US]         | Per shop category |
+      | active              | true              |
+      | parent category     | home              |
+      | link rewrite[en-US] | per-shop-category |
+      | associated shops    | shop1,shop2       |
+    # The category starts enabled for both shops
+    When shop context "test_shop" is loaded
+    Then category "perShopCategory" should have following details:
+      | active | true |
+    When shop context "test_shop_2" is loaded
+    Then category "perShopCategory" should have following details:
+      | active | true |
+    # Disabling it while shop2 is the current context only affects shop2
+    When I edit category "perShopCategory" with following details:
+      | active | false |
+    Then category "perShopCategory" should have following details:
+      | active | false |
+    # ... the category is still enabled for shop1
+    When shop context "test_shop" is loaded
+    Then category "perShopCategory" should have following details:
+      | active | true |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Category visibility (the `active` / "Displayed" flag) was stored only in the `category` table, so toggling it applied to **every shop** in a multistore installation. This PR makes `active` a shop-scoped field so visibility can be configured independently per shop.<br><br>• Adds an `active` column to `category_shop`.<br>• Declares `active` as `'shop' => 'both'` in the `Category` ObjectModel, so it is written to both `category` (kept for backward compatibility) and per-shop `category_shop`.<br>• Reads visibility from `category_shop.active` in the storefront/back-office queries (`Category`, `Search`, `Manufacturer`, `Supplier`), the category grid, the empty-categories monitoring grid and the admin tree repository.<br><br>The admin add/edit/toggle paths need no change: ObjectModel writes shop fields for the current BO shop context, so the existing "Displayed" toggle now applies only to the selected shop(s). The front `CategoryController`'s `$this->category->active` check is automatically per-shop because the ObjectModel constructor loads the context shop's `category_shop` row.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automated: `php vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s category --tags category-visibility-per-shop` (new scenario, passes).<br><br>Manual (multistore):<br>1. Enable the multistore feature and create a second shop.<br>2. Associate a category with both shops (visible/enabled in both).<br>3. Switch the BO shop context to shop B, open the category, set **Displayed = No** and save.<br>4. Front office of **shop B**: the category is hidden; front office of **shop A**: the category is still visible.<br>5. Re-enabling it for shop B does not change shop A.
| UI Tests          |
| Fixed issue or discussion?     | Fixes #9859
| Related PRs       | Companion autoupgrade migration: PrestaShop/autoupgrade#1890 (targets `7.6.x`, adds the `category_shop.active` column via `add_column()` and back-fills it from `category.active`).<br><br>Note: `ps_facetedsearch` and `ps_linklist` also filter `category.active`; they keep working through the backward-compatible `category.active` column and can receive matching per-shop updates separately.
| Sponsor company   |

