### PR TITLE
Reject product/tag names that the search engine cannot index

### DIFF
--- a/classes/Tag.php
+++ b/classes/Tag.php
@@ -99,7 +99,7 @@ class TagCore extends ObjectModel
 
         $list = [];
         foreach ($tagList as $tag) {
-            if (!Validate::isGenericName($tag)) {
+            if (!Validate::isGenericName($tag) || !Validate::isSearchableName($tag, (int) $idLang, (string) Language::getIsoById((int) $idLang))) {
                 return false;
             }
             $tagMaxLength = self::$definition['fields']['name']['size'];

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -465,6 +465,33 @@ class ValidateCore
     }
 
     /**
+     * Check that a name can actually be found by the search engine.
+     *
+     * The rule cannot be expressed as a character class: the indexer keeps some hyphenated terms
+     * (e.g. "----") and drops some terms that contain letters (e.g. "a+"), so we ask the indexer
+     * itself. A name is searchable when Search::extractKeyWords() yields at least one keyword.
+     *
+     * We use the indexation path (the strict one). The query path would keep terms like "a+" that
+     * indexation drops - a tag surviving the query path but not indexation would still be
+     * unfindable in the front-office search, so validation must follow indexation.
+     *
+     * @param string $name Name to validate
+     * @param int $idLang Language id used by the indexer
+     * @param string $isoCode Language iso code used by the indexer
+     *
+     * @return bool Validity is ok or not
+     */
+    public static function isSearchableName($name, $idLang, $isoCode)
+    {
+        $words = array_filter(
+            array_map('trim', (array) Search::extractKeyWords((string) $name, (int) $idLang, true, (string) $isoCode)),
+            static function ($word) { return $word !== ''; }
+        );
+
+        return $words !== [];
+    }
+
+    /**
      * Check for HTML field validity (no XSS please !).
      *
      * @param string $html HTML field to validate

--- a/src/Adapter/Product/CommandHandler/SetProductTagsHandler.php
+++ b/src/Adapter/Product/CommandHandler/SetProductTagsHandler.php
@@ -8,11 +8,15 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
+use Language;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Update\ProductTagUpdater;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetProductTagsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductTagsHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
+use Validate;
 
 /**
  * Handles UpdateProductTagsCommand using legacy object model
@@ -47,7 +51,37 @@ final class SetProductTagsHandler implements UpdateProductTagsHandlerInterface
      */
     public function handle(SetProductTagsCommand $command): void
     {
+        foreach ($command->getLocalizedTagsList() as $localizedTags) {
+            $this->assertTagsAreSearchable($localizedTags);
+        }
+
         $product = $this->productRepository->getProductByDefaultShop($command->getProductId());
         $this->productTagUpdater->setProductTags($product, $command->getLocalizedTagsList());
+    }
+
+    /**
+     * Rejects tags that the search engine strips to nothing at indexation.
+     * Kept here (not in the LocalizedTags value object) because the check delegates
+     * to the indexer, which needs a booted shop - the value object stays pure.
+     *
+     * @throws ProductConstraintException
+     */
+    private function assertTagsAreSearchable(LocalizedTags $localizedTags): void
+    {
+        $idLang = $localizedTags->getLanguageId()->getValue();
+        $isoCode = (string) Language::getIsoById($idLang);
+
+        foreach ($localizedTags->getTags() as $tag) {
+            if (!Validate::isSearchableName($tag, $idLang, $isoCode)) {
+                throw new ProductConstraintException(
+                    sprintf(
+                        'Product tag "%s" in language with id "%s" cannot be found by the search engine',
+                        $tag,
+                        $idLang
+                    ),
+                    ProductConstraintException::INVALID_TAG
+                );
+            }
+        }
     }
 }

--- a/src/Adapter/Tag/CommandHandler/AddTagHandler.php
+++ b/src/Adapter/Tag/CommandHandler/AddTagHandler.php
@@ -16,6 +16,7 @@ use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\CannotAddTagException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\DuplicateTagException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\ValueObject\TagId;
+use Language;
 use Tag;
 use Validate;
 
