### PR TITLE
Fix unit price ratio currency conversion and specific price issue

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5614,7 +5614,7 @@ class ProductCore extends ObjectModel
         ]);
 
         // Always recompute unit prices based on initial ratio so that discounts are applied on unit price as well
-        $unitPriceRatio = self::computeUnitPriceRatio($row, $id_product_attribute, $quantityToUseForPriceCalculations, $context);
+        $unitPriceRatio = self::computeUnitPriceRatio($row, $id_product_attribute, $context);
         $row['unit_price_ratio'] = $unitPriceRatio;
         $row['unit_price_tax_excluded'] = $unitPriceRatio != 0 ? $priceTaxExcluded / $unitPriceRatio : 0.0;
         $row['unit_price_tax_included'] = $unitPriceRatio != 0 ? $priceTaxIncluded / $unitPriceRatio : 0.0;
@@ -5631,61 +5631,49 @@ class ProductCore extends ObjectModel
     }
 
     /**
-     * Compute unit price ratio based on the saved unit price, we make sure that quantities, currency rates and
-     * combination impact are taken into account.
+     * Compute unit price ratio based on the saved prices on both product and combinations.
      *
      * @param array $productRow
      * @param int $combinationId
-     * @param int $quantity
      * @param Context $context
      *
      * @return float
      */
-    private static function computeUnitPriceRatio(array $productRow, int $combinationId, int $quantity, Context $context): float
+    private static function computeUnitPriceRatio(array $productRow, int $combinationId, Context $context): float
     {
+        // If we have a combination Id, we will prepare it
+        if ($combinationId) {
+            $combination = new Combination($combinationId);
+        }
+
+        // First, we get the unit price without tax saved in the database
         $baseUnitPrice = 0.0;
         if (isset($productRow['unit_price'])) {
-            // Unit price is supposed to be in DB and accessible in the row
             $baseUnitPrice = (float) $productRow['unit_price'];
         }
 
-        // Then if combination has an impact we apply it on unit price
+        // Then, if combination has an impact we apply it on unit price
         if ($combinationId) {
-            $combination = new Combination($combinationId);
             $baseUnitPrice = $baseUnitPrice + $combination->unit_price_impact;
         }
 
+        // If there is none, nothing to calculate
         if ($baseUnitPrice == 0) {
             return 0;
         }
 
-        // Finally, we apply the currency rate
-        $defaultCurrencyId = Currency::getDefaultCurrencyId();
-        $currencyId = Validate::isLoadedObject($context->currency) ? (int) $context->currency->id : $defaultCurrencyId;
-        if ($currencyId !== $defaultCurrencyId) {
-            $baseUnitPrice = Tools::convertPrice($baseUnitPrice, $currencyId);
+        // Now, we get a basic price of this product, with no discounts, exactly as in the backoffice.
+        // We are not using new Product because that "breaks" the price attribute in the constructor.
+        $baseProductPrice = (float) Db::getInstance()->getValue('
+            SELECT price
+            FROM ' . _DB_PREFIX_ . 'product_shop
+            WHERE id_product = ' . (int) $productRow['id_product'] . ' AND id_shop = ' . (int) $context->shop->id
+        );
+        if ($combinationId) {
+            $baseProductPrice = $baseProductPrice + $combination->price;
         }
 
-        // Compute price ratio based on initial product price and initial unit price (without taxes, group discount, cart rules)
-        $noSpecificPrice = null;
-        $baseProductPrice = Product::getPriceStatic(
-            (int) $productRow['id_product'],
-            false,
-            $combinationId,
-            6,
-            null,
-            false,
-            false,
-            $quantity,
-            false,
-            null,
-            null,
-            null,
-            $noSpecificPrice,
-            true,
-            false
-        );
-
+        // And we calculate the precise ratio
         return $baseProductPrice / $baseUnitPrice;
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/PricesAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/PricesAssertionFeatureContext.php
@@ -8,9 +8,12 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
+use Context;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductPricesInformation;
+use Product;
+use ProductAssembler;
 use RuntimeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use TaxRulesGroup;
@@ -57,6 +60,62 @@ class PricesAssertionFeatureContext extends AbstractProductFeatureContext
         $pricesInfo = $this->getProductForEditing($productReference)->getPricesInformation();
 
         $this->assertPricesInfos($pricesInfo, $data);
+    }
+
+    /**
+     * @Then product :productReference should have following front office prices:
+     *
+     * @param string $productReference
+     * @param TableNode $tableNode
+     */
+    public function assertFrontOfficePriceFields(string $productReference, TableNode $tableNode): void
+    {
+        $expectedPrices = $tableNode->getRowsHash();
+        $actualProductProperties = $this->getFrontOfficeProductProperties($productReference);
+
+        foreach ($expectedPrices as $fieldName => $expectedPrice) {
+            // Each expected field must exist in the front-office product array returned by Product::getProductProperties().
+            if (!array_key_exists($fieldName, $actualProductProperties)) {
+                throw new RuntimeException(sprintf('Front office product price field "%s" was not found', $fieldName));
+            }
+
+            $expectedNumber = new DecimalNumber((string) $expectedPrice);
+            $actualNumber = new DecimalNumber((string) $actualProductProperties[$fieldName]);
+
+            // Numeric fields are compared as DecimalNumber values to match the existing product price assertions.
+            if (!$expectedNumber->equals($actualNumber)) {
+                throw new RuntimeException(sprintf(
+                    'Front office product %s expected to be "%s", but is "%s"',
+                    $fieldName,
+                    $expectedNumber,
+                    $actualNumber
+                ));
+            }
+        }
+    }
+
+    /**
+     * Gets product properties through the legacy front-office product assembler.
+     *
+     * @param string $productReference
+     *
+     * @return array<string, mixed>
+     */
+    private function getFrontOfficeProductProperties(string $productReference): array
+    {
+        // Reset Product static caches so price changes and specific prices from previous Behat steps are read fresh.
+        Product::resetStaticCache();
+
+        $productId = $this->getSharedStorage()->get($productReference);
+        $productAssembler = new ProductAssembler(Context::getContext());
+        $productProperties = $productAssembler->assembleProduct(['id_product' => $productId]);
+
+        // The assembler should always return a front-office product array for a valid shared product reference.
+        if (!is_array($productProperties)) {
+            throw new RuntimeException(sprintf('Front office product properties for "%s" could not be loaded', $productReference));
+        }
+
+        return $productProperties;
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/unit_price_with_specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/unit_price_with_specific_price.feature
@@ -1,0 +1,30 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags unit-price-specific-price
+@restore-products-before-feature
+@clear-cache-before-feature
+@unit-price-specific-price
+@specific-prices
+Feature: Calculate product unit price for Front Office with specific prices
+  As a customer
+  I need product unit prices to use the displayed product price with the stored unit price ratio
+
+  Scenario: Fixed specific price should not be used to calculate unit price ratio
+    Given I add product "product1" with following information:
+      | name[en-US] | Unit price product |
+      | type        | standard           |
+    When I update product "product1" with following values:
+      | price      | 100 |
+      | unit_price | 10  |
+    And I add a specific price price1 to product product1 with following details:
+      | reduction type  | amount |
+      | reduction value | 0      |
+      | includes tax    | false  |
+      | fixed price     | 80     |
+      | from quantity   | 1      |
+    Then product product1 should have following prices information:
+      | price            | 100 |
+      | unit_price       | 10  |
+      | unit_price_ratio | 10  |
+    And product product1 should have following front office prices:
+      | price_tax_exc           | 80 |
+      | unit_price_ratio        | 10 |
+      | unit_price_tax_excluded | 8  |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | https://github.com/PrestaShop/PrestaShop/pull/26762 broke unit price calculation. In some cases, the unit price was wrong due to currency conversion issues and specific prices. Now, the ratio is calculated like in the backoffice, with no specific prices, no reductions, no currency conversion.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/29000618551
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Summary
- Before: the unit price ratio was calculated using a converted unit price and a product price returned by getPriceStatic().
- After: both the unit price and the product price are taken directly from the stored product values, without currency conversion, specific prices, reductions, or price calculations. Like in the backoffice that fills the backup ratio into database.

### What was wrong
- The unit price was stored in the default currency and then converted to the current currency.
- Because the product price went through price calculation, specific prices that were using fixed prices could still affect the price.
- As the result, we were getting slightly wrong values due to currency converting both the unit price AND the base product price.
- But what was even more wrong, if you created a specific price that wasn't a reduction, the unit price was completely broken.

### Solution
- Does not perform currency conversion, works with default currency, native values, like in the backoffice.
- Does not use specific prices. Does not use reductions. Does not use getPriceStatic().
- Properly applies combination impact to both unit price and the base product price.
- Unit prices are now calculated correctly in all currencies. ✅
- I had to use a direct database query because the price attribute on Product object is broken in the constructor.