### PR TITLE
refactor: use short array syntax

### DIFF
--- a/tests/Unit/Resources/config/params.php
+++ b/tests/Unit/Resources/config/params.php
@@ -1,9 +1,9 @@
 <?php
 
-return array(
-    'parameters' => array(
+return [
+    'parameters' => [
         'a' => '127.0.0.1',
         'b' => '',
         'c_d' => '1234',
-    ),
-);
+    ],
+];


### PR DESCRIPTION
### 问题背景
此 PR 旨在改进代码风格，使其符合现代 PHP 的最佳实践和仓库的编码标准。旧式的 `array()` 语法虽然功能上完全等价，但使用 `[]` 短数组语法可以使代码更简洁、更易读，并与其他 PHP 项目保持一致。

### 修改内容
- 将 `tests/Unit/Resources/config/params.php` 文件中的数组语法从旧式 `array(...)` 更新为现代的 `[...]` 短数组语法。
- **原因**：此修改纯粹是为了提升代码的可读性和风格一致性，不涉及任何逻辑变更。现代 PHP 社区广泛推荐使用 `[]` 语法，因为它更简洁。
- **提升**：代码更简洁，更符合当前 PHP 编码标准（如 PSR 系列），有助于保持整个仓库代码风格的一致性。

### 验证方式
- 此更改仅涉及语法形式，不改变任何功能或逻辑。文件内容在语义上是完全相同的。
- 已确认现有的单元测试在修改后依然通过，因为代码行为没有任何变化。
- 无需添加新的测试，因为这是纯粹的代码风格优化。

### 其他信息
- **Breaking Changes**: 无。这是一个纯代码风格的修改，不会影响任何 API 或功能行为。
- **文档更新**: 不需要。此修改不涉及功能或用法的变更。
- **已知限制**: 无。这是标准且安全的重构。