### PR TITLE
Fix states lookup using row indexes instead of country IDs

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -650,7 +650,7 @@ class CarrierCore extends ObjectModel
         $states = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
             SELECT s.*
             FROM `' . _DB_PREFIX_ . 'state` s
-            WHERE s.id_country IN (' . implode(',', array_keys($countries)) . ')
+            WHERE s.id_country IN (' . implode(',', array_keys($result)) . ')
               AND s.active = 1
             ORDER BY s.`name` ASC'
         );


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `Carrier::getDeliveredCountries()` builds its states sub-query from `array_keys($countries)`, but `$countries` is the raw `executeS()` result with numeric row indexes (0, 1, 2, …) — not country IDs. Only `$result` is keyed by `id_country`. As a consequence, states of unrelated countries are fetched, and the line `$result[$state['id_country']]['states'][] = $state` silently auto-creates malformed entries containing only a `states` key (no `id_country`, no `name`). When `PS_RESTRICT_DELIVERED_COUNTRIES` is enabled, `CustomerAddressFormatter::getFormat()` iterates this array and emits `Undefined array key "id_country"` / `"name"` warnings (CustomerAddressFormatter.php:100-101), and the FO address form's country dropdown contains broken/extra entries. This PR uses `array_keys($result)` instead, so only states of actually delivered countries are fetched and no phantom entries can be created. Regression introduced in #40044 (shipped since 9.0.2).
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. In the BO, go to International > Locations > Countries and enable "Restrict country selections in front office to those covered by active carriers" (`PS_RESTRICT_DELIVERED_COUNTRIES`). 2. Make sure at least one country with a **low ID** and active states (e.g. enable a country whose `id_country` is below the number of delivered countries) is active but **not** covered by any active carrier. 3. In the FO, open the address creation form (My account > Addresses > Create new address). Before the fix: PHP warnings `Undefined array key "id_country"` / `"name"` from `CustomerAddressFormatter.php:100-101` in the logs, and broken/unexpected entries in the country dropdown. After the fix: no warnings, the dropdown lists only carrier-covered countries, and their states load correctly.
| UI Tests          | Will be added after opening the PR.
| Fixed issue or discussion?     | Fixes #40376
| Related PRs       | ~
| Sponsor company   | ~

Supersedes #40377, which contained the same fix but was closed unmerged because it targeted `9.0.x` after the 9.1.0 release — this resubmits it against `9.1.x` as requested by maintainers there. Credit to @matrixino for the original diagnosis in #40376.