### PR TITLE
Accept a scalar id in Edit/DeleteSqlRequestCommand constructors

### DIFF
--- a/src/Core/Domain/SqlManagement/Command/DeleteSqlRequestCommand.php
+++ b/src/Core/Domain/SqlManagement/Command/DeleteSqlRequestCommand.php
@@ -19,11 +19,11 @@ class DeleteSqlRequestCommand
     private $sqlRequestId;
 
     /**
-     * @param SqlRequestId $sqlRequestId
+     * @param int|SqlRequestId $sqlRequestId
      */
-    public function __construct(SqlRequestId $sqlRequestId)
+    public function __construct(int|SqlRequestId $sqlRequestId)
     {
-        $this->setSqlRequestId($sqlRequestId);
+        $this->setSqlRequestId($sqlRequestId instanceof SqlRequestId ? $sqlRequestId : new SqlRequestId($sqlRequestId));
     }
 
     /**

--- a/src/Core/Domain/SqlManagement/Command/EditSqlRequestCommand.php
+++ b/src/Core/Domain/SqlManagement/Command/EditSqlRequestCommand.php
@@ -30,11 +30,11 @@ class EditSqlRequestCommand
     private $sql;
 
     /**
-     * @param SqlRequestId $sqlRequestId
+     * @param int|SqlRequestId $sqlRequestId
      */
-    public function __construct(SqlRequestId $sqlRequestId)
+    public function __construct(int|SqlRequestId $sqlRequestId)
     {
-        $this->setSqlRequestId($sqlRequestId);
+        $this->setSqlRequestId($sqlRequestId instanceof SqlRequestId ? $sqlRequestId : new SqlRequestId($sqlRequestId));
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataHandler/SqlRequestFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/SqlRequestFormDataHandler.php
@@ -45,9 +45,7 @@ final class SqlRequestFormDataHandler implements FormDataHandlerInterface
      */
     public function update($id, array $data)
     {
-        $sqlRequestId = new SqlRequestId($id);
-
-        $command = (new EditSqlRequestCommand($sqlRequestId))
+        $command = (new EditSqlRequestCommand((int) $id))
             ->setName($data['name'])
             ->setSql($data['sql']);
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
@@ -21,7 +21,6 @@ use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetSqlRequestExecution
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetSqlRequestSettings;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\SqlRequestExecutionResult;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\SqlRequestSettings;
-use PrestaShop\PrestaShop\Core\Domain\SqlManagement\ValueObject\SqlRequestId;
 use PrestaShop\PrestaShop\Core\Export\Exception\FileWritingException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface as ConfigurationFormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
@@ -223,9 +222,7 @@ class SqlManagerController extends PrestaShopAdminController
     public function deleteAction(int $sqlRequestId): RedirectResponse
     {
         try {
-            $deleteSqlRequestCommand = new DeleteSqlRequestCommand(
-                new SqlRequestId($sqlRequestId)
-            );
+            $deleteSqlRequestCommand = new DeleteSqlRequestCommand($sqlRequestId);
 
             $this->dispatchCommand($deleteSqlRequestCommand);
 

--- a/tests/Integration/Behaviour/Features/Context/SqlManagerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/SqlManagerFeatureContext.php
@@ -160,7 +160,7 @@ class SqlManagerFeatureContext extends AbstractDomainFeatureContext
         try {
             /** @var SqlRequestId $sqlRequestId */
             $sqlRequestId = $this->getCommandBus()->handle(
-                (new EditSqlRequestCommand(new SqlRequestId((int) $sqlRequestId)))
+                (new EditSqlRequestCommand((int) $sqlRequestId))
                     ->setName($data['name'])
                     ->setSql($data['sql'])
             );

--- a/tests/Unit/Core/Domain/SqlManagement/Command/SqlRequestCommandTest.php
+++ b/tests/Unit/Core/Domain/SqlManagement/Command/SqlRequestCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\SqlManagement\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\DeleteSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\EditSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\ValueObject\SqlRequestId;
+
+class SqlRequestCommandTest extends TestCase
+{
+    public function testEditAcceptsBothAScalarIdAndAValueObject(): void
+    {
+        self::assertSame(1, (new EditSqlRequestCommand(1))->getSqlRequestId()->getValue());
+        self::assertSame(1, (new EditSqlRequestCommand(new SqlRequestId(1)))->getSqlRequestId()->getValue());
+    }
+
+    public function testDeleteAcceptsBothAScalarIdAndAValueObject(): void
+    {
+        self::assertSame(1, (new DeleteSqlRequestCommand(1))->getSqlRequestId()->getValue());
+        self::assertSame(1, (new DeleteSqlRequestCommand(new SqlRequestId(1)))->getSqlRequestId()->getValue());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow `EditSqlRequestCommand` and `DeleteSqlRequestCommand` to be built from a scalar id, like every other domain command
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to #39630
| How to test?      | SQL Manager (edit/delete a SQL request) must keep working as before; unit/integration suites stay green
| Possible impacts? | None — the constructor argument is only widened

`EditSqlRequestCommand` and `DeleteSqlRequestCommand` were the only `SqlManagement` commands
requiring a `SqlRequestId` **value object** as their constructor argument. Every other domain
command (`EditAttributeCommand`, `DeleteOrderStateCommand`, …) accepts a **scalar id** and builds
the value object internally.

Because of this inconsistency the API Platform `CQRSApiNormalizer` cannot build these two commands:
it always passes scalar values to command constructors (`VALUE_OBJECT_RETURNED_AS_SCALAR`), so the
`int` id reaches a `SqlRequestId`-typed argument and raises a `TypeError`. This blocks the SQL Manager
edit/delete endpoints in the Admin API module (PrestaShop/ps_apiresources).

This PR widens the argument to `int|SqlRequestId`:

```php
public function __construct(int|SqlRequestId $sqlRequestId)
{
    $this->setSqlRequestId($sqlRequestId instanceof SqlRequestId ? $sqlRequestId : new SqlRequestId($sqlRequestId));
}
```

Both existing value-object callers (`SqlManagerController`, `SqlRequestFormDataHandler`) keep working
unchanged, and the API normalizer can now pass a scalar id. Fully backward compatible, no behaviour change.
