### PR TITLE
TEST – [DO NOT MERGE] Validate ui-testing-library PR #1010 (quick access empty-name) on 9.1.x

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OSL-3.0",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
-        "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+        "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#f99bf21e99b98e70a7f735a7db1fcbd1262d0f06",
         "chai": "^4.5.0",
         "chai-string": "^1.6.0",
         "dotenv": "^17.2.3",
@@ -547,7 +547,8 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#c0bd52981c7aabf06e9d9c92c882ef71ab7cc879",
+      "resolved": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#f99bf21e99b98e70a7f735a7db1fcbd1262d0f06",
+      "integrity": "sha512-3U53Oo0t0IssgGqpVkHpvaTujvVkD0j0NJ+MOh3y48hsgnJc8ZnEG0KLwBP7hkIVf13fF4pwAPgCTUzqZ25jcA==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8975,8 +8976,9 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#c0bd52981c7aabf06e9d9c92c882ef71ab7cc879",
-      "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
+      "version": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#f99bf21e99b98e70a7f735a7db1fcbd1262d0f06",
+      "integrity": "sha512-3U53Oo0t0IssgGqpVkHpvaTujvVkD0j0NJ+MOh3y48hsgnJc8ZnEG0KLwBP7hkIVf13fF4pwAPgCTUzqZ25jcA==",
+      "from": "@prestashop-core/ui-testing@https://github.com/mattgoud/ui-testing-library#f99bf21e99b98e70a7f735a7db1fcbd1262d0f06",
       "requires": {
         "@faker-js/faker": "^10.1.0",
         "@playwright/test": "^1.48.1",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -111,7 +111,7 @@
   "homepage": "https://github.com/PrestaShop/PrestaShop/tree/develop/tests/UI#readme",
   "dependencies": {
     "@faker-js/faker": "^10.1.0",
-    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+    "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#f99bf21e99b98e70a7f735a7db1fcbd1262d0f06",
     "chai": "^4.5.0",
     "chai-string": "^1.6.0",
     "dotenv": "^17.2.3",


### PR DESCRIPTION
> ⚠️ **Test PR — DO NOT MERGE.** Created only to run UI tests against ui-testing-library PR [PrestaShop/ui-testing-library#1010](https://github.com/PrestaShop/ui-testing-library/pull/1010) on the 9.1.x branch. Will be closed and its branch deleted once the run is validated.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Temporarily pins `tests/UI/package.json` (and `package-lock.json`) to the ui-testing-library PR PrestaShop/ui-testing-library#1010 fork commit `f99bf21e` (branch `fix/41608-quick-access-modal-inline-validation`), **rebased on ui-testing-library `main`** so it now also includes the merged quick access legacy-grid fix (PrestaShop/ui-testing-library#1030). #1010 adds `addCurrentPageToQuickAccessWithEmptyName()` to `BOBasePage`. On `develop` (9.2.0) the BO header uses the new modal with inline validation; on ≤ 9.1.x the action still triggers the native `window.prompt()` (no modal), so the method dismisses the prompt and returns `null`. **This PR only validates that the library change does not break the existing 9.1.x quick-access campaign (no regression)**, now that the quick access grid selectors are fixed for 9.1.x. The empty-name behaviour test itself belongs to the `develop` core PR where the modal actually exists (PrestaShop/PrestaShop#41612 follow-up).
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the `functional:BO:header` campaign via [ga.tests.ui.pr](https://github.com/PrestaShop/ga.tests.ui.pr/) against this PR with `base_branch: 9.1.x`. The existing test `campaigns/functional/BO/15_header/02_quickAccess.ts` must stay green with the pinned library.
| UI tests          | :green_circle:  https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27760756969
| Fixed issue or discussion?     | Validates PrestaShop/ui-testing-library#1010
| Related PRs       | PrestaShop/ui-testing-library#1010, PrestaShop/ui-testing-library#1030, #41612
| Sponsor company   | PrestaShop SA