### PR TITLE
Avoid uncaught exception on customer service attachment with unsupported extension

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -535,12 +535,14 @@ class AdminCustomerThreadsControllerCore extends AdminController
             }
         }
 
-        if (!$extension) {
-            throw new PrestaShopException('Invalid file extension.');
-        }
+        if (!$extension || !Validate::isFileName($filename)) {
+            $this->errors[] = $this->trans(
+                'The file type of this attachment is not supported and cannot be displayed.',
+                [],
+                'Admin.Orderscustomers.Notification'
+            );
 
-        if (!Validate::isFileName($filename)) {
-            throw new PrestaShopException('Invalid filename.');
+            return;
         }
 
         if (ob_get_level() && ob_get_length() > 0) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When opening a Customer Service thread attachment whose extension is not in the openable whitelist, `AdminCustomerThreadsController::openUploadedFile()` threw a raw `PrestaShopException` (`Invalid file extension.` / `Invalid filename.`), producing a fatal white error page in the BO. This PR replaces the thrown exceptions with a translated error notification displayed on the thread view, so the merchant gets clear feedback instead of a crash. The two guards are merged and the early `return` lets `initContent()` fall through to the normal thread rendering where the error is shown.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a Customer Service thread that has an attachment, then craft the attachment view URL with a filename whose extension is not in the openable list (e.g. an existing upload renamed/served with an unsupported extension). Before: a fatal `[PrestaShopException] Invalid file extension.` page is shown. After: you stay on the thread view with a clean error notification "The file type of this attachment is not supported and cannot be displayed.". Supported attachments (txt, rtf, doc, docx, pdf, zip, png, jpeg, gif, jpg, webp) still open/download normally.
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes #35278
| Related PRs       |
| Sponsor company   |

This hardens the behaviour described in the issue. Note that the exact `.webp` reproduction from the report is already fixed by the merged #37775 (which synced the BO openable list with the front-office contact form); this change ensures any future mismatch — or a crafted URL / legacy file — no longer results in a fatal exception page.