### PR TITLE
Display invoice prefix in employee language on order view page

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -236,7 +236,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 $product['location'],
                 !empty($product['id_order_invoice']) ? $product['id_order_invoice'] : null,
                 !empty($product['id_order_invoice'])
-                    ? $orderInvoice->getInvoiceNumberFormatted((int) $order->getAssociatedLanguage()->getId())
+                    ? $orderInvoice->getInvoiceNumberFormatted($this->contextLanguageId)
                     : '',
                 $productType,
                 (bool) Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($product['product_id'])),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | On the BO Orders > View page, the invoice prefix shown in the **Products** block was formatted using the order's (customer's) language instead of the connected employee's language. As a result, the prefix could differ from the one shown in the **Documents** tab (e.g. `#FRxxxxx` instead of `#INxxxx`) on a multilingual shop. `GetOrderProductsForViewingHandler` now formats the invoice number with the employee context language (`$this->contextLanguageId`), consistent with `GetOrderForViewingHandler` which already uses the context language for the Documents tab, delivery slips, credit slips and payment-linked invoices.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install a multilingual shop (e.g. English as default + French) with distinct invoice prefixes per language (Configure `PS_INVOICE_PREFIX`, e.g. `IN` for English and `FR` for French).<br>2. In the FO, switch to French and place an order.<br>3. In the BO, open that order (employee language = English) and generate an invoice.<br>4. In the **Products** block, the invoice number column must now show the English prefix (`#INxxxxx`), matching the **Documents** tab — not the French prefix (`#FRxxxxx`).
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/29149625208
| Fixed issue or discussion?     | Fixes #29009
| Related PRs       | 
| Sponsor company   | 
