### PR TITLE
Handle only carrier compatible with products and active

### DIFF
--- a/src/Adapter/Carrier/QueryHandler/GetCarriersForProductHandler.php
+++ b/src/Adapter/Carrier/QueryHandler/GetCarriersForProductHandler.php
@@ -12,7 +12,6 @@ use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Query\GetCarriersForProduct;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryHandler\GetCarriersForProductHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryResult\CarrierSummary;
-use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 #[AsQueryHandler]
@@ -34,11 +33,7 @@ final class GetCarriersForProductHandler implements GetCarriersForProductHandler
         $carriers = [];
 
         foreach ($productCarriers[$productId] as $productCarrier) {
-            $carrier = $this->carrierRepository->get(new CarrierId($productCarrier['id_carrier']));
-
-            if ($carrier->active) {
-                $carriers[] = new CarrierSummary($productCarrier['id_carrier'], $productCarrier['name']);
-            }
+            $carriers[] = new CarrierSummary($productCarrier['id_carrier'], $productCarrier['name']);
         }
 
         return $carriers;

--- a/src/Adapter/Carrier/QueryHandler/GetCarriersForProductHandler.php
+++ b/src/Adapter/Carrier/QueryHandler/GetCarriersForProductHandler.php
@@ -12,6 +12,7 @@ use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Query\GetCarriersForProduct;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryHandler\GetCarriersForProductHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryResult\CarrierSummary;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 #[AsQueryHandler]
@@ -33,7 +34,11 @@ final class GetCarriersForProductHandler implements GetCarriersForProductHandler
         $carriers = [];
 
         foreach ($productCarriers[$productId] as $productCarrier) {
-            $carriers[] = new CarrierSummary($productCarrier['id_carrier'], $productCarrier['name']);
+            $carrier = $this->carrierRepository->get(new CarrierId($productCarrier['id_carrier']));
+
+            if ($carrier->active) {
+                $carriers[] = new CarrierSummary($productCarrier['id_carrier'], $productCarrier['name']);
+            }
         }
 
         return $carriers;

--- a/src/Adapter/Carrier/Repository/CarrierRepository.php
+++ b/src/Adapter/Carrier/Repository/CarrierRepository.php
@@ -441,7 +441,7 @@ class CarrierRepository extends AbstractMultiShopObjectModelRepository
                 'pc',
                 $this->prefix . 'carrier',
                 'c',
-                'c.id_reference = pc.id_carrier_reference AND c.deleted = 0'
+                'c.id_reference = pc.id_carrier_reference AND c.deleted = 0 AND c.active = 1'
             )
             ->where($qb->expr()->in('pc.id_product', ':product_ids'))
             ->andWhere('pc.id_shop = :shop_id')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | filter only carrier enabled and not deleted on shipment creation process. Fixes #41650
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | see description
| UI Tests          | https://github.com/Poulinhoo/ga.tests.ui.pr/actions/runs/27266241690
