### PR TITLE
Fix: Module Development and Distribution: Prestashop deletes automatically src/Entity/index.php, but it does not recursively in subfolders

### DIFF
--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -14,6 +14,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -128,14 +129,12 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
                 // APIPlatform is looping on included resources and doing a require_once on those resources in ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories.
                 // This means that everything in those files is interpreted including the exit statement in some of those files ( especially in some index.php files used as an old way to make the directory read only ).
                 // Since we cannot override or decorate the reflection class itself we have no other choice but to delete those files.
-                $indexFiles = Finder::create()
-                    ->files()
-                    ->in($entitiesRessourcesPath)
-                    ->name('index.php');
-
-                foreach ($indexFiles as $indexFile) {
-                    unlink($indexFile->getRealPath() ?: $indexFile->getPathname());
-                }
+                (new Filesystem())->remove(
+                    Finder::create()
+                        ->files()
+                        ->in($entitiesRessourcesPath)
+                        ->name('index.php')
+                );
                 $paths[] = $entitiesRessourcesPath;
             }
 

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -14,6 +14,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Throwable;
@@ -127,8 +128,13 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
                 // APIPlatform is looping on included resources and doing a require_once on those resources in ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories.
                 // This means that everything in those files is interpreted including the exit statement in some of those files ( especially in some index.php files used as an old way to make the directory read only ).
                 // Since we cannot override or decorate the reflection class itself we have no other choice but to delete those files.
-                if (file_exists($entitiesRessourcesPath . '/index.php')) {
-                    unlink($entitiesRessourcesPath . '/index.php');
+                $indexFiles = Finder::create()
+                    ->files()
+                    ->in($entitiesRessourcesPath)
+                    ->name('index.php');
+
+                foreach ($indexFiles as $indexFile) {
+                    unlink($indexFile->getRealPath() ?: $indexFile->getPathname());
                 }
                 $paths[] = $entitiesRessourcesPath;
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x
| Description?      | This PR fixes module entity scanning for API Platform when entities are organized in nested folders under `src/Entity`.<br/>Previously, PrestaShop only removed `src/Entity/index.php` before API Platform recursively scanned module entity resources. If a module also contained nested files like `src/Entity/Category/index.php`, those files were still required during resource discovery and could trigger redirects or exits, causing the process to fail. This change makes the cleanup recursive so all index.php files inside `src/Entity` are removed before the scan.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | 1. Install the test module [entities_more_folders.zip](https://github.com/user-attachments/files/28958723/entities_more_folders.zip).<br>2. Go to the Back Office.<br>3. Make sure you are not redirected outside the Back Office.<br>4. Make sure the Back Office loads correctly without a 500 error.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/27551588773
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41673
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/40094/
| Sponsor company   | Codencode snc
