### PR TITLE
Use new shipping calculator on order creation (Improved shipment) 

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -7,6 +7,7 @@
 use PrestaShop\PrestaShop\Adapter\MailTemplate\MailPartialTemplateRenderer;
 use PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentCreator;
 use PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentService;
+use PrestaShop\PrestaShop\Adapter\Shipment\ShipmentShippingCostUpdater;
 use PrestaShop\PrestaShop\Adapter\StockManager;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
@@ -1088,37 +1089,22 @@ abstract class PaymentModuleCore extends Module
         );
         $order->total_discounts = $order->total_discounts_tax_incl;
 
-        $order->total_shipping_tax_incl = Tools::ps_round(
-            (float) abs($cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $order->product_list, null)),
-            $computingPrecision
-        );
-
-        $order->total_shipping_tax_excl = Tools::ps_round(
-            (float) abs($cart->getOrderTotal(false, Cart::ONLY_SHIPPING, $order->product_list, null)),
-            $computingPrecision
-        );
-
-        // loop for each carrier to store the shipping cost
-        if ($this->isFeatureFlagIsEnabledForMultiShipment()) {
-            foreach ($productList as $carrierId => $product) {
-                $totalShippingTaxExcl = Tools::ps_round(
-                    (float) abs($cart->getOrderTotal(false, Cart::ONLY_SHIPPING, $order->product_list, $carrierId)),
-                    $computingPrecision
-                );
-                $totalShippingTaxIncl = Tools::ps_round(
-                    (float) abs($cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $order->product_list, $carrierId)),
-                    $computingPrecision
-                );
-
-                $productList[$carrierId]['total_shipping_tax_excl'] = $totalShippingTaxExcl;
-                $productList[$carrierId]['total_shipping_tax_incl'] = $totalShippingTaxIncl;
-            }
-        }
-
-        $order->total_shipping = $order->total_shipping_tax_incl;
-
         if (null !== $carrier && Validate::isLoadedObject($carrier)) {
             $order->carrier_tax_rate = $carrier->getTaxesRate(new Address((int) $cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}));
+        }
+
+        if (!$this->isFeatureFlagIsEnabledForMultiShipment()) {
+            $order->total_shipping_tax_incl = Tools::ps_round(
+                (float) abs($cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $order->product_list, null)),
+                $computingPrecision
+            );
+
+            $order->total_shipping_tax_excl = Tools::ps_round(
+                (float) abs($cart->getOrderTotal(false, Cart::ONLY_SHIPPING, $order->product_list, null)),
+                $computingPrecision
+            );
+
+            $order->total_shipping = $order->total_shipping_tax_incl;
         }
 
         $order->total_wrapping_tax_excl = Tools::ps_round(
@@ -1199,6 +1185,10 @@ abstract class PaymentModuleCore extends Module
 
         if ($this->isFeatureFlagIsEnabledForMultiShipment()) {
             $this->addShipmentToOrder($order, $productList);
+
+            /** @var ShipmentShippingCostUpdater $shipmentShippingCostUpdater */
+            $shipmentShippingCostUpdater = $this->get(ShipmentShippingCostUpdater::class);
+            $order = $shipmentShippingCostUpdater->recalculateForOrder((int) $order->id);
         }
 
         return ['order' => $order, 'orderDetail' => $order_detail];
@@ -1355,12 +1345,8 @@ abstract class PaymentModuleCore extends Module
 
     private function addShipmentToOrder(Order $order, array $productsByCarrier)
     {
-        if (!$this->isFeatureFlagIsEnabledForMultiShipment()) {
-            return;
-        }
-
         /** @var OrderShipmentCreator $orderShipmentCreator */
-        $orderShipmentCreator = $this->get('PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentCreator');
+        $orderShipmentCreator = $this->get(OrderShipmentCreator::class);
         $physicalProductsByCarrier = [];
 
         foreach ($productsByCarrier as $carrierId => $products) {
@@ -1370,8 +1356,6 @@ abstract class PaymentModuleCore extends Module
 
             if (!empty($filteredProducts)) {
                 $physicalProductsByCarrier[$carrierId]['product_list'] = array_values($filteredProducts);
-                $physicalProductsByCarrier[$carrierId]['total_shipping_tax_excl'] = $products['total_shipping_tax_excl'];
-                $physicalProductsByCarrier[$carrierId]['total_shipping_tax_incl'] = $products['total_shipping_tax_incl'];
             }
         }
         $orderShipmentCreator->addShipmentOrder($order, $physicalProductsByCarrier);

--- a/config/services/common.yml
+++ b/config/services/common.yml
@@ -9,6 +9,7 @@ imports:
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/core/common.yml }
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/bundle/common.yml }
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/extra_property/common.yml }
+    - { resource: ../../src/PrestaShopBundle/Resources/config/services/core/shipping_cost.yml }
 
 services:
     _defaults:

--- a/src/Adapter/Carrier/ShippingCost/Provider/ShippingTaxRateProvider.php
+++ b/src/Adapter/Carrier/ShippingCost/Provider/ShippingTaxRateProvider.php
@@ -23,7 +23,7 @@ class ShippingTaxRateProvider implements ShippingTaxRateProviderInterface
     public function __construct(
         private readonly CarrierRepository $carrierRepository,
         private readonly AddressRepository $addressRepository,
-        private readonly LoggerInterface $logger,
+        private readonly ?LoggerInterface $logger = null,
     ) {
     }
 
@@ -35,10 +35,12 @@ class ShippingTaxRateProvider implements ShippingTaxRateProviderInterface
 
             return new TaxRate(new DecimalNumber((string) $carrier->getTaxesRate($address)));
         } catch (Exception $e) {
-            $this->logger->error(
-                sprintf('Failed to retrieve tax rate for carrier %d and address %d: %s', $carrierId, $addressId, $e->getMessage()),
-                ['exception' => $e]
-            );
+            if ($this->logger) {
+                $this->logger->error(
+                    sprintf('Failed to retrieve tax rate for carrier %d and address %d: %s', $carrierId, $addressId, $e->getMessage()),
+                    ['exception' => $e]
+                );
+            }
 
             return TaxRate::zero();
         }

--- a/src/Adapter/Shipment/OrderShipmentCreator.php
+++ b/src/Adapter/Shipment/OrderShipmentCreator.php
@@ -35,8 +35,8 @@ class OrderShipmentCreator
             $shipment->setCarrierId((int) $carrierId);
             $shipment->setAddressId((int) $order->id_address_delivery);
             $shipment->setTrackingNumber(null);
-            $shipment->setShippingCostTaxExcluded((float) $products['total_shipping_tax_excl']);
-            $shipment->setShippingCostTaxIncluded((float) $products['total_shipping_tax_incl']);
+            $shipment->setShippingCostTaxExcluded(0);
+            $shipment->setShippingCostTaxIncluded(0);
             $shipment->setDeliveredAt(null);
             $shipment->setShippedAt(null);
             $shipment->setCancelledAt(null);
@@ -50,8 +50,8 @@ class OrderShipmentCreator
             $orderCarrier->id_order = (int) $order->id;
             $orderCarrier->id_carrier = $carrierId;
             $orderCarrier->weight = (float) $productWeight[0];
-            $orderCarrier->shipping_cost_tax_excl = (float) $products['total_shipping_tax_excl'];
-            $orderCarrier->shipping_cost_tax_incl = (float) $products['total_shipping_tax_incl'];
+            $orderCarrier->shipping_cost_tax_excl = 0;
+            $orderCarrier->shipping_cost_tax_incl = 0;
             $orderCarrier->add();
             // match products with order details to get quantities & orderDetailId
             foreach (OrderDetail::getList($order->id) as $orderDetailProduct) {

--- a/src/Adapter/Shipment/OrderShippingTotalUpdater.php
+++ b/src/Adapter/Shipment/OrderShippingTotalUpdater.php
@@ -21,7 +21,7 @@ class OrderShippingTotalUpdater
     ) {
     }
 
-    public function update(Order $order): void
+    public function update(Order $order): Order
     {
         $totalTaxExcluded = 0.00;
         $totalTaxIncluded = 0.00;
@@ -35,5 +35,7 @@ class OrderShippingTotalUpdater
         $order->total_shipping_tax_incl = $totalTaxIncluded;
         $order->total_shipping = $totalTaxIncluded;
         $order->update();
+
+        return $order;
     }
 }

--- a/src/Adapter/Shipment/ShipmentShippingCostUpdater.php
+++ b/src/Adapter/Shipment/ShipmentShippingCostUpdater.php
@@ -31,7 +31,7 @@ class ShipmentShippingCostUpdater
     ) {
     }
 
-    public function recalculateForOrder(int $orderId): void
+    public function recalculateForOrder(int $orderId): Order
     {
         $order = $this->orderRepository->get(new OrderId($orderId));
         $productsDetail = $order->getProductsDetail();
@@ -40,7 +40,7 @@ class ShipmentShippingCostUpdater
             $this->recalculateShipment($shipment, $order, $productsDetail);
         }
 
-        $this->orderShippingTotalUpdater->update($order);
+        return $this->orderShippingTotalUpdater->update($order);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsType.php
@@ -10,6 +10,8 @@ use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\OutOfRangeBehavior;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\ShippingMethod;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier\Type\CarrierRangesType;
 use PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier\Type\CostsZoneType;
 use PrestaShopBundle\Form\Admin\Type\MultipleZoneChoiceType;
@@ -29,7 +31,8 @@ class ShippingLocationsAndCostsType extends TranslatorAwareType
         array $locales,
         private readonly RouterInterface $router,
         private readonly ConfigurationInterface $configuration,
-        private readonly CurrencyDataProviderInterface $currencyDataProvider
+        private readonly CurrencyDataProviderInterface $currencyDataProvider,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagChecker,
     ) {
         parent::__construct($translator, $locales);
     }
@@ -37,6 +40,12 @@ class ShippingLocationsAndCostsType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         parent::buildForm($builder, $options);
+
+        if ($this->featureFlagChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT)) {
+            $shippingWeightTraduction = $this->trans("Based on the shipment's total weight", 'Admin.Shipping.Feature');
+        } else {
+            $shippingWeightTraduction = $this->trans("Based on the order's total weight", 'Admin.Shipping.Feature');
+        }
 
         $builder
             ->add('zones', MultipleZoneChoiceType::class, [
@@ -90,7 +99,7 @@ class ShippingLocationsAndCostsType extends TranslatorAwareType
                 'label' => $this->trans('Shipping costs', 'Admin.Shipping.Feature'),
                 'choices' => [
                     $this->trans("Based on the order's total price", 'Admin.Shipping.Feature') => ShippingMethod::BY_PRICE,
-                    $this->trans("Based on the order's total weight", 'Admin.Shipping.Feature') => ShippingMethod::BY_WEIGHT,
+                    $shippingWeightTraduction => ShippingMethod::BY_WEIGHT,
                 ],
                 'default_empty_data' => ShippingMethod::BY_PRICE,
                 'expanded' => true,

--- a/src/PrestaShopBundle/Resources/config/services/adapter/address.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/address.yml
@@ -60,8 +60,3 @@ services:
 
   prestashop.adapter.address.formatter:
     class: 'PrestaShop\PrestaShop\Adapter\Address\AddressFormatter'
-
-  PrestaShop\PrestaShop\Adapter\Address\Repository\AddressRepository:
-    arguments:
-      - '@doctrine.dbal.default_connection'
-      - '%database_prefix%'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
@@ -1,6 +1,7 @@
 services:
   _defaults:
     public: true
+    autowire: true
 
   PrestaShop\PrestaShop\Adapter\Configuration: ~
 
@@ -31,6 +32,10 @@ services:
       - '@PrestaShop\PrestaShop\Adapter\Order\Repository\OrderDetailRepository'
       - '@PrestaShop\PrestaShop\Adapter\LegacyContext'
       - '@PrestaShop\PrestaShop\Adapter\Tools'
+
+  PrestaShop\PrestaShop\Adapter\Shipment\OrderShippingTotalUpdater:
+
+  PrestaShop\PrestaShop\Adapter\Shipment\ShipmentShippingCostUpdater:
 
   prestashop.adapter.legacy.context:
     alias: PrestaShop\PrestaShop\Adapter\LegacyContext
@@ -63,3 +68,10 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller:
     class: PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller
+
+  PrestaShop\PrestaShop\Adapter\Address\Repository\AddressRepository:
+    arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'
+
+  PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/shipment.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/shipment.yml
@@ -12,7 +12,3 @@ services:
   PrestaShop\PrestaShop\Adapter\Shipment\ShipmentProductQuantityUpdater:
 
   PrestaShop\PrestaShop\Adapter\Shipment\ShipmentProductAssigner:
-
-  PrestaShop\PrestaShop\Adapter\Shipment\OrderShippingTotalUpdater:
-
-  PrestaShop\PrestaShop\Adapter\Shipment\ShipmentShippingCostUpdater:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use new shipping calculator on order creation
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/41646
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/27699538949
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41646
| Related PRs       | -
| Sponsor company   | -
