### PR TITLE
Require at least one group when saving a customer

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
@@ -21,6 +21,11 @@ export default class CustomerForm {
     // update default group below if it's no longer in the list.
     $(customerFormMap.customerGroupCheckboxes).on('change', (event) => {
       this.checkOrUpdateDefaultGroup($(event.currentTarget).is(':checked'));
+      if ($(customerFormMap.customerGroupCheckboxes).is(':checked')) {
+        const $formGroup = $(customerFormMap.customerGroupCheckboxes).first().closest('.form-group');
+        $formGroup.removeClass('has-error');
+        $formGroup.find(`.${customerFormMap.groupAccessErrorClass}`).remove();
+      }
     });
 
     // Watch is_guest switch change and update other inputs accordingly
@@ -31,6 +36,31 @@ export default class CustomerForm {
         this.adaptFormForRegisteredCustomer();
       }
     });
+
+    // Prevent submitting the form when no group is selected
+    $(customerFormMap.customerForm).on('submit', (event) => {
+      this.preventSubmitWithoutGroup(event);
+    });
+  }
+
+  private preventSubmitWithoutGroup(event: JQueryEventObject): void {
+    if ($(customerFormMap.customerGroupCheckboxes).is(':checked')) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const message = <string> $(customerFormMap.customerForm).attr('data-at-least-one-group-message');
+    const $formGroup = $(customerFormMap.customerGroupCheckboxes).first().closest('.form-group');
+
+    $formGroup.addClass('has-error');
+    if (!$formGroup.find(`.${customerFormMap.groupAccessErrorClass}`).length) {
+      const $error = $('<div>', {class: `alert alert-danger ${customerFormMap.groupAccessErrorClass}`});
+      $error.append($('<div>', {class: 'alert-text'}).text(message));
+      $formGroup.append($error);
+    }
+
+    $formGroup[0]?.scrollIntoView({behavior: 'smooth', block: 'center'});
   }
 
   private checkOrUpdateDefaultGroup(wasChecked: boolean): void {

--- a/admin-dev/themes/new-theme/js/pages/customer/customer-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/customer-form-map.ts
@@ -12,8 +12,10 @@ export default {
   requiredFieldsFormAlertOptin: '#customerRequiredFieldsAlertMessageOptin',
   requiredFieldsFormCheckboxOptin: '#customerRequiredFieldsContainer input[type="checkbox"][value="optin"]',
 
-  // Customer group inputs
+  // Customer form and group inputs
+  customerForm: 'form[name="customer"]',
   customerGroupCheckboxes: 'input[type="checkbox"][name="customer[group_ids][]"]',
+  groupAccessErrorClass: 'js-at-least-one-group-error',
   defaultGroupSelect: '#customer_default_group_id',
   defaultGroupSelectedOption: '#customer_default_group_id option:selected',
 

--- a/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
@@ -12,6 +12,7 @@ use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\CommandHandler\AddCustomerHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerEmptyGroupsException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\DuplicateCustomerEmailException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
@@ -147,6 +148,11 @@ final class AddCustomerHandler extends AbstractCustomerHandler implements AddCus
      */
     private function assertCustomerCanAccessDefaultGroup(AddCustomerCommand $command)
     {
+        // A customer must belong to at least one group
+        if (empty($command->getGroupIds())) {
+            throw new CustomerEmptyGroupsException('A customer must belong to at least one group');
+        }
+
         if (!in_array($command->getDefaultGroupId(), $command->getGroupIds())) {
             throw new CustomerDefaultGroupAccessException(sprintf('Customer default group with id "%s" must be in access groups', $command->getDefaultGroupId()));
         }

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -12,6 +12,7 @@ use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\CommandHandler\EditCustomerHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerEmptyGroupsException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\DuplicateCustomerEmailException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\RequiredField;
@@ -229,6 +230,11 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
         // If nothing is updated on groups, nothing to do here
         if (null === $command->getDefaultGroupId() && null === $command->getGroupIds()) {
             return;
+        }
+
+        // A customer must belong to at least one group
+        if (null !== $command->getGroupIds() && empty($command->getGroupIds())) {
+            throw new CustomerEmptyGroupsException('A customer must belong to at least one group');
         }
 
         // Arrange data to compare, we will use customer's original data if not provided in the command

--- a/src/Core/Domain/Customer/Exception/CustomerEmptyGroupsException.php
+++ b/src/Core/Domain/Customer/Exception/CustomerEmptyGroupsException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Customer\Exception;
+
+/**
+ * Exception is thrown when a customer is saved without any access group.
+ * A customer must belong to at least one group.
+ */
+class CustomerEmptyGroupsException extends CustomerException
+{
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -20,6 +20,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Command\TransformGuestToCustomerC
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerByEmailNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerEmptyGroupsException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerTransformationException;
@@ -942,6 +943,11 @@ class CustomerController extends PrestaShopAdminController
             ],
             CustomerDefaultGroupAccessException::class => $this->trans(
                 'A default customer group must be selected in group box.',
+                [],
+                'Admin.Orderscustomers.Notification'
+            ),
+            CustomerEmptyGroupsException::class => $this->trans(
+                'You must select at least one group.',
                 [],
                 'Admin.Orderscustomers.Notification'
             ),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -29,6 +29,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -283,6 +284,12 @@ class CustomerType extends TranslatorAwareType
                 'empty_data' => [],
                 'choices' => $this->groupByIdChoiceProvider->getChoices(),
                 'display_total_items' => true,
+                'constraints' => [
+                    new Count([
+                        'min' => 1,
+                        'minMessage' => $this->trans('You must select at least one group.', 'Admin.Notifications.Error'),
+                    ]),
+                ],
             ])
             ->add('default_group_id', GroupType::class, [
                 'label' => $this->trans('Default customer group', 'Admin.Orderscustomers.Feature'),

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
@@ -8,7 +8,7 @@
 {% set isGuest = isGuest|default(false) %}
 
 {% block customer_form %}
-  {{ form_start(customerForm) }}
+  {{ form_start(customerForm, {attr: {'data-at-least-one-group-message': 'You must select at least one group.'|trans({}, 'Admin.Notifications.Error')}}) }}
     <div class="card">
       <h3 class="card-header">
         <i class="material-icons">person</i>

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -218,3 +218,25 @@ Feature: Customer Management
     And I attempt to edit customer "CUST-13" and I change the following properties:
       | defaultGroupId | Visitor |
     Then I should be returned an error message 'Customer default group with id "1" must be in access groups'
+
+  Scenario: Fail to create a customer with no groups
+    When I attempt to create a customer "CUST-14" with following properties:
+      | firstName      | Mathieu                          |
+      | lastName       | Napoler                          |
+      | email          | customerfourteen@prestashop.com  |
+      | password       | PrestaShopForever1_!             |
+      | defaultGroupId | Customer                         |
+      | groupIds       | []                               |
+    Then I should be returned an error message 'A customer must belong to at least one group'
+
+  Scenario: Fail to remove all groups from a customer
+    When I create a customer "CUST-15" with following properties:
+      | firstName      | Mathieu                          |
+      | lastName       | Customer                         |
+      | email          | customerfifteen@prestashop.com   |
+      | password       | PrestaShopForever1_!             |
+      | defaultGroupId | Customer                         |
+      | groupIds       | [Customer]                       |
+    And I attempt to edit customer "CUST-15" and I change the following properties:
+      | groupIds | [] |
+    Then I should be returned an error message 'A customer must belong to at least one group'

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/12_editCustomerWithoutGroup.ts
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/12_editCustomerWithoutGroup.ts
@@ -1,0 +1,159 @@
+import testContext from '@utils/testContext';
+import {expect} from 'chai';
+
+import {
+  boCustomersPage,
+  boCustomersCreatePage,
+  boDashboardPage,
+  boLoginPage,
+  type BrowserContext,
+  FakerCustomer,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_customers_customers_editCustomerWithoutGroup';
+
+// Check that editing a customer without any access group is blocked with an inline error
+describe('BO - Customers - Customers : Edit customer without group access', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+  let numberOfCustomers: number = 0;
+
+  const createCustomerData: FakerCustomer = new FakerCustomer();
+
+  // before and after functions
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should go to \'Customers > Customers\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToCustomersPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.customersParentLink,
+      boDashboardPage.customersLink,
+    );
+    await boCustomersPage.closeSfToolBar(page);
+
+    const pageTitle = await boCustomersPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boCustomersPage.pageTitle);
+  });
+
+  it('should reset all filters', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'resetFirst', baseContext);
+
+    numberOfCustomers = await boCustomersPage.resetAndGetNumberOfLines(page);
+    expect(numberOfCustomers).to.be.above(0);
+  });
+
+  // 1 : Create a fresh customer so the test is self-contained
+  describe('Create customer in BO', async () => {
+    it('should go to add new customer page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewCustomerPage', baseContext);
+
+      await boCustomersPage.goToAddNewCustomerPage(page);
+
+      const pageTitle = await boCustomersCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomersCreatePage.pageTitleCreate);
+    });
+
+    it('should create customer and check result', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createCustomer', baseContext);
+
+      const textResult = await boCustomersCreatePage.createEditCustomer(page, createCustomerData);
+      expect(textResult).to.equal(boCustomersPage.successfulCreationMessage);
+
+      const numberOfCustomersAfterCreation = await boCustomersPage.getNumberOfElementInGrid(page);
+      expect(numberOfCustomersAfterCreation).to.be.equal(numberOfCustomers + 1);
+    });
+  });
+
+  // 2 : Edit the customer and try to save with no group access
+  describe('Edit customer without group access', async () => {
+    it(`should filter list by email '${createCustomerData.email}'`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterToEditCustomer', baseContext);
+
+      await boCustomersPage.resetFilter(page);
+      await boCustomersPage.filterCustomers(page, 'input', 'email', createCustomerData.email);
+
+      const textEmail = await boCustomersPage.getTextColumnFromTableCustomers(page, 1, 'email');
+      expect(textEmail).to.contains(createCustomerData.email);
+    });
+
+    it('should go to edit customer page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToEditPage', baseContext);
+
+      await boCustomersPage.goToEditCustomerPage(page, 1);
+
+      const pageTitle = await boCustomersCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomersCreatePage.pageTitleEdit);
+    });
+
+    it('should uncheck all group access and try to save', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'saveWithoutGroup', baseContext);
+
+      await boCustomersCreatePage.uncheckAllGroupAccess(page);
+      await boCustomersCreatePage.clickOnSaveButton(page);
+
+      // The save is blocked : the page does not navigate to the list, we stay on the edit page
+      const pageTitle = await boCustomersCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomersCreatePage.pageTitleEdit);
+
+      const errorMessage = await boCustomersCreatePage.getGroupAccessErrorMessage(page);
+      expect(errorMessage).to.contains('You must select at least one group.');
+    });
+  });
+
+  // 3 : Delete the created customer
+  describe('Delete customer', async () => {
+    it('should go to \'Customers > Customers\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomersPageToDelete', baseContext);
+
+      await boCustomersCreatePage.goToSubMenu(
+        page,
+        boCustomersCreatePage.customersParentLink,
+        boCustomersCreatePage.customersLink,
+      );
+
+      const pageTitle = await boCustomersPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomersPage.pageTitle);
+    });
+
+    it(`should filter list by email '${createCustomerData.email}'`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterToDelete', baseContext);
+
+      await boCustomersPage.resetFilter(page);
+      await boCustomersPage.filterCustomers(page, 'input', 'email', createCustomerData.email);
+
+      const textEmail = await boCustomersPage.getTextColumnFromTableCustomers(page, 1, 'email');
+      expect(textEmail).to.contains(createCustomerData.email);
+    });
+
+    it('should delete customer', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteCustomer', baseContext);
+
+      const textResult = await boCustomersPage.deleteCustomer(page, 1);
+      expect(textResult).to.equal(boCustomersPage.successfulDeleteMessage);
+
+      const numberOfCustomersAfterDelete = await boCustomersPage.resetAndGetNumberOfLines(page);
+      expect(numberOfCustomersAfterDelete).to.be.equal(numberOfCustomers);
+    });
+  });
+});

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -744,7 +744,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#117cd6fd9555843de91caaedf67c51606b76f862",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#1673a321ea127fa9a78135f7a1d380da2b52d51e",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------
| Branch?           | develop
| Description?      | Require at least one access group when saving a customer in the BO, with a clear inline message.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to #35589
| Sponsor company   |
| How to test?      | See below.

### Context

The HTTP 400 originally reported in #35589 (removing all of a customer's groups) was already fixed by #37211 — it now returns a flash *"A default customer group must be selected in group box."*. That message is misleading (it talks about the **default** group while the real problem is that **no** group is selected) and only appears as a top-of-page flash.

### What this PR does

Makes "a customer must belong to at least one group" an explicit, clearly-worded rule across three layers:

- **Form** — a `Count(min: 1)` constraint on `group_ids` (`CustomerType`) shows an inline error under *Group access*: *"You must select at least one group."*
- **Domain** — a dedicated `CustomerEmptyGroupsException` is thrown by the Edit/Add customer command handlers when the group list is empty (defense-in-depth for non-form callers), mapped to a flash in `CustomerController`.
- **Client** — a small submit guard in `CustomerForm.ts` blocks the submission and shows the inline message immediately (no round-trip); it clears as soon as a group is re-checked.

Covered by two new BDD scenarios (`customer_management.feature`) and a UI campaign test.

> ⚠️ The UI test depends on companion page-object helpers in PrestaShop/ui-testing-library#1008 — that PR must be merged (and the `tests/UI` dependency resolve to it) before the UI campaign passes here.

### How to test

1. BO > Customers, edit a customer.
2. Uncheck every access group, click **Save**.
3. Expected: the save is blocked and an inline error *"You must select at least one group."* appears under *Group access* (no top-of-page-only flash, no 400).
4. Re-check a group → the error clears and saving works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
