### PR TITLE
Set payment error status on orders left without status when order creation fails

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -332,468 +332,493 @@ abstract class PaymentModuleCore extends Module
             $id_order_state = Configuration::get('PS_OS_ERROR');
         }
 
-        if (!$this->isFeatureFlagIsEnabledForMultiShipment()) {
-            foreach ($package_list as $id_address => $packageByAddress) {
-                foreach ($packageByAddress as $id_package => $package) {
-                    $orderData = $this->createOrderFromCart(
-                        $this->context->cart,
-                        $this->context->currency,
-                        $package['product_list'],
-                        $id_address,
-                        $this->context,
-                        $reference,
-                        $secure_key,
-                        $payment_method,
-                        $this->name,
-                        $dont_touch_amount,
-                        $amount_paid,
-                        0,
-                        $cart_total_paid,
-                        self::DEBUG_MODE,
-                        $order_status,
-                        $id_order_state,
-                        isset($package['id_carrier']) ? $package['id_carrier'] : null
-                    );
-                    $order = $orderData['order'];
-                    $order_list[] = $order;
-                    $order_detail_list[] = $orderData['orderDetail'];
+        // Wrap order creation so a server error mid-process cannot leave an order
+        // with no status (current_state = 0).
+        try {
+            if (!$this->isFeatureFlagIsEnabledForMultiShipment()) {
+                foreach ($package_list as $id_address => $packageByAddress) {
+                    foreach ($packageByAddress as $id_package => $package) {
+                        $orderData = $this->createOrderFromCart(
+                            $this->context->cart,
+                            $this->context->currency,
+                            $package['product_list'],
+                            $id_address,
+                            $this->context,
+                            $reference,
+                            $secure_key,
+                            $payment_method,
+                            $this->name,
+                            $dont_touch_amount,
+                            $amount_paid,
+                            0,
+                            $cart_total_paid,
+                            self::DEBUG_MODE,
+                            $order_status,
+                            $id_order_state,
+                            isset($package['id_carrier']) ? $package['id_carrier'] : null
+                        );
+                        $order = $orderData['order'];
+                        $order_list[] = $order;
+                        $order_detail_list[] = $orderData['orderDetail'];
+                    }
                 }
-            }
-        } else {
-            $productsByCarriers = [];
-            $idAddress = null;
-
-            foreach ($package_list as $id_address => $packageByAddress) {
-                $idAddress = $id_address;
-                foreach ($packageByAddress as $id_package => $package) {
-                    $productsByCarriers[$package['id_carrier']]['product_list'] = $package['product_list'];
-                }
-            }
-            $orderData = $this->createOrderFromCart(
-                $this->context->cart,
-                $this->context->currency,
-                $productsByCarriers,
-                $idAddress,
-                $this->context,
-                $reference,
-                $secure_key,
-                $payment_method,
-                $this->name,
-                $dont_touch_amount,
-                $amount_paid,
-                0,
-                $cart_total_paid,
-                self::DEBUG_MODE,
-                $order_status,
-                $id_order_state,
-                null
-            );
-            $order = $orderData['order'];
-            $order_list[] = $order;
-            $order_detail_list[] = $orderData['orderDetail'];
-        }
-        // The country can only change if the address used for the calculation is the delivery address, and if multi-shipping is activated
-        if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_delivery' && isset($context_country)) {
-            $this->context->country = $context_country;
-        }
-
-        if (!$this->context->country->active) {
-            PrestaShopLogger::addLog('PaymentModule::validateOrder - Country is not active', 3, null, 'Cart', (int) $id_cart, true);
-
-            throw new PrestaShopException('The order address country is not active.');
-        }
-
-        if (self::DEBUG_MODE) {
-            PrestaShopLogger::addLog('PaymentModule::validateOrder - Payment is about to be added', 1, null, 'Cart', (int) $id_cart, true);
-        }
-
-        // Register Payment only if the order status validate the order
-        if ($order_status->logable) {
-            // $order is the last order loop in the foreach
-            // The method addOrderPayment of the class Order make a create a paymentOrder
-            // linked to the order reference and not to the order id
-            if (isset($extra_vars['transaction_id'])) {
-                $transaction_id = $extra_vars['transaction_id'];
             } else {
-                $transaction_id = null;
-            }
+                $productsByCarriers = [];
+                $idAddress = null;
 
-            if (!isset($order) || !$order->addOrderPayment($amount_paid, null, $transaction_id)) {
-                PrestaShopLogger::addLog('PaymentModule::validateOrder - Cannot save Order Payment', 3, null, 'Cart', (int) $id_cart, true);
-
-                throw new PrestaShopException('Can\'t save Order Payment');
-            }
-        }
-
-        // Next !
-        $products = $this->context->cart->getProducts();
-
-        // Make sure CartRule caches are empty
-        CartRule::cleanCache();
-        foreach ($order_detail_list as $key => $order_detail) {
-            /** @var Order $order */
-            $order = $order_list[$key];
-            if (!isset($order->id)) {
-                $error = $this->trans('Order creation failed', [], 'Admin.Payment.Notification');
-                PrestaShopLogger::addLog($error, 4, 2, 'Cart', (int) $order->id_cart);
-                throw new PrestaShopException($error);
-            }
-            if (!$secure_key) {
-                $message .= '<br />' . $this->trans('Warning: the secure key is empty, check your payment account before validation', [], 'Admin.Payment.Notification');
-            }
-            // Optional message to attach to this order
-            if (!empty($message)) {
-                $message = strip_tags($message, '<br>');
-                if (Validate::isCleanHtml($message)) {
-                    if (self::DEBUG_MODE) {
-                        PrestaShopLogger::addLog('PaymentModule::validateOrder - Message is about to be added', 1, null, 'Cart', (int) $id_cart, true);
-                    }
-                    $msg = new Message();
-                    $msg->message = $message;
-                    $msg->id_cart = (int) $id_cart;
-                    $msg->id_customer = (int) $order->id_customer;
-                    $msg->id_order = (int) $order->id;
-                    $msg->private = true;
-                    $msg->add();
-                }
-            }
-
-            // Insert new Order detail list using cart for the current order
-            // $orderDetail = new OrderDetail(null, null, $this->context);
-            // $orderDetail->createList($order, $this->context->cart, $id_order_state);
-
-            // Construct order detail table for the email
-            $virtual_product = true;
-
-            $product_var_tpl_list = [];
-            foreach ($order->product_list as $product) {
-                $price = Product::getPriceStatic((int) $product['id_product'], false, $product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null, 6, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
-                $price_wt = Product::getPriceStatic((int) $product['id_product'], true, $product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null, 2, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
-
-                $product_price = Product::getTaxCalculationMethod() == PS_TAX_EXC ? Tools::ps_round($price, Context::getContext()->getComputingPrecision()) : $price_wt;
-
-                $carrierName = null;
-                if ($orderShipmentService->orderHasShipment($order->id)) {
-                    $carrierName = $orderShipmentService->getCarrierForProduct($order->id, (int) $product['id_product'])->name;
-                }
-
-                $product_var_tpl = [
-                    'id_product' => $product['id_product'],
-                    'id_product_attribute' => $product['id_product_attribute'],
-                    'reference' => $product['reference'],
-                    'name' => $this->trans(
-                        '%name%%attributes%%carrier%',
-                        [
-                            '%name%' => $product['name'],
-                            '%attributes%' => !empty($product['attributes']) ? $this->trans(' - %attributes%', ['%attributes%' => $product['attributes']], 'Emails.Body') : '',
-                            '%carrier%' => $carrierName ? $this->trans(' - Carrier: %carrier_name%', ['%carrier_name%' => $carrierName], 'Emails.Body') : '',
-                        ], 'Emails.Body'),
-                    'price' => Tools::getContextLocale($this->context)->formatPrice($product_price * $product['quantity'], $this->context->currency->iso_code),
-                    'quantity' => $product['quantity'],
-                    'customization' => [],
-                ];
-
-                if (isset($product['price']) && $product['price']) {
-                    $product_var_tpl['unit_price'] = Tools::getContextLocale($this->context)->formatPrice($product_price, $this->context->currency->iso_code);
-                    $product_var_tpl['unit_price_full'] = Tools::getContextLocale($this->context)->formatPrice($product_price, $this->context->currency->iso_code)
-                        . ' ' . $product['unity'];
-                } else {
-                    $product_var_tpl['unit_price'] = $product_var_tpl['unit_price_full'] = '';
-                }
-
-                $customized_datas = Product::getAllCustomizedDatas((int) $order->id_cart, null, true, null, (int) $product['id_customization']);
-                if (isset($customized_datas[$product['id_product']][$product['id_product_attribute']])) {
-                    $product_var_tpl['customization'] = [];
-                    foreach ($customized_datas[$product['id_product']][$product['id_product_attribute']][$order->id_address_delivery] as $customization) {
-                        $customization_text = '';
-                        if (isset($customization['datas'][Product::CUSTOMIZE_TEXTFIELD])) {
-                            foreach ($customization['datas'][Product::CUSTOMIZE_TEXTFIELD] as $text) {
-                                $customization_text .= '<strong>' . $text['name'] . '</strong>: ' . htmlspecialchars($text['value'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '<br />';
-                            }
-                        }
-
-                        if (isset($customization['datas'][Product::CUSTOMIZE_FILE])) {
-                            $customization_text .= $this->trans('%d image(s)', [count($customization['datas'][Product::CUSTOMIZE_FILE])], 'Admin.Payment.Notification') . '<br />';
-                        }
-
-                        $customization_quantity = (int) $customization['quantity'];
-
-                        $product_var_tpl['customization'][] = [
-                            'customization_text' => $customization_text,
-                            'customization_quantity' => $customization_quantity,
-                            'quantity' => Tools::getContextLocale($this->context)->formatPrice($customization_quantity * $product_price, $this->context->currency->iso_code),
-                        ];
+                foreach ($package_list as $id_address => $packageByAddress) {
+                    $idAddress = $id_address;
+                    foreach ($packageByAddress as $id_package => $package) {
+                        $productsByCarriers[$package['id_carrier']]['product_list'] = $package['product_list'];
                     }
                 }
-
-                Hook::exec('actionPaymentModuleProductVarTplAfter', [
-                    'product_var_tpl' => &$product_var_tpl,
-                    'product' => $product,
-                    'order' => $order,
-                    'context' => $this->context,
-                ]);
-
-                $product_var_tpl_list[] = $product_var_tpl;
-                // Check if is not a virtual product for the displaying of shipping
-                if (!$product['is_virtual']) {
-                    $virtual_product &= false;
-                }
-            }
-
-            $product_list_txt = '';
-            $product_list_html = '';
-            if (count($product_var_tpl_list) > 0) {
-                $product_list_txt = $this->getEmailTemplateContent('order_conf_product_list.txt', Mail::TYPE_TEXT, $product_var_tpl_list);
-                $product_list_html = $this->getEmailTemplateContent('order_conf_product_list.tpl', Mail::TYPE_HTML, $product_var_tpl_list);
-            }
-
-            $total_reduction_value_ti = 0;
-            $total_reduction_value_tex = 0;
-
-            $cart_rules_list = $this->createOrderCartRules(
-                $order,
-                $this->context->cart,
-                $order_list,
-                $total_reduction_value_ti,
-                $total_reduction_value_tex,
-                $id_order_state
-            );
-
-            $cart_rules_list_txt = '';
-            $cart_rules_list_html = '';
-            if (count($cart_rules_list) > 0) {
-                $cart_rules_list_txt = $this->getEmailTemplateContent('order_conf_cart_rules.txt', Mail::TYPE_TEXT, $cart_rules_list);
-                $cart_rules_list_html = $this->getEmailTemplateContent('order_conf_cart_rules.tpl', Mail::TYPE_HTML, $cart_rules_list);
-            }
-
-            // Specify order id for message
-            $old_message = Message::getMessageByCartId((int) $this->context->cart->id);
-            if ($old_message && !$old_message['private']) {
-                $update_message = new Message((int) $old_message['id_message']);
-                $update_message->id_order = (int) $order->id;
-                $update_message->update();
-
-                // Add this message in the customer thread
-                $customer_thread = new CustomerThread();
-                $customer_thread->id_contact = 0;
-                $customer_thread->id_customer = (int) $order->id_customer;
-                $customer_thread->id_shop = (int) $this->context->shop->id;
-                $customer_thread->id_order = (int) $order->id;
-                $customer_thread->id_lang = (int) $this->context->language->id;
-                $customer_thread->email = $this->context->customer->email;
-                $customer_thread->status = 'open';
-                $customer_thread->token = Tools::passwdGen(12);
-                $customer_thread->add();
-
-                $customer_message = new CustomerMessage();
-                $customer_message->id_customer_thread = $customer_thread->id;
-                $customer_message->id_employee = 0;
-                $customer_message->message = $update_message->message;
-                $customer_message->private = false;
-
-                if (!$customer_message->add()) {
-                    $this->_errors[] = $this->trans('An error occurred while saving message', [], 'Admin.Payment.Notification');
-                }
-            }
-
-            if (self::DEBUG_MODE) {
-                PrestaShopLogger::addLog('PaymentModule::validateOrder - Hook validateOrder is about to be called', 1, null, 'Cart', (int) $id_cart, true);
-            }
-
-            // Hook validate order
-            Hook::exec('actionValidateOrder', [
-                'cart' => $this->context->cart,
-                'order' => $order,
-                'customer' => $this->context->customer,
-                'currency' => $this->context->currency,
-                'orderStatus' => $order_status,
-            ]);
-
-            if ($order_status->logable) {
-                foreach ($this->context->cart->getProducts() as $product) {
-                    ProductSale::addProductSale((int) $product['id_product'], (int) $product['cart_quantity']);
-                }
-            }
-
-            if (self::DEBUG_MODE) {
-                PrestaShopLogger::addLog('PaymentModule::validateOrder - Order Status is about to be added', 1, null, 'Cart', (int) $id_cart, true);
-            }
-
-            // Set the order status
-            $new_history = new OrderHistory();
-            $new_history->id_order = (int) $order->id;
-            $new_history->changeIdOrderState((int) $id_order_state, $order, true);
-            $new_history->addWithemail(true, $extra_vars);
-
-            // Switch to back order if needed
-            if (Configuration::get('PS_STOCK_MANAGEMENT')
-                    && Configuration::get('PS_ENABLE_BACKORDER_STATUS')
-                    && ($order_detail->getStockState()
-                    || $order_detail->product_quantity_in_stock < 0)) {
-                $history = new OrderHistory();
-                $history->id_order = (int) $order->id;
-                $history->changeIdOrderState(
-                    (int) Configuration::get($order->hasBeenPaid() ? 'PS_OS_OUTOFSTOCK_PAID' : 'PS_OS_OUTOFSTOCK_UNPAID'),
-                    $order,
-                    true
+                $orderData = $this->createOrderFromCart(
+                    $this->context->cart,
+                    $this->context->currency,
+                    $productsByCarriers,
+                    $idAddress,
+                    $this->context,
+                    $reference,
+                    $secure_key,
+                    $payment_method,
+                    $this->name,
+                    $dont_touch_amount,
+                    $amount_paid,
+                    0,
+                    $cart_total_paid,
+                    self::DEBUG_MODE,
+                    $order_status,
+                    $id_order_state,
+                    null
                 );
-                $history->addWithemail();
+                $order = $orderData['order'];
+                $order_list[] = $order;
+                $order_detail_list[] = $orderData['orderDetail'];
+            }
+            // The country can only change if the address used for the calculation is the delivery address, and if multi-shipping is activated
+            if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_delivery' && isset($context_country)) {
+                $this->context->country = $context_country;
             }
 
-            unset($order_detail);
+            if (!$this->context->country->active) {
+                PrestaShopLogger::addLog('PaymentModule::validateOrder - Country is not active', 3, null, 'Cart', (int) $id_cart, true);
 
-            // Order is reloaded because the status just changed
-            $order = new Order((int) $order->id);
+                throw new PrestaShopException('The order address country is not active.');
+            }
 
-            // Send an e-mail to customer (one order = one email)
-            if ($id_order_state != Configuration::get('PS_OS_ERROR') && $id_order_state != Configuration::get('PS_OS_CANCELED') && $this->context->customer->id) {
-                $invoice = new Address((int) $order->id_address_invoice);
-                $delivery = new Address((int) $order->id_address_delivery);
-                $delivery_state = $delivery->id_state ? new State((int) $delivery->id_state) : false;
-                $invoice_state = $invoice->id_state ? new State((int) $invoice->id_state) : false;
-                $carrier = $order->id_carrier ? new Carrier($order->id_carrier) : false;
-                $orderLanguage = new Language((int) $order->id_lang);
+            if (self::DEBUG_MODE) {
+                PrestaShopLogger::addLog('PaymentModule::validateOrder - Payment is about to be added', 1, null, 'Cart', (int) $id_cart, true);
+            }
 
-                // Join PDF invoice
-                if ((int) Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
-                    $currentLanguage = $this->context->language;
-                    $this->context->language = $orderLanguage;
-                    $this->context->getTranslator()->setLocale($orderLanguage->locale);
-                    $order_invoice_list = $order->getInvoicesCollection();
-                    Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => $order_invoice_list]);
-                    $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty);
-                    $file_attachement['content'] = $pdf->render(false);
-                    $file_attachement['name'] = $pdf->getFilename();
-                    $file_attachement['mime'] = 'application/pdf';
-                    $this->context->language = $currentLanguage;
-                    $this->context->getTranslator()->setLocale($currentLanguage->locale);
+            // Register Payment only if the order status validate the order
+            if ($order_status->logable) {
+                // $order is the last order loop in the foreach
+                // The method addOrderPayment of the class Order make a create a paymentOrder
+                // linked to the order reference and not to the order id
+                if (isset($extra_vars['transaction_id'])) {
+                    $transaction_id = $extra_vars['transaction_id'];
                 } else {
-                    $file_attachement = null;
+                    $transaction_id = null;
+                }
+
+                if (!isset($order) || !$order->addOrderPayment($amount_paid, null, $transaction_id)) {
+                    PrestaShopLogger::addLog('PaymentModule::validateOrder - Cannot save Order Payment', 3, null, 'Cart', (int) $id_cart, true);
+
+                    throw new PrestaShopException('Can\'t save Order Payment');
+                }
+            }
+
+            // Next !
+            $products = $this->context->cart->getProducts();
+
+            // Make sure CartRule caches are empty
+            CartRule::cleanCache();
+            foreach ($order_detail_list as $key => $order_detail) {
+                /** @var Order $order */
+                $order = $order_list[$key];
+                if (!isset($order->id)) {
+                    $error = $this->trans('Order creation failed', [], 'Admin.Payment.Notification');
+                    PrestaShopLogger::addLog($error, 4, 2, 'Cart', (int) $order->id_cart);
+                    throw new PrestaShopException($error);
+                }
+                if (!$secure_key) {
+                    $message .= '<br />' . $this->trans('Warning: the secure key is empty, check your payment account before validation', [], 'Admin.Payment.Notification');
+                }
+                // Optional message to attach to this order
+                if (!empty($message)) {
+                    $message = strip_tags($message, '<br>');
+                    if (Validate::isCleanHtml($message)) {
+                        if (self::DEBUG_MODE) {
+                            PrestaShopLogger::addLog('PaymentModule::validateOrder - Message is about to be added', 1, null, 'Cart', (int) $id_cart, true);
+                        }
+                        $msg = new Message();
+                        $msg->message = $message;
+                        $msg->id_cart = (int) $id_cart;
+                        $msg->id_customer = (int) $order->id_customer;
+                        $msg->id_order = (int) $order->id;
+                        $msg->private = true;
+                        $msg->add();
+                    }
+                }
+
+                // Insert new Order detail list using cart for the current order
+                // $orderDetail = new OrderDetail(null, null, $this->context);
+                // $orderDetail->createList($order, $this->context->cart, $id_order_state);
+
+                // Construct order detail table for the email
+                $virtual_product = true;
+
+                $product_var_tpl_list = [];
+                foreach ($order->product_list as $product) {
+                    $price = Product::getPriceStatic((int) $product['id_product'], false, $product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null, 6, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
+                    $price_wt = Product::getPriceStatic((int) $product['id_product'], true, $product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null, 2, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
+
+                    $product_price = Product::getTaxCalculationMethod() == PS_TAX_EXC ? Tools::ps_round($price, Context::getContext()->getComputingPrecision()) : $price_wt;
+
+                    $carrierName = null;
+                    if ($orderShipmentService->orderHasShipment($order->id)) {
+                        $carrierName = $orderShipmentService->getCarrierForProduct($order->id, (int) $product['id_product'])->name;
+                    }
+
+                    $product_var_tpl = [
+                        'id_product' => $product['id_product'],
+                        'id_product_attribute' => $product['id_product_attribute'],
+                        'reference' => $product['reference'],
+                        'name' => $this->trans(
+                            '%name%%attributes%%carrier%',
+                            [
+                                '%name%' => $product['name'],
+                                '%attributes%' => !empty($product['attributes']) ? $this->trans(' - %attributes%', ['%attributes%' => $product['attributes']], 'Emails.Body') : '',
+                                '%carrier%' => $carrierName ? $this->trans(' - Carrier: %carrier_name%', ['%carrier_name%' => $carrierName], 'Emails.Body') : '',
+                            ], 'Emails.Body'),
+                        'price' => Tools::getContextLocale($this->context)->formatPrice($product_price * $product['quantity'], $this->context->currency->iso_code),
+                        'quantity' => $product['quantity'],
+                        'customization' => [],
+                    ];
+
+                    if (isset($product['price']) && $product['price']) {
+                        $product_var_tpl['unit_price'] = Tools::getContextLocale($this->context)->formatPrice($product_price, $this->context->currency->iso_code);
+                        $product_var_tpl['unit_price_full'] = Tools::getContextLocale($this->context)->formatPrice($product_price, $this->context->currency->iso_code)
+                            . ' ' . $product['unity'];
+                    } else {
+                        $product_var_tpl['unit_price'] = $product_var_tpl['unit_price_full'] = '';
+                    }
+
+                    $customized_datas = Product::getAllCustomizedDatas((int) $order->id_cart, null, true, null, (int) $product['id_customization']);
+                    if (isset($customized_datas[$product['id_product']][$product['id_product_attribute']])) {
+                        $product_var_tpl['customization'] = [];
+                        foreach ($customized_datas[$product['id_product']][$product['id_product_attribute']][$order->id_address_delivery] as $customization) {
+                            $customization_text = '';
+                            if (isset($customization['datas'][Product::CUSTOMIZE_TEXTFIELD])) {
+                                foreach ($customization['datas'][Product::CUSTOMIZE_TEXTFIELD] as $text) {
+                                    $customization_text .= '<strong>' . $text['name'] . '</strong>: ' . htmlspecialchars($text['value'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '<br />';
+                                }
+                            }
+
+                            if (isset($customization['datas'][Product::CUSTOMIZE_FILE])) {
+                                $customization_text .= $this->trans('%d image(s)', [count($customization['datas'][Product::CUSTOMIZE_FILE])], 'Admin.Payment.Notification') . '<br />';
+                            }
+
+                            $customization_quantity = (int) $customization['quantity'];
+
+                            $product_var_tpl['customization'][] = [
+                                'customization_text' => $customization_text,
+                                'customization_quantity' => $customization_quantity,
+                                'quantity' => Tools::getContextLocale($this->context)->formatPrice($customization_quantity * $product_price, $this->context->currency->iso_code),
+                            ];
+                        }
+                    }
+
+                    Hook::exec('actionPaymentModuleProductVarTplAfter', [
+                        'product_var_tpl' => &$product_var_tpl,
+                        'product' => $product,
+                        'order' => $order,
+                        'context' => $this->context,
+                    ]);
+
+                    $product_var_tpl_list[] = $product_var_tpl;
+                    // Check if is not a virtual product for the displaying of shipping
+                    if (!$product['is_virtual']) {
+                        $virtual_product &= false;
+                    }
+                }
+
+                $product_list_txt = '';
+                $product_list_html = '';
+                if (count($product_var_tpl_list) > 0) {
+                    $product_list_txt = $this->getEmailTemplateContent('order_conf_product_list.txt', Mail::TYPE_TEXT, $product_var_tpl_list);
+                    $product_list_html = $this->getEmailTemplateContent('order_conf_product_list.tpl', Mail::TYPE_HTML, $product_var_tpl_list);
+                }
+
+                $total_reduction_value_ti = 0;
+                $total_reduction_value_tex = 0;
+
+                $cart_rules_list = $this->createOrderCartRules(
+                    $order,
+                    $this->context->cart,
+                    $order_list,
+                    $total_reduction_value_ti,
+                    $total_reduction_value_tex,
+                    $id_order_state
+                );
+
+                $cart_rules_list_txt = '';
+                $cart_rules_list_html = '';
+                if (count($cart_rules_list) > 0) {
+                    $cart_rules_list_txt = $this->getEmailTemplateContent('order_conf_cart_rules.txt', Mail::TYPE_TEXT, $cart_rules_list);
+                    $cart_rules_list_html = $this->getEmailTemplateContent('order_conf_cart_rules.tpl', Mail::TYPE_HTML, $cart_rules_list);
+                }
+
+                // Specify order id for message
+                $old_message = Message::getMessageByCartId((int) $this->context->cart->id);
+                if ($old_message && !$old_message['private']) {
+                    $update_message = new Message((int) $old_message['id_message']);
+                    $update_message->id_order = (int) $order->id;
+                    $update_message->update();
+
+                    // Add this message in the customer thread
+                    $customer_thread = new CustomerThread();
+                    $customer_thread->id_contact = 0;
+                    $customer_thread->id_customer = (int) $order->id_customer;
+                    $customer_thread->id_shop = (int) $this->context->shop->id;
+                    $customer_thread->id_order = (int) $order->id;
+                    $customer_thread->id_lang = (int) $this->context->language->id;
+                    $customer_thread->email = $this->context->customer->email;
+                    $customer_thread->status = 'open';
+                    $customer_thread->token = Tools::passwdGen(12);
+                    $customer_thread->add();
+
+                    $customer_message = new CustomerMessage();
+                    $customer_message->id_customer_thread = $customer_thread->id;
+                    $customer_message->id_employee = 0;
+                    $customer_message->message = $update_message->message;
+                    $customer_message->private = false;
+
+                    if (!$customer_message->add()) {
+                        $this->_errors[] = $this->trans('An error occurred while saving message', [], 'Admin.Payment.Notification');
+                    }
                 }
 
                 if (self::DEBUG_MODE) {
-                    PrestaShopLogger::addLog('PaymentModule::validateOrder - Mail is about to be sent', 1, null, 'Cart', (int) $id_cart, true);
+                    PrestaShopLogger::addLog('PaymentModule::validateOrder - Hook validateOrder is about to be called', 1, null, 'Cart', (int) $id_cart, true);
                 }
 
-                if (Validate::isEmail($this->context->customer->email)) {
-                    if ($orderShipmentService->orderHasShipment($order->id)) {
-                        $carriers = $orderShipmentService->getAllCarriersForOrder($order->id);
-                        $carrierNames = array_map(fn ($carrier) => $carrier->name, $carriers);
-                        $carrierNames = implode(', ', $carrierNames);
-                    } else {
-                        $carrier = new Carrier($order->id_carrier);
-                        $carrierNames = $carrier->name;
+                // Hook validate order
+                Hook::exec('actionValidateOrder', [
+                    'cart' => $this->context->cart,
+                    'order' => $order,
+                    'customer' => $this->context->customer,
+                    'currency' => $this->context->currency,
+                    'orderStatus' => $order_status,
+                ]);
+
+                if ($order_status->logable) {
+                    foreach ($this->context->cart->getProducts() as $product) {
+                        ProductSale::addProductSale((int) $product['id_product'], (int) $product['cart_quantity']);
                     }
+                }
 
-                    $data = [
-                        '{firstname}' => $this->context->customer->firstname,
-                        '{lastname}' => $this->context->customer->lastname,
-                        '{email}' => $this->context->customer->email,
-                        '{delivery_block_txt}' => $this->_getFormatedAddress($delivery, AddressFormat::FORMAT_NEW_LINE),
-                        '{invoice_block_txt}' => $this->_getFormatedAddress($invoice, AddressFormat::FORMAT_NEW_LINE),
-                        '{delivery_block_html}' => $this->_getFormatedAddress($delivery, '<br />', [
-                            'firstname' => '<span style="font-weight:bold;">%s</span>',
-                            'lastname' => '<span style="font-weight:bold;">%s</span>',
-                        ]),
-                        '{invoice_block_html}' => $this->_getFormatedAddress($invoice, '<br />', [
-                            'firstname' => '<span style="font-weight:bold;">%s</span>',
-                            'lastname' => '<span style="font-weight:bold;">%s</span>',
-                        ]),
-                        '{delivery_company}' => $delivery->company,
-                        '{delivery_firstname}' => $delivery->firstname,
-                        '{delivery_lastname}' => $delivery->lastname,
-                        '{delivery_address1}' => $delivery->address1,
-                        '{delivery_address2}' => $delivery->address2,
-                        '{delivery_city}' => $delivery->city,
-                        '{delivery_postal_code}' => $delivery->postcode,
-                        '{delivery_country}' => $delivery->country,
-                        '{delivery_state}' => $delivery->id_state ? $delivery_state->name : '',
-                        '{delivery_phone}' => ($delivery->phone) ? $delivery->phone : $delivery->phone_mobile,
-                        '{delivery_other}' => $delivery->other,
-                        '{invoice_company}' => $invoice->company,
-                        '{invoice_vat_number}' => $invoice->vat_number,
-                        '{invoice_firstname}' => $invoice->firstname,
-                        '{invoice_lastname}' => $invoice->lastname,
-                        '{invoice_address2}' => $invoice->address2,
-                        '{invoice_address1}' => $invoice->address1,
-                        '{invoice_city}' => $invoice->city,
-                        '{invoice_postal_code}' => $invoice->postcode,
-                        '{invoice_country}' => $invoice->country,
-                        '{invoice_state}' => $invoice->id_state ? $invoice_state->name : '',
-                        '{invoice_phone}' => ($invoice->phone) ? $invoice->phone : $invoice->phone_mobile,
-                        '{invoice_other}' => $invoice->other,
-                        '{order_name}' => $order->getUniqReference(),
-                        '{id_order}' => $order->id,
-                        '{date}' => Tools::displayDate(date('Y-m-d H:i:s'), true),
-                        '{carrier}' => ($virtual_product || !isset($carrierNames)) ? $this->trans('No carrier', [], 'Admin.Payment.Notification') : $carrierNames,
-                        '{payment}' => $order->payment,
-                        '{products}' => $product_list_html,
-                        '{products_txt}' => $product_list_txt,
-                        '{discounts}' => $cart_rules_list_html,
-                        '{discounts_txt}' => $cart_rules_list_txt,
-                        '{total_paid}' => Tools::getContextLocale($this->context)->formatPrice($order->total_paid, $this->context->currency->iso_code),
-                        '{total_paid_tax_excl}' => Tools::getContextLocale($this->context)->formatPrice($order->total_paid_tax_excl, $this->context->currency->iso_code),
-                        '{total_shipping_tax_excl}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping_tax_excl, $this->context->currency->iso_code),
-                        '{total_shipping_tax_incl}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping_tax_incl, $this->context->currency->iso_code),
-                        '{total_tax_paid}' => Tools::getContextLocale($this->context)->formatPrice($order->total_paid_tax_incl - $order->total_paid_tax_excl, $this->context->currency->iso_code),
-                        '{recycled_packaging_label}' => $order->recyclable ? $this->trans('Yes', [], 'Shop.Theme.Global') : $this->trans('No', [], 'Shop.Theme.Global'),
-                        '{message}' => $order->getFirstMessage(),
-                    ];
+                if (self::DEBUG_MODE) {
+                    PrestaShopLogger::addLog('PaymentModule::validateOrder - Order Status is about to be added', 1, null, 'Cart', (int) $id_cart, true);
+                }
 
-                    if (Product::getTaxCalculationMethod() == PS_TAX_EXC) {
-                        $data = array_merge($data, [
-                            '{total_products}' => Tools::getContextLocale($this->context)->formatPrice($order->total_products, $this->context->currency->iso_code),
-                            '{total_discounts}' => Tools::getContextLocale($this->context)->formatPrice($order->total_discounts_tax_excl, $this->context->currency->iso_code),
-                            '{total_shipping}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping_tax_excl, $this->context->currency->iso_code),
-                            '{total_wrapping}' => Tools::getContextLocale($this->context)->formatPrice($order->total_wrapping_tax_excl, $this->context->currency->iso_code),
-                        ]);
-                    } else {
-                        $data = array_merge($data, [
-                            '{total_products}' => Tools::getContextLocale($this->context)->formatPrice($order->total_products_wt, $this->context->currency->iso_code),
-                            '{total_discounts}' => Tools::getContextLocale($this->context)->formatPrice($order->total_discounts, $this->context->currency->iso_code),
-                            '{total_shipping}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping, $this->context->currency->iso_code),
-                            '{total_wrapping}' => Tools::getContextLocale($this->context)->formatPrice($order->total_wrapping, $this->context->currency->iso_code),
-                        ]);
-                    }
+                // Set the order status
+                $new_history = new OrderHistory();
+                $new_history->id_order = (int) $order->id;
+                $new_history->changeIdOrderState((int) $id_order_state, $order, true);
+                $new_history->addWithemail(true, $extra_vars);
 
-                    if (is_array($extra_vars)) {
-                        $data = array_merge($data, $extra_vars);
-                    }
-
-                    Mail::Send(
-                        (int) $order->id_lang,
-                        'order_conf',
-                        $this->context->getTranslator()->trans(
-                            'Order confirmation',
-                            [],
-                            'Emails.Subject',
-                            $orderLanguage->locale
-                        ),
-                        $data,
-                        $this->context->customer->email,
-                        $this->context->customer->firstname . ' ' . $this->context->customer->lastname,
-                        null,
-                        null,
-                        $file_attachement,
-                        null,
-                        _PS_MAIL_DIR_,
-                        false,
-                        (int) $order->id_shop
+                // Switch to back order if needed
+                if (Configuration::get('PS_STOCK_MANAGEMENT')
+                        && Configuration::get('PS_ENABLE_BACKORDER_STATUS')
+                        && ($order_detail->getStockState()
+                        || $order_detail->product_quantity_in_stock < 0)) {
+                    $history = new OrderHistory();
+                    $history->id_order = (int) $order->id;
+                    $history->changeIdOrderState(
+                        (int) Configuration::get($order->hasBeenPaid() ? 'PS_OS_OUTOFSTOCK_PAID' : 'PS_OS_OUTOFSTOCK_UNPAID'),
+                        $order,
+                        true
                     );
+                    $history->addWithemail();
+                }
+
+                unset($order_detail);
+
+                // Order is reloaded because the status just changed
+                $order = new Order((int) $order->id);
+
+                // Send an e-mail to customer (one order = one email)
+                if ($id_order_state != Configuration::get('PS_OS_ERROR') && $id_order_state != Configuration::get('PS_OS_CANCELED') && $this->context->customer->id) {
+                    $invoice = new Address((int) $order->id_address_invoice);
+                    $delivery = new Address((int) $order->id_address_delivery);
+                    $delivery_state = $delivery->id_state ? new State((int) $delivery->id_state) : false;
+                    $invoice_state = $invoice->id_state ? new State((int) $invoice->id_state) : false;
+                    $carrier = $order->id_carrier ? new Carrier($order->id_carrier) : false;
+                    $orderLanguage = new Language((int) $order->id_lang);
+
+                    // Join PDF invoice
+                    if ((int) Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
+                        $currentLanguage = $this->context->language;
+                        $this->context->language = $orderLanguage;
+                        $this->context->getTranslator()->setLocale($orderLanguage->locale);
+                        $order_invoice_list = $order->getInvoicesCollection();
+                        Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => $order_invoice_list]);
+                        $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty);
+                        $file_attachement['content'] = $pdf->render(false);
+                        $file_attachement['name'] = $pdf->getFilename();
+                        $file_attachement['mime'] = 'application/pdf';
+                        $this->context->language = $currentLanguage;
+                        $this->context->getTranslator()->setLocale($currentLanguage->locale);
+                    } else {
+                        $file_attachement = null;
+                    }
+
+                    if (self::DEBUG_MODE) {
+                        PrestaShopLogger::addLog('PaymentModule::validateOrder - Mail is about to be sent', 1, null, 'Cart', (int) $id_cart, true);
+                    }
+
+                    if (Validate::isEmail($this->context->customer->email)) {
+                        if ($orderShipmentService->orderHasShipment($order->id)) {
+                            $carriers = $orderShipmentService->getAllCarriersForOrder($order->id);
+                            $carrierNames = array_map(fn ($carrier) => $carrier->name, $carriers);
+                            $carrierNames = implode(', ', $carrierNames);
+                        } else {
+                            $carrier = new Carrier($order->id_carrier);
+                            $carrierNames = $carrier->name;
+                        }
+
+                        $data = [
+                            '{firstname}' => $this->context->customer->firstname,
+                            '{lastname}' => $this->context->customer->lastname,
+                            '{email}' => $this->context->customer->email,
+                            '{delivery_block_txt}' => $this->_getFormatedAddress($delivery, AddressFormat::FORMAT_NEW_LINE),
+                            '{invoice_block_txt}' => $this->_getFormatedAddress($invoice, AddressFormat::FORMAT_NEW_LINE),
+                            '{delivery_block_html}' => $this->_getFormatedAddress($delivery, '<br />', [
+                                'firstname' => '<span style="font-weight:bold;">%s</span>',
+                                'lastname' => '<span style="font-weight:bold;">%s</span>',
+                            ]),
+                            '{invoice_block_html}' => $this->_getFormatedAddress($invoice, '<br />', [
+                                'firstname' => '<span style="font-weight:bold;">%s</span>',
+                                'lastname' => '<span style="font-weight:bold;">%s</span>',
+                            ]),
+                            '{delivery_company}' => $delivery->company,
+                            '{delivery_firstname}' => $delivery->firstname,
+                            '{delivery_lastname}' => $delivery->lastname,
+                            '{delivery_address1}' => $delivery->address1,
+                            '{delivery_address2}' => $delivery->address2,
+                            '{delivery_city}' => $delivery->city,
+                            '{delivery_postal_code}' => $delivery->postcode,
+                            '{delivery_country}' => $delivery->country,
+                            '{delivery_state}' => $delivery->id_state ? $delivery_state->name : '',
+                            '{delivery_phone}' => ($delivery->phone) ? $delivery->phone : $delivery->phone_mobile,
+                            '{delivery_other}' => $delivery->other,
+                            '{invoice_company}' => $invoice->company,
+                            '{invoice_vat_number}' => $invoice->vat_number,
+                            '{invoice_firstname}' => $invoice->firstname,
+                            '{invoice_lastname}' => $invoice->lastname,
+                            '{invoice_address2}' => $invoice->address2,
+                            '{invoice_address1}' => $invoice->address1,
+                            '{invoice_city}' => $invoice->city,
+                            '{invoice_postal_code}' => $invoice->postcode,
+                            '{invoice_country}' => $invoice->country,
+                            '{invoice_state}' => $invoice->id_state ? $invoice_state->name : '',
+                            '{invoice_phone}' => ($invoice->phone) ? $invoice->phone : $invoice->phone_mobile,
+                            '{invoice_other}' => $invoice->other,
+                            '{order_name}' => $order->getUniqReference(),
+                            '{id_order}' => $order->id,
+                            '{date}' => Tools::displayDate(date('Y-m-d H:i:s'), true),
+                            '{carrier}' => ($virtual_product || !isset($carrierNames)) ? $this->trans('No carrier', [], 'Admin.Payment.Notification') : $carrierNames,
+                            '{payment}' => $order->payment,
+                            '{products}' => $product_list_html,
+                            '{products_txt}' => $product_list_txt,
+                            '{discounts}' => $cart_rules_list_html,
+                            '{discounts_txt}' => $cart_rules_list_txt,
+                            '{total_paid}' => Tools::getContextLocale($this->context)->formatPrice($order->total_paid, $this->context->currency->iso_code),
+                            '{total_paid_tax_excl}' => Tools::getContextLocale($this->context)->formatPrice($order->total_paid_tax_excl, $this->context->currency->iso_code),
+                            '{total_shipping_tax_excl}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping_tax_excl, $this->context->currency->iso_code),
+                            '{total_shipping_tax_incl}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping_tax_incl, $this->context->currency->iso_code),
+                            '{total_tax_paid}' => Tools::getContextLocale($this->context)->formatPrice($order->total_paid_tax_incl - $order->total_paid_tax_excl, $this->context->currency->iso_code),
+                            '{recycled_packaging_label}' => $order->recyclable ? $this->trans('Yes', [], 'Shop.Theme.Global') : $this->trans('No', [], 'Shop.Theme.Global'),
+                            '{message}' => $order->getFirstMessage(),
+                        ];
+
+                        if (Product::getTaxCalculationMethod() == PS_TAX_EXC) {
+                            $data = array_merge($data, [
+                                '{total_products}' => Tools::getContextLocale($this->context)->formatPrice($order->total_products, $this->context->currency->iso_code),
+                                '{total_discounts}' => Tools::getContextLocale($this->context)->formatPrice($order->total_discounts_tax_excl, $this->context->currency->iso_code),
+                                '{total_shipping}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping_tax_excl, $this->context->currency->iso_code),
+                                '{total_wrapping}' => Tools::getContextLocale($this->context)->formatPrice($order->total_wrapping_tax_excl, $this->context->currency->iso_code),
+                            ]);
+                        } else {
+                            $data = array_merge($data, [
+                                '{total_products}' => Tools::getContextLocale($this->context)->formatPrice($order->total_products_wt, $this->context->currency->iso_code),
+                                '{total_discounts}' => Tools::getContextLocale($this->context)->formatPrice($order->total_discounts, $this->context->currency->iso_code),
+                                '{total_shipping}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping, $this->context->currency->iso_code),
+                                '{total_wrapping}' => Tools::getContextLocale($this->context)->formatPrice($order->total_wrapping, $this->context->currency->iso_code),
+                            ]);
+                        }
+
+                        if (is_array($extra_vars)) {
+                            $data = array_merge($data, $extra_vars);
+                        }
+
+                        Mail::Send(
+                            (int) $order->id_lang,
+                            'order_conf',
+                            $this->context->getTranslator()->trans(
+                                'Order confirmation',
+                                [],
+                                'Emails.Subject',
+                                $orderLanguage->locale
+                            ),
+                            $data,
+                            $this->context->customer->email,
+                            $this->context->customer->firstname . ' ' . $this->context->customer->lastname,
+                            null,
+                            null,
+                            $file_attachement,
+                            null,
+                            _PS_MAIL_DIR_,
+                            false,
+                            (int) $order->id_shop
+                        );
+                    }
+                }
+
+                $order->updateOrderDetailTax();
+
+                // sync all stock
+                (new StockManager())->updatePhysicalProductQuantity(
+                    (int) $order->id_shop,
+                    (int) Configuration::get('PS_OS_ERROR'),
+                    (int) Configuration::get('PS_OS_CANCELED'),
+                    null,
+                    (int) $order->id
+                );
+            } // End foreach $order_detail_list
+        } catch (Throwable $e) {
+            // Creation aborted on a server error. Any order row already inserted would
+            // otherwise keep current_state = 0, which the back office then renders with
+            // the first status pre-selected. Move each one to the payment error status
+            // so the merchant can spot and handle it.
+            $errorState = (int) Configuration::get('PS_OS_ERROR');
+            if ($errorState && !empty($order_list)) {
+                foreach ($order_list as $brokenOrder) {
+                    // Skip orders that never got persisted or already have a status.
+                    if (!Validate::isLoadedObject($brokenOrder) || (int) $brokenOrder->current_state) {
+                        continue;
+                    }
+                    $errorHistory = new OrderHistory();
+                    $errorHistory->id_order = (int) $brokenOrder->id;
+                    $errorHistory->changeIdOrderState($errorState, $brokenOrder, true);
+                    $errorHistory->add();
                 }
             }
 
-            $order->updateOrderDetailTax();
-
-            // sync all stock
-            (new StockManager())->updatePhysicalProductQuantity(
-                (int) $order->id_shop,
-                (int) Configuration::get('PS_OS_ERROR'),
-                (int) Configuration::get('PS_OS_CANCELED'),
-                null,
-                (int) $order->id
-            );
-        } // End foreach $order_detail_list
+            // Re-throw so the existing error flow (logging, 500 page) stays unchanged.
+            throw $e;
+        }
 
         // Use the last order as currentOrder
         if (isset($order) && $order->id) {

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -802,18 +802,32 @@ abstract class PaymentModuleCore extends Module
             // otherwise keep current_state = 0, which the back office then renders with
             // the first status pre-selected. Move each one to the payment error status
             // so the merchant can spot and handle it.
-            $errorState = (int) Configuration::get('PS_OS_ERROR');
-            if ($errorState && !empty($order_list)) {
-                foreach ($order_list as $brokenOrder) {
-                    // Skip orders that never got persisted or already have a status.
-                    if (!Validate::isLoadedObject($brokenOrder) || (int) $brokenOrder->current_state) {
-                        continue;
+            try {
+                $errorState = (int) Configuration::get('PS_OS_ERROR');
+                if ($errorState) {
+                    /** @var Order $brokenOrder */
+                    foreach (Order::getByReference($reference) as $brokenOrder) {
+                        if (!Validate::isLoadedObject($brokenOrder)
+                            || (int) $brokenOrder->id_cart !== (int) $id_cart
+                            || (int) $brokenOrder->current_state
+                        ) {
+                            continue;
+                        }
+                        $errorHistory = new OrderHistory();
+                        $errorHistory->id_order = (int) $brokenOrder->id;
+                        $errorHistory->changeIdOrderState($errorState, $brokenOrder, true);
+                        $errorHistory->add();
                     }
-                    $errorHistory = new OrderHistory();
-                    $errorHistory->id_order = (int) $brokenOrder->id;
-                    $errorHistory->changeIdOrderState($errorState, $brokenOrder, true);
-                    $errorHistory->add();
                 }
+            } catch (Throwable $recoveryException) {
+                PrestaShopLogger::addLog(
+                    'PaymentModule::validateOrder - Unable to set the payment error status on the incomplete order(s): ' . $recoveryException->getMessage(),
+                    3,
+                    null,
+                    'Cart',
+                    (int) $id_cart,
+                    true
+                );
             }
 
             // Re-throw so the existing error flow (logging, 500 page) stays unchanged.


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When `PaymentModule::validateOrder()` aborts on a server error after the order rows were already inserted, the orders are left with `current_state = 0`. The back office then shows an empty status in the orders list but pre-selects the first status of the dropdown on the order page. This PR wraps the order creation block in a `try/catch`: on failure, every already-persisted order that still has no status is moved to the existing **Payment error** status (`PS_OS_ERROR`), then the original exception is re-thrown so the error flow is unchanged. The diff is mostly re-indentation of the wrapped block — review with whitespace hidden (`?w=1`).
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Force a server error during order creation, e.g. add `throw new Exception('test');` in `PaymentModule::validateOrder()` right before the `// Set the order status` block. 2. Place an order from the front office (e.g. bank wire). 3. Without this fix the order is saved with no status (`current_state = 0`) and the BO order page pre-selects the first status of the dropdown. 4. With this fix the order is saved with the **Payment error** status, consistent in the orders list and the order page. 5. Remove the forced exception and confirm normal orders are unaffected.
| Fixed issue or discussion? | Fixes #32743
| Sponsor company   |
