### PR TITLE
Improve file download charset support, performance, remove depracted call

### DIFF
--- a/controllers/front/AttachmentController.php
+++ b/controllers/front/AttachmentController.php
@@ -12,50 +12,27 @@ class AttachmentControllerCore extends FrontController
             Tools::redirect('index.php');
         }
 
+        $attachmentPath = _PS_DOWNLOAD_DIR_ . $attachment->file;
+
+        if (!file_exists($attachmentPath)) {
+            Tools::redirect('pagenotfound');
+        }
+
         Hook::exec('actionDownloadAttachment', ['attachment' => &$attachment]);
 
-        if (ob_get_level() && ob_get_length() > 0) {
+        while (ob_get_level()) {
             ob_end_clean();
         }
 
+        $filenameFallback = mb_convert_encoding($attachment->file_name, 'ISO-8859-1');
+
         header('Content-Transfer-Encoding: binary');
         header('Content-Type: ' . $attachment->mime);
-        header('Content-Length: ' . filesize(_PS_DOWNLOAD_DIR_ . $attachment->file));
-        header('Content-Disposition: attachment; filename="' . utf8_decode($attachment->file_name) . '"');
+        header('Content-Length: ' . filesize($attachmentPath));
+        header('Content-Disposition: attachment; filename="' . $filenameFallback . '"; filename*=utf8\'\' ' . urlencode($attachment->file_name));
         @set_time_limit(0);
-        $this->readfileChunked(_PS_DOWNLOAD_DIR_ . $attachment->file);
+        readfile(_PS_DOWNLOAD_DIR_ . $attachment->file);
+
         exit;
-    }
-
-    /**
-     * @see   http://ca2.php.net/manual/en/function.readfile.php#54295
-     */
-    public function readfileChunked(string $filename, bool $retbytes = true)
-    {
-        // how many bytes per chunk
-        $chunksize = 1 * (1024 * 1024);
-        $buffer = '';
-        $totalBytes = 0;
-
-        $handle = fopen($filename, 'rb');
-        if ($handle === false) {
-            return false;
-        }
-        while (!feof($handle)) {
-            $buffer = fread($handle, $chunksize);
-            echo $buffer;
-            ob_flush();
-            flush();
-            if ($retbytes) {
-                $totalBytes += strlen($buffer);
-            }
-        }
-        $status = fclose($handle);
-        if ($retbytes && $status) {
-            // return num. bytes delivered like readfile() does.
-            return $totalBytes;
-        }
-
-        return $status;
     }
 }

--- a/controllers/front/AttachmentController.php
+++ b/controllers/front/AttachmentController.php
@@ -1,4 +1,8 @@
 <?php
+
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\String\UnicodeString;
+
 /**
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
@@ -20,16 +24,19 @@ class AttachmentControllerCore extends FrontController
             Tools::redirect('pagenotfound');
         }
 
-        while (ob_get_level()) {
-            ob_end_clean();
+        while (ob_get_level() && @ob_end_clean()) {
         }
 
-        $filenameFallback = mb_convert_encoding($attachment->file_name, 'ISO-8859-1');
+        $disposition = HeaderUtils::makeDisposition(
+            HeaderUtils::DISPOSITION_ATTACHMENT,
+            $attachment->file_name,
+            (new UnicodeString($attachment->file_name))->ascii(),
+        );
 
         header('Content-Transfer-Encoding: binary');
         header('Content-Type: ' . $attachment->mime);
         header('Content-Length: ' . filesize($attachmentPath));
-        header('Content-Disposition: attachment; filename="' . $filenameFallback . '"; filename*=utf8\'\' ' . urlencode($attachment->file_name));
+        header('Content-Disposition: ' . $disposition);
         @set_time_limit(0);
         readfile($attachmentPath);
 

--- a/controllers/front/AttachmentController.php
+++ b/controllers/front/AttachmentController.php
@@ -12,13 +12,13 @@ class AttachmentControllerCore extends FrontController
             Tools::redirect('index.php');
         }
 
+        Hook::exec('actionDownloadAttachment', ['attachment' => &$attachment]);
+
         $attachmentPath = _PS_DOWNLOAD_DIR_ . $attachment->file;
 
         if (!file_exists($attachmentPath)) {
             Tools::redirect('pagenotfound');
         }
-
-        Hook::exec('actionDownloadAttachment', ['attachment' => &$attachment]);
 
         while (ob_get_level()) {
             ob_end_clean();
@@ -31,7 +31,7 @@ class AttachmentControllerCore extends FrontController
         header('Content-Length: ' . filesize($attachmentPath));
         header('Content-Disposition: attachment; filename="' . $filenameFallback . '"; filename*=utf8\'\' ' . urlencode($attachment->file_name));
         @set_time_limit(0);
-        readfile(_PS_DOWNLOAD_DIR_ . $attachment->file);
+        readfile($attachmentPath);
 
         exit;
     }

--- a/controllers/front/AttachmentController.php
+++ b/controllers/front/AttachmentController.php
@@ -1,12 +1,12 @@
 <?php
-
-use Symfony\Component\HttpFoundation\HeaderUtils;
-use Symfony\Component\String\UnicodeString;
-
 /**
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\String\UnicodeString;
+
 class AttachmentControllerCore extends FrontController
 {
     public function postProcess(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improve `AttachmentController` with better support for non-ASCII file names ([RFC-6266](https://datatracker.ietf.org/doc/html/rfc6266#section-4.3)), missing file handling, performance, CPU usage, execution time and memory usage.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use the provided file (random binary content named with 'this is a test' in Thai, if GitHub renames the download, rename the file) to test non-ASCII files names on a product document. For performance tests, find the uploaded file in prestashop's `download`  folder and use the following command (linux) to make it bigger: `head -c 1G /dev/urandom > download/the_file_guid`, to test deleted file handling, just delete the file from the filesystem without using Prestashop's BO.
| UI Tests          | No UI changes
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Novius


[นี่คือการทดสอบ.debug](https://github.com/user-attachments/files/28951391/default.debug)
