### PR TITLE
Improve management of forms in multipart when using Swagger API

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/Encoder/MultipartDecoder.php
+++ b/src/PrestaShopBundle/ApiPlatform/Encoder/MultipartDecoder.php
@@ -31,7 +31,22 @@ class MultipartDecoder implements DecoderInterface
             return null;
         }
 
-        return $request->request->all() + $request->files->all();
+        // Swagger UI (and the OpenAPI standard) serializes object/array properties as a JSON string in a single
+        // multipart part (e.g. legends={"en-US":"value"}), whereas PHP only parses the bracket syntax
+        // (legends[en-US]=value) into an array. We decode any part that resolves to an array so these nested
+        // structures reach the denormalizer as arrays. Scalar parts (e.g. cover=true, position=0) are left as
+        // strings and coerced later by the normalizer (denormalizationContext DISABLE_TYPE_ENFORCEMENT).
+        $parameters = array_map(static function ($value) {
+            if (!is_string($value)) {
+                return $value;
+            }
+
+            $decoded = json_decode($value, true);
+
+            return is_array($decoded) ? $decoded : $value;
+        }, $request->request->all());
+
+        return $parameters + $request->files->all();
     }
 
     public function supportsDecoding(string $format)

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Encoder/MultipartDecoderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Encoder/MultipartDecoderTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\ApiPlatform\Encoder;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class MultipartDecoderTest extends TestCase
+{
+    public function testSupportsDecoding(): void
+    {
+        $decoder = new MultipartDecoder(new RequestStack());
+
+        $this->assertTrue($decoder->supportsDecoding(MultipartDecoder::FORMAT));
+        $this->assertFalse($decoder->supportsDecoding('json'));
+    }
+
+    public function testItReturnsNullWhenThereIsNoCurrentRequest(): void
+    {
+        $decoder = new MultipartDecoder(new RequestStack());
+
+        $this->assertNull($decoder->decode('', MultipartDecoder::FORMAT));
+    }
+
+    /**
+     * Swagger UI and the OpenAPI standard serialize object/array properties as a JSON string in a single
+     * multipart part, so the decoder must turn those back into arrays for the denormalizer.
+     */
+    public function testItDecodesJsonStringPartsIntoArrays(): void
+    {
+        $decoder = $this->createDecoderForRequest([
+            'legends' => '{"en-US":"Some legend","fr-FR":"Légende quelconque"}',
+        ]);
+
+        $this->assertSame(
+            ['legends' => ['en-US' => 'Some legend', 'fr-FR' => 'Légende quelconque']],
+            $decoder->decode('', MultipartDecoder::FORMAT)
+        );
+    }
+
+    /**
+     * Scalar parts (booleans, integers, plain strings) must be left untouched so the normalizer keeps coercing
+     * them as before (denormalizationContext DISABLE_TYPE_ENFORCEMENT). Decoding them here would change their type.
+     *
+     * @dataProvider getScalarParts
+     */
+    public function testItLeavesScalarPartsAsStrings(string $value): void
+    {
+        $decoder = $this->createDecoderForRequest(['field' => $value]);
+
+        $this->assertSame(['field' => $value], $decoder->decode('', MultipartDecoder::FORMAT));
+    }
+
+    public static function getScalarParts(): iterable
+    {
+        yield 'boolean true' => ['true'];
+        yield 'boolean false' => ['false'];
+        yield 'integer' => ['0'];
+        yield 'plain string' => ['some legend'];
+        yield 'null literal' => ['null'];
+    }
+
+    /**
+     * PHP already parses the bracket syntax (legends[en-US]=value) into a real array, which must be preserved.
+     */
+    public function testItPreservesArraysProducedByBracketSyntax(): void
+    {
+        $decoder = $this->createDecoderForRequest([
+            'legends' => ['en-US' => 'Some legend', 'fr-FR' => 'Légende quelconque'],
+        ]);
+
+        $this->assertSame(
+            ['legends' => ['en-US' => 'Some legend', 'fr-FR' => 'Légende quelconque']],
+            $decoder->decode('', MultipartDecoder::FORMAT)
+        );
+    }
+
+    public function testItMergesUploadedFiles(): void
+    {
+        $file = new UploadedFile(__FILE__, 'image.jpg', null, null, true);
+        $decoder = $this->createDecoderForRequest(
+            ['legends' => '{"en-US":"Some legend"}'],
+            ['image' => $file]
+        );
+
+        $decoded = $decoder->decode('', MultipartDecoder::FORMAT);
+
+        $this->assertSame(['en-US' => 'Some legend'], $decoded['legends']);
+        $this->assertSame($file, $decoded['image']);
+    }
+
+    /**
+     * @param array<string, mixed> $requestParameters
+     * @param array<string, UploadedFile> $files
+     */
+    private function createDecoderForRequest(array $requestParameters, array $files = []): MultipartDecoder
+    {
+        $request = new Request([], $requestParameters, [], [], $files);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return new MultipartDecoder($requestStack);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Because of the multipart forms, some arrays are not properly handled when sent via Swagger. This is the case when trying to modify the metadata that comes with a product image. This PR fixes the transformation of the data from Swagger forms to PHP expectations of arrays, reported with the exception `Symfony\Component\Serializer\Exception\NotNormalizableValueException: Failed to denormalize attribute "localizedLegends" value for class "PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\UpdateProductImageCommand": Expected argument of type "?array", "string" given at property path "localizedLegends"`.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try modifying the legend of an existing picture with `[POST] /products/images/{imageId}`, which must pass.
| UI Tests          | https://github.com/Quetzacoalt91/ga.tests.ui.pr/actions/runs/27601300635
| Fixed issue or discussion?     | /
| Related PRs       | /
| Sponsor company   | @PrestaShopCorp