### PR TITLE
TEST – [DO NOT MERGE] Validate ui-testing-library PR #1004 (states grid toggle) on 9.1.x

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OSL-3.0",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
-        "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
+        "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#1d64661f2b9219ca777ae18458897dc80bbb20fd",
         "chai": "^4.5.0",
         "chai-string": "^1.6.0",
         "dotenv": "^17.2.3",
@@ -547,7 +547,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
+      "resolved": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#1d64661f2b9219ca777ae18458897dc80bbb20fd",
       "integrity": "sha512-rVrQO3vdU5oG9i6as1pajhynCIjYI6i/Kdx6+nrOluAzuSSXpTjTRPbM1WcXqiSI447UX5j8BYzD0ffGXTzk+Q==",
       "license": "MIT",
       "dependencies": {
@@ -8976,9 +8976,9 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
+      "version": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#1d64661f2b9219ca777ae18458897dc80bbb20fd",
       "integrity": "sha512-rVrQO3vdU5oG9i6as1pajhynCIjYI6i/Kdx6+nrOluAzuSSXpTjTRPbM1WcXqiSI447UX5j8BYzD0ffGXTzk+Q==",
-      "from": "@prestashop-core/ui-testing@https://github.com/mattgoud/ui-testing-library#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
+      "from": "@prestashop-core/ui-testing@https://github.com/mattgoud/ui-testing-library#1d64661f2b9219ca777ae18458897dc80bbb20fd",
       "requires": {
         "@faker-js/faker": "^10.1.0",
         "@playwright/test": "^1.48.1",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OSL-3.0",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
-        "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+        "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
         "chai": "^4.5.0",
         "chai-string": "^1.6.0",
         "dotenv": "^17.2.3",
@@ -547,7 +547,8 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0cdcbdd5210ea8dbfd2f739c8f9912b7601d5f65",
+      "resolved": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
+      "integrity": "sha512-rVrQO3vdU5oG9i6as1pajhynCIjYI6i/Kdx6+nrOluAzuSSXpTjTRPbM1WcXqiSI447UX5j8BYzD0ffGXTzk+Q==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8975,8 +8976,9 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0cdcbdd5210ea8dbfd2f739c8f9912b7601d5f65",
-      "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
+      "version": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
+      "integrity": "sha512-rVrQO3vdU5oG9i6as1pajhynCIjYI6i/Kdx6+nrOluAzuSSXpTjTRPbM1WcXqiSI447UX5j8BYzD0ffGXTzk+Q==",
+      "from": "@prestashop-core/ui-testing@https://github.com/mattgoud/ui-testing-library#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
       "requires": {
         "@faker-js/faker": "^10.1.0",
         "@playwright/test": "^1.48.1",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -111,7 +111,7 @@
   "homepage": "https://github.com/PrestaShop/PrestaShop/tree/develop/tests/UI#readme",
   "dependencies": {
     "@faker-js/faker": "^10.1.0",
-    "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
+    "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#1d64661f2b9219ca777ae18458897dc80bbb20fd",
     "chai": "^4.5.0",
     "chai-string": "^1.6.0",
     "dotenv": "^17.2.3",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -111,7 +111,7 @@
   "homepage": "https://github.com/PrestaShop/PrestaShop/tree/develop/tests/UI#readme",
   "dependencies": {
     "@faker-js/faker": "^10.1.0",
-    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+    "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#76649fc419bd3f3a14d0a4f080817786bdd9b6e6",
     "chai": "^4.5.0",
     "chai-string": "^1.6.0",
     "dotenv": "^17.2.3",


### PR DESCRIPTION
> ⚠️ **Test PR — DO NOT MERGE.** Created only to run UI tests against ui-testing-library PR [PrestaShop/ui-testing-library#1004](https://github.com/PrestaShop/ui-testing-library/pull/1004) on the 9.1.x branch. Will be closed and its branch deleted once the run is validated.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Temporarily pins `tests/UI/package.json` (and `package-lock.json`) to the ui-testing-library PR PrestaShop/ui-testing-library#1004 fork commit `1d64661f` (branch `fix/state-grid-toggle-no-growl`). That PR makes `setStateStatus` version-aware: on `develop` (9.2.0) it follows the toggle redirect and asserts the success **flash** message, while a new `versions/9.1` override keeps the legacy **growl**-based behavior for ≤ 9.1.x. This PR validates the ≤ 9.1.x (growl) code path on the 9.1.x branch, since 9.1.x has no `9.1` directory fallback and the toggle is still an async growl action there.
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the `functional:BO:international` campaign via [ga.tests.ui.pr](https://github.com/PrestaShop/ga.tests.ui.pr/) against this PR with `base_branch: 9.1.x`. The relevant test is `campaigns/functional/BO/11_international/02_locations/03_states/01_filterAndQuickEditStates.ts`, step `setStateStatus`: on 9.1.x the toggle is async, so the method must fall back to the growl-based path (`getGrowlMessageContent` / `closeGrowlMessage`) and return the success message.
| UI tests| https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27208338974 :green_circle: 
| Fixed issue or discussion?     | Validates PrestaShop/ui-testing-library#1004
| Related PRs       | PrestaShop/ui-testing-library#1004, #41620
| Sponsor company   | PrestaShop SA
