### PR TITLE
Document ReorderPositionsButtonType convention for position columns

### DIFF
--- a/.ai/Component/Grid/CONTEXT.md
+++ b/.ai/Component/Grid/CONTEXT.md
@@ -57,6 +57,7 @@ When grid data needs post-processing (e.g. resolving image URLs from IDs, format
 
 - Column IDs must be `snake_case` and **exactly match** the SQL column aliases in the query builder
 - **Column ordering:** `BulkActionColumn` is always first, `ActionColumn` is always last. `PositionColumn` (if present) goes second after BulkActionColumn
+- **`PositionColumn` requires a `ReorderPositionsButtonType` filter** (associated with the position column) — it provides the drag-and-drop "Rearrange" UX. Canonical example: `FeatureValueGridDefinitionFactory`; see the [`create-position-column`](skills/create-position-column/SKILL.md) skill
 - `ToggleColumn` requires a dedicated AJAX toggle route — it cannot work without one
 - Grid definition must declare a `GRID_ID` const shared between the definition factory, the `{Domain}Filters` class, and the JS Grid constructor
 

--- a/.ai/Component/Grid/skills/create-position-column/SKILL.md
+++ b/.ai/Component/Grid/skills/create-position-column/SKILL.md
@@ -2,26 +2,40 @@
 name: create-position-column
 description: >
   Documents how to add drag-and-drop row reordering to a PrestaShop grid.
-  Requires a PositionColumn in the definition, a dedicated update-position
-  route, and position handling in the repository.
+  Requires a PositionColumn in the definition, a ReorderPositionsButtonType
+  filter, a dedicated update-position route, and position handling in the
+  repository.
 needs: [create-grid-definition, create-admin-routing]
-produces: "PositionColumn configuration and position-update route wiring"
+produces: "PositionColumn + ReorderPositionsButtonType filter and position-update route wiring"
 conditional: "only for entities with position/sort support"
 ---
 
 # create-position-column
 
+Canonical reference: [`FeatureValueGridDefinitionFactory`](../../../../../src/Core/Grid/Definition/Factory/FeatureValueGridDefinitionFactory.php).
+
 ## Instructions
 
 1. Add `PositionColumn` as the second column (after BulkActionColumn) in the Grid Definition.
 2. Configure the position update route: `->setOption('update_method', 'POST')->setOption('update_route', 'admin_{domain}s_update_position')`.
-3. Create the `admin_{domain}s_update_position` POST route in the routing YAML (see `create-admin-routing` skill).
-4. In the controller, handle the AJAX position update: receive `positions[]` array, dispatch `UpdatePosition{Domain}Command` (or use QueryBuilder directly).
-5. In the repository, update the `position` column for the moved entities.
+3. **Add a `ReorderPositionsButtonType` filter associated with the position column** (see Rules below) — mandatory, not optional.
+4. Create the `admin_{domain}s_update_position` POST route in the routing YAML (see `create-admin-routing` skill).
+5. In the controller, handle the AJAX position update: receive `positions[]` array, dispatch `UpdatePosition{Domain}Command` (or use QueryBuilder directly).
+6. In the repository, update the `position` column for the moved entities.
 
 ## Rules
 
 Column ordering conventions (PositionColumn as second column) are in [Grid/CONTEXT.md](../../CONTEXT.md#column-definitions). Skill-specific reminders:
+
+- **Always pair the PositionColumn with a `ReorderPositionsButtonType` filter.** It renders a "Rearrange" button (`js-btn-reorder-positions`) that toggles inline drag-and-drop mode — dramatically better UX than a numeric position search field. Use:
+
+  ```php
+  use PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType;
+
+  ->add((new Filter('position', ReorderPositionsButtonType::class))
+      ->setAssociatedColumn('position')
+  );
+  ```
 
 - Position updates are always AJAX — return JSON response, not redirect
 - Position values start at 0 or 1 — be consistent with existing PS convention


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Documents the convention that a grid `PositionColumn` must be paired with a `ReorderPositionsButtonType` filter (drag-and-drop "Rearrange" UX). Updates the `create-position-column` AI skill and the Grid component `CONTEXT.md`, using `FeatureValueGridDefinitionFactory` as canonical reference. Documentation/AI-tooling only — no code change.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No runtime impact. Verify the updated `.ai/Component/Grid/CONTEXT.md` and `.ai/Component/Grid/skills/create-position-column/SKILL.md` read correctly.
| Fixed issue or discussion?     | N/A
