### PR TITLE
Automatically remove install/ folder after a successful installation

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -50,6 +50,7 @@ use PrestashopInstallerException;
 use PrestaShopLoggerInterface;
 use Psr\Log\LogLevel;
 use PSRLoggerAdapter;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 use Throwable;
@@ -1237,7 +1238,36 @@ class Install extends AbstractInstall
 
         $this->getLogger()->logInfo(sprintf('You can now access your backoffice at %s.', $adminUrl));
 
+        $this->removeInstallFolder();
+
         return true;
+    }
+
+    /**
+     * Remove the install/ folder after a successful installation.
+     *
+     * In dev environments the folder is named "install-dev" and must be kept; only
+     * the "install" folder shipped in release packages is targeted here. Failure to
+     * remove the folder is non-fatal: a warning is logged so the merchant can remove
+     * it manually.
+     */
+    private function removeInstallFolder(): void
+    {
+        $installFolder = _PS_ROOT_DIR_ . '/install';
+
+        if (!is_dir($installFolder)) {
+            return;
+        }
+
+        try {
+            (new Filesystem())->remove($installFolder);
+            $this->getLogger()->logInfo('The install/ folder was removed.');
+        } catch (Throwable $e) {
+            $this->getLogger()->logWarning(sprintf(
+                'The install/ folder could not be removed automatically (%s). Please delete it manually for security reasons.',
+                $e->getMessage()
+            ));
+        }
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | After a successful installation, the `install/` folder is now removed automatically by the installer. Previously, merchants were shown a message asking them to delete the folder manually — a step that is easy to miss and leaves a security-sensitive directory exposed on production shops (see #41691, where the user only managed to log in to the BO after manually deleting `install/`). The `install-dev` folder used in dev environments is intentionally left untouched: only a folder named exactly `install` at the project root is targeted. If the removal fails (permissions, file locks, etc.), the failure is logged as a warning and does not break the installation.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Start from a release package (or any setup where the installer folder is named `install/`, not `install-dev/`). <br> 2. Run a fresh installation through the web installer or the CLI installer (`php install/index_cli.php …`). <br> 3. Once installation completes successfully, check the project root: the `install/` folder must be gone. <br> 4. Check the installer log: an info entry `The install/ folder was removed.` should be present. <br> 5. Re-run the installer in a dev environment (folder named `install-dev/`) and verify the folder is **not** deleted.
| UI Tests          | N/A — change only triggers after the installation flow completes.
| Fixed issue or discussion?     | Fixes #41691
| Related PRs       | —
| Sponsor company   | Creabilis.com