### PR TITLE
Reject duplicate ISO code when creating or editing a country (FF Country)

### DIFF
--- a/src/Adapter/Country/Repository/CountryRepository.php
+++ b/src/Adapter/Country/Repository/CountryRepository.php
@@ -74,7 +74,6 @@ final class CountryRepository extends AbstractObjectModelRepository implements C
     public function add(Country $country): Country
     {
         $this->countryValidator->validate($country);
-        $this->assertIsoCodeIsUnique($country);
 
         $this->addObjectModel($country, CannotAddCountryException::class);
 
@@ -93,7 +92,6 @@ final class CountryRepository extends AbstractObjectModelRepository implements C
     public function update(Country $country): Country
     {
         $this->countryValidator->validate($country);
-        $this->assertIsoCodeIsUnique($country);
 
         $this->updateObjectModel($country, CannotEditCountryException::class);
 
@@ -103,27 +101,5 @@ final class CountryRepository extends AbstractObjectModelRepository implements C
     public function delete(CountryId $countryId): void
     {
         $this->deleteObjectModel($this->get($countryId), CannotDeleteCountryException::class);
-    }
-
-    /**
-     * Ensures no other country already uses the same ISO code, replicating the legacy
-     * AdminCountriesController uniqueness check so the migrated page behaves identically.
-     *
-     * The ISO code format and presence are already guaranteed by the prior
-     * CountryValidator::validate() call (iso_code is required and validated as a
-     * language ISO code in the Country ObjectModel definition).
-     *
-     * @throws DuplicateCountryIsoCodeException
-     */
-    private function assertIsoCodeIsUnique(Country $country): void
-    {
-        $existingCountryId = (int) Country::getByIso($country->iso_code);
-
-        if (0 !== $existingCountryId && $existingCountryId !== (int) $country->id) {
-            throw new DuplicateCountryIsoCodeException(sprintf(
-                'Country with ISO code "%s" already exists',
-                $country->iso_code
-            ));
-        }
     }
 }

--- a/src/Adapter/Country/Repository/CountryRepository.php
+++ b/src/Adapter/Country/Repository/CountryRepository.php
@@ -18,7 +18,6 @@ use PrestaShop\PrestaShop\Core\Domain\Country\Exception\DuplicateCountryIsoCodeE
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
-use Validate;
 
 /**
  * Provides methods to access data storage of Country
@@ -110,14 +109,14 @@ final class CountryRepository extends AbstractObjectModelRepository implements C
      * Ensures no other country already uses the same ISO code, replicating the legacy
      * AdminCountriesController uniqueness check so the migrated page behaves identically.
      *
+     * The ISO code format and presence are already guaranteed by the prior
+     * CountryValidator::validate() call (iso_code is required and validated as a
+     * language ISO code in the Country ObjectModel definition).
+     *
      * @throws DuplicateCountryIsoCodeException
      */
     private function assertIsoCodeIsUnique(Country $country): void
     {
-        if (empty($country->iso_code) || !Validate::isLanguageIsoCode($country->iso_code)) {
-            return;
-        }
-
         $existingCountryId = (int) Country::getByIso($country->iso_code);
 
         if (0 !== $existingCountryId && $existingCountryId !== (int) $country->id) {

--- a/src/Adapter/Country/Repository/CountryRepository.php
+++ b/src/Adapter/Country/Repository/CountryRepository.php
@@ -14,9 +14,11 @@ use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotDeleteCountryExcep
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotEditCountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\DuplicateCountryIsoCodeException;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
+use Validate;
 
 /**
  * Provides methods to access data storage of Country
@@ -67,11 +69,13 @@ final class CountryRepository extends AbstractObjectModelRepository implements C
      * @return Country
      *
      * @throws CountryConstraintException
+     * @throws DuplicateCountryIsoCodeException
      * @throws CoreException
      */
     public function add(Country $country): Country
     {
         $this->countryValidator->validate($country);
+        $this->assertIsoCodeIsUnique($country);
 
         $this->addObjectModel($country, CannotAddCountryException::class);
 
@@ -84,11 +88,13 @@ final class CountryRepository extends AbstractObjectModelRepository implements C
      * @return Country
      *
      * @throws CannotEditCountryException
+     * @throws DuplicateCountryIsoCodeException
      * @throws CoreException
      */
     public function update(Country $country): Country
     {
         $this->countryValidator->validate($country);
+        $this->assertIsoCodeIsUnique($country);
 
         $this->updateObjectModel($country, CannotEditCountryException::class);
 
@@ -98,5 +104,27 @@ final class CountryRepository extends AbstractObjectModelRepository implements C
     public function delete(CountryId $countryId): void
     {
         $this->deleteObjectModel($this->get($countryId), CannotDeleteCountryException::class);
+    }
+
+    /**
+     * Ensures no other country already uses the same ISO code, replicating the legacy
+     * AdminCountriesController uniqueness check so the migrated page behaves identically.
+     *
+     * @throws DuplicateCountryIsoCodeException
+     */
+    private function assertIsoCodeIsUnique(Country $country): void
+    {
+        if (empty($country->iso_code) || !Validate::isLanguageIsoCode($country->iso_code)) {
+            return;
+        }
+
+        $existingCountryId = (int) Country::getByIso($country->iso_code);
+
+        if (0 !== $existingCountryId && $existingCountryId !== (int) $country->id) {
+            throw new DuplicateCountryIsoCodeException(sprintf(
+                'Country with ISO code "%s" already exists',
+                $country->iso_code
+            ));
+        }
     }
 }

--- a/src/Adapter/Country/Validate/CountryValidator.php
+++ b/src/Adapter/Country/Validate/CountryValidator.php
@@ -11,6 +11,7 @@ namespace PrestaShop\PrestaShop\Adapter\Country\Validate;
 use Country;
 use PrestaShop\PrestaShop\Adapter\AbstractObjectModelValidator;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\DuplicateCountryIsoCodeException;
 
 /**
  * Validates Country properties using legacy object model
@@ -21,6 +22,30 @@ class CountryValidator extends AbstractObjectModelValidator
     {
         if (!$country->validateFields(false) || !$country->validateFieldsLang(false)) {
             throw new CountryConstraintException('Country contains invalid field values');
+        }
+
+        $this->assertIsoCodeIsUnique($country);
+    }
+
+    /**
+     * Ensures no other country already uses the same ISO code, replicating the legacy
+     * AdminCountriesController uniqueness check so the migrated page behaves identically.
+     *
+     * The ISO code format and presence are already guaranteed by the field validation
+     * above (iso_code is required and validated as a language ISO code in the Country
+     * ObjectModel definition), so Country::getByIso() never receives an invalid value.
+     *
+     * @throws DuplicateCountryIsoCodeException
+     */
+    private function assertIsoCodeIsUnique(Country $country): void
+    {
+        $existingCountryId = (int) Country::getByIso($country->iso_code);
+
+        if (0 !== $existingCountryId && $existingCountryId !== (int) $country->id) {
+            throw new DuplicateCountryIsoCodeException(sprintf(
+                'Country with ISO code "%s" already exists',
+                $country->iso_code
+            ));
         }
     }
 }

--- a/src/Core/Domain/Country/Exception/DuplicateCountryIsoCodeException.php
+++ b/src/Core/Domain/Country/Exception/DuplicateCountryIsoCodeException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\Exception;
+
+/**
+ * Is thrown when an ISO code which already exists is used to create or update another country
+ */
+class DuplicateCountryIsoCodeException extends CountryException
+{
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -354,7 +354,7 @@ class CountryController extends PrestaShopAdminController
                 'Admin.International.Feature'
             ),
             DuplicateCountryIsoCodeException::class => $this->trans(
-                'This ISO code already exists.You cannot create two countries with the same ISO code.',
+                'This ISO code already exists. You cannot create two countries with the same ISO code.',
                 [],
                 'Admin.International.Notification'
             ),

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -20,6 +20,7 @@ use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryConstraintExcepti
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\DeleteCountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\DuplicateCountryIsoCodeException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Country\QueryResult\CountryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneException;
@@ -351,6 +352,11 @@ class CountryController extends PrestaShopAdminController
                 'Country contains invalid field values.',
                 [],
                 'Admin.International.Feature'
+            ),
+            DuplicateCountryIsoCodeException::class => $this->trans(
+                'This ISO code already exists.You cannot create two countries with the same ISO code.',
+                [],
+                'Admin.International.Notification'
             ),
             DeleteCountryException::class => $this->trans(
                 'Country cannot be deleted.',

--- a/tests/Integration/Behaviour/Features/Context/Domain/CountryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CountryFeatureContext.php
@@ -19,6 +19,7 @@ use PrestaShop\PrestaShop\Core\Domain\Country\Exception\BulkCountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\DuplicateCountryIsoCodeException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\InvalidAddressFormatException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Country\QueryResult\CountryForEditing;
@@ -197,6 +198,7 @@ class CountryFeatureContext extends AbstractDomainFeatureContext
     {
         $map = [
             'InvalidAddressFormat' => InvalidAddressFormatException::class,
+            'DuplicateCountryIsoCode' => DuplicateCountryIsoCodeException::class,
         ];
 
         if (!isset($map[$exceptionShortName])) {

--- a/tests/Integration/Behaviour/Features/Scenario/Country/bulk_toggle_countries_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Country/bulk_toggle_countries_status.feature
@@ -10,7 +10,7 @@ Feature: Bulk toggle countries status
     Given language "language1" with locale "en-US" exists
     And I add new country "bulk_country_1" with following properties:
       | name[en-US]                | Bulk Country 1                                   |
-      | iso_code                   | QA                                               |
+      | iso_code                   | QX                                               |
       | call_prefix                | 21                                               |
       | default_currency           | 1                                                |
       | zone                       | 1                                                |

--- a/tests/Integration/Behaviour/Features/Scenario/Country/country_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Country/country_management.feature
@@ -39,6 +39,44 @@ Feature: country management
       | display_tax_label          | true                                             |
       | shop_association           | 1                                                |
 
+  Scenario: Adding a country with an already existing ISO code is rejected
+    When I add new country "duplicate" with following properties:
+      | name[en-US]                | duplicateName                                    |
+      | name[fr-FR]                | duplicateNameFr                                  |
+      | iso_code                   | TE                                               |
+      | call_prefix                | 123                                              |
+      | default_currency           | 1                                                |
+      | zone                       | 1                                                |
+      | need_zip_code              | true                                             |
+      | zip_code_format            | 1 NL                                             |
+      | address_format             | firstname lastname\naddress1\ncity\nCountry:name |
+      | is_enabled                 | true                                             |
+      | contains_states            | false                                            |
+      | need_identification_number | false                                            |
+      | display_tax_label          | true                                             |
+      | shop_association           | 1                                                |
+    Then I should get an "DuplicateCountryIsoCode" error
+
+  Scenario: Editing a country to use an already existing ISO code is rejected
+    When I add new country "second" with following properties:
+      | name[en-US]                | secondName                                       |
+      | name[fr-FR]                | secondNameFr                                     |
+      | iso_code                   | TS                                               |
+      | call_prefix                | 123                                              |
+      | default_currency           | 1                                                |
+      | zone                       | 1                                                |
+      | need_zip_code              | true                                             |
+      | zip_code_format            | 1 NL                                             |
+      | address_format             | firstname lastname\naddress1\ncity\nCountry:name |
+      | is_enabled                 | true                                             |
+      | contains_states            | false                                            |
+      | need_identification_number | false                                            |
+      | display_tax_label          | true                                             |
+      | shop_association           | 1                                                |
+    And I edit country "second" with following properties:
+      | iso_code | TE |
+    Then I should get an "DuplicateCountryIsoCode" error
+
   Scenario: edit country
     Given language "language1" with locale "en-US" exists
     And language "language2" with locale "fr-FR" exists

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
@@ -80,8 +80,10 @@ class CountryControllerTest extends FormGridControllerTestCase
 
         // Use a different format than testCreate so the assertion proves the edit
         // round-trips. All required fields are present.
+        // ISO code must be a user-assigned code absent from the country fixtures
+        // (e.g. ZZ), otherwise the duplicate ISO code validation rejects the edit.
         $addressFormat = "firstname lastname\ncompany\naddress1\npostcode city\nCountry:name";
-        $isoCode = 'BB';
+        $isoCode = 'ZZ';
         $zipCodeFormat = '2NL';
 
         // First update the country with new data
@@ -124,7 +126,7 @@ class CountryControllerTest extends FormGridControllerTestCase
         $gridFilters = [
             ['country[id_country]' => $countryId],
             ['country[name]' => 'editName'],
-            ['country[iso_code]' => 'BB'],
+            ['country[iso_code]' => 'ZZ'],
             ['country[call_prefix]' => 1234],
             ['country[zone_name]' => 'Europe'],
             ['country[active]' => 1],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | With the Country feature flag enabled (migrated Symfony page), it was possible to create or edit a country using an ISO code already assigned to another country, with no error. The legacy `AdminCountriesController::postProcess()` performed this uniqueness check, but it was never ported to the CQRS code. This PR replicates the legacy validation in `CountryRepository::assertIsoCodeIsUnique()`, called from both `add()` and `update()`. A dedicated `DuplicateCountryIsoCodeException` is thrown and mapped in `CountryController` to the same message used by the legacy page.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable the Country feature flag (Advanced Parameters > Feature flags).<br>2. Go to International > Countries.<br>3. Click "Add new country", fill the form with an ISO code that already exists (e.g. `FR`) and save.<br>4. Expected: the error "This ISO code already exists. You cannot create two countries with the same ISO code." is displayed and the country is not created.<br>5. Edit an existing country and change its ISO code to one already used by another country → same error.<br>6. Creating/editing with a unique ISO code still works.
| UI Tests          | :green_circle: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27613615212
| Fixed issue or discussion?     | Fixes #41740
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA
