### PR TITLE
Add delivery slip in documents tab (Improved shipment) 

### DIFF
--- a/classes/pdf/HTMLTemplateShipmentDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateShipmentDeliverySlip.php
@@ -65,10 +65,12 @@ class HTMLTemplateShipmentDeliverySlipCore extends HTMLTemplate
 
         // Use delivery slip prefix and shipment ID as the number
         $prefix = Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id);
+
         $this->title = sprintf(
-            HTMLTemplateShipmentDeliverySlip::l('%1$s%2$06d'),
+            HTMLTemplateShipmentDeliverySlip::l('%s%06d%s'),
             $prefix,
-            $this->shipment->getId()
+            $this->order->id,
+            '-' . $this->shipment->getId()
         );
 
         // footer informations
@@ -248,6 +250,6 @@ class HTMLTemplateShipmentDeliverySlipCore extends HTMLTemplate
      */
     public function getFilename()
     {
-        return Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id, null, $this->order->id_shop) . sprintf('%06d', $this->shipment->getId()) . '.pdf';
+        return Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id, null, $this->order->id_shop) . sprintf('%06d%s', $this->order->id, '-' . $this->shipment->getId()) . '.pdf';
     }
 }

--- a/classes/pdf/HTMLTemplateShipmentDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateShipmentDeliverySlip.php
@@ -4,6 +4,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
+use PrestaShop\PrestaShop\Core\Domain\Shipment\ValueObject\DeliverySlipNumber;
 use PrestaShop\PrestaShop\Core\Util\Sorter;
 use PrestaShopBundle\Entity\Shipment;
 
@@ -66,11 +67,10 @@ class HTMLTemplateShipmentDeliverySlipCore extends HTMLTemplate
         // Use delivery slip prefix and shipment ID as the number
         $prefix = Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id);
 
-        $this->title = sprintf(
-            HTMLTemplateShipmentDeliverySlip::l('%s%06d%s'),
+        $this->title = DeliverySlipNumber::format(
             $prefix,
             $this->order->id,
-            '-' . $this->shipment->getId()
+            $this->shipment->getId()
         );
 
         // footer informations
@@ -250,6 +250,11 @@ class HTMLTemplateShipmentDeliverySlipCore extends HTMLTemplate
      */
     public function getFilename()
     {
-        return Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id, null, $this->order->id_shop) . sprintf('%06d%s', $this->order->id, '-' . $this->shipment->getId()) . '.pdf';
+        return Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id, null, $this->order->id_shop)
+            . DeliverySlipNumber::format(
+                '',
+                $this->order->id,
+                $this->shipment->getId()
+            ) . '.pdf';
     }
 }

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -66,6 +66,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderSourceForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderSourcesForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderStatusForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\ValueObject\DeliverySlipNumber;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
@@ -516,11 +517,10 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                     continue;
                 }
 
-                $number = sprintf(
-                    '%s%06d%s',
+                $number = DeliverySlipNumber::format(
                     $conf[$this->contextLanguageId] ?? '',
                     $order->id,
-                    '-' . $shipment->getId()
+                    $shipment->getId()
                 );
 
                 $documentsForViewing[] = new OrderDocumentForViewing(

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -410,6 +410,9 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
 
         $documentsForViewing = [];
 
+        $shipments = $this->shipmentRepository->findByOrderId((int) $order->id);
+        $hasShipments = !empty($shipments);
+
         /** @var OrderInvoice|OrderSlip $document */
         foreach ($documents as $document) {
             $type = null;
@@ -423,6 +426,10 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                 $type = isset($document->is_delivery) ? OrderDocumentType::DELIVERY_SLIP : OrderDocumentType::INVOICE;
             } elseif ($document instanceof OrderSlip) {
                 $type = OrderDocumentType::CREDIT_SLIP;
+            }
+
+            if ($hasShipments && OrderDocumentType::DELIVERY_SLIP === $type) {
+                continue;
             }
 
             if (OrderDocumentType::INVOICE === $type) {
@@ -495,11 +502,45 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             );
         }
 
+        if ($hasShipments) {
+            $conf = $this->configuration->get(
+                'PS_DELIVERY_PREFIX',
+                null,
+                ShopConstraint::shop((int) $order->id_shop)
+            );
+
+            foreach ($shipments as $shipment) {
+                $shipmentDate = $shipment->getPackedAt();
+
+                if (!$shipmentDate) {
+                    continue;
+                }
+
+                $number = sprintf(
+                    '%s%06d',
+                    $conf[$this->contextLanguageId] ?? '',
+                    $shipment->getId()
+                );
+
+                $documentsForViewing[] = new OrderDocumentForViewing(
+                    $shipment->getId(),
+                    OrderDocumentType::DELIVERY_SLIP,
+                    DateTimeImmutable::createFromMutable($shipmentDate),
+                    $number,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false
+                );
+            }
+        }
+
         $canGenerateInvoice = $this->configuration->get('PS_INVOICE')
             && count($order->getInvoicesCollection())
             && $order->invoice_number;
 
-        $canGenerateDeliverySlip = (bool) $order->delivery_number;
+        $canGenerateDeliverySlip = $hasShipments ? true : (bool) $order->delivery_number;
 
         return new OrderDocumentsForViewing(
             $canGenerateInvoice,

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -517,9 +517,10 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                 }
 
                 $number = sprintf(
-                    '%s%06d',
+                    '%s%06d%s',
                     $conf[$this->contextLanguageId] ?? '',
-                    $shipment->getId()
+                    $order->id,
+                    '-' . $shipment->getId()
                 );
 
                 $documentsForViewing[] = new OrderDocumentForViewing(

--- a/src/Core/Domain/Shipment/ValueObject/DeliverySlipNumber.php
+++ b/src/Core/Domain/Shipment/ValueObject/DeliverySlipNumber.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Shipment\ValueObject;
+
+/**
+ * Formats the delivery slip number for shipment-based delivery slips.
+ *
+ * The canonical format is: {prefix}{orderId:06d}-{shipmentId}
+ * Example: "DE000042-7"
+ */
+final class DeliverySlipNumber
+{
+    public const NUMBER_FORMAT = '%s%06d-%d';
+
+    /**
+     * Returns the formatted delivery slip number for a shipment.
+     *
+     * @param string $prefix Localized delivery prefix (PS_DELIVERY_PREFIX)
+     * @param int $orderId The order ID, zero-padded to 6 digits
+     * @param int $shipmentId The shipment ID appended after a dash
+     */
+    public static function format(string $prefix, int $orderId, int $shipmentId): string
+    {
+        return sprintf(self::NUMBER_FORMAT, $prefix, $orderId, $shipmentId);
+    }
+}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
@@ -48,7 +48,7 @@
             </a>
           {% elseif document.type == 'delivery_slip' %}
             <a target="_blank" rel="noopener noreferrer nofollow"
-               href="{{ path('admin_orders_generate_delivery_slip_pdf', {orderId: orderForViewing.id}) }}"
+               href="{{ orderHasShipment ? path('admin_orders_generate_shipment_delivery_slip_pdf', {shipmentId: document.id}) : path('admin_orders_generate_delivery_slip_pdf', {orderId: orderForViewing.id}) }}"
             >
               {{ document.referenceNumber }}
             </a>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | new delivery slip system with improved shipment feature flag not update "Documents" tab in orders. This PR add delivery slip documents 
| Type?             | improvement
| Category?         |BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | use new delivery slip system with improved shipment feature flag
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/27532932402
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -
