### PR TITLE
Fix flaky quick access filter UI test (multi-tab)

### DIFF
--- a/tests/UI/campaigns/functional/BO/15_header/02_quickAccess.ts
+++ b/tests/UI/campaigns/functional/BO/15_header/02_quickAccess.ts
@@ -125,10 +125,15 @@ describe('BO - Header : Quick access links', async () => {
     it('should check the new link from Quick access', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkNewLink', baseContext);
 
-      page = await boDashboardPage.quickAccessToPageNewWindow(page, quickAccessLinkData.name);
+      const newPage = await boDashboardPage.quickAccessToPageNewWindow(page, quickAccessLinkData.name);
 
-      const pageTitle = await boCustomersCreatePage.getPageTitle(page);
+      const pageTitle = await boCustomersCreatePage.getPageTitle(newPage);
       expect(pageTitle).to.contains(boCustomersCreatePage.pageTitleCreate);
+
+      // Close the tab opened in a new window and keep working on the original tab.
+      // Reading the grid on the freshly-opened tab while several heavy BO tabs stay open makes
+      // the later "filter by link name" step flaky (the filtered row renders after the read timeout).
+      await newPage.close();
     });
 
     it('should go to \'Manage quick access\' page', async function () {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | The UI test `functional/BO/15_header/02_quickAccess.ts` is flaky on the GA runners: the step **`should filter quick access table by link name`** times out on `page.waitForSelector` waiting for `#quick_access_grid_table tbody tr:nth-child(1) td:nth-child(3)`.<br><br>Root cause: the previous step (`should check the new link from Quick access`) reassigns `page` to the tab opened by `quickAccessToPageNewWindow`. The manage + filter steps then run on that freshly-opened tab **while several heavy BO tabs stay open**. The grid filter is a full-page navigation, but under that contention the filtered grid renders **after** the 10s read timeout — the failure screenshots show the row (`New customer`, id 8) present, just too late.<br><br>Fix: verify the new-window link on its own tab, **close it**, and run the manage + filter steps on the original (cleanly loaded) tab. Test-only change, no production code touched.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the `functional:BO:header` campaign via [ga.tests.ui.pr](https://github.com/PrestaShop/ga.tests.ui.pr/) against this PR. The `02_quickAccess.ts` campaign must stay green, in particular the `should filter quick access table by link name` step.
| UI Tests          |https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27694681815 :green_circle:
| Fixed issue or discussion?     | Flaky test observed on 9.1.x GA runs (e.g. https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27677012938)
| Related PRs       | -
| Sponsor company   | PrestaShop SA

This was diagnosed while validating ui-testing-library PR #1010 — the failure is unrelated to that library change (the filter code path is identical between the pinned fork commit and `main`); it is a pre-existing flakiness of this campaign on 9.1.x.