### PR TITLE
Fill default address format when creating a country (FF Country)

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataProvider/CountryFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CountryFormDataProvider.php
@@ -11,6 +11,7 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Country\QueryResult\CountryForEditing;
+use PrestaShopBundle\Form\Admin\Improve\International\Locations\AddressFormatType;
 
 /**
  * Provides data for zone add/edit form.
@@ -88,6 +89,7 @@ class CountryFormDataProvider implements FormDataProviderInterface
             'contains_states' => false,
             'need_identification_number' => false,
             'display_tax_label' => true,
+            'address_format' => AddressFormatType::DEFAULT_LAYOUT,
         ];
 
         if ($this->multistoreEnabled) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When the `Countries` feature flag is enabled, creating a new country in International > Locations > Countries rendered the address-format builder empty. `CountryFormDataProvider::getDefaultData()` (used by the Symfony create form) did not provide an `address_format` value, unlike the legacy controller which pre-fills it. The default now uses `AddressFormatType::DEFAULT_LAYOUT`, the canonical PrestaShop default layout (also used by the builder's "Default for this country" reset action).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable the `Countries` feature flag (Advanced Parameters > Feature Flags). 2. Go to International > Locations > Countries. 3. Click "Add new country". 4. The Address format field should be pre-filled with the default layout (firstname/lastname, company, vat_number, address1, address2, postcode/city, Country:name, phone) instead of being empty.
| UI Tests          | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27558190153 :green_circle: 
| Fixed issue or discussion?     | Fixes #41721
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA
