### PR TITLE
Add "Order creation error" order status for orders created without a status (#32743)

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -332,6 +332,9 @@ abstract class PaymentModuleCore extends Module
             $id_order_state = Configuration::get('PS_OS_ERROR');
         }
 
+        // Wrap order creation so a server error mid-process cannot leave an order
+        // with no status (current_state = 0). See PrestaShop issue #32743.
+        try {
         if (!$this->isFeatureFlagIsEnabledForMultiShipment()) {
             foreach ($package_list as $id_address => $packageByAddress) {
                 foreach ($packageByAddress as $id_package => $package) {
@@ -794,6 +797,32 @@ abstract class PaymentModuleCore extends Module
                 (int) $order->id
             );
         } // End foreach $order_detail_list
+        } catch (Exception $e) {
+            // Creation aborted on a server error. Any order row already inserted would
+            // otherwise keep current_state = 0, which the back office then renders with
+            // the first status pre-selected. Flag each one so the merchant can spot and
+            // fix it. See PrestaShop issue #32743.
+            $creationErrorState = (int) Configuration::get('PS_OS_CREATION_ERROR');
+            if ($creationErrorState && !empty($order_list)) {
+                foreach ($order_list as $brokenOrder) {
+                    // Skip orders that never got persisted or already have a status.
+                    if (!Validate::isLoadedObject($brokenOrder) || (int) $brokenOrder->current_state) {
+                        continue;
+                    }
+                    try {
+                        $errorHistory = new OrderHistory();
+                        $errorHistory->id_order = (int) $brokenOrder->id;
+                        $errorHistory->changeIdOrderState($creationErrorState, $brokenOrder, true);
+                        $errorHistory->add();
+                    } catch (Exception $ignored) {
+                        // Never mask the original failure with a secondary error.
+                    }
+                }
+            }
+
+            // Re-throw so the existing error flow (logging, 500 page) stays unchanged.
+            throw $e;
+        }
 
         // Use the last order as currentOrder
         if (isset($order) && $order->id) {

--- a/classes/lang/KeysReference/OrderStateLang.php
+++ b/classes/lang/KeysReference/OrderStateLang.php
@@ -17,3 +17,4 @@ trans('On backorder (not paid)', 'Admin.Orderscustomers.Feature');
 trans('Awaiting bank wire payment', 'Admin.Orderscustomers.Feature');
 trans('Remote payment accepted', 'Admin.Orderscustomers.Feature');
 trans('Awaiting Cash On Delivery validation', 'Admin.Orderscustomers.Feature');
+trans('Order creation error', 'Admin.Orderscustomers.Feature');

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -383,6 +383,9 @@
   <configuration id="PS_OS_ERROR" name="PS_OS_ERROR">
     <value>8</value>
   </configuration>
+  <configuration id="PS_OS_CREATION_ERROR" name="PS_OS_CREATION_ERROR">
+    <value>14</value>
+  </configuration>
   <configuration id="PS_OS_OUTOFSTOCK" name="PS_OS_OUTOFSTOCK">
     <value>9</value>
   </configuration>

--- a/install-dev/data/xml/order_state.xml
+++ b/install-dev/data/xml/order_state.xml
@@ -54,5 +54,8 @@
     <order_state id="Awaiting_cod_validation" invoice="0" send_email="0" color="#34209E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0">
       <module_name>ps_cashondelivery</module_name>
     </order_state>
+    <order_state id="Order_creation_error" invoice="0" send_email="0" color="#E74C3C" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+      <module_name/>
+    </order_state>
   </entities>
 </entity_order_state>

--- a/install-dev/langs/en/data/order_state.xml
+++ b/install-dev/langs/en/data/order_state.xml
@@ -52,4 +52,8 @@
     <name>Awaiting Cash On Delivery validation</name>
     <template>cashondelivery</template>
   </order_state>
+  <order_state id="Order_creation_error">
+    <name>Order creation error</name>
+    <template/>
+  </order_state>
 </entity_order_state>

--- a/translations/default/AdminOrderscustomersFeature.xlf
+++ b/translations/default/AdminOrderscustomersFeature.xlf
@@ -1001,6 +1001,11 @@ Best regards,</target>
         <target>Order ID</target>
         <note>File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/linked_orders.html.twig [Line: 19]</note>
       </trans-unit>
+      <trans-unit id="4504ca0156a810f102f9b12cd10e7196">
+        <source>Order creation error</source>
+        <target>Order creation error</target>
+        <note>File: classes/lang/KeysReference/OrderStateLang.php [Line: 20]</note>
+      </trans-unit>
       <trans-unit id="f13673c7e261fd8d00915c9cb768ad95">
         <source>Order message</source>
         <target>Order message</target>


### PR DESCRIPTION
# PR — PrestaShop/PrestaShop (core)

**Base:** `PrestaShop/PrestaShop:develop`
**Head:** `idnovate/PrestaShop:fix/32743-order-creation-error-status`

## Title

Add "Order creation error" order status for orders created without a status (#32743)

## Description

| Questions          | Answers |
| ------------------ | ------- |
| Description?       | When order creation aborts on a server error, the order row is already inserted but its status is never set, leaving `current_state = 0`. The back office then renders such an order with the first status in the list pre-selected. This PR introduces a dedicated **Order creation error** status and assigns it to any partially-created order so merchants can spot and fix it. |
| Type?              | bug fix |
| BC breaks?         | no |
| Deprecations?      | no |
| Fixed ticket?      | Fixes #32743 |
| How to test?       | See below. |

### What changed

- `install-dev/data/xml/order_state.xml` — new `Order_creation_error` entity (red, unremovable, no email, not logable). Becomes order state id **14** on a fresh install.
- `install-dev/data/xml/configuration.xml` — new `PS_OS_CREATION_ERROR` configuration mapping to id `14`.
- `install-dev/langs/en/data/order_state.xml` — localized install name for the new status.
- `classes/lang/KeysReference/OrderStateLang.php` — registers the `Order creation error` translation source key (domain `Admin.Orderscustomers.Feature`) so it enters the catalogs.
- `translations/default/AdminOrderscustomersFeature.xlf` — the extracted English source unit for that key (id `4504ca0156a810f102f9b12cd10e7196` = md5 of the source). Non-English locales are served from Crowdin and are not edited here.
- `classes/PaymentModule.php` — wraps the order-creation + status-assignment block in `validateOrder()` in a `try/catch`. On failure, every already-inserted order that still has `current_state = 0` is moved to `PS_OS_CREATION_ERROR`, then the original exception is re-thrown so the existing error flow is unchanged.

### How to test

1. Force a server error during order creation (e.g. `throw new Exception('test');` inside `PaymentModule::validateOrder()` after the order is added).
2. Place an order from the front office.
3. Before the fix: the order is saved with no status and the BO order page shows the first status selected.
4. After the fix: the order is saved with the **Order creation error** status, clearly flagged in red in the BO.
5. Remove the forced exception and confirm normal orders are unaffected.

### Notes

- Backward compatible (1.6→9): plain `Exception` catch, no typed properties / enums / promotion.
- The matching DB migration for existing shops lives in a separate PR on `PrestaShop/autoupgrade`.
- Status name translations for non-English locales are managed via Crowdin from the source key added here. PrestaShop has no per-language install XML for order-state names (only `install-dev/langs/en/...` exists), so nothing is hand-translated in this PR.
