### PR TITLE
Prevent empty ean13 into product URL

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -180,10 +180,13 @@ class LinkCore
             $product = $this->getProductObject($product, $idLang, $idShop);
         }
         $params['rewrite'] = (!$alias) ? $product->getFieldByLang('link_rewrite') : $alias;
-        if (!$ean13) {
-            $product = $this->getProductObject($product, $idLang, $idShop);
+
+        if ($dispatcher->hasKeyword('product_rule', $idLang, 'ean13', $idShop)) {
+            if (!$ean13) {
+                $product = $this->getProductObject($product, $idLang, $idShop);
+            }
+            $params['ean13'] = (!$ean13) ? $product->ean13 : $ean13;
         }
-        $params['ean13'] = (!$ean13) ? $product->ean13 : $ean13;
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'meta_title', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['meta_title'] = Tools::str2url($product->getFieldByLang('meta_title'));


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix little issue introduced into https://github.com/PrestaShop/PrestaShop/pull/41386 `ean13` parameter is always added to the URL when SEO configuration does not include it. It will have to be cherry-picked to develop.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see below
| UI Tests             | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/27820256746
| Fixed issue or discussion?     |   https://github.com/PrestaShop/PrestaShop/pull/41386#issuecomment-4720085657
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41386
| Sponsor company   | VersusVenture (PrestaModule / BusinessTech)

### Using product routes: `{id}{-:id_product_attribute}-{rewrite}.html`

#### Product with GTIN

URL without patch : `https://yourshopurl.com/18-38-carnet-de-notes-colibri.html?ean13=1234567891234`
URL with the patch : `https://yourshopurl.com/18-38-carnet-de-notes-colibri.html`

#### Product without GTIN

URL without patch : `https://yourshopurl.com/17-32-carnet-de-notes-ours-brun.html?ean13=`
URL with the patch : `https://yourshopurl.com/17-32-carnet-de-notes-ours-brun.html`

### Using product routes: `{id}{-:id_product_attribute}{-:ean13}-{rewrite}.html`

#### Product with GTIN

URL without patch : `https://yourshopurl.com/18-38-1234567891234-carnet-de-notes-colibri.html`
URL with the patch : `https://yourshopurl.com/18-38-1234567891234-carnet-de-notes-colibri.html`

#### Product without GTIN

URL without patch : `https://yourshopurl.com/17-32-carnet-de-notes-ours-brun.html`
URL with the patch : `https://yourshopurl.com/17-32-carnet-de-notes-ours-brun.html`