### PR TITLE
Optimize carrier list resolution for restricted and mixed carts

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -527,10 +527,11 @@ class CarrierCore extends ObjectModel
      *                             - ALL_CARRIERS
      * @param bool $active Returns only active carriers when true
      * @param array|string|null $ids_group
+     * @param array|null $ids_carrier IDs of the carriers to check
      *
      * @return array Carriers
      */
-    public static function getCarriers($id_lang, $active = false, $delete = false, $id_zone = false, $ids_group = null, $modules_filters = self::PS_CARRIERS_ONLY)
+    public static function getCarriers($id_lang, $active = false, $delete = false, $id_zone = false, $ids_group = null, $modules_filters = self::PS_CARRIERS_ONLY, $ids_carrier = null)
     {
         // Filter by groups and no groups => return empty array
         if ($ids_group && !is_array($ids_group)) {
@@ -544,6 +545,9 @@ class CarrierCore extends ObjectModel
                 ($id_zone ? 'LEFT JOIN `' . _DB_PREFIX_ . 'zone` z ON (z.`id_zone` = ' . (int) $id_zone . ')' : '') . '
                 ' . Shop::addSqlAssociation('carrier', 'c') . '
                 WHERE c.`deleted` = ' . ($delete ? '1' : '0');
+        if ($ids_carrier && !empty($ids_carrier)) {
+            $sql .= ' AND c.`id_carrier` IN (' . implode(',', array_map('intval', $ids_carrier)) . ') ';
+        }
         if ($active) {
             $sql .= ' AND c.`active` = 1 ';
         }
@@ -698,10 +702,11 @@ class CarrierCore extends ObjectModel
      * @param array|null $groups Group of the Customer
      * @param CartCore|null $cart Optional Cart object
      * @param array $error Contains an error message if an error occurs
+     * @param array|null $ids_carrier IDs of the carriers to check
      *
      * @return array Carriers for the order
      */
-    public static function getCarriersForOrder($id_zone, $groups = null, $cart = null, &$error = [])
+    public static function getCarriersForOrder($id_zone, $groups = null, $cart = null, &$error = [], $ids_carrier = null)
     {
         // First, initialize the context, language, currency
         $context = Context::getContext();
@@ -719,77 +724,84 @@ class CarrierCore extends ObjectModel
         }
 
         // And get all carriers available in the system
-        $result = Carrier::getCarriers($id_lang, true, false, (int) $id_zone, $groups, self::PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE);
+        $result = Carrier::getCarriers($id_lang, true, false, (int) $id_zone, $groups, self::PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE, $ids_carrier);
         $results_array = [];
 
         foreach ($result as $k => $row) {
-            $carrier = new Carrier((int) $row['id_carrier']);
-            $shipping_method = $carrier->getShippingMethod();
-            if ($shipping_method != Carrier::SHIPPING_METHOD_FREE) {
-                /*
-                 * First, we check loosely if the carrier is available for the zone with at least one range.
-                 * No weight, no price, just check if the carrier has any ranges for the zone.
-                 * If not, we remove it from the list immediately.
-                 * If yes, we must still check the behavior of the carrier for out-of-range prices below.
-                 */
-                if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT && $carrier->getMaxDeliveryPriceByWeight($id_zone) === false) {
-                    $error[$carrier->id] = Carrier::SHIPPING_WEIGHT_EXCEPTION;
-                    unset($result[$k]);
-
-                    continue;
-                }
-                if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE && $carrier->getMaxDeliveryPriceByPrice($id_zone) === false) {
-                    $error[$carrier->id] = Carrier::SHIPPING_PRICE_EXCEPTION;
-                    unset($result[$k]);
-
-                    continue;
-                }
-
-                /*
-                 * Second, if out-of-range behavior carrier is set to "Deactivate carrier", we have to specifically check
-                 * for current weight/price of the cart and remove the carrier if it is not available for the current cart.
-                 */
-                if ($row['range_behavior'] == OutOfRangeBehavior::DISABLED) {
+            $cache_id = 'Carrier::getCarriersForOrder_' . (int) $id_zone . '-' . (int) $row['id_carrier'];
+            if (!Cache::isStored($cache_id)) {
+                $carrier = new Carrier((int) $row['id_carrier']);
+                $shipping_method = $carrier->getShippingMethod();
+                if ($shipping_method != Carrier::SHIPPING_METHOD_FREE) {
                     /*
-                     * Resolve default zone to use for shipping if no address is provided yet. Country in the context is
-                     * always assigned. It may be a default country or a geolocated country set it FrontController.
+                     * First, we check loosely if the carrier is available for the zone with at least one range.
+                     * No weight, no price, just check if the carrier has any ranges for the zone.
+                     * If not, we remove it from the list immediately.
+                     * If yes, we must still check the behavior of the carrier for out-of-range prices below.
                      */
-                    if (!$id_zone) {
-                        $id_zone = (int) Context::getContext()->country->id_zone;
-                    }
-
-                    // Get only carriers that have a range compatible with cart
-                    if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT
-                        && (Carrier::checkDeliveryPriceByWeight($row['id_carrier'], $cart->getTotalWeight(), $id_zone) === false)) {
+                    if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT && $carrier->getMaxDeliveryPriceByWeight($id_zone) === false) {
                         $error[$carrier->id] = Carrier::SHIPPING_WEIGHT_EXCEPTION;
                         unset($result[$k]);
 
                         continue;
                     }
-
-                    if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE
-                        && (Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING), $id_zone, $id_currency ?? null) === false)) {
+                    if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE && $carrier->getMaxDeliveryPriceByPrice($id_zone) === false) {
                         $error[$carrier->id] = Carrier::SHIPPING_PRICE_EXCEPTION;
                         unset($result[$k]);
 
                         continue;
                     }
+
+                    /*
+                     * Second, if out-of-range behavior carrier is set to "Deactivate carrier", we have to specifically check
+                     * for current weight/price of the cart and remove the carrier if it is not available for the current cart.
+                     */
+                    if ($row['range_behavior'] == OutOfRangeBehavior::DISABLED) {
+                        /*
+                         * Resolve default zone to use for shipping if no address is provided yet. Country in the context is
+                         * always assigned. It may be a default country or a geolocated country set it FrontController.
+                         */
+                        if (!$id_zone) {
+                            $id_zone = (int) Context::getContext()->country->id_zone;
+                        }
+
+                        // Get only carriers that have a range compatible with cart
+                        if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT
+                            && (Carrier::checkDeliveryPriceByWeight($row['id_carrier'], $cart->getTotalWeight(), $id_zone) === false)) {
+                            $error[$carrier->id] = Carrier::SHIPPING_WEIGHT_EXCEPTION;
+                            unset($result[$k]);
+
+                            continue;
+                        }
+
+                        if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE
+                            && (Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING), $id_zone, $id_currency ?? null) === false)) {
+                            $error[$carrier->id] = Carrier::SHIPPING_PRICE_EXCEPTION;
+                            unset($result[$k]);
+
+                            continue;
+                        }
+                    }
                 }
+
+                // Calculate the price of the carrier
+                $row['price'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], true, null, null, $id_zone));
+                $row['price_tax_exc'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], false, null, null, $id_zone));
+
+                // If price is false, then the carrier is unavailable (carrier module)
+                if ($row['price'] === false) {
+                    unset($result[$k]);
+
+                    continue;
+                }
+
+                // Locate an image (original resolution, we should probably move to use a presenter and thumbnails here)
+                $row['img'] = file_exists(_PS_SHIP_IMG_DIR_ . (int) $row['id_carrier'] . '.jpg') ? _THEME_SHIP_DIR_ . (int) $row['id_carrier'] . '.jpg' : '';
+
+                Cache::store($cache_id, $row);
+            } else {
+                $row = Cache::retrieve($cache_id);
             }
-
-            // Calculate the price of the carrier
-            $row['price'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], true, null, null, $id_zone));
-            $row['price_tax_exc'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], false, null, null, $id_zone));
-
-            // If price is false, then the carrier is unavailable (carrier module)
-            if ($row['price'] === false) {
-                unset($result[$k]);
-
-                continue;
-            }
-
-            // Locate an image (original resolution, we should probably move to use a presenter and thumbnails here)
-            $row['img'] = file_exists(_PS_SHIP_IMG_DIR_ . (int) $row['id_carrier'] . '.jpg') ? _THEME_SHIP_DIR_ . (int) $row['id_carrier'] . '.jpg' : '';
 
             $results_array[] = $row;
         }
