### PR TITLE
Add missing breadcrumb link to OrderDetailController

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -22,7 +22,45 @@ class OrderDetailControllerCore extends FrontController
 
     protected $order_to_display;
 
+    protected $order;
+
     protected $reference;
+
+    protected function loadOrder(): void
+    {
+        $id_order = (int) Tools::getValue('id_order');
+        $id_order = $id_order && Validate::isUnsignedId($id_order) ? $id_order : false;
+
+        if (!$id_order) {
+            $reference = Tools::getValue('reference');
+            $reference = $reference && Validate::isReference($reference) ? $reference : false;
+            $order = $reference ? Order::getByReference($reference)->getFirst() : false;
+            $id_order = $order ? $order->id : false;
+        }
+
+        if (!$id_order) {
+            $this->redirect_after = '404';
+            $this->redirect();
+        }
+
+        $order = new Order($id_order);
+        if (!Validate::isLoadedObject($order) || $order->id_customer != $this->context->customer->id) {
+            $this->redirect_after = '404';
+            $this->redirect();
+        }
+
+        if ($order->id_shop != $this->context->shop->id && $this->context->customer->id_shop_group == $this->context->shop->id_shop_group) {
+            $shopGroup = new ShopGroup($this->context->customer->id_shop_group);
+            if (!$shopGroup->share_order) {
+                $this->redirect_after = '404';
+                $this->redirect();
+            }
+        }
+
+        $this->order = $order;
+        $this->order_to_display = (new OrderPresenter())->present($order);
+        $this->reference = $order->reference;
+    }
 
     /**
      * Start forms process.
@@ -146,67 +184,37 @@ class OrderDetailControllerCore extends FrontController
      */
     public function initContent(): void
     {
-        parent::initContent();
         if (Configuration::isCatalogMode()) {
             Tools::redirect('index.php');
         }
 
-        $id_order = (int) Tools::getValue('id_order');
-        $id_order = $id_order && Validate::isUnsignedId($id_order) ? $id_order : false;
+        $this->loadOrder();
 
-        if (!$id_order) {
-            $reference = Tools::getValue('reference');
-            $reference = $reference && Validate::isReference($reference) ? $reference : false;
-            $order = $reference ? Order::getByReference($reference)->getFirst() : false;
-            $id_order = $order ? $order->id : false;
+        parent::initContent();
+
+        if (Tools::getIsset('errorQuantity')) {
+            $this->errors[] = $this->trans('You do not have enough products to request an additional merchandise return.', [], 'Shop.Notifications.Error');
+        } elseif (Tools::getIsset('errorMsg')) {
+            $this->errors[] = $this->trans('Please provide an explanation for your RMA.', [], 'Shop.Notifications.Error');
+        } elseif (Tools::getIsset('errorDetail1')) {
+            $this->errors[] = $this->trans('Please check at least one product you would like to return.', [], 'Shop.Notifications.Error');
+        } elseif (Tools::getIsset('errorDetail2')) {
+            $this->errors[] = $this->trans('For each product you wish to add, please specify the desired quantity.', [], 'Shop.Notifications.Error');
+        } elseif (Tools::getIsset('errorNotReturnable')) {
+            $this->errors[] = $this->trans('This order cannot be returned', [], 'Shop.Notifications.Error');
+        } elseif (Tools::getIsset('messagesent')) {
+            $this->success[] = $this->trans('Message successfully sent', [], 'Shop.Notifications.Success');
         }
 
-        if (!$id_order) {
-            $this->redirect_after = '404';
-            $this->redirect();
-        } else {
-            if (Tools::getIsset('errorQuantity')) {
-                $this->errors[] = $this->trans('You do not have enough products to request an additional merchandise return.', [], 'Shop.Notifications.Error');
-            } elseif (Tools::getIsset('errorMsg')) {
-                $this->errors[] = $this->trans('Please provide an explanation for your RMA.', [], 'Shop.Notifications.Error');
-            } elseif (Tools::getIsset('errorDetail1')) {
-                $this->errors[] = $this->trans('Please check at least one product you would like to return.', [], 'Shop.Notifications.Error');
-            } elseif (Tools::getIsset('errorDetail2')) {
-                $this->errors[] = $this->trans('For each product you wish to add, please specify the desired quantity.', [], 'Shop.Notifications.Error');
-            } elseif (Tools::getIsset('errorNotReturnable')) {
-                $this->errors[] = $this->trans('This order cannot be returned', [], 'Shop.Notifications.Error');
-            } elseif (Tools::getIsset('messagesent')) {
-                $this->success[] = $this->trans('Message successfully sent', [], 'Shop.Notifications.Success');
-            }
+        /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
+        $featureFlagManager = $this->get(FeatureFlagStateCheckerInterface::class);
 
-            $order = new Order($id_order);
-            if (Validate::isLoadedObject($order) && $order->id_customer == $this->context->customer->id) {
-                if ($order->id_shop != $this->context->shop->id && $this->context->customer->id_shop_group == $this->context->shop->id_shop_group) {
-                    $shopGroup = new ShopGroup($this->context->customer->id_shop_group);
-                    if (!$shopGroup->share_order) {
-                        $this->redirect_after = '404';
-                        $this->redirect();
-                    }
-                }
-                $this->order_to_display = (new OrderPresenter())->present($order);
-
-                $this->reference = $order->reference;
-
-                /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
-                $featureFlagManager = $this->get(FeatureFlagStateCheckerInterface::class);
-
-                $this->context->smarty->assign([
-                    'order' => $this->order_to_display,
-                    'orderIsVirtual' => $order->isVirtual(),
-                    'HOOK_DISPLAYORDERDETAIL' => Hook::exec('displayOrderDetail', ['order' => $order]),
-                    'is_multishipment_enabled' => $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
-                ]);
-            } else {
-                $this->redirect_after = '404';
-                $this->redirect();
-            }
-            unset($order);
-        }
+        $this->context->smarty->assign([
+            'order' => $this->order_to_display,
+            'orderIsVirtual' => $this->order->isVirtual(),
+            'HOOK_DISPLAYORDERDETAIL' => Hook::exec('displayOrderDetail', ['order' => $this->order]),
+            'is_multishipment_enabled' => $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
+        ]);
 
         $this->setTemplate('customer/order-detail');
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      |The order detail breadcrumb already includes logic to display the order reference, but the related property is currently assigned only after the breadcrumb is built. This change ensures the order reference is loaded earlier so the missing breadcrumb item can be displayed as expected. It also includes a small refactor in `OrderDetailController` to extract order loading and validation into a dedicated method, making `initContent()` easier to read and maintain. This also improves accessibility by providing a clearer navigation structure for users and assistive technologies.
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to the FO order detail page and verify that the breadcrumb is displayed as `Home >Your account > Order history > ORDER_REFERENCE`
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/27036131452
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Codencode snc

### With fix
<img width="1226" height="402" alt="With fix" src="https://github.com/user-attachments/assets/cc8e16d1-356a-47a1-9ee7-b706a7724519" />

### Without fix
<img width="1193" height="396" alt="Without fix" src="https://github.com/user-attachments/assets/a455456c-30ff-4d69-831d-5e7b6554222e" />

