### PR TITLE
Add MPN field to Webservice in Order.php

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -263,6 +263,7 @@ class OrderCore extends ObjectModel
                     'product_ean13' => ['setter' => false],
                     'product_isbn' => ['setter' => false],
                     'product_upc' => ['setter' => false],
+                    'product_mpn' => ['setter' => false],
                     'product_price' => ['setter' => false],
                     'id_customization' => ['required' => false, 'xlink_resource' => 'customizations'],
                     'unit_price_tax_incl' => ['setter' => false],
@@ -1634,6 +1635,7 @@ class OrderCore extends ObjectModel
             `product_ean13`,
             `product_isbn`,
             `product_upc`,
+            `product_mpn`,
             `unit_price_tax_incl`,
             `unit_price_tax_excl`
             FROM `' . _DB_PREFIX_ . 'order_detail`


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | API order response /api/orders/ID contains associations -> order_rows section, where details about ordered products are placed. But these details are missing product MPN field, which may be useful by some external systems.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Set up an API key in the shop<br/>Go to /api/orders/orderID<br/>Examine the XML output
| Fixed issue or discussion?     | Fixes #40334
| Sponsor company   | GreenMouse