@@ -24,11 +25,28 @@ class AddTagHandler implements AddTagCommandHandlerInterface
 {
     public function handle(AddTagCommand $command): TagId
     {
+        $this->assertTagNameIsSearchable($command->getName(), (int) $command->getLanguageId());
         $this->assertTagIsNotDuplicate($command);
 
         $tag = $this->createLegacyTagFromCommand($command);
 
         return new TagId((int) $tag->id);
+    }
+
+    /**
+     * Asserts that the tag name yields at least one keyword when passed through the search
+     * indexer - otherwise the tag would be saved but never findable in the front-office search.
+     *
+     * @throws TagConstraintException
+     */
+    protected function assertTagNameIsSearchable(?string $name, int $idLang): void
+    {
+        if (!Validate::isSearchableName((string) $name, $idLang, (string) Language::getIsoById($idLang))) {
+            throw new TagConstraintException(
+                sprintf('Tag "%s" cannot be found by the search engine', $name),
+                TagConstraintException::INVALID_NAME
+            );
+        }
     }
 
     /**

--- a/src/Adapter/Tag/CommandHandler/AddTagHandler.php
+++ b/src/Adapter/Tag/CommandHandler/AddTagHandler.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Tag\CommandHandler;
 
+use Language;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Command\AddTagCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tag\CommandHandler\AddTagCommandHandlerInterface;
@@ -16,7 +17,6 @@ use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\CannotAddTagException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\DuplicateTagException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\ValueObject\TagId;
-use Language;
 use Tag;
 use Validate;
 

--- a/src/Adapter/Tag/CommandHandler/EditTagHandler.php
+++ b/src/Adapter/Tag/CommandHandler/EditTagHandler.php
@@ -16,7 +16,9 @@ use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\CannotUpdateTagException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\ValueObject\TagId;
+use Language;
 use Tag;
+use Validate;
 
 #[AsCommandHandler]
 class EditTagHandler implements EditTagCommandHandlerInterface
@@ -52,6 +54,13 @@ class EditTagHandler implements EditTagCommandHandlerInterface
         EditTagCommand $command
     ): void {
         if (null !== $command->getName()) {
+            $idLang = null !== $command->getLanguageId() ? (int) $command->getLanguageId() : (int) $tag->id_lang;
+            if (!Validate::isSearchableName($command->getName(), $idLang, (string) Language::getIsoById($idLang))) {
+                throw new TagConstraintException(
+                    sprintf('Tag "%s" cannot be found by the search engine', $command->getName()),
+                    TagConstraintException::INVALID_NAME
+                );
+            }
             $tag->name = $command->getName();
         }
 

--- a/src/Adapter/Tag/CommandHandler/EditTagHandler.php
+++ b/src/Adapter/Tag/CommandHandler/EditTagHandler.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Tag\CommandHandler;
 
+use Language;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Command\EditTagCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tag\CommandHandler\EditTagCommandHandlerInterface;
@@ -16,7 +17,6 @@ use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\CannotUpdateTagException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\ValueObject\TagId;
-use Language;
 use Tag;
 use Validate;
 

--- a/src/Core/Domain/Tag/Exception/TagConstraintException.php
+++ b/src/Core/Domain/Tag/Exception/TagConstraintException.php
@@ -15,4 +15,9 @@ class TagConstraintException extends TagException
      * When id is not valid
      */
     public const INVALID_ID = 10;
+
+    /**
+     * When the name is not valid (e.g. made of special characters only, which the search engine cannot index)
+     */
+    public const INVALID_NAME = 20;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/TagController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/TagController.php
@@ -13,6 +13,7 @@ use PrestaShop\PrestaShop\Core\Domain\Tag\Command\BulkDeleteTagCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Command\DeleteTagCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\CannotAddTagException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\CannotUpdateTagException;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagNotFoundException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
@@ -212,6 +213,13 @@ class TagController extends PrestaShopAdminController
                 [],
                 'Admin.Advparameters.Notification'
             ),
+            TagConstraintException::class => [
+                TagConstraintException::INVALID_NAME => $this->trans(
+                    'The tag must contain at least one letter or number so it can be found by the search.',
+                    [],
+                    'Admin.Advparameters.Notification'
+                ),
+            ],
         ];
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/TagFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/TagFeatureContext.php
@@ -15,6 +15,7 @@ use PrestaShop\PrestaShop\Core\Domain\Tag\Command\BulkDeleteTagCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Command\DeleteTagCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Command\EditTagCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\DuplicateTagException;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Query\GetTagForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Tag\QueryResult\EditableTag;
@@ -95,6 +96,14 @@ class TagFeatureContext extends AbstractDomainFeatureContext
     public function assertLastErrorIsDuplicateTag(): void
     {
         $this->assertLastErrorIs(DuplicateTagException::class);
+    }
+
+    /**
+     * @Then I should get error that tag name is invalid
+     */
+    public function assertLastErrorIsInvalidTagName(): void
+    {
+        $this->assertLastErrorIs(TagConstraintException::class, TagConstraintException::INVALID_NAME);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
@@ -60,6 +60,14 @@ Feature: Update product tags from Back Office (BO)
       | locale | value            |
       | en-US  | mechanic,watch   |
       | fr-FR  | montre,mécanique |
+    # A tag made of special characters only is stripped by search indexation and can never be found, so it is rejected
+    When I update product "productTags" tags with following values:
+      | tags[en-US] | ++++ |
+    Then I should get error that product tag is invalid
+    And product "productTags" localized "tags" should be:
+      | locale | value            |
+      | en-US  | mechanic,watch   |
+      | fr-FR  | montre,mécanique |
 
   Scenario: Remove all product tags
     When I update product "productTags" tags with following values:

--- a/tests/Integration/Behaviour/Features/Scenario/Tag/tag_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Tag/tag_management.feature
@@ -58,6 +58,19 @@ Feature: Tag management
     And tag "tag1" language should be "english"
     And tag "tag1" products should be "product2,product3"
 
+  Scenario: Creating a tag made of special characters only should not be allowed
+    Given I add a tag "tagInvalid" with specified properties:
+      | name             | ++++                |
+      | language         | french              |
+      | products         | product1,product2   |
+    Then I should get error that tag name is invalid
+
+  Scenario: Editing a tag to a name made of special characters only should not be allowed
+    When I edit tag "tag1" with specified properties:
+      | name             | ++++                |
+    Then I should get error that tag name is invalid
+    And tag "tag1" name should be "Tag 2"
+
   Scenario: Deleting tag
     When I delete the tag "tag1"
     Then the tag "tag1" should be deleted

--- a/tests/Integration/Classes/ValidateSearchableNameTest.php
+++ b/tests/Integration/Classes/ValidateSearchableNameTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Language;
+use PHPUnit\Framework\TestCase;
+use Validate;
+
+/**
+ * Validate::isSearchableName() delegates to Search::extractKeyWords(), which reads the
+ * search blacklist from Configuration and therefore needs a booted shop. This is why the
+ * coverage lives under tests/Integration/ rather than tests/Unit/.
+ *
+ * The truth table below pins the two premise-breaking examples raised in the review of
+ * PR #41664 (`----` is indexable, `a+` is not) alongside the obvious cases.
+ */
+class ValidateSearchableNameTest extends TestCase
+{
+    private const DEFAULT_LANG_ID = 1;
+
+    /**
+     * @dataProvider provideSearchableNames
+     */
+    public function testItAcceptsNamesTheIndexerKeeps(string $name): void
+    {
+        $this->assertTrue(
+            Validate::isSearchableName($name, self::DEFAULT_LANG_ID, $this->isoCode()),
+            sprintf('Expected "%s" to be searchable', $name)
+        );
+    }
+
+    /**
+     * @dataProvider provideNonSearchableNames
+     */
+    public function testItRejectsNamesTheIndexerStripsToNothing(string $name): void
+    {
+        $this->assertFalse(
+            Validate::isSearchableName($name, self::DEFAULT_LANG_ID, $this->isoCode()),
+            sprintf('Expected "%s" to be rejected as non-searchable', $name)
+        );
+    }
+
+    public function provideSearchableNames(): array
+    {
+        return [
+            'plain word'                          => ['summer'],
+            'digits only'                         => ['2024'],
+            'letters with leading special chars'  => ['+++promo'],
+            'accented letters'                    => ['été'],
+            // Hyphen-only terms are kept: PREG_CLASS_SEARCH_EXCLUDE only strips a term made
+            // entirely of excluded characters when the whole-term check matches, and the
+            // hyphen-preserving pass in extractKeyWords() adds "----" back. Verified on 9.x.
+            'dashes only are indexable'           => ['----'],
+            'hyphenated word'                     => ['t-shirt'],
+            // '/' is not in PREG_CLASS_SEARCH_EXCLUDE, so this term survives sanitization -
+            // another case a "contains letter/digit" rule would have over-rejected.
+            'slash keeps the term alive'          => ['+-*/'],
+        ];
+    }
+
+    public function provideNonSearchableNames(): array
+    {
+        return [
+            'plus signs'                => ['++++'],
+            'asterisks'                 => ['***'],
+            'hashes'                    => ['###'],
+            'single plus'               => ['+'],
+            'whitespace only'           => ['   '],
+            'empty string'              => [''],
+            // Contains a letter but indexation yields no keyword (verified on 9.x). This
+            // is why a character-class rule like "contains any letter or digit" was not
+            // enough - it would under-reject "a+".
+            'letter followed by excluded char' => ['a+'],
+            // Single-char tokens are filtered by the indexer under the default English lang.
+            'single letter'             => ['a'],
+            // CJK is only tokenised for iso zh/tw/ja; with iso "en" it drops.
+            'cjk letters under non-cjk lang' => ['中文'],
+        ];
+    }
+
+    private function isoCode(): string
+    {
+        return (string) Language::getIsoById(self::DEFAULT_LANG_ID);
+    }
+}

--- a/tests/Integration/Classes/ValidateSearchableNameTest.php
+++ b/tests/Integration/Classes/ValidateSearchableNameTest.php
@@ -49,36 +49,36 @@ class ValidateSearchableNameTest extends TestCase
     public function provideSearchableNames(): array
     {
         return [
-            'plain word'                          => ['summer'],
-            'digits only'                         => ['2024'],
-            'letters with leading special chars'  => ['+++promo'],
-            'accented letters'                    => ['été'],
+            'plain word' => ['summer'],
+            'digits only' => ['2024'],
+            'letters with leading special chars' => ['+++promo'],
+            'accented letters' => ['été'],
             // Hyphen-only terms are kept: PREG_CLASS_SEARCH_EXCLUDE only strips a term made
             // entirely of excluded characters when the whole-term check matches, and the
             // hyphen-preserving pass in extractKeyWords() adds "----" back. Verified on 9.x.
-            'dashes only are indexable'           => ['----'],
-            'hyphenated word'                     => ['t-shirt'],
+            'dashes only are indexable' => ['----'],
+            'hyphenated word' => ['t-shirt'],
             // '/' is not in PREG_CLASS_SEARCH_EXCLUDE, so this term survives sanitization -
             // another case a "contains letter/digit" rule would have over-rejected.
-            'slash keeps the term alive'          => ['+-*/'],
+            'slash keeps the term alive' => ['+-*/'],
         ];
     }
 
     public function provideNonSearchableNames(): array
     {
         return [
-            'plus signs'                => ['++++'],
-            'asterisks'                 => ['***'],
-            'hashes'                    => ['###'],
-            'single plus'               => ['+'],
-            'whitespace only'           => ['   '],
-            'empty string'              => [''],
+            'plus signs' => ['++++'],
+            'asterisks' => ['***'],
+            'hashes' => ['###'],
+            'single plus' => ['+'],
+            'whitespace only' => ['   '],
+            'empty string' => [''],
             // Contains a letter but indexation yields no keyword (verified on 9.x). This
             // is why a character-class rule like "contains any letter or digit" was not
             // enough - it would under-reject "a+".
             'letter followed by excluded char' => ['a+'],
             // Single-char tokens are filtered by the indexer under the default English lang.
-            'single letter'             => ['a'],
+            'single letter' => ['a'],
             // CJK is only tokenised for iso zh/tw/ja; with iso "en" it drops.
             'cjk letters under non-cjk lang' => ['中文'],
         ];

--- a/tests/Unit/Classes/ValidateCoreTest.php
+++ b/tests/Unit/Classes/ValidateCoreTest.php
@@ -390,4 +390,8 @@ class ValidateCoreTest extends TestCase
             [false, [45, true, 9]],
         ];
     }
+
+    // Validate::isSearchableName() delegates to Search::extractKeyWords(), which reads the
+    // search blacklist from Configuration and therefore needs a booted shop. Its coverage
+    // lives in tests/Integration/Classes/ValidateSearchableNameTest.
 }

--- a/tests/Unit/Core/Domain/Product/ValueObject/LocalizedTagsTest.php
+++ b/tests/Unit/Core/Domain/Product/ValueObject/LocalizedTagsTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Product\ValueObject;
+
+use Generator;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
+
+/**
+ * LocalizedTags only enforces the shape of a tag (VALID_TAG_PATTERN, i.e. no
+ * <, >, { or }). The searchability rule - "the indexer must yield at least one
+ * keyword" - is enforced in SetProductTagsHandler because it needs a booted
+ * shop; see tests/Integration/Classes/ValidateSearchableNameTest.
+ */
+class LocalizedTagsTest extends TestCase
+{
+    public function testItIsEmptyWhenConstructedWithoutAnyTag(): void
+    {
+        $localizedTags = new LocalizedTags(1, []);
+
+        Assert::assertTrue($localizedTags->isEmpty());
+        Assert::assertSame([], $localizedTags->getTags());
+    }
+
+    public function testItExposesTheLanguageIdItWasBuiltWith(): void
+    {
+        $localizedTags = new LocalizedTags(3, []);
+
+        Assert::assertSame(3, $localizedTags->getLanguageId()->getValue());
+    }
+
+    /**
+     * @dataProvider getShapeValidTags
+     *
+     * @param string[] $tags
+     * @param string[] $expectedTags
+     */
+    public function testItAcceptsTagsWithValidShape(array $tags, array $expectedTags): void
+    {
+        $localizedTags = new LocalizedTags(1, $tags);
+        Assert::assertSame($expectedTags, $localizedTags->getTags());
+    }
+
+    /**
+     * @dataProvider getShapeInvalidTags
+     */
+    public function testItRejectsTagsWithForbiddenCharacters(string $tag): void
+    {
+        $this->expectException(ProductConstraintException::class);
+        $this->expectExceptionCode(ProductConstraintException::INVALID_TAG);
+
+        new LocalizedTags(1, [$tag]);
+    }
+
+    public function getShapeValidTags(): Generator
+    {
+        // Empty values are filtered out before validation, not rejected.
+        yield 'empty values are skipped' => [['', 'summer'], ['summer']];
+        yield 'plain word' => [['summer'], ['summer']];
+        yield 'digits' => [['2024'], ['2024']];
+        yield 'accented letters' => [['été'], ['été']];
+        yield 'cjk letters' => [['中文'], ['中文']];
+        yield 'hyphenated word' => [['t-shirt'], ['t-shirt']];
+        // Would be rejected downstream by the searchability check in
+        // SetProductTagsHandler, but LocalizedTags itself accepts them.
+        yield 'punctuation only (shape ok)' => [['++++'], ['++++']];
+    }
+
+    public function getShapeInvalidTags(): Generator
+    {
+        yield 'contains <' => ['<script>'];
+        yield 'contains >' => ['tag>'];
+        yield 'contains {' => ['tag{x'];
+        yield 'contains }' => ['tag}'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A product tag made only of characters that the search indexer strips (e.g. `++++`, `***`, `a+`) could be saved on a product or created on the Tags page, but the front-office search engine turned such terms into nothing during indexation, so the product could never be found through that tag. This PR asks the indexer itself. `Validate::isSearchableName($name, $idLang, $isoCode)` delegates to `Search::extractKeyWords()` and returns `false` when the indexer yields no keyword — validation follows indexation by construction, without a duplicate rule. Enforcement lives at the write boundaries: **`SetProductTagsHandler`** for the product SEO tab (moved out of the `LocalizedTags` value object, which is now shape-only, because the check needs a booted shop for the search blacklist), the **`Add`/`Edit` tag handlers** for the Symfony Tags page (new `TagConstraintException::INVALID_NAME`), and **`Tag::addTags`** as a safety net for CSV import.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | **Product page:** create/edit a product V2, go to the SEO tab, add the tag `++++` (or `***`, `+`, `a+`) and save → the tag is now rejected with a validation error (previously it was saved but unsearchable). Adding a normal tag like `summer` or a hyphenated `t-shirt` still works. Note: `----` is *accepted* — the indexer actually keeps hyphen-only terms, so validation now matches. <br> **Tags page** (Shop Parameters > Search > Tags): create or edit a tag named `++++` → an error is shown (\"Tag ... cannot be found by the search engine\"). A tag containing letters (e.g. `+++promo`) is accepted. <br> **CSV import** (Advanced Parameters > Import > Products, mapping a Tags column): a row carrying a non-searchable tag is skipped rather than saved. <br> **Regression:** existing tags and multilingual tags keep working; a normal tag remains findable in the FO search. Automated coverage: unit `LocalizedTagsTest` (shape only) + integration `ValidateSearchableNameTest` (indexer-backed truth table, pinning `----` searchable and `a+` non-searchable — the two premise-breaking cases from the review), Behat scenarios in `update_tags.feature` and `tag_management.feature`.
| UI Tests          |
| Fixed issue or discussion?     | Fixes #28293
| Related PRs       |
| Sponsor company   |