### PR TITLE
Merge `9.1.x` into `develop`

### DIFF
--- a/src/Core/Grid/Query/FeatureQueryBuilder.php
+++ b/src/Core/Grid/Query/FeatureQueryBuilder.php
@@ -63,7 +63,7 @@ class FeatureQueryBuilder extends AbstractDoctrineQueryBuilder
                 'f',
                 $this->dbPrefix . 'feature_value',
                 'fv',
-                'f.id_feature = fv.id_feature'
+                'f.id_feature = fv.id_feature AND (fv.custom IS NULL OR fv.custom = 0)'
             )
             ->groupBy('f.id_feature')
         ;

--- a/src/Core/Grid/Query/FeatureValueQueryBuilder.php
+++ b/src/Core/Grid/Query/FeatureValueQueryBuilder.php
@@ -70,6 +70,7 @@ class FeatureValueQueryBuilder extends AbstractDoctrineQueryBuilder
             ->createQueryBuilder()
             ->from($this->dbPrefix . 'feature_value', 'fv')
             ->where('fv.id_feature = :featureId')
+            ->andWhere('(fv.custom IS NULL OR fv.custom = 0)')
             ->setParameter('featureId', $searchCriteria->getFeatureId())
             ->leftJoin(
                 'fv',

--- a/tests/UI/campaigns/functional/BO/15_header/02_quickAccess.ts
+++ b/tests/UI/campaigns/functional/BO/15_header/02_quickAccess.ts
@@ -125,10 +125,15 @@ describe('BO - Header : Quick access links', async () => {
     it('should check the new link from Quick access', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkNewLink', baseContext);
 
-      page = await boDashboardPage.quickAccessToPageNewWindow(page, quickAccessLinkData.name);
+      const newPage = await boDashboardPage.quickAccessToPageNewWindow(page, quickAccessLinkData.name);
 
-      const pageTitle = await boCustomersCreatePage.getPageTitle(page);
+      const pageTitle = await boCustomersCreatePage.getPageTitle(newPage);
       expect(pageTitle).to.contains(boCustomersCreatePage.pageTitleCreate);
+
+      // Close the tab opened in a new window and keep working on the original tab.
+      // Reading the grid on the freshly-opened tab while several heavy BO tabs stay open makes
+      // the later "filter by link name" step flaky (the filtered row renders after the read timeout).
+      await newPage.close();
     });
 
     it('should go to \'Manage quick access\' page', async function () {

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -547,7 +547,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0cdcbdd5210ea8dbfd2f739c8f9912b7601d5f65",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#c0bd52981c7aabf06e9d9c92c882ef71ab7cc879",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8975,7 +8975,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0cdcbdd5210ea8dbfd2f739c8f9912b7601d5f65",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#c0bd52981c7aabf06e9d9c92c882ef71ab7cc879",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Merge `9.1.x` into `develop`
| Type?             | improvement
| Category?         | ME
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI 🟢
| UI Tests          | :green_circle: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/27772541894
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | PrestaShop SA

Manual merge PR -  the automated "Create merge PR" action failed on a conflict in `tests/UI/package-lock.json` ([run](https://github.com/PrestaShop/PrestaShop/actions/runs/27759912966)).

Conflict resolution: kept `develop`'s lockfile format (lockfileVersion 3) and bumped the `@prestashop-core/ui-testing` resolved hash to `9.1.x`'s newer `main` pin (`c0bd529`, ui-testing-library #1030).