### PR TITLE
Show all customer groups in the customer form even when names are duplicated

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/GroupByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/GroupByIdChoiceProvider.php
@@ -7,7 +7,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 
 use Group;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 /**
@@ -16,22 +16,15 @@ use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
 {
     /**
-     * @var ConfigurationInterface
-     */
-    private $configuration;
-
-    /**
      * @var int
      */
     private $contextLangId;
 
     /**
-     * @param ConfigurationInterface $configuration
      * @param int $contextLangId
      */
-    public function __construct(ConfigurationInterface $configuration, int $contextLangId)
+    public function __construct(int $contextLangId)
     {
-        $this->configuration = $configuration;
         $this->contextLangId = $contextLangId;
     }
 
@@ -40,24 +33,13 @@ final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
      */
     public function getChoices(): array
     {
-        $choices = [];
-        $groups = Group::getGroups($this->contextLangId, true);
-
-        $groupsToSkip = [
-            (int) $this->configuration->get('PS_UNIDENTIFIED_GROUP'),
-            (int) $this->configuration->get('PS_GUEST_GROUP'),
-        ];
-
-        foreach ($groups as $group) {
-            $groupId = $group['id_group'];
-
-            if (in_array($groups, $groupsToSkip)) {
-                continue;
-            }
-
-            $choices[$group['name']] = (int) $groupId;
-        }
-
-        return $choices;
+        // Use FormChoiceFormatter so groups sharing the same name don't collapse
+        // into a single choice (the name is used as the choice key by Symfony).
+        return FormChoiceFormatter::formatFormChoices(
+            Group::getGroups($this->contextLangId, true),
+            'id_group',
+            'name',
+            false
+        );
     }
 }

--- a/tests/UI/campaigns/regression/customers/duplicateGroupNamesInCustomerForm.ts
+++ b/tests/UI/campaigns/regression/customers/duplicateGroupNamesInCustomerForm.ts
@@ -1,0 +1,195 @@
+import testContext from '@utils/testContext';
+import {expect} from 'chai';
+
+import {
+  boCustomerGroupsPage,
+  boCustomerGroupsCreatePage,
+  boCustomerSettingsPage,
+  boCustomersPage,
+  boCustomersCreatePage,
+  boDashboardPage,
+  boLoginPage,
+  type BrowserContext,
+  FakerGroup,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+// https://github.com/PrestaShop/PrestaShop/issues/28977
+const baseContext: string = 'regression_customers_duplicateGroupNamesInCustomerForm';
+
+/*
+Regression test for issue #28977:
+The customer "Default customer group" / "Group access" selectors used to be keyed by group
+name, so two groups sharing the same name collapsed into a single entry.
+Scenario:
+- Create two customer groups with the exact same name
+- Go to the add customer page
+- Check that both groups are listed in the "Default customer group" dropdown
+- Delete the two created groups
+ */
+describe('Regression - Customers : Groups sharing the same name are all displayed in the customer form', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+  let numberOfGroups: number = 0;
+
+  const groupName: string = 'DuplicateAccessGroup';
+  const firstGroupData: FakerGroup = new FakerGroup({name: groupName});
+  const secondGroupData: FakerGroup = new FakerGroup({name: groupName});
+
+  // before and after functions
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  describe('Create two groups sharing the same name', async () => {
+    it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.shopParametersParentLink,
+        boDashboardPage.customerSettingsLink,
+      );
+      await boCustomerSettingsPage.closeSfToolBar(page);
+
+      const pageTitle = await boCustomerSettingsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerSettingsPage.pageTitle);
+    });
+
+    it('should go to \'Groups\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToGroupsPage', baseContext);
+
+      await boCustomerSettingsPage.goToGroupsPage(page);
+
+      const pageTitle = await boCustomerGroupsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsPage.pageTitle);
+    });
+
+    it('should reset all filters and get number of groups', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'resetFilterFirst', baseContext);
+
+      numberOfGroups = await boCustomerGroupsPage.resetAndGetNumberOfLines(page);
+      expect(numberOfGroups).to.be.above(0);
+    });
+
+    it('should create the first group', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createFirstGroup', baseContext);
+
+      await boCustomerGroupsPage.goToNewGroupPage(page);
+
+      const textResult = await boCustomerGroupsCreatePage.createEditGroup(page, firstGroupData);
+      expect(textResult).to.contains(boCustomerGroupsPage.successfulCreationMessage);
+
+      const numberOfGroupsAfterCreation = await boCustomerGroupsPage.getNumberOfElementInGrid(page);
+      expect(numberOfGroupsAfterCreation).to.be.equal(numberOfGroups + 1);
+    });
+
+    it('should create the second group with the same name', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createSecondGroup', baseContext);
+
+      await boCustomerGroupsPage.goToNewGroupPage(page);
+
+      const textResult = await boCustomerGroupsCreatePage.createEditGroup(page, secondGroupData);
+      expect(textResult).to.contains(boCustomerGroupsPage.successfulCreationMessage);
+
+      const numberOfGroupsAfterCreation = await boCustomerGroupsPage.getNumberOfElementInGrid(page);
+      expect(numberOfGroupsAfterCreation).to.be.equal(numberOfGroups + 2);
+    });
+  });
+
+  describe('Check both groups are displayed in the add customer form', async () => {
+    it('should go to \'Customers > Customers\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomersPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.customersParentLink,
+        boDashboardPage.customersLink,
+      );
+
+      const pageTitle = await boCustomersPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomersPage.pageTitle);
+    });
+
+    it('should go to add new customer page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewCustomerPage', baseContext);
+
+      await boCustomersPage.goToAddNewCustomerPage(page);
+
+      const pageTitle = await boCustomersCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomersCreatePage.pageTitleCreate);
+    });
+
+    it('should check that both groups are listed in the default customer group dropdown', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDefaultGroupOptions', baseContext);
+
+      const groupOptions = await boCustomersCreatePage.getDefaultCustomerGroupOptions(page);
+      const matchingOptions = groupOptions.filter((option: string) => option.includes(groupName));
+      expect(matchingOptions.length).to.be.equal(2);
+    });
+  });
+
+  describe('Delete the two created groups', async () => {
+    it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPageToDelete', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.shopParametersParentLink,
+        boDashboardPage.customerSettingsLink,
+      );
+
+      const pageTitle = await boCustomerSettingsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerSettingsPage.pageTitle);
+    });
+
+    it('should go to \'Groups\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToGroupsPageToDelete', baseContext);
+
+      await boCustomerSettingsPage.goToGroupsPage(page);
+
+      const pageTitle = await boCustomerGroupsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsPage.pageTitle);
+    });
+
+    it('should filter the list by the duplicated name', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterToDelete', baseContext);
+
+      await boCustomerGroupsPage.resetFilter(page);
+      await boCustomerGroupsPage.filterTable(page, 'input', 'b!name', groupName);
+
+      const numberOfGroupsAfterFilter = await boCustomerGroupsPage.getNumberOfElementInGrid(page);
+      expect(numberOfGroupsAfterFilter).to.be.equal(2);
+    });
+
+    it('should bulk delete the two groups', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'bulkDeleteGroups', baseContext);
+
+      const textResult = await boCustomerGroupsPage.bulkDeleteGroups(page);
+      expect(textResult).to.contains(boCustomerGroupsPage.successfulMultiDeleteMessage);
+    });
+
+    it('should reset filter and check the number of groups', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'resetFilterAfterDelete', baseContext);
+
+      const numberOfGroupsAfterDelete = await boCustomerGroupsPage.resetAndGetNumberOfLines(page);
+      expect(numberOfGroupsAfterDelete).to.be.equal(numberOfGroups);
+    });
+  });
+});


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Customer groups sharing the same name were not all displayed in the **Group access** and **Default customer group** selectors of the Customer add/edit form (and the *Orders > Add new order > Add new customer* form, which reuses it). The Adapter `GroupByIdChoiceProvider` built the Symfony choices array keyed by the group **name**, so groups with an identical name collapsed into a single entry (last one wins). The guest/unidentified group filtering was broken too (`in_array($groups, ...)` tested the whole array instead of the current id). The provider now delegates to `FormChoiceFormatter` (like the Core provider already does), which disambiguates duplicate names by appending their id, and the filtering compares the group id.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **Shop Parameters > Customer Settings > Groups** and create two groups with the exact same name.<br>2. Go to **Customers > Add new customer**.<br>3. Both groups must now appear in the **Group access** list and in the **Default customer group** dropdown (duplicates shown as `Name (id)`).<br>4. Same check on **Orders > Add new order > Add new customer**.
| UI Tests          | A regression campaign is added (`tests/UI/campaigns/regression/customers/duplicateGroupNamesInCustomerForm.ts`). It requires the companion ui-testing-library change (see Related PRs).
| Fixed issue or discussion?     | Fixes #28977
| Related PRs       | Requires a ui-testing-library PR adding `BOCustomersCreatePage.getDefaultCustomerGroupOptions()` (used by the new campaign). https://github.com/PrestaShop/ui-testing-library/pull/1003
| Sponsor company   |

### Notes

The **Category** add/edit form already used the Core `GroupByIdChoiceProvider` (which goes through `FormChoiceFormatter`), so it was not affected — only the Customer/Order forms went through the buggy Adapter provider.

