### PR TITLE
Fix API Client creation error caused by non-int form handler result

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/TagFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/TagFormDataHandler.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
-use PrestaShop\PrestaShop\Core\Domain\ApiClient\ValueObject\CreatedApiClient;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Command\AddTagCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tag\Command\EditTagCommand;
+use PrestaShop\PrestaShop\Core\Domain\Tag\ValueObject\TagId;
 
 class TagFormDataHandler implements FormDataHandlerInterface
 {
@@ -22,14 +22,14 @@ class TagFormDataHandler implements FormDataHandlerInterface
 
     public function create(array $data)
     {
-        /** @var CreatedApiClient $createdApiClient */
-        $createdApiClient = $this->commandBus->handle(new AddTagCommand(
+        /** @var TagId $tagId */
+        $tagId = $this->commandBus->handle(new AddTagCommand(
             $data['name'],
             (int) $data['language'],
             $this->getProductIds($data['products']),
         ));
 
-        return $createdApiClient;
+        return $tagId->getValue();
     }
 
     public function update($id, array $data)

--- a/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
+++ b/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
@@ -6,6 +6,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler;
 
+use PrestaShop\PrestaShop\Core\Domain\ApiClient\ValueObject\CreatedApiClient;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Form\ExtraPropertiesFormDataPersister;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\FormDataHandlerInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
@@ -131,11 +132,14 @@ final class FormHandler implements FormHandlerInterface
 
         $newId = $this->dataHandler->update($id, $data);
 
-        $this->extraPropertiesFormDataPersister->persist(
-            $form,
-            $this->getExtraPropertyEntityName($form),
-            (int) ($newId ?? $id)
-        );
+        $entityId = $this->resolveExtraPropertyEntityId($newId ?? $id);
+        if (null !== $entityId) {
+            $this->extraPropertiesFormDataPersister->persist(
+                $form,
+                $this->getExtraPropertyEntityName($form),
+                $entityId
+            );
+        }
 
         $this->hookDispatcher->dispatchWithParameters('actionAfterUpdate' . Container::camelize($form->getName()) . 'FormHandler', [
             'id' => $id,
@@ -162,11 +166,14 @@ final class FormHandler implements FormHandlerInterface
 
         $id = $this->dataHandler->create($data);
 
-        $this->extraPropertiesFormDataPersister->persist(
-            $form,
-            $this->getExtraPropertyEntityName($form),
-            (int) $id
-        );
+        $entityId = $this->resolveExtraPropertyEntityId($id);
+        if (null !== $entityId) {
+            $this->extraPropertiesFormDataPersister->persist(
+                $form,
+                $this->getExtraPropertyEntityName($form),
+                $entityId
+            );
+        }
 
         $this->hookDispatcher->dispatchWithParameters('actionAfterCreate' . Container::camelize($form->getName()) . 'FormHandler', [
             'id' => $id,
@@ -183,5 +190,37 @@ final class FormHandler implements FormHandlerInterface
     private function getExtraPropertyEntityName(FormInterface $form): string
     {
         return $form->getConfig()->getType()->getBlockPrefix();
+    }
+
+    /**
+     * Best-effort extraction of an integer entity id from a data handler result.
+     *
+     * Most handlers return a plain int, the rest an identity value object exposing
+     * getValue(): int. Anything else (e.g. an array of ids) cannot be reduced to a
+     * single int, so null is returned and the extra properties are simply not
+     * persisted rather than crashing on a force cast.
+     *
+     * CreatedApiClient is handled as an explicit exception: it carries both an id
+     * and a secret (so it has no top-level getValue()), but the id is needed to
+     * persist extra properties. Such composite results are rare enough that an
+     * ad hoc case is preferable to a generic, over-engineered resolution.
+     *
+     * @param mixed $id
+     */
+    private function resolveExtraPropertyEntityId($id): ?int
+    {
+        if (is_int($id) || (is_string($id) && ctype_digit($id))) {
+            return (int) $id;
+        }
+
+        if ($id instanceof CreatedApiClient) {
+            return $id->getApiClientId()->getValue();
+        }
+
+        if (is_object($id) && method_exists($id, 'getValue') && is_int($id->getValue())) {
+            return $id->getValue();
+        }
+
+        return null;
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/Handler/FormHandlerTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/Handler/FormHandlerTest.php
@@ -7,12 +7,20 @@
 namespace Tests\Unit\Core\Form\IdentifiableObject\Handler;
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\ApiClient\ValueObject\CreatedApiClient;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Form\ExtraPropertiesFormDataPersister;
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormHandler;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\FormDataHandlerInterface;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler as IdentifiableObjectFormHandler;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\ResolvedFormTypeInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FormHandlerTest extends TestCase
 {
@@ -102,7 +110,7 @@ class FormHandlerTest extends TestCase
                 $this->equalTo(['form_builder' => $this->formBuilderMock])
             );
 
-        $formMock = $this->createMock(\Symfony\Component\Form\FormInterface::class);
+        $formMock = $this->createMock(FormInterface::class);
         $this->formBuilderMock
             ->method('getForm')
             ->will($this->returnValue($formMock));
@@ -130,5 +138,141 @@ class FormHandlerTest extends TestCase
             );
 
         $this->handler->save(['x' => 'y']);
+    }
+
+    /**
+     * The following tests cover the identifiable-object FormHandler (a different class,
+     * aliased as IdentifiableObjectFormHandler) and specifically the int-id resolution that
+     * guards the ExtraPropertiesFormDataPersister::persist() call.
+     *
+     * @see IdentifiableObjectFormHandler::resolveExtraPropertyEntityId()
+     */
+    public function testCreatePersistsExtraPropertiesWhenHandlerReturnsInt(): void
+    {
+        $persister = $this->createMock(ExtraPropertiesFormDataPersister::class);
+        $persister
+            ->expects($this->once())
+            ->method('persist')
+            ->with($this->anything(), 'test_entity', 42);
+
+        $handler = $this->createIdentifiableObjectHandler($this->createDataHandler(42), $persister);
+
+        $result = $handler->handle($this->createValidForm());
+
+        $this->assertSame(42, $result->getIdentifiableObjectId());
+    }
+
+    public function testCreatePersistsExtraPropertiesWhenHandlerReturnsValueObjectWithGetValue(): void
+    {
+        $valueObject = new class(42) {
+            public function __construct(private int $value)
+            {
+            }
+
+            public function getValue(): int
+            {
+                return $this->value;
+            }
+        };
+
+        $persister = $this->createMock(ExtraPropertiesFormDataPersister::class);
+        $persister
+            ->expects($this->once())
+            ->method('persist')
+            ->with($this->anything(), 'test_entity', 42);
+
+        $handler = $this->createIdentifiableObjectHandler($this->createDataHandler($valueObject), $persister);
+
+        $result = $handler->handle($this->createValidForm());
+
+        // The raw value object is preserved for the controller (e.g. CreatedApiClient secret).
+        $this->assertSame($valueObject, $result->getIdentifiableObjectId());
+    }
+
+    public function testCreatePersistsExtraPropertiesForCreatedApiClient(): void
+    {
+        // CreatedApiClient has no top-level getValue() (it carries id + secret),
+        // but is handled as an explicit exception so its id can still be persisted.
+        $createdApiClient = new CreatedApiClient(42, 'a-secret');
+
+        $persister = $this->createMock(ExtraPropertiesFormDataPersister::class);
+        $persister
+            ->expects($this->once())
+            ->method('persist')
+            ->with($this->anything(), 'test_entity', 42);
+
+        $handler = $this->createIdentifiableObjectHandler($this->createDataHandler($createdApiClient), $persister);
+
+        $result = $handler->handle($this->createValidForm());
+
+        // The raw value object is preserved for the controller (secret + redirect).
+        $this->assertSame($createdApiClient, $result->getIdentifiableObjectId());
+    }
+
+    public function testCreateSkipsExtraPropertiesPersistenceWhenIdCannotBeResolved(): void
+    {
+        // Unresolvable result (no int, not a CreatedApiClient, no getValue()).
+        $createdApiClientLike = new class() {
+            public function getSecret(): string
+            {
+                return 'secret';
+            }
+        };
+
+        $persister = $this->createMock(ExtraPropertiesFormDataPersister::class);
+        $persister
+            ->expects($this->never())
+            ->method('persist');
+
+        $handler = $this->createIdentifiableObjectHandler($this->createDataHandler($createdApiClientLike), $persister);
+
+        $result = $handler->handle($this->createValidForm());
+
+        // No crash, and the original object still flows through to the controller.
+        $this->assertSame($createdApiClientLike, $result->getIdentifiableObjectId());
+    }
+
+    private function createIdentifiableObjectHandler(
+        FormDataHandlerInterface $dataHandler,
+        ExtraPropertiesFormDataPersister $persister
+    ): IdentifiableObjectFormHandler {
+        return new IdentifiableObjectFormHandler(
+            $dataHandler,
+            $this->createMock(HookDispatcherInterface::class),
+            $this->createMock(TranslatorInterface::class),
+            false,
+            $persister
+        );
+    }
+
+    /**
+     * @param mixed $createReturn
+     */
+    private function createDataHandler($createReturn): FormDataHandlerInterface
+    {
+        $dataHandler = $this->createMock(FormDataHandlerInterface::class);
+        $dataHandler
+            ->method('create')
+            ->willReturn($createReturn);
+
+        return $dataHandler;
+    }
+
+    private function createValidForm(): FormInterface
+    {
+        $resolvedType = $this->createMock(ResolvedFormTypeInterface::class);
+        $resolvedType->method('getBlockPrefix')->willReturn('test_entity');
+
+        $config = $this->createMock(FormConfigInterface::class);
+        $config->method('getType')->willReturn($resolvedType);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('isSubmitted')->willReturn(true);
+        $form->method('isValid')->willReturn(true);
+        $form->method('getName')->willReturn('testEntity');
+        $form->method('getData')->willReturn([]);
+        $form->method('getConfig')->willReturn($config);
+
+        return $form;
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Creating an API Client from the BO (Advanced Parameters > Admin API) showed an error and stayed on the creation form, even though the client was actually created — so the generated secret was never displayed and had to be regenerated. The newly added `ExtraPropertiesFormDataPersister::persist()` call in the identifiable-object `FormHandler` force-casts the data handler result to `int`. `ApiClientFormDataHandler` legitimately returns a `CreatedApiClient` value object (it carries both the new id and the generated secret, both needed by the controller), so `(int) $object` threw a fatal `Error: Object of class CreatedApiClient could not be converted to int`. The form handler is now resilient to non-int results: it resolves the id best-effort (plain int, or a value object exposing `getValue(): int`) and simply skips the `persist()` call when no int can be derived. Also fixes a copy-paste bug in `TagFormDataHandler`, which returned a `TagId` object instead of its int value (same crash).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **Advanced Parameters > Admin API**. 2. Click **Add new API client**, fill the form and **Save**. 3. Expected: no error, a success message, redirect to the edit page, and the generated secret shown in a flash message. 4. Smoke check: create a **Tag** (Shop Parameters > Tags) — it should save and redirect to the list without error. 5. Unit tests: `php vendor/bin/phpunit tests/Unit/Core/Form/IdentifiableObject/Handler/FormHandlerTest.php`.
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/27747728747
| Fixed issue or discussion?     | Fixes #41762
| Related PRs       |
| Sponsor company   |

### Details

`FormHandler::resolveExtraPropertyEntityId()` centralises the id extraction for both create and update paths:

- plain `int` (or numeric string) → used as-is;
- value object with `getValue(): int` (the vast majority of handlers) → unwrapped;
- anything else (e.g. `CreatedApiClient`, an array of ids) → `null`, so `persist()` is skipped rather than crashing.

`ApiClientFormDataHandler` is intentionally left untouched — it must keep returning the whole `CreatedApiClient` so the controller can flash the secret and redirect via `getApiClientId()->getValue()`. The raw return value is still passed to `FormHandlerResult`, so the controller flow is unchanged.