@@ -1588,11 +1600,11 @@ class CarrierCore extends ObjectModel
         }
 
         $available_carrier_list = [];
-        $cache_id = 'Carrier::getAvailableCarrierList_getCarriersForOrder_' . (int) $id_zone . '-' . (int) $cart->id;
+        $cache_id = 'Carrier::getAvailableCarrierList_getCarriersForOrder_' . (int) $id_zone . '-' . (int) $cart->id . '-' . (int) $product->id;
         if (!Cache::isStored($cache_id)) {
             $customer = new Customer($cart->id_customer);
             $carrier_error = [];
-            $carriers = Carrier::getCarriersForOrder($id_zone, $customer->getGroups(), $cart, $carrier_error);
+            $carriers = Carrier::getCarriersForOrder($id_zone, $customer->getGroups(), $cart, $carrier_error, !empty($carrier_list) ? $carrier_list : null);
             Cache::store($cache_id, [$carriers, $carrier_error]);
         } else {
             list($carriers, $carrier_error) = Cache::retrieve($cache_id);

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -728,7 +728,7 @@ class CarrierCore extends ObjectModel
         $results_array = [];
 
         foreach ($result as $k => $row) {
-            $cache_id = 'Carrier::getCarriersForOrder_' . (int) $id_zone . '-' . (int) $row['id_carrier'];
+            $cache_id = 'Carrier::getCarriersForOrder_' . (int) $id_zone . '-' . (int) $row['id_carrier'] . '-' . (int) $cart->id . '-' . (int) ($id_currency ?? 0);
             if (Cache::isStored($cache_id)) {
                 $results_array[] = Cache::retrieve($cache_id);
                 continue;

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -729,80 +729,80 @@ class CarrierCore extends ObjectModel
 
         foreach ($result as $k => $row) {
             $cache_id = 'Carrier::getCarriersForOrder_' . (int) $id_zone . '-' . (int) $row['id_carrier'];
-            if (!Cache::isStored($cache_id)) {
-                $carrier = new Carrier((int) $row['id_carrier']);
-                $shipping_method = $carrier->getShippingMethod();
-                if ($shipping_method != Carrier::SHIPPING_METHOD_FREE) {
-                    /*
-                     * First, we check loosely if the carrier is available for the zone with at least one range.
-                     * No weight, no price, just check if the carrier has any ranges for the zone.
-                     * If not, we remove it from the list immediately.
-                     * If yes, we must still check the behavior of the carrier for out-of-range prices below.
-                     */
-                    if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT && $carrier->getMaxDeliveryPriceByWeight($id_zone) === false) {
-                        $error[$carrier->id] = Carrier::SHIPPING_WEIGHT_EXCEPTION;
-                        unset($result[$k]);
+            if (Cache::isStored($cache_id)) {
+                $results_array[] = Cache::retrieve($cache_id);
+                continue;
+            }
 
-                        continue;
-                    }
-                    if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE && $carrier->getMaxDeliveryPriceByPrice($id_zone) === false) {
-                        $error[$carrier->id] = Carrier::SHIPPING_PRICE_EXCEPTION;
-                        unset($result[$k]);
+            $carrier = new Carrier((int) $row['id_carrier']);
+            $shipping_method = $carrier->getShippingMethod();
+            if ($shipping_method != Carrier::SHIPPING_METHOD_FREE) {
+                /*
+                 * First, we check loosely if the carrier is available for the zone with at least one range.
+                 * No weight, no price, just check if the carrier has any ranges for the zone.
+                 * If not, we remove it from the list immediately.
+                 * If yes, we must still check the behavior of the carrier for out-of-range prices below.
+                 */
+                if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT && $carrier->getMaxDeliveryPriceByWeight($id_zone) === false) {
+                    $error[$carrier->id] = Carrier::SHIPPING_WEIGHT_EXCEPTION;
+                    unset($result[$k]);
 
-                        continue;
-                    }
-
-                    /*
-                     * Second, if out-of-range behavior carrier is set to "Deactivate carrier", we have to specifically check
-                     * for current weight/price of the cart and remove the carrier if it is not available for the current cart.
-                     */
-                    if ($row['range_behavior'] == OutOfRangeBehavior::DISABLED) {
-                        /*
-                         * Resolve default zone to use for shipping if no address is provided yet. Country in the context is
-                         * always assigned. It may be a default country or a geolocated country set it FrontController.
-                         */
-                        if (!$id_zone) {
-                            $id_zone = (int) Context::getContext()->country->id_zone;
-                        }
-
-                        // Get only carriers that have a range compatible with cart
-                        if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT
-                            && (Carrier::checkDeliveryPriceByWeight($row['id_carrier'], $cart->getTotalWeight(), $id_zone) === false)) {
-                            $error[$carrier->id] = Carrier::SHIPPING_WEIGHT_EXCEPTION;
-                            unset($result[$k]);
-
-                            continue;
-                        }
-
-                        if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE
-                            && (Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING), $id_zone, $id_currency ?? null) === false)) {
-                            $error[$carrier->id] = Carrier::SHIPPING_PRICE_EXCEPTION;
-                            unset($result[$k]);
-
-                            continue;
-                        }
-                    }
+                    continue;
                 }
-
-                // Calculate the price of the carrier
-                $row['price'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], true, null, null, $id_zone));
-                $row['price_tax_exc'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], false, null, null, $id_zone));
-
-                // If price is false, then the carrier is unavailable (carrier module)
-                if ($row['price'] === false) {
+                if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE && $carrier->getMaxDeliveryPriceByPrice($id_zone) === false) {
+                    $error[$carrier->id] = Carrier::SHIPPING_PRICE_EXCEPTION;
                     unset($result[$k]);
 
                     continue;
                 }
 
-                // Locate an image (original resolution, we should probably move to use a presenter and thumbnails here)
-                $row['img'] = file_exists(_PS_SHIP_IMG_DIR_ . (int) $row['id_carrier'] . '.jpg') ? _THEME_SHIP_DIR_ . (int) $row['id_carrier'] . '.jpg' : '';
+                /*
+                 * Second, if out-of-range behavior carrier is set to "Deactivate carrier", we have to specifically check
+                 * for current weight/price of the cart and remove the carrier if it is not available for the current cart.
+                 */
+                if ($row['range_behavior'] == OutOfRangeBehavior::DISABLED) {
+                    /*
+                     * Resolve default zone to use for shipping if no address is provided yet. Country in the context is
+                     * always assigned. It may be a default country or a geolocated country set it FrontController.
+                     */
+                    if (!$id_zone) {
+                        $id_zone = (int) Context::getContext()->country->id_zone;
+                    }
 
-                Cache::store($cache_id, $row);
-            } else {
-                $row = Cache::retrieve($cache_id);
+                    // Get only carriers that have a range compatible with cart
+                    if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT
+                        && (Carrier::checkDeliveryPriceByWeight($row['id_carrier'], $cart->getTotalWeight(), $id_zone) === false)) {
+                        $error[$carrier->id] = Carrier::SHIPPING_WEIGHT_EXCEPTION;
+                        unset($result[$k]);
+
+                        continue;
+                    }
+
+                    if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE
+                        && (Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING), $id_zone, $id_currency ?? null) === false)) {
+                        $error[$carrier->id] = Carrier::SHIPPING_PRICE_EXCEPTION;
+                        unset($result[$k]);
+
+                        continue;
+                    }
+                }
             }
 
+            // Calculate the price of the carrier
+            $row['price'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], true, null, null, $id_zone));
+            $row['price_tax_exc'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], false, null, null, $id_zone));
+
+            // If price is false, then the carrier is unavailable (carrier module)
+            if ($row['price'] === false) {
+                unset($result[$k]);
+
+                continue;
+            }
+
+            // Locate an image (original resolution, we should probably move to use a presenter and thumbnails here)
+            $row['img'] = file_exists(_PS_SHIP_IMG_DIR_ . (int) $row['id_carrier'] . '.jpg') ? _THEME_SHIP_DIR_ . (int) $row['id_carrier'] . '.jpg' : '';
+
+            Cache::store($cache_id, $row);
             $results_array[] = $row;
         }
 

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -545,7 +545,7 @@ class CarrierCore extends ObjectModel
                 ($id_zone ? 'LEFT JOIN `' . _DB_PREFIX_ . 'zone` z ON (z.`id_zone` = ' . (int) $id_zone . ')' : '') . '
                 ' . Shop::addSqlAssociation('carrier', 'c') . '
                 WHERE c.`deleted` = ' . ($delete ? '1' : '0');
-        if ($ids_carrier && !empty($ids_carrier)) {
+        if (!empty($ids_carrier)) {
             $sql .= ' AND c.`id_carrier` IN (' . implode(',', array_map('intval', $ids_carrier)) . ') ';
         }
         if ($active) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2741,23 +2741,39 @@ class CartCore extends ObjectModel
             'in_stock' => [],
             'out_of_stock' => [],
         ];
+        $physical_carrier_union = [];
 
         foreach ($product_list as &$product) {
             // Assign delivery address if missing, for compatibility
             $product['id_address_delivery'] = (int) $this->id_address_delivery;
 
-            // Get product's carriers - the product can have some specific limitations
-            $product['carrier_list'] = Carrier::getAvailableCarrierList(
-                new Product($product['id_product']),
-                0,
-                (int) $this->id_address_delivery,
-                null,
-                $this
-            );
+            // Get product's carriers - skip virtual products (they inherit physical carriers later)
+            if (empty($product['is_virtual'])) {
+                $product['carrier_list'] = Carrier::getAvailableCarrierList(
+                    new Product($product['id_product']),
+                    0,
+                    (int) $this->id_address_delivery,
+                    null,
+                    $this
+                );
 
-            // Apply fallback if no carrier is found
-            if (empty($product['carrier_list'])) {
-                $product['carrier_list'] = [0 => 0];
+                // Apply fallback if no carrier is found
+                if (empty($product['carrier_list'])) {
+                    $product['carrier_list'] = [0 => 0];
+                }
+
+                foreach ($product['carrier_list'] as $id_carrier) {
+                    if ($id_carrier) {
+                        $physical_carrier_union[(int) $id_carrier] = (int) $id_carrier;
+                    }
+                }
+            }
+        }
+        unset($product);
+
+        foreach ($product_list as &$product) {
+            if (!empty($product['is_virtual'])) {
+                $product['carrier_list'] = !empty($physical_carrier_union) ? $physical_carrier_union : [0 => 0];
             }
 
             // If "send in-stock items first" is enabled and properly implemented sometime in the future, we separate products by stock
@@ -2916,6 +2932,21 @@ class CartCore extends ObjectModel
      *               );
      *               If there are no carriers available for an address, return an empty  array
      */
+    protected function packageContainsOnlyVirtualProducts(array $package)
+    {
+        if (empty($package['product_list'])) {
+            return false;
+        }
+
+        foreach ($package['product_list'] as $product) {
+            if (empty($product['is_virtual'])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public function getDeliveryOptionList(?Country $default_country = null, $flush = false)
     {
         if (isset(static::$cacheDeliveryOptionList[$this->id]) && !$flush) {
@@ -2962,6 +2993,10 @@ class CartCore extends ObjectModel
 
             // Foreach packages, get the carriers with best price, best position and best grade
             foreach ($packages as $id_package => $package) {
+                if ($this->packageContainsOnlyVirtualProducts($package)) {
+                    continue;
+                }
+
                 /*
                  * Usually, there is only one package of products with multiple carriers.
                  * But, if there is no carrier that sends everything in the cart, the core will
@@ -3019,6 +3054,11 @@ class CartCore extends ObjectModel
 
                 $best_price_carriers[$id_package] = $best_price_carrier;
                 $best_grade_carriers[$id_package] = $best_grade_carrier;
+            }
+
+            if (empty($best_price_carriers)) {
+                unset($delivery_option_list[$id_address]);
+                continue;
             }
 
             // Reset $best_price_carrier, it's now an array
@@ -3088,38 +3128,44 @@ class CartCore extends ObjectModel
             $delivery_option_list[$id_address][$key]['is_best_grade'] = true;
 
             // Get all delivery options with a unique carrier
-            foreach ($common_carriers as $id_carrier) {
-                $key = '';
-                $package_list = [];
-                $product_list = [];
-                $price_with_tax = 0;
-                $price_without_tax = 0;
+            if (is_array($common_carriers)) {
+                foreach ($common_carriers as $id_carrier) {
+                    $key = '';
+                    $package_list = [];
+                    $product_list = [];
+                    $price_with_tax = 0;
+                    $price_without_tax = 0;
 
-                foreach ($packages as $id_package => $package) {
-                    $key .= $id_carrier . ',';
-                    $price_with_tax += $carriers_price[$id_address][$id_package][$id_carrier]['with_tax'];
-                    $price_without_tax += $carriers_price[$id_address][$id_package][$id_carrier]['without_tax'];
-                    $package_list[] = $id_package;
-                    $product_list = array_merge($product_list, $package['product_list']);
-                }
+                    foreach ($packages as $id_package => $package) {
+                        if ($this->packageContainsOnlyVirtualProducts($package)) {
+                            continue;
+                        }
 
-                if (!isset($delivery_option_list[$id_address][$key])) {
-                    $delivery_option_list[$id_address][$key] = [
-                        'is_best_price' => false,
-                        'is_best_grade' => false,
-                        'unique_carrier' => true,
-                        'carrier_list' => [
-                            $id_carrier => [
-                                'price_with_tax' => $price_with_tax,
-                                'price_without_tax' => $price_without_tax,
-                                'instance' => $carriers_instance[$id_carrier],
-                                'package_list' => $package_list,
-                                'product_list' => $product_list,
+                        $key .= $id_carrier . ',';
+                        $price_with_tax += $carriers_price[$id_address][$id_package][$id_carrier]['with_tax'];
+                        $price_without_tax += $carriers_price[$id_address][$id_package][$id_carrier]['without_tax'];
+                        $package_list[] = $id_package;
+                        $product_list = array_merge($product_list, $package['product_list']);
+                    }
+
+                    if (!isset($delivery_option_list[$id_address][$key])) {
+                        $delivery_option_list[$id_address][$key] = [
+                            'is_best_price' => false,
+                            'is_best_grade' => false,
+                            'unique_carrier' => true,
+                            'carrier_list' => [
+                                $id_carrier => [
+                                    'price_with_tax' => $price_with_tax,
+                                    'price_without_tax' => $price_without_tax,
+                                    'instance' => $carriers_instance[$id_carrier],
+                                    'package_list' => $package_list,
+                                    'product_list' => $product_list,
+                                ],
                             ],
-                        ],
-                    ];
-                } else {
-                    $delivery_option_list[$id_address][$key]['unique_carrier'] = (count($delivery_option_list[$id_address][$key]['carrier_list']) <= 1);
+                        ];
+                    } else {
+                        $delivery_option_list[$id_address][$key]['unique_carrier'] = (count($delivery_option_list[$id_address][$key]['carrier_list']) <= 1);
+                    }
                 }
             }
         }
@@ -3181,6 +3227,11 @@ class CartCore extends ObjectModel
         //    - Calculate the average position
         foreach ($delivery_option_list as $id_address => $delivery_option) {
             foreach ($delivery_option as $key => $value) {
+                if (empty($value['carrier_list'])) {
+                    unset($delivery_option_list[$id_address][$key]);
+                    continue;
+                }
+
                 $total_price_with_tax = 0;
                 $total_price_without_tax = 0;
                 $total_price_without_tax_with_rules = 0;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3128,44 +3128,42 @@ class CartCore extends ObjectModel
             $delivery_option_list[$id_address][$key]['is_best_grade'] = true;
 
             // Get all delivery options with a unique carrier
-            if (is_array($common_carriers)) {
-                foreach ($common_carriers as $id_carrier) {
-                    $key = '';
-                    $package_list = [];
-                    $product_list = [];
-                    $price_with_tax = 0;
-                    $price_without_tax = 0;
+            foreach (is_array($common_carriers) ? $common_carriers : [] as $id_carrier) {
+                $key = '';
+                $package_list = [];
+                $product_list = [];
+                $price_with_tax = 0;
+                $price_without_tax = 0;
 
-                    foreach ($packages as $id_package => $package) {
-                        if ($this->packageContainsOnlyVirtualProducts($package)) {
-                            continue;
-                        }
-
-                        $key .= $id_carrier . ',';
-                        $price_with_tax += $carriers_price[$id_address][$id_package][$id_carrier]['with_tax'];
-                        $price_without_tax += $carriers_price[$id_address][$id_package][$id_carrier]['without_tax'];
-                        $package_list[] = $id_package;
-                        $product_list = array_merge($product_list, $package['product_list']);
+                foreach ($packages as $id_package => $package) {
+                    if ($this->packageContainsOnlyVirtualProducts($package)) {
+                        continue;
                     }
 
-                    if (!isset($delivery_option_list[$id_address][$key])) {
-                        $delivery_option_list[$id_address][$key] = [
-                            'is_best_price' => false,
-                            'is_best_grade' => false,
-                            'unique_carrier' => true,
-                            'carrier_list' => [
-                                $id_carrier => [
-                                    'price_with_tax' => $price_with_tax,
-                                    'price_without_tax' => $price_without_tax,
-                                    'instance' => $carriers_instance[$id_carrier],
-                                    'package_list' => $package_list,
-                                    'product_list' => $product_list,
-                                ],
+                    $key .= $id_carrier . ',';
+                    $price_with_tax += $carriers_price[$id_address][$id_package][$id_carrier]['with_tax'];
+                    $price_without_tax += $carriers_price[$id_address][$id_package][$id_carrier]['without_tax'];
+                    $package_list[] = $id_package;
+                    $product_list = array_merge($product_list, $package['product_list']);
+                }
+
+                if (!isset($delivery_option_list[$id_address][$key])) {
+                    $delivery_option_list[$id_address][$key] = [
+                        'is_best_price' => false,
+                        'is_best_grade' => false,
+                        'unique_carrier' => true,
+                        'carrier_list' => [
+                            $id_carrier => [
+                                'price_with_tax' => $price_with_tax,
+                                'price_without_tax' => $price_without_tax,
+                                'instance' => $carriers_instance[$id_carrier],
+                                'package_list' => $package_list,
+                                'product_list' => $product_list,
                             ],
-                        ];
-                    } else {
-                        $delivery_option_list[$id_address][$key]['unique_carrier'] = (count($delivery_option_list[$id_address][$key]['carrier_list']) <= 1);
-                    }
+                        ],
+                    ];
+                } else {
+                    $delivery_option_list[$id_address][$key]['unique_carrier'] = (count($delivery_option_list[$id_address][$key]['carrier_list']) <= 1);
                 }
             }
         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2901,6 +2901,26 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * @param array<string, mixed> $package
+     *
+     * @return bool
+     */
+    protected function packageContainsOnlyVirtualProducts(array $package)
+    {
+        if (empty($package['product_list'])) {
+            return false;
+        }
+
+        foreach ($package['product_list'] as $product) {
+            if (empty($product['is_virtual'])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Get all deliveries options available for the current cart.
      *
      * @param Country $default_country
@@ -2932,21 +2952,6 @@ class CartCore extends ObjectModel
      *               );
      *               If there are no carriers available for an address, return an empty  array
      */
-    protected function packageContainsOnlyVirtualProducts(array $package)
-    {
-        if (empty($package['product_list'])) {
-            return false;
-        }
-
-        foreach ($package['product_list'] as $product) {
-            if (empty($product['is_virtual'])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     public function getDeliveryOptionList(?Country $default_country = null, $flush = false)
     {
         if (isset(static::$cacheDeliveryOptionList[$this->id]) && !$flush) {


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------------------------------------------------------- |
| Branch?           | develop |
| Description?      | Optimize carrier resolution when many carriers are defined in the shop, especially for products with carrier restrictions and for carts mixing virtual and physical products. After these changes, add-to-cart is now quasi-instantaneous on our production-like shop (131 carriers, restricted product carriers). |
| Type?             | improvement |
| Category?         | FO |
| BC breaks?        | no |
| Deprecations?     | no |
| How to test?      | See below |
| UI Tests          | https://github.com/Prestaplugins/ga.tests.ui.pr/actions/runs/28113407574 |
| Fixed issue or discussion? | Fixes #40670 |
| Related PRs       | Supersedes #40671 |
| Sponsor company   | Prestaplugins |

## Summary

This PR completes the work started in #40671 (closed without merge) by addressing both performance problems described in #40670 and in the discussion on the previous PR.

### 1. Carrier performance (`classes/Carrier.php`)

- **`getCarriers()`**: optional `$ids_carrier` filter to load only relevant carriers in SQL instead of the full carrier list.
- **`getCarriersForOrder()`**: passes the optional carrier filter; caches each carrier evaluation per zone (`Carrier::getCarriersForOrder_{zone}-{id_carrier}`) to avoid repeating heavy checks.
- **`getAvailableCarrierList()`**: passes product carrier restrictions to `getCarriersForOrder()`; fixes cache key to include the product id.

### 2. Mixed virtual + physical carts (`classes/Cart.php`)

- **`getPackageList()`**: does not call `getAvailableCarrierList()` for virtual products; virtual products inherit the union of physical product carriers.
- **`getDeliveryOptionList()`**: ignores packages that contain only virtual products; skips building delivery options when no physical package remains; guards against empty `carrier_list` (prevents division by zero on virtual-only carts).

### Performance (real shop, 131 carriers, product with carrier restriction)

| Action | Before | After |
|--------|--------|-------|
| Add to cart | ~3.7 s | quasi-instantaneous |
| Page load (cart totals) | significant delay on every FO page | negligible |

Methods involved are called on most front-office pages to compute cart totals, so the impact is global, not limited to checkout.

## How to test

1. Create a shop with many carriers (50+ recommended).
2. Create a product restricted to one or a few carriers.
3. **Add to cart** from the product page: response should be fast.
4. Browse FO pages with a cart in session: no noticeable delay when cart subtotals are computed.
5. **Mixed cart**: add a virtual product + a physical product with carrier restriction → checkout shows carriers correctly (no "There is no carrier…").
6. **Virtual-only cart**: no fatal error, no shipping options (expected).
7. **Physical-only cart**: unchanged behaviour vs. native.

## Notes

- Supersedes closed PR #40671, which only contained the `Carrier.php` part and was missing the `Cart.php` fix for virtual + physical carts.
- Tested on PrestaShop 8.2.0 (production shop) and 9.1.4. This branch targets `develop` with the same logic adapted to the refactored `Cart::getPackageList()` from PS 9.x.
