### PR TITLE
Fix:  Changing an order's status throws "Duplicate entry '<idp>-<idpa>-0-0' for product_sqlstock" when the order contains a deleted combination (single-shop)

### DIFF
--- a/src/Adapter/Combination.php
+++ b/src/Adapter/Combination.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Adapter;
+
+use Combination as CombinationLegacy;
+
+/**
+ * Adapter for Combination legacy class.
+ */
+class Combination
+{
+    /**
+     * Check if a combination exists in database.
+     *
+     * @param int $combinationId
+     *
+     * @return bool
+     */
+    public function existsInDatabase(int $combinationId): bool
+    {
+        return CombinationLegacy::existsInDatabase($combinationId);
+    }
+}

--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -366,7 +366,9 @@ class StockManager
         $product = new Product($productId);
 
         if ($product->id) {
-            if ($productAttributeId > 0 && !Combination::existsInDatabase($productAttributeId)) {
+            $combinationAdapter = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\Combination');
+
+            if ($productAttributeId > 0 && !$combinationAdapter->existsInDatabase((int) $productAttributeId)) {
                 return false;
             }
 

--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -366,6 +366,10 @@ class StockManager
         $product = new Product($productId);
 
         if ($product->id) {
+            if ($productAttributeId > 0 && !Combination::existsInDatabase($productAttributeId)) {
+                return false;
+            }
+
             $stockManager = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\StockManager');
             $stockAvailable = $stockManager->getStockAvailableByProduct($product, $productAttributeId, $params['id_shop'] ?? null);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR prevents stock movement creation for deleted product combinations by stopping `prepareMovement()` when `productAttributeId > 0` and the related combination no longer exists, using an adapter to avoid direct legacy usage in Core, preventing unintended `stock_available` recreation during order status changes and duplicate key errors.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Single-shop install (no multistore).<br/> Create a product with a combination (e.g. weight "100 g") → id_product_attribute = A.2. <br/> 3. Place an order containing that combination (order_detail.product_attribute_id = A).<br/> 4. Delete combination A from the product (e.g. replace it with another weight).<br/> 5. Set that order to a status that updates stock (e.g. "Delivered"). → The order status is updated successfully and no stock_available row (product, A, 0, 0) is created.<br/> 6. Set another order that also contains combination A to that status. → The order status is updated successfully, no duplicate entry error is thrown, and no stock_available row is recreated for the deleted combination.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/27062428116
| Fixed issue or discussion?     | Fixes #41593
| Related PRs       | 
| Sponsor company   | Codencode snc
