### PR TITLE
Update Search.php

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -217,7 +217,7 @@ class SearchCore
                     ? 'REGEXP CONCAT(\'\\\\b\', alias, \'\\\\b\')'
                     : 'REGEXP CONCAT(\'(^|[[:space:]]|[[:<:]])\', alias, \'([[:space:]]|[[:>:]]|$)\')'
             );
-            $query = str_replace('/TERM/', pSQL($string), $query);
+            $query = str_replace('TERM', pSQL($string), $query);
             $aliases = Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->executeS($query);
             $words = explode(' ', $string);
             $processed_words = [];


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------------------------------------------------------- |
| Branch?           | 9.1.x |
| Description?      | Fixes the PrestaShop 9 search alias replacement issue. The alias lookup SQL contains the placeholder TERM, but the current code tries to replace /TERM/. Because of this mismatch, the searched term is never injected into the alias query, so aliases saved in the Back Office are ignored on the front-office search page. Changing /TERM/ to TERM makes the placeholder replacement work correctly and restores native search alias functionality. |
| Type?             | bug fix |
| Category?         | FO |
| BC breaks?        | no |
| Deprecations?     | no |
| How to test?      | 1. In Back Office, go to Shop Parameters > Search > Aliases. 2. Add a test alias, for example sneker as the alias and sneakers as the result. 3. Make sure there is at least one active, indexed product containing sneakers in its searchable content. 4. Rebuild the search index if needed. 5. In the front office, search for sneker, for example using /search?controller=search&s=sneker. 6. Before this fix, the alias replacement is not applied and the search may return no products. After this fix, the search behaves like searching for sneakers. |
| UI Tests          | Not run. |
| Fixed issue or discussion?     | Fixes #41510 |
| Related PRs       | None |
| Sponsor company   | None |