### PR TITLE
Keep the group form open when the discount is invalid

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -525,13 +525,17 @@ class AdminGroupsControllerCore extends AdminController
     {
         if (!$this->validateDiscount(Tools::getValue('reduction'))) {
             $this->errors[] = $this->trans('The discount value is incorrect (must be a percentage).', [], 'Admin.Shopparameters.Notification');
-        } else {
-            $this->updateCategoryReduction();
-            $object = parent::processSave();
-            $this->updateRestrictions();
+            // Stay on the form to display the error instead of redirecting to the list
+            $this->display = 'edit';
 
-            return $object;
+            return false;
         }
+
+        $this->updateCategoryReduction();
+        $object = parent::processSave();
+        $this->updateRestrictions();
+
+        return $object;
     }
 
     protected function validateDiscount($reduction)

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/04_customerSettings/02_groups/04_invalidDiscount.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/04_customerSettings/02_groups/04_invalidDiscount.ts
@@ -23,9 +23,10 @@ Submitting a group with an invalid discount (banned symbols) used to redirect to
 It should stay on the form and display the error instead.
 
 Scenario:
-- Go to 'Add new group' page
-- Fill the form with an invalid discount value
-- Save and check that an error is displayed AND we stay on the creation form
+- Add path: fill the 'Add new group' form with an invalid discount, save,
+  check that the error is displayed AND that we stay on the creation form.
+- Edit path: create a valid group, open its edit form, submit an invalid
+  discount, check that the error is displayed AND that we stay on the edit form.
  */
 describe('BO - Shop Parameters - Customer Settings : Invalid discount keeps the group form open', async () => {
   let browserContext: BrowserContext;
@@ -33,6 +34,7 @@ describe('BO - Shop Parameters - Customer Settings : Invalid discount keeps the 
   let numberOfGroups: number = 0;
 
   const groupData: FakerGroup = new FakerGroup();
+  const editGroupData: FakerGroup = new FakerGroup();
   const invalidDiscount: string = 'abc%$';
 
   // before and after functions
@@ -85,40 +87,117 @@ describe('BO - Shop Parameters - Customer Settings : Invalid discount keeps the 
     expect(numberOfGroups).to.be.above(0);
   });
 
-  it('should go to add new group page', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewGroup', baseContext);
+  describe('Add path : invalid discount keeps the creation form open', async () => {
+    it('should go to add new group page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewGroup', baseContext);
 
-    await boCustomerGroupsPage.goToNewGroupPage(page);
+      await boCustomerGroupsPage.goToNewGroupPage(page);
 
-    const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
-    expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleCreate);
+      const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleCreate);
+    });
+
+    it('should fill the form with an invalid discount and check the error message', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'submitInvalidDiscountCreate', baseContext);
+
+      const errorMessage = await boCustomerGroupsCreatePage.setInvalidDiscount(page, groupData, invalidDiscount);
+      expect(errorMessage).to.contains('The discount value is incorrect (must be a percentage).');
+    });
+
+    it('should check that we stayed on the group creation form', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkStayedOnCreateForm', baseContext);
+
+      const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleCreate);
+    });
+
+    it('should go back to \'Groups\' page and check that no group was created', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkNoGroupCreated', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.shopParametersParentLink,
+        boDashboardPage.customerSettingsLink,
+      );
+      await boCustomerSettingsPage.goToGroupsPage(page);
+
+      const numberOfGroupsAfter = await boCustomerGroupsPage.resetAndGetNumberOfLines(page);
+      expect(numberOfGroupsAfter).to.be.equal(numberOfGroups);
+    });
   });
 
-  it('should fill the form with an invalid discount and check the error message', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'submitInvalidDiscount', baseContext);
+  describe('Edit path : invalid discount keeps the edit form open', async () => {
+    it('should create a valid group to edit', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createGroupToEdit', baseContext);
 
-    const errorMessage = await boCustomerGroupsCreatePage.setInvalidDiscount(page, groupData, invalidDiscount);
-    expect(errorMessage).to.contains('The discount value is incorrect (must be a percentage).');
-  });
+      await boCustomerGroupsPage.goToNewGroupPage(page);
 
-  it('should check that we stayed on the group creation form', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'checkStayedOnForm', baseContext);
+      const textResult = await boCustomerGroupsCreatePage.createEditGroup(page, editGroupData);
+      expect(textResult).to.contains(boCustomerGroupsPage.successfulCreationMessage);
 
-    const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
-    expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleCreate);
-  });
+      const numberOfGroupsAfterCreation = await boCustomerGroupsPage.getNumberOfElementInGrid(page);
+      expect(numberOfGroupsAfterCreation).to.be.equal(numberOfGroups + 1);
+    });
 
-  it('should go back to \'Groups\' page and check that no group was created', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'checkNoGroupCreated', baseContext);
+    it('should filter the list by the new group name', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterForEdit', baseContext);
 
-    await boDashboardPage.goToSubMenu(
-      page,
-      boDashboardPage.shopParametersParentLink,
-      boDashboardPage.customerSettingsLink,
-    );
-    await boCustomerSettingsPage.goToGroupsPage(page);
+      await boCustomerGroupsPage.resetFilter(page);
+      await boCustomerGroupsPage.filterTable(page, 'input', 'b!name', editGroupData.name);
 
-    const numberOfGroupsAfter = await boCustomerGroupsPage.resetAndGetNumberOfLines(page);
-    expect(numberOfGroupsAfter).to.be.equal(numberOfGroups);
+      const textColumn = await boCustomerGroupsPage.getTextColumn(page, 1, 'b!name');
+      expect(textColumn).to.contains(editGroupData.name);
+    });
+
+    it('should go to the edit group page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToEditGroupPage', baseContext);
+
+      await boCustomerGroupsPage.gotoEditGroupPage(page, 1);
+
+      const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleEdit);
+    });
+
+    it('should submit an invalid discount and check the error message', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'submitInvalidDiscountEdit', baseContext);
+
+      const errorMessage = await boCustomerGroupsCreatePage.setInvalidDiscount(page, editGroupData, invalidDiscount);
+      expect(errorMessage).to.contains('The discount value is incorrect (must be a percentage).');
+    });
+
+    it('should check that we stayed on the group edit form', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkStayedOnEditForm', baseContext);
+
+      const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleEdit);
+    });
+
+    it('should go back to \'Groups\' page and check the group count is unchanged', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkGroupCountUnchanged', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.shopParametersParentLink,
+        boDashboardPage.customerSettingsLink,
+      );
+      await boCustomerSettingsPage.goToGroupsPage(page);
+
+      const numberOfGroupsAfterEdit = await boCustomerGroupsPage.resetAndGetNumberOfLines(page);
+      expect(numberOfGroupsAfterEdit).to.be.equal(numberOfGroups + 1);
+    });
+
+    it('should delete the created group', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteCreatedGroup', baseContext);
+
+      await boCustomerGroupsPage.resetFilter(page);
+      await boCustomerGroupsPage.filterTable(page, 'input', 'b!name', editGroupData.name);
+
+      const textResult = await boCustomerGroupsPage.deleteGroup(page, 1);
+      expect(textResult).to.contains(boCustomerGroupsPage.successfulDeleteMessage);
+
+      await boCustomerGroupsPage.resetFilter(page);
+      const numberOfGroupsAfterDelete = await boCustomerGroupsPage.resetAndGetNumberOfLines(page);
+      expect(numberOfGroupsAfterDelete).to.be.equal(numberOfGroups);
+    });
   });
 });

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/04_customerSettings/02_groups/04_invalidDiscount.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/04_customerSettings/02_groups/04_invalidDiscount.ts
@@ -1,0 +1,124 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {
+  boCustomerGroupsPage,
+  boCustomerGroupsCreatePage,
+  boCustomerSettingsPage,
+  boDashboardPage,
+  boLoginPage,
+  type BrowserContext,
+  FakerGroup,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+import {expect} from 'chai';
+
+const baseContext: string = 'functional_BO_shopParameters_customerSettings_groups_invalidDiscount';
+
+/*
+Regression test for https://github.com/PrestaShop/PrestaShop/issues/28415
+Submitting a group with an invalid discount (banned symbols) used to redirect to the groups list.
+It should stay on the form and display the error instead.
+
+Scenario:
+- Go to 'Add new group' page
+- Fill the form with an invalid discount value
+- Save and check that an error is displayed AND we stay on the creation form
+ */
+describe('BO - Shop Parameters - Customer Settings : Invalid discount keeps the group form open', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+  let numberOfGroups: number = 0;
+
+  const groupData: FakerGroup = new FakerGroup();
+  const invalidDiscount: string = 'abc%$';
+
+  // before and after functions
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.shopParametersParentLink,
+      boDashboardPage.customerSettingsLink,
+    );
+    await boCustomerSettingsPage.closeSfToolBar(page);
+
+    const pageTitle = await boCustomerSettingsPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boCustomerSettingsPage.pageTitle);
+  });
+
+  it('should go to \'Groups\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToGroupsPage', baseContext);
+
+    await boCustomerSettingsPage.goToGroupsPage(page);
+
+    const pageTitle = await boCustomerGroupsPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boCustomerGroupsPage.pageTitle);
+  });
+
+  it('should reset all filters and get number of groups in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'resetFilterFirst', baseContext);
+
+    numberOfGroups = await boCustomerGroupsPage.resetAndGetNumberOfLines(page);
+    expect(numberOfGroups).to.be.above(0);
+  });
+
+  it('should go to add new group page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewGroup', baseContext);
+
+    await boCustomerGroupsPage.goToNewGroupPage(page);
+
+    const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
+    expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleCreate);
+  });
+
+  it('should fill the form with an invalid discount and check the error message', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'submitInvalidDiscount', baseContext);
+
+    const errorMessage = await boCustomerGroupsCreatePage.setInvalidDiscount(page, groupData, invalidDiscount);
+    expect(errorMessage).to.contains('The discount value is incorrect (must be a percentage).');
+  });
+
+  it('should check that we stayed on the group creation form', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkStayedOnForm', baseContext);
+
+    const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
+    expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleCreate);
+  });
+
+  it('should go back to \'Groups\' page and check that no group was created', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkNoGroupCreated', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.shopParametersParentLink,
+      boDashboardPage.customerSettingsLink,
+    );
+    await boCustomerSettingsPage.goToGroupsPage(page);
+
+    const numberOfGroupsAfter = await boCustomerGroupsPage.resetAndGetNumberOfLines(page);
+    expect(numberOfGroupsAfter).to.be.equal(numberOfGroups);
+  });
+});


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In **Shop Parameters > Customer Settings > Groups**, adding/editing a group with an invalid discount (banned symbols) redirected the user back to the groups list instead of staying on the form, losing the typed values. The error message was shown on the list page. This PR keeps the form open and displays the error in place. The add/edit form is still served by the legacy `AdminGroups` controller (the Symfony `CustomerGroupsController` only handles the listing and redirects create/edit to legacy), so the fix is in the legacy controller.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **Shop Parameters > Customer Settings > Groups**. 2. Click **Add new group**. 3. Fill the name and enter an invalid value in the **Discount** field (e.g. `abc%$`). 4. Click **Save**. 5. Expected: you stay on the group creation form and the error *"The discount value is incorrect (must be a percentage)."* is displayed; no group is created. Same behavior when editing an existing group.
| UI Tests          | New regression test added: `functional/BO/13_shopParameters/04_customerSettings/02_groups/04_invalidDiscount.ts`. CI run link to be added.
| Fixed issue or discussion?     | Fixes #28415
| Related PRs       | Requires PrestaShop/ui-testing-library#1002 (adds the `setInvalidDiscount` page-object method used by the new test).
| Sponsor company   |

## Root cause

`AdminGroupsController::processSave()` added an error when `validateDiscount()` failed but returned without calling `parent::processSave()`. The mechanism that keeps the user on the form on error (`$this->display = 'edit'`) lives in the base `processAdd()`/`processUpdate()`, which were never reached. Since `initProcess()` pre-sets `$this->display = 'list'` for a normal save submission, the list was rendered instead of the form.

## Fix

Set `$this->display = 'edit'` (and `return false`) when `validateDiscount()` fails, matching the base controller behavior and the convention used in other legacy controllers (e.g. `AdminTaxRulesGroupController`, `AdminCartRulesController`).