### PR TITLE
Delivery slip multi shipment - remove Total amount paid

### DIFF
--- a/classes/pdf/HTMLTemplateShipmentDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateShipmentDeliverySlip.php
@@ -166,7 +166,6 @@ class HTMLTemplateShipmentDeliverySlipCore extends HTMLTemplate
             'addresses_tab' => $this->smarty->fetch($this->getTemplate('delivery-slip.addresses-tab')),
             'summary_tab' => $this->smarty->fetch($this->getTemplate('shipment-delivery-slip.summary-tab')),
             'product_tab' => $this->smarty->fetch($this->getTemplate('shipment-delivery-slip.product-tab')),
-            'payment_tab' => $this->smarty->fetch($this->getTemplate('delivery-slip.payment-tab')),
         ];
         $this->smarty->assign($tpls);
 

--- a/pdf/delivery-slip.tpl
+++ b/pdf/delivery-slip.tpl
@@ -45,14 +45,16 @@
 		<td colspan="12" height="20">&nbsp;</td>
 	</tr>
 
-	<tr>
-		<td colspan="7" class="left">
+	{if isset($payment_tab)}
+		<tr>
+			<td colspan="7" class="left">
 
-			{$payment_tab}
+				{$payment_tab}
 
-		</td>
-		<td colspan="5">&nbsp;</td>
-	</tr>
+			</td>
+			<td colspan="5">&nbsp;</td>
+		</tr>
+	{/if}
 
 	<!-- Hook -->
 	{if isset($HOOK_DISPLAY_PDF)}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If you generate the delivery slip of a shipment, at the bottom of the document there is the total amount of the order. Since delivery slip is not anymore link to a 1:1 relation to an order but to a shipment we need to erase totally this information from the delivery slip.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | generate shipment delivery slip
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/27765392446
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -
