### PR TITLE
Reject non-http(s) back url schemes in BackUrlProvider

### DIFF
--- a/src/Core/Util/Url/BackUrlProvider.php
+++ b/src/Core/Util/Url/BackUrlProvider.php
@@ -22,9 +22,10 @@ class BackUrlProvider
     {
         $backUrl = rawurldecode($request->query->get('back', ''));
 
-        // The back url is later followed as a redirection target and as a link href, so a value
-        // pointing somewhere else than the current host is dropped to avoid an open redirection.
-        if ('' === $backUrl || !$this->belongsToCurrentHost($backUrl, $request)) {
+        // The back url is also rendered as the cancel-button href, so a javascript: or data: value
+        // would become a clickable script link. External http(s) targets stay supported, only a non
+        // http(s) scheme is dropped, in which case both consumers fall back to their safe default.
+        if ('' !== $backUrl && !$this->hasHttpScheme($backUrl)) {
             return '';
         }
 
@@ -33,35 +34,19 @@ class BackUrlProvider
 
     /**
      * @param string $url
-     * @param Request $request
      *
      * @return bool
      */
-    private function belongsToCurrentHost(string $url, Request $request): bool
+    private function hasHttpScheme(string $url): bool
     {
-        // Browsers treat backslashes as forward slashes, so normalise them first otherwise a value
-        // such as "/\evil.com" would smuggle an external host past the checks below.
+        // Browsers treat backslashes as forward slashes, so normalise them before reading the scheme.
         $normalisedUrl = str_replace('\\', '/', $url);
 
-        // Protocol-relative urls ("//host") resolve to an external host once the browser prepends
-        // the current scheme.
-        if (str_starts_with($normalisedUrl, '//')) {
-            return false;
+        // A url without an explicit scheme is relative (or protocol-relative) and is kept as before.
+        if (!preg_match('#^\s*([a-z][a-z0-9+.\-]*)\s*:#i', $normalisedUrl, $matches)) {
+            return true;
         }
 
-        // Only http(s) urls are accepted, which also rules out javascript: and data: schemes.
-        if (preg_match('#^([a-z][a-z0-9+.\-]*):#i', $normalisedUrl, $matches)
-            && !in_array(strtolower($matches[1]), ['http', 'https'], true)
-        ) {
-            return false;
-        }
-
-        $parsedUrl = parse_url($normalisedUrl);
-        if (false === $parsedUrl) {
-            return false;
-        }
-
-        // Relative urls have no host and stay on the current shop, absolute ones must target it.
-        return empty($parsedUrl['host']) || 0 === strcasecmp($parsedUrl['host'], (string) $request->getHost());
+        return in_array(strtolower(trim($matches[1])), ['http', 'https'], true);
     }
 }

--- a/src/Core/Util/Url/BackUrlProvider.php
+++ b/src/Core/Util/Url/BackUrlProvider.php
@@ -20,8 +20,48 @@ class BackUrlProvider
      */
     public function getBackUrl(Request $request)
     {
-        $backUrl = $request->query->get('back', '');
+        $backUrl = rawurldecode($request->query->get('back', ''));
 
-        return rawurldecode($backUrl);
+        // The back url is later followed as a redirection target and as a link href, so a value
+        // pointing somewhere else than the current host is dropped to avoid an open redirection.
+        if ('' === $backUrl || !$this->belongsToCurrentHost($backUrl, $request)) {
+            return '';
+        }
+
+        return $backUrl;
+    }
+
+    /**
+     * @param string $url
+     * @param Request $request
+     *
+     * @return bool
+     */
+    private function belongsToCurrentHost(string $url, Request $request): bool
+    {
+        // Browsers treat backslashes as forward slashes, so normalise them first otherwise a value
+        // such as "/\evil.com" would smuggle an external host past the checks below.
+        $normalisedUrl = str_replace('\\', '/', $url);
+
+        // Protocol-relative urls ("//host") resolve to an external host once the browser prepends
+        // the current scheme.
+        if (str_starts_with($normalisedUrl, '//')) {
+            return false;
+        }
+
+        // Only http(s) urls are accepted, which also rules out javascript: and data: schemes.
+        if (preg_match('#^([a-z][a-z0-9+.\-]*):#i', $normalisedUrl, $matches)
+            && !in_array(strtolower($matches[1]), ['http', 'https'], true)
+        ) {
+            return false;
+        }
+
+        $parsedUrl = parse_url($normalisedUrl);
+        if (false === $parsedUrl) {
+            return false;
+        }
+
+        // Relative urls have no host and stay on the current shop, absolute ones must target it.
+        return empty($parsedUrl['host']) || 0 === strcasecmp($parsedUrl['host'], (string) $request->getHost());
     }
 }

--- a/src/Core/Util/Url/BackUrlProvider.php
+++ b/src/Core/Util/Url/BackUrlProvider.php
@@ -39,14 +39,21 @@ class BackUrlProvider
      */
     private function hasHttpScheme(string $url): bool
     {
-        // Browsers treat backslashes as forward slashes, so normalise them before reading the scheme.
-        $normalisedUrl = str_replace('\\', '/', $url);
+        // Browsers strip ASCII tab, LF and CR from anywhere in a URL and trim leading C0 controls
+        // before reading the scheme, and treat backslashes as forward slashes. Normalise the same
+        // way first, or "java\tscript:" passes as relative here and still runs in the browser.
+        $normalisedUrl = str_replace(['\\', "\t", "\n", "\r"], ['/', '', '', ''], $url);
+        $normalisedUrl = ltrim($normalisedUrl, "\x00..\x20");
 
-        // A url without an explicit scheme is relative (or protocol-relative) and is kept as before.
-        if (!preg_match('#^\s*([a-z][a-z0-9+.\-]*)\s*:#i', $normalisedUrl, $matches)) {
+        $matched = preg_match('#^([a-z][a-z0-9+.\-]*):#i', $normalisedUrl, $matches);
+        if (false === $matched) {
+            // A failed match says nothing about the value, so refuse instead of letting it through.
+            return false;
+        }
+        if (0 === $matched) {
             return true;
         }
 
-        return in_array(strtolower(trim($matches[1])), ['http', 'https'], true);
+        return in_array(strtolower($matches[1]), ['http', 'https'], true);
     }
 }

--- a/tests/Unit/Core/Util/Url/BackUrlProviderTest.php
+++ b/tests/Unit/Core/Util/Url/BackUrlProviderTest.php
@@ -33,7 +33,7 @@ class BackUrlProviderTest extends TestCase
     /**
      * @dataProvider provideBackUrls
      */
-    public function testItOnlyKeepsBackUrlsPointingToTheCurrentShop(string $backUrl, string $expected)
+    public function testItDropsOnlyNonHttpSchemes(string $backUrl, string $expected)
     {
         $backUrlProvider = new BackUrlProvider();
 
@@ -68,19 +68,14 @@ class BackUrlProviderTest extends TestCase
             'http://localhost.org/admin-dev/index.php/sell/customers/2/view',
         ];
 
-        yield 'external host is dropped' => [
-            'https://evil.example/login',
-            '',
+        yield 'external http url stays' => [
+            'https://dashboard.example/control',
+            'https://dashboard.example/control',
         ];
 
-        yield 'protocol relative url is dropped' => [
-            '//evil.example/login',
-            '',
-        ];
-
-        yield 'backslash host is dropped' => [
-            '/\\evil.example',
-            '',
+        yield 'protocol relative url stays' => [
+            '//dashboard.example/control',
+            '//dashboard.example/control',
         ];
 
         yield 'javascript scheme is dropped' => [
@@ -90,11 +85,6 @@ class BackUrlProviderTest extends TestCase
 
         yield 'data scheme is dropped' => [
             'data:text/html,<script>alert(1)</script>',
-            '',
-        ];
-
-        yield 'look-alike host is dropped' => [
-            'http://localhost.org.evil.example/',
             '',
         ];
     }

--- a/tests/Unit/Core/Util/Url/BackUrlProviderTest.php
+++ b/tests/Unit/Core/Util/Url/BackUrlProviderTest.php
@@ -17,11 +17,85 @@ class BackUrlProviderTest extends TestCase
         $backUrlProvider = new BackUrlProvider();
 
         $actualResult = $backUrlProvider->getBackUrl(
-            new Request([
-                'back' => 'http%3A%2F%2Flocalhost',
-            ])
+            new Request(
+                ['back' => 'http%3A%2F%2Flocalhost'],
+                [],
+                [],
+                [],
+                [],
+                ['HTTP_HOST' => 'localhost']
+            )
         );
 
         $this->assertEquals('http://localhost', $actualResult);
+    }
+
+    /**
+     * @dataProvider provideBackUrls
+     */
+    public function testItOnlyKeepsBackUrlsPointingToTheCurrentShop(string $backUrl, string $expected)
+    {
+        $backUrlProvider = new BackUrlProvider();
+
+        $actualResult = $backUrlProvider->getBackUrl(
+            new Request(
+                ['back' => rawurlencode($backUrl)],
+                [],
+                [],
+                [],
+                [],
+                ['HTTP_HOST' => 'localhost.org']
+            )
+        );
+
+        $this->assertEquals($expected, $actualResult);
+    }
+
+    public static function provideBackUrls(): iterable
+    {
+        yield 'relative url stays' => [
+            '/admin-dev/index.php?controller=AdminCustomers&conf=4',
+            '/admin-dev/index.php?controller=AdminCustomers&conf=4',
+        ];
+
+        yield 'bare relative url stays' => [
+            'index.php?controller=AdminProducts',
+            'index.php?controller=AdminProducts',
+        ];
+
+        yield 'absolute url on the same host stays' => [
+            'http://localhost.org/admin-dev/index.php/sell/customers/2/view',
+            'http://localhost.org/admin-dev/index.php/sell/customers/2/view',
+        ];
+
+        yield 'external host is dropped' => [
+            'https://evil.example/login',
+            '',
+        ];
+
+        yield 'protocol relative url is dropped' => [
+            '//evil.example/login',
+            '',
+        ];
+
+        yield 'backslash host is dropped' => [
+            '/\\evil.example',
+            '',
+        ];
+
+        yield 'javascript scheme is dropped' => [
+            'javascript:alert(document.cookie)',
+            '',
+        ];
+
+        yield 'data scheme is dropped' => [
+            'data:text/html,<script>alert(1)</script>',
+            '',
+        ];
+
+        yield 'look-alike host is dropped' => [
+            'http://localhost.org.evil.example/',
+            '',
+        ];
     }
 }

--- a/tests/Unit/Core/Util/Url/BackUrlProviderTest.php
+++ b/tests/Unit/Core/Util/Url/BackUrlProviderTest.php
@@ -51,6 +51,45 @@ class BackUrlProviderTest extends TestCase
         $this->assertEquals($expected, $actualResult);
     }
 
+    /**
+     * The fail-closed branch is the security-relevant half of the guard and nothing else exercises it:
+     * preg_match() has to return false, not 0. Exhausting the backtrack limit does that. The JIT is
+     * disabled alongside because its error path would not reach the same branch, and the test needs
+     * its own process: PHP caches compiled patterns per process, so once an earlier test has compiled
+     * this pattern with the JIT enabled, setting pcre.jit at runtime no longer affects it and the
+     * backtrack limit is never hit.
+     *
+     * @runInSeparateProcess
+     *
+     * @preserveGlobalState disabled
+     */
+    public function testItDropsTheUrlWhenTheSchemeCheckErrors()
+    {
+        $backUrlProvider = new BackUrlProvider();
+        $previousLimit = ini_get('pcre.backtrack_limit');
+        $previousJit = ini_get('pcre.jit');
+        ini_set('pcre.backtrack_limit', '2');
+        ini_set('pcre.jit', '0');
+
+        try {
+            $actualResult = $backUrlProvider->getBackUrl(
+                new Request(
+                    ['back' => rawurlencode(str_repeat('a', 50) . ':')],
+                    [],
+                    [],
+                    [],
+                    [],
+                    ['HTTP_HOST' => 'localhost']
+                )
+            );
+        } finally {
+            ini_set('pcre.backtrack_limit', (string) $previousLimit);
+            ini_set('pcre.jit', (string) $previousJit);
+        }
+
+        $this->assertSame('', $actualResult, 'a scheme check that errored must not let the value through');
+    }
+
     public static function provideBackUrls(): iterable
     {
         yield 'relative url stays' => [

--- a/tests/Unit/Core/Util/Url/BackUrlProviderTest.php
+++ b/tests/Unit/Core/Util/Url/BackUrlProviderTest.php
@@ -87,5 +87,25 @@ class BackUrlProviderTest extends TestCase
             'data:text/html,<script>alert(1)</script>',
             '',
         ];
+
+        yield 'javascript scheme with leading control character is dropped' => [
+            "\0javascript:alert(1)",
+            '',
+        ];
+
+        yield 'javascript scheme with embedded tab is dropped' => [
+            "java\tscript:alert(1)",
+            '',
+        ];
+
+        yield 'javascript scheme with embedded line feed is dropped' => [
+            "java\nscript:alert(1)",
+            '',
+        ];
+
+        yield 'javascript scheme with embedded carriage return is dropped' => [
+            "java\rscript:alert(1)",
+            '',
+        ];
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In the back office, open a form that uses the cancel button (for example a customer edit page) and append `&back=javascript:alert(document.cookie)` to the URL. Before the change the cancel link carries that `javascript:` value as its href; after it, the link falls back to the default route. Confirm that a normal relative back url and an absolute http(s) back url (including an external one) still work unchanged.
| Fixed issue or discussion?     | n/a
| UI Tests          | n/a

**Problem**

`BackUrlProvider::getBackUrl` returns the decoded `back` query value as-is. Two consumers trust it: `BackUrlRedirectResponseListener` feeds it to `RedirectResponse::setTargetUrl`, and `PathWithBackUrlExtension::getPathWithBackUrl` renders it as the cancel-button href. A value such as `back=javascript:alert(document.cookie)` therefore becomes a clickable script link in the admin template.

**Cause**

The decoded value is rendered into an href without any scheme check, so non http(s) schemes (`javascript:`, `data:`) are kept verbatim.

**Fix**

The provider now drops a `back` value only when it carries an explicit scheme that is not `http`/`https`; in that case both consumers fall back to their existing safe default. Relative urls and absolute http(s) urls are kept untouched, so external back targets (used to redirect to an external dashboard) keep working as before.
