### PR TITLE
Fix: HTMLPurifier through twig extension is not adhering to cache dir config

### DIFF
--- a/src/PrestaShopBundle/Utils/HTMLPurifier.php
+++ b/src/PrestaShopBundle/Utils/HTMLPurifier.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Utils;
 
 use HTMLPurifier_Config;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class HTMLPurifier
 {
@@ -17,12 +18,16 @@ class HTMLPurifier
      */
     private $instance;
 
-    public function __construct()
+    public function __construct(ParameterBagInterface $parameterBag)
     {
         $config = HTMLPurifier_Config::createDefault();
         // We must keep IDs that are by JS used to target element
         $config->set('Attr.EnableID', true);
         $config->set('Attr.AllowedFrameTargets', ['_blank']);
+
+        $legacyCacheDir = $parameterBag->get('prestashop.legacy_cache_dir');
+        $config->set('Cache.SerializerPath', $legacyCacheDir . 'purifier');
+
         $purifier = new \HTMLPurifier($config);
         $this->instance = $purifier;
     }

--- a/src/PrestaShopBundle/Utils/HTMLPurifier.php
+++ b/src/PrestaShopBundle/Utils/HTMLPurifier.php
@@ -9,7 +9,8 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Utils;
 
 use HTMLPurifier_Config;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Filesystem;
 
 class HTMLPurifier
 {
@@ -18,15 +19,20 @@ class HTMLPurifier
      */
     private $instance;
 
-    public function __construct(ParameterBagInterface $parameterBag)
-    {
+    public function __construct(
+        private readonly Filesystem $filesystem,
+        #[Autowire(param: 'prestashop.legacy_cache_dir')]
+        private readonly string $cacheDir,
+    ) {
         $config = HTMLPurifier_Config::createDefault();
         // We must keep IDs that are by JS used to target element
         $config->set('Attr.EnableID', true);
         $config->set('Attr.AllowedFrameTargets', ['_blank']);
 
-        $legacyCacheDir = $parameterBag->get('prestashop.legacy_cache_dir');
-        $config->set('Cache.SerializerPath', $legacyCacheDir . 'purifier');
+        $serializerPath = $this->cacheDir . 'purifier';
+        $this->filesystem->mkdir($serializerPath);
+
+        $config->set('Cache.SerializerPath', $serializerPath);
 
         $purifier = new \HTMLPurifier($config);
         $this->instance = $purifier;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes the cache directory used by `PrestaShopBundle\Utils\HTMLPurifier`. <br/>HTMLPurifier cache files are now stored in PrestaShop’s cache directory instead of being generated inside the `vendor/` directory.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |no
| How to test?      | 1. Clear the PrestaShop cache.<br/>2. Make sure the following directory does not already contain newly generated HTMLPurifier cache files: `vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache`<br/>3.Open an admin order page.<br/>4. Check that the HTMLPurifier cache files are generated inside the PrestaShop cache directory, for example: `var/cache/*/purifier`<br/>5. Confirm that no new HTMLPurifier cache files are generated under the vendor/ directory.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/prestaShop/PrestaShop/issues/41669
| Related PRs       | 
| Sponsor company   | Codencode snc

---

@jolelievre @kpodemski, if preferred, I can also inject the legacy cache directory as a service argument:

```yaml
$legacyCacheDir: '%prestashop.legacy_cache_dir%'
```

similar to what is already done here:

https://github.com/PrestaShop/PrestaShop/blob/68d1e873234c85ff75c706861bfabfeb3f6ff089/src/PrestaShopBundle/Resources/config/services/bundle/cache.yml#L25-L29

What do you think?
Maybe I should target the develop branch?

