### PR TITLE
Fix custom feature value selection when no predefined values exist

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/feature-values-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/feature-values-manager.ts
@@ -278,21 +278,20 @@ export default class FeatureValuesManager {
 
   private doRenderFeatureValueChoices(featureValuesData: FeatureValue[]): void {
     this.$featureValueSelector.empty();
-    if (featureValuesData.length) {
-      const selectedFeatureValues = this.getFeatureValueIds();
-      // First add placeholder and custom value options
-      this.addFeatureValue(this.$featureValueSelector.data('placeholderLabel'), 0);
-      this.addFeatureValue(this.$featureValueSelector.data('customValueLabel'), -1);
 
-      // Then loop through the pre-defined feature values
-      $.each(featureValuesData, (index, featureValue) => {
-        if (featureValue.id !== 0 && !selectedFeatureValues.includes(featureValue.id)) {
-          this.addFeatureValue(featureValue.value, featureValue.id);
-        }
-      });
-    }
+    const selectedFeatureValues = this.getFeatureValueIds();
+    // Always add placeholder and custom value options, even when no predefined values exist.
+    this.addFeatureValue(this.$featureValueSelector.data('placeholderLabel'), 0);
+    this.addFeatureValue(this.$featureValueSelector.data('customValueLabel'), -1);
 
-    this.$featureValueSelector.prop('disabled', featureValuesData.length === 0);
+    // Then add the available predefined feature values.
+    $.each(featureValuesData, (index, featureValue) => {
+      if (featureValue.id !== 0 && !selectedFeatureValues.includes(featureValue.id)) {
+        this.addFeatureValue(featureValue.value, featureValue.id);
+      }
+    });
+
+    this.$featureValueSelector.prop('disabled', false);
     this.$featureValueSelector.val(0).trigger('change');
     this.$featureValueSelector.select2();
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x
| Description?      | This PR fixes an issue in the product page where it was not possible to add a custom feature value when the selected feature had no predefined values.<br/>The feature value selector now always includes the placeholder and custom value options, even when the AJAX response does not contain any predefined feature values.
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | 1. Go to **Catalog > Attributes & Features > Features**.<br/>2. Create a new feature without adding any predefined values.<br/>3. Go to **Catalog > Products** and edit a product.<br/>4. In the **Details** tab, add the feature created in step 2.<br/>5. Check that the feature value selector is enabled.<br/>6. Select **Custom value**.<br/>7. Enter a custom value.<br/>8. Save the product.<br/>9. Reopen the product and check that the custom feature value is correctly saved<br/><br/>**Note: this fix requires recompiling the assets of the `new-theme` admin theme.**
 UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/27575638352
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41730 https://github.com/PrestaShop/PrestaShop/issues/37285 https://github.com/PrestaShop/PrestaShop/issues/40661
| Related PRs       |
| Sponsor company   | Codencode snc
