### PR TITLE
Display an input to upload files on Admin API OpenAPI interface

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/OpenApi/Factory/CQRSOpenApiFactory.php
+++ b/src/PrestaShopBundle/ApiPlatform/OpenApi/Factory/CQRSOpenApiFactory.php
@@ -23,6 +23,7 @@ use ApiPlatform\OpenApi\OpenApi;
 use ArrayObject;
 use PrestaShop\PrestaShop\Adapter\Feature\MultistoreFeature;
 use PrestaShopBundle\ApiPlatform\OpenApi\Adapter\SchemaAdapterChain;
+use PrestaShopBundle\ApiPlatform\OpenApi\FileUploadRequestBodyBuilder;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -51,6 +52,7 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
         protected readonly MultistoreFeature $multistoreFeature,
         protected readonly SchemaAdapterChain $resourceSchemaAdapterChain,
         protected readonly SchemaAdapterChain $operationSchemaAdapterChain,
+        protected readonly FileUploadRequestBodyBuilder $fileUploadRequestBodyBuilder,
         // No property promotion for this one since it's already defined in the ResourceMetadataTrait
         ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory,
     ) {
@@ -67,6 +69,7 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
         $parentOpenApi = $this->decorated->__invoke($context);
         $domainsByUri = [];
         $scopesByUri = [];
+        $uploadedFilesByUri = [];
 
         foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
             $resourceMetadataCollection = $this->resourceMetadataFactory->create($resourceClass);
@@ -90,6 +93,13 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
                     }
                     if ($operation instanceof HttpOperation && !empty($operation->getExtraProperties()['scopes'])) {
                         $scopesByUri[$operation->getUriTemplate()][strtolower($operation->getMethod())] = $operation->getExtraProperties()['scopes'];
+                    }
+                    // Detect uploaded file properties for multipart/form-data operations, they are documented in the paths loop below
+                    if ($operation instanceof HttpOperation && !empty($operation->getUriTemplate())) {
+                        $uploadedFileProperties = $this->fileUploadRequestBodyBuilder->getUploadedFileProperties($operation);
+                        if (!empty($uploadedFileProperties)) {
+                            $uploadedFilesByUri[$operation->getUriTemplate()][strtolower($operation->getMethod())] = $uploadedFileProperties;
+                        }
                     }
 
                     $definition = $this->getSchemaDefinition($parentOpenApi, $operation);
@@ -134,6 +144,15 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
                     if ($this->multistoreFeature->isActive()) {
                         $existingParameters = $updatedOperation->getParameters() ?? [];
                         $updatedOperation = $updatedOperation->withParameters(array_merge($existingParameters, $this->getMultiShopParameters()));
+                    }
+
+                    // Document uploaded file properties in the multipart/form-data request body
+                    if (!empty($uploadedFilesByUri[$path][$httpMethod])) {
+                        $updatedOperation = $this->fileUploadRequestBodyBuilder->adaptOperation(
+                            $updatedOperation,
+                            $parentOpenApi->getComponents()->getSchemas(),
+                            $uploadedFilesByUri[$path][$httpMethod],
+                        );
                     }
 
                     $setterMethod = 'with' . ucfirst($httpMethod);

--- a/src/PrestaShopBundle/ApiPlatform/OpenApi/FileUploadRequestBodyBuilder.php
+++ b/src/PrestaShopBundle/ApiPlatform/OpenApi/FileUploadRequestBodyBuilder.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\ApiPlatform\OpenApi;
+
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\OpenApi\Model\MediaType;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ArrayObject;
+use PrestaShopBundle\ApiPlatform\Encoder\MultipartDecoder;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionProperty;
+use SplFileInfo;
+
+/**
+ * Documents uploaded file properties for operations based on multipart/form-data input.
+ *
+ * The input schema of CQRS write operations is generated from the CQRS command class, which
+ * only contains the uploaded file path as a string (e.g. AddProductImageCommand::$filePath),
+ * so the file itself is absent from the generated schema and Swagger UI displays no file input.
+ * The API resource class is the one that declares the uploaded file as a SplFileInfo/File
+ * property, so this builder injects those properties into the request body schema of multipart
+ * operations as `type: string, format: binary`, which is the OpenAPI way of describing a binary
+ * file part.
+ *
+ * The request body schema is inlined (dereferenced) on purpose: a component schema can be shared
+ * by several operations based on the same CQRS command (e.g. module upload by source URL or by
+ * archive file), so the file properties must only be documented on the multipart operation, not
+ * on the shared schema.
+ */
+class FileUploadRequestBodyBuilder
+{
+    public const MULTIPART_CONTENT_TYPE = 'multipart/form-data';
+
+    protected const COMPONENT_SCHEMA_PREFIX = '#/components/schemas/';
+
+    /**
+     * Returns the public properties of the operation's API resource typed as SplFileInfo (or a
+     * child class like Symfony's File), mapped to whether they accept null (optional upload).
+     * Returns an empty array for operations that don't accept multipart/form-data input.
+     *
+     * @return array<string, bool>
+     */
+    public function getUploadedFileProperties(HttpOperation $operation): array
+    {
+        if (!array_key_exists(MultipartDecoder::FORMAT, $operation->getInputFormats() ?? [])
+            || !class_exists($operation->getClass())
+        ) {
+            return [];
+        }
+
+        $fileProperties = [];
+        $reflectionClass = new ReflectionClass($operation->getClass());
+        foreach ($reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic() || !$property->getType() instanceof ReflectionNamedType) {
+                continue;
+            }
+
+            $propertyType = $property->getType()->getName();
+            if ($propertyType === SplFileInfo::class || is_subclass_of($propertyType, SplFileInfo::class)) {
+                $fileProperties[$property->getName()] = $property->getType()->allowsNull();
+            }
+        }
+
+        return $fileProperties;
+    }
+
+    /**
+     * Replaces the multipart/form-data request body schema of the OpenAPI operation by an inline
+     * schema containing the original properties plus the uploaded file properties.
+     *
+     * @param ArrayObject $componentSchemas The components.schemas of the OpenAPI documentation, used to dereference the original schema
+     * @param array<string, bool> $uploadedFileProperties Uploaded file property names mapped to whether they accept null
+     */
+    public function adaptOperation(OpenApiOperation $openApiOperation, ArrayObject $componentSchemas, array $uploadedFileProperties): OpenApiOperation
+    {
+        $requestBody = $openApiOperation->getRequestBody();
+        if (empty($uploadedFileProperties)
+            || null === $requestBody
+            || null === $requestBody->getContent()
+            || !$requestBody->getContent()->offsetExists(self::MULTIPART_CONTENT_TYPE)
+        ) {
+            return $openApiOperation;
+        }
+
+        /** @var MediaType $mediaType */
+        $mediaType = $requestBody->getContent()->offsetGet(self::MULTIPART_CONTENT_TYPE);
+        $schema = $this->dereferenceSchema($mediaType->getSchema(), $componentSchemas);
+
+        $properties = (array) ($schema['properties'] ?? []);
+        $required = (array) ($schema['required'] ?? []);
+        foreach ($uploadedFileProperties as $propertyName => $allowsNull) {
+            $properties[$propertyName] = new ArrayObject([
+                'type' => 'string',
+                'format' => 'binary',
+            ]);
+            if (!$allowsNull && !in_array($propertyName, $required, true)) {
+                $required[] = $propertyName;
+            }
+        }
+
+        $inlineSchema = new ArrayObject([
+            'type' => 'object',
+            'properties' => $properties,
+        ]);
+        if (!empty($required)) {
+            $inlineSchema['required'] = array_values($required);
+        }
+
+        $content = clone $requestBody->getContent();
+        $content->offsetSet(self::MULTIPART_CONTENT_TYPE, $mediaType->withSchema($inlineSchema));
+
+        return $openApiOperation->withRequestBody($requestBody->withContent($content));
+    }
+
+    /**
+     * Resolves a `$ref` schema pointing to components.schemas so that the file properties can be
+     * merged with the schema's own properties in the final inline schema.
+     */
+    protected function dereferenceSchema(?ArrayObject $schema, ArrayObject $componentSchemas): ArrayObject
+    {
+        if (null === $schema) {
+            return new ArrayObject();
+        }
+
+        if (!empty($schema['$ref']) && str_starts_with($schema['$ref'], self::COMPONENT_SCHEMA_PREFIX)) {
+            $schemaName = substr($schema['$ref'], strlen(self::COMPONENT_SCHEMA_PREFIX));
+            if ($componentSchemas->offsetExists($schemaName)) {
+                return $componentSchemas->offsetGet($schemaName);
+            }
+        }
+
+        return $schema;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/open_api.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/open_api.yml
@@ -57,6 +57,8 @@ services:
       - { name: 'prestashop.openapi.schema_adapter.resource', priority: 10 }
       - { name: 'prestashop.openapi.schema_adapter.operation', priority: 40 }
 
+  PrestaShopBundle\ApiPlatform\OpenApi\FileUploadRequestBodyBuilder: ~
+
   # Schema adapter chains - orchestrates adapters in the correct order
   prestashop_bundle.api_platform.open_api.resource_schema_adapter_chain:
     class: PrestaShopBundle\ApiPlatform\OpenApi\Adapter\SchemaAdapterChain

--- a/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
+++ b/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
@@ -800,6 +800,42 @@ class CQRSOpenApiFactoryTest extends KernelTestCase
         ];
     }
 
+    public function testMultipartFileUploadRequestBody(): void
+    {
+        /** @var OpenApiFactoryInterface $openApiFactory */
+        $openApiFactory = $this->getContainer()->get(OpenApiFactoryInterface::class);
+        /** @var OpenApi $openApi */
+        $openApi = $openApiFactory->__invoke();
+
+        // The multipart operation documents the uploaded file properties declared in the API resource class
+        $multipartOperation = $openApi->getPaths()->getPath('/test/file-upload')->getPost();
+        $content = $multipartOperation->getRequestBody()->getContent();
+        $this->assertTrue($content->offsetExists('multipart/form-data'));
+
+        $schema = $content->offsetGet('multipart/form-data')->getSchema();
+        // The schema is inlined so that file properties are only documented on the multipart operation
+        $this->assertArrayNotHasKey('$ref', (array) $schema);
+        $this->assertArrayHasKey('productId', $schema['properties']);
+        $this->assertEquals(['type' => 'string', 'format' => 'binary'], (array) $schema['properties']['file']);
+        $this->assertEquals(['type' => 'string', 'format' => 'binary'], (array) $schema['properties']['optionalFile']);
+        // Non-nullable file properties are required, nullable ones are optional
+        $this->assertContains('file', $schema['required']);
+        $this->assertNotContains('optionalFile', $schema['required']);
+
+        // The JSON operation based on the same CQRS command keeps its schema reference, and the
+        // shared component schema is not polluted by the file properties
+        $jsonOperation = $openApi->getPaths()->getPath('/test/file-upload-json')->getPost();
+        $jsonContent = $jsonOperation->getRequestBody()->getContent();
+        $this->assertFalse($jsonContent->offsetExists('multipart/form-data'));
+
+        $jsonSchema = $jsonContent->offsetGet('application/json')->getSchema();
+        $this->assertEquals('#/components/schemas/FileUploadResource.AddProductImageCommand', $jsonSchema['$ref']);
+
+        $componentSchema = $openApi->getComponents()->getSchemas()['FileUploadResource.AddProductImageCommand'];
+        $this->assertArrayNotHasKey('file', (array) $componentSchema['properties']);
+        $this->assertArrayNotHasKey('optionalFile', (array) $componentSchema['properties']);
+    }
+
     public function testApiPropertyOpenApiContextApplied(): void
     {
         /** @var OpenApiFactoryInterface $openApiFactory */

--- a/tests/Resources/ApiPlatform/Resources/FileUploadResource.php
+++ b/tests/Resources/ApiPlatform/Resources/FileUploadResource.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Resources\ApiPlatform\Resources;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\AddProductImageCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\File\File;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/test/file-upload',
+            inputFormats: ['multipart' => ['multipart/form-data']],
+            CQRSCommand: AddProductImageCommand::class,
+            scopes: ['file_upload_write'],
+            CQRSCommandMapping: [
+                '[file].pathName' => '[pathName]',
+            ],
+        ),
+        // Operation based on the same CQRS command but with JSON input, its schema must not document the file properties
+        new CQRSCreate(
+            uriTemplate: '/test/file-upload-json',
+            CQRSCommand: AddProductImageCommand::class,
+            scopes: ['file_upload_write'],
+        ),
+    ]
+)]
+class FileUploadResource
+{
+    public int $productId;
+
+    public File $file;
+
+    public ?File $optionalFile;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When using the Admin API documentation with Swagger, the endpoints using file uploads (for instances images) are not usable. This PR adds an actual file input on the form so anyone can try the related endpoints. 
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You can test the endpoint POST /products/{productId}/images
| UI Tests          | https://github.com/Quetzacoalt91/ga.tests.ui.pr/actions/runs/27601255153
| Fixed issue or discussion?     | /
| Related PRs       | /
| Sponsor company   | @PrestaShopCorp

# Tests results

<details>

<summary>[POST] /products/{productId}/images</summary>

### Before

<img width="1690" height="1323" alt="image" src="https://github.com/user-attachments/assets/564b5d7d-9a4b-4e4b-96c4-d9b9cfcbb258" />


### After

<img width="1690" height="1073" alt="Screenshot 2026-06-10 at 18-23-44 Backoffice API - API Platform" src="https://github.com/user-attachments/assets/79978b35-e823-4250-abe0-ee61958097e6" />
</details>

