### PR TITLE
Set payment error status on orders when validation aborts on inactive country (#28648)

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -400,6 +400,18 @@ abstract class PaymentModuleCore extends Module
         if (!$this->context->country->active) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Country is not active', 3, null, 'Cart', (int) $id_cart, true);
 
+            // The order(s) were already created above; flag them with the payment
+            // error status so they are not left without a status (current_state = 0)
+            // when we abort here.
+            foreach ($order_list as $orderWithError) {
+                if (Validate::isLoadedObject($orderWithError) && !(int) $orderWithError->current_state) {
+                    $history = new OrderHistory();
+                    $history->id_order = (int) $orderWithError->id;
+                    $history->changeIdOrderState((int) Configuration::get('PS_OS_ERROR'), $orderWithError, true);
+                    $history->add();
+                }
+            }
+
             throw new PrestaShopException('The order address country is not active.');
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When geolocation is enabled and a payment notification request originates from a disabled country, `PaymentModule::validateOrder()` reaches the `if (!$this->context->country->active)` guard and throws — but the orders have already been created just above, so they are left persisted with `current_state = 0`. This PR assigns the existing **Payment error** status (`PS_OS_ERROR`) to those already-created orders before the exception is thrown, so they are no longer left without a status and the merchant can see and handle them. See more details below the table.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Disable a country (e.g. United Kingdom) in the back office. 2. Enable geolocation. 3. Place an order from an enabled country using a redirect-based payment gateway, so the payment notification request reaches `validateOrder()` with the context country resolved to the disabled one (a VPN from the disabled country reproduces it). 4. Before the fix: the order is persisted with no status and the BO shows the first status pre-selected. 5. After the fix: the order is flagged with the **Payment error** status. 6. Place a normal order and confirm it still receives its correct status.
| UI Tests          | Not yet run — can launch a campaign (MySQL + MariaDB) on request; no UI behaviour changes beyond the order receiving an existing status.
| Fixed issue or discussion?     | Fixes #28648
| Related PRs       |
| Sponsor company   |

### Details

Root cause: in `PaymentModule::validateOrder()` the orders are created (via `createOrderFromCart()` → `$order->add()`, which persists `current_state = 0`) before the method reaches the `if (!$this->context->country->active)` guard. When a payment notification request comes from a disabled country (geolocation), that guard throws and the already-created orders remain saved with no status.

Fix: inside that guard, before throwing, each already-created order in `$order_list` that still has `current_state = 0` is moved to `PS_OS_ERROR` using the standard `OrderHistory::changeIdOrderState()` idiom already used in this method. The exception is still thrown afterwards, so the existing control flow is unchanged.

Notes:

- Reuses the existing `Payment error` status (`PS_OS_ERROR`) — no new order status, no install-fixture or migration changes required.
- The `Validate::isLoadedObject()` + `current_state` checks make it a no-op for any order that was not persisted or already has a status.
- Backward compatible: no typed properties / enums / promotion.
- Scope: this flags the affected orders rather than changing the country-activity validation itself. If the preferred direction for #28648 is to let such orders validate (e.g. resolve the country from the order address instead of the request context), that is a separate, larger change and can be discussed on the issue.
