### PR TITLE
Fix image-types list endpoint returning 405 by making grid data facto…

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -691,7 +691,6 @@ services:
 
   prestashop.core.grid.data_factory.image_type:
     class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
-    public: false
     arguments:
       - '@PrestaShop\PrestaShop\Core\Grid\Query\ImageTypeQueryBuilder'
       - '@prestashop.core.hook.dispatcher'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `GET /admin-api/image-types` from Admin API (in progress) return a `405 Method Not Allowed (Allow: POST)` error
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | GET /admin-api/image-types?shopId=1 returns the paginated list of image types (before the fix: 405 Method Not Allowed).
| UI Tests          | https://github.com/axel-paillaud/ga.tests.ui.pr/actions/runs/27736482983
| Fixed issue or discussion?     | 
| Related PRs       | ps_apiresources ImageSettings (draft)
| Sponsor company   | axel-paillaud

## Problem

`GET /admin-api/image-types` returned a `405 Method Not Allowed (Allow: POST)` error even though a `PaginatedList` operation was defined on that URI in `ImageTypeList.php`.

<img width="895" height="736" alt="Screenshot_2026-06-18_06-14-43" src="https://github.com/user-attachments/assets/ac13ffa4-4294-4291-b057-d29532bef43b" />

## Root cause

`CQRSNotFoundMetadataCollectionFactoryDecorator` uses `$container->has('gridDataFactory')` to check whether an operation is valid before registering it as a route. In Symfony, `$container->has()` returns `false` for private services after container compilation.

The service `prestashop.core.grid.data_factory.image_type` had an explicit `public: false` in `grid_data_factory.yml`, overriding the `_defaults: public: true` set at the top of that file. As a result, the decorator considered the `PaginatedList` operation invalid and silently removed it, leaving only the `POST /image-types` route registered.

All other named grid data factory services in the same file are public by default. I don't know why image_type had public: false, maybe an oversight

## Fix

Remove the `public: false` override on `prestashop.core.grid.data_factory.image_type` so it inherits `public: true` from the file defaults, consistent with every other data factory in that file.

<img width="895" height="736" alt="Screenshot_2026-06-18_06-15-11" src="https://github.com/user-attachments/assets/79755256-604f-4a07-bb2b-74d5b86a3d40" />

## Impact

No functional change to the service itself. The service was already injected into `prestashop.core.grid.factory.image_type` as a dependency. Making it public only allows the container to expose it via `$container->has()` / `$container->get()`, which is required by the API operation discovery mechanism.
