### PR TITLE
TEST – [DO NOT MERGE] Validate ui-testing-library PR #1030 (quick access legacy grid) on 9.1.x

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OSL-3.0",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
-        "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+        "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#ef32ae455c8dfe235e85adf7fd875b57dc3b6d24",
         "chai": "^4.5.0",
         "chai-string": "^1.6.0",
         "dotenv": "^17.2.3",
@@ -547,7 +547,8 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0cdcbdd5210ea8dbfd2f739c8f9912b7601d5f65",
+      "resolved": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#ef32ae455c8dfe235e85adf7fd875b57dc3b6d24",
+      "integrity": "sha512-NB/h92WvmMbIImH+bUTARpKfn+jh7YkgAt1JWt5yRAT/JpG7Ony2sjdx0bFqt4zWibOZzP2CFuaFlL0kH+0dTQ==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8975,8 +8976,9 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0cdcbdd5210ea8dbfd2f739c8f9912b7601d5f65",
-      "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
+      "version": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#ef32ae455c8dfe235e85adf7fd875b57dc3b6d24",
+      "integrity": "sha512-NB/h92WvmMbIImH+bUTARpKfn+jh7YkgAt1JWt5yRAT/JpG7Ony2sjdx0bFqt4zWibOZzP2CFuaFlL0kH+0dTQ==",
+      "from": "@prestashop-core/ui-testing@https://github.com/mattgoud/ui-testing-library#ef32ae455c8dfe235e85adf7fd875b57dc3b6d24",
       "requires": {
         "@faker-js/faker": "^10.1.0",
         "@playwright/test": "^1.48.1",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -111,7 +111,7 @@
   "homepage": "https://github.com/PrestaShop/PrestaShop/tree/develop/tests/UI#readme",
   "dependencies": {
     "@faker-js/faker": "^10.1.0",
-    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+    "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#ef32ae455c8dfe235e85adf7fd875b57dc3b6d24",
     "chai": "^4.5.0",
     "chai-string": "^1.6.0",
     "dotenv": "^17.2.3",


### PR DESCRIPTION
> ⚠️ **Test PR — DO NOT MERGE.** Created only to run UI tests against ui-testing-library PR [PrestaShop/ui-testing-library#1030](https://github.com/PrestaShop/ui-testing-library/pull/1030) on the 9.1.x branch. Will be closed and its branch deleted once the run is validated.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Temporarily pins `tests/UI/package.json` (and `package-lock.json`) to the ui-testing-library PR PrestaShop/ui-testing-library#1030 fork commit `ef32ae4` (branch `fix/quickaccess-legacy-grid-selectors-9.1`). That PR fixes the quick access page object on ≤ 9.1.x: `versions/9.1/quickAccess` inherited its table cell selectors from `versions/develop`, which targets the Symfony grid `#quick_access_grid_table` that does not exist on 9.1.x (legacy HelperList `#table-quick_access`), so `getTextColumn()` timed out. The fix re-derives the cell selectors from the legacy grid table.
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the `functional:BO:header` campaign via [ga.tests.ui.pr](https://github.com/PrestaShop/ga.tests.ui.pr/) against this PR with `base_branch: 9.1.x`. `campaigns/functional/BO/15_header/02_quickAccess.ts` must be fully green — in particular the step **`should filter quick access table by link name`** (`getTextColumn`), which previously timed out on `#quick_access_grid_table tbody tr:nth-child(1) td:nth-child(3)`.
| UI tests          |https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27748482866 :green_circle: 
| Fixed issue or discussion?     | Validates PrestaShop/ui-testing-library#1030
| Related PRs       | PrestaShop/ui-testing-library#1030
| Sponsor company   | PrestaShop SA