### PR TITLE
Update phpstan exclusion pattern from release creator and add unit tests

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
@@ -121,7 +122,7 @@ class ReleaseCreator
         'tools/assets$',
         '\.webpack$',
         'rector\.php',
-        'phpstan(.*)?',
+        '^(?!.*vendor).*phpstan.*\.neon',
         '\.header-stamp.*',
         // Filter AI tools (MD files are alredy filtered via a generic rule above)
         '\.ai.*',
@@ -376,7 +377,7 @@ class ReleaseCreator
      */
     protected function getCurrentVersion()
     {
-        require_once $this->projectPath.'/src/Core/Version.php';
+        require_once $this->projectPath . '/src/Core/Version.php';
         return \PrestaShop\PrestaShop\Core\Version::VERSION;
     }
 
@@ -388,33 +389,33 @@ class ReleaseCreator
      */
     protected function setupShopVersion()
     {
-        $kernelFile = $this->tempProjectPath.'/app/AppKernel.php';
+        $kernelFile = $this->tempProjectPath . '/app/AppKernel.php';
         $version = new Version($this->version);
 
         $kernelFileContent = file_get_contents($kernelFile);
         $kernelFileContent = preg_replace(
             '~const VERSION = \'(.*)\';~',
-            "const VERSION = '".$version->getVersion()."';",
+            "const VERSION = '" . $version->getVersion() . "';",
             $kernelFileContent
         );
         $kernelFileContent = preg_replace(
             '~const MAJOR_VERSION_STRING = \'(.*)\';~',
-            "const MAJOR_VERSION_STRING = '".$version->getMajorVersionString()."';",
+            "const MAJOR_VERSION_STRING = '" . $version->getMajorVersionString() . "';",
             $kernelFileContent
         );
         $kernelFileContent = preg_replace(
             '~const MAJOR_VERSION = (.*);~',
-            "const MAJOR_VERSION = ".$version->getMajorVersion().";",
+            "const MAJOR_VERSION = " . $version->getMajorVersion() . ";",
             $kernelFileContent
         );
         $kernelFileContent = preg_replace(
             '~const MINOR_VERSION = (.*);~',
-            "const MINOR_VERSION = ".$version->getMinorVersion().";",
+            "const MINOR_VERSION = " . $version->getMinorVersion() . ";",
             $kernelFileContent
         );
         $kernelFileContent = preg_replace(
             '~const RELEASE_VERSION = (.*);~',
-            "const RELEASE_VERSION = ".$version->getReleaseVersion().";",
+            "const RELEASE_VERSION = " . $version->getReleaseVersion() . ";",
             $kernelFileContent
         );
 
@@ -433,7 +434,7 @@ class ReleaseCreator
      */
     protected function setInstallDevConfigurationConstants()
     {
-        $configPath = $this->tempProjectPath.'/install-dev/data/xml/configuration.xml';
+        $configPath = $this->tempProjectPath . '/install-dev/data/xml/configuration.xml';
 
         if (file_exists($configPath)) {
             $configPathContent = file_get_contents($configPath);
@@ -482,7 +483,7 @@ class ReleaseCreator
         $iterator = new \RecursiveIteratorIterator($directory);
         $regex = new \RegexIterator($iterator, '/^.*\/.*license(\.txt)?$/i', \RecursiveRegexIterator::GET_MATCH);
 
-        foreach($regex as $file => $value) {
+        foreach ($regex as $file => $value) {
             $content .= file_get_contents($file) . "\r\n\r\n";
         }
 
@@ -754,7 +755,7 @@ class ReleaseCreator
 
                 // Remove files.
                 foreach ($filesRemoveList as $file_to_remove) {
-                    if ($folder.'/'.$file_to_remove == $value) {
+                    if ($folder . '/' . $file_to_remove == $value) {
                         unset($filesList[$key]);
                         exec("rm -f {$argValue}");
 
@@ -764,7 +765,7 @@ class ReleaseCreator
 
                 // Remove folders.
                 foreach ($foldersRemoveList as $folder_to_remove) {
-                    if ($folder.'/'.$folder_to_remove == $value) {
+                    if ($folder . '/' . $folder_to_remove == $value) {
                         unset($filesList[$key]);
                         exec("rm -rf {$argValue}");
 
@@ -774,7 +775,7 @@ class ReleaseCreator
 
                 // Pattern to remove.
                 foreach ($patternsRemoveList as $pattern_to_remove) {
-                    if (preg_match('#'.$pattern_to_remove.'#', $value) == 1) {
+                    if (preg_match('#' . $pattern_to_remove . '#', $value) == 1) {
                         unset($filesList[$key]);
                         exec("rm -rf {$argValue}");
 
@@ -786,7 +787,7 @@ class ReleaseCreator
 
                 // Remove folders.
                 foreach ($foldersRemoveList as $folder_to_remove) {
-                    if ($folder.'/'.$folder_to_remove == $key) {
+                    if ($folder . '/' . $folder_to_remove == $key) {
                         unset($filesList[$key]);
                         exec("rm -rf {$argKey}");
 
@@ -796,7 +797,7 @@ class ReleaseCreator
 
                 // Pattern to remove.
                 foreach ($patternsRemoveList as $pattern_to_remove) {
-                    if (preg_match('#'.$pattern_to_remove.'#', $key) == 1) {
+                    if (preg_match('#' . $pattern_to_remove . '#', $key) == 1) {
                         unset($filesList[$key]);
                         exec("rm -rf {$argKey}");
 

--- a/tools/build/tests/Unit/Library/ReleaseCreatorTest.php
+++ b/tools/build/tests/Unit/Library/ReleaseCreatorTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the phpstan exclusion pattern used in ReleaseCreator::$patternsRemoveList.
+ *
+ * Old pattern: 'phpstan(.*)?'
+ *   - Matched ANY path containing "phpstan" (binaries, .phar, vendor configs…).
+ *
+ * New pattern: '^(?!.*vendor).*phpstan.*\.neon'
+ *   - ^              — anchors from the start of the string.
+ *   - (?!.*vendor)   — negative lookahead: rejects paths that contain "vendor" anywhere.
+ *   - .*phpstan.*    — phpstan may appear anywhere after the anchor (supports absolute paths).
+ *   - \.neon         — restricts exclusion to .neon config files only.
+ */
+class ReleaseCreatorTest extends TestCase
+{
+    private const OLD_PHPSTAN_PATTERN = 'phpstan(.*)?';
+    private const NEW_PHPSTAN_PATTERN = '^(?!.*vendor).*phpstan.*\.neon';
+
+    private function patternMatches(string $pattern, string $path): bool
+    {
+        return preg_match('#' . $pattern . '#', $path) === 1;
+    }
+
+    // -------------------------------------------------------------------------
+    // New pattern — .neon files OUTSIDE vendor that SHOULD be excluded
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider providePhpstanNeonFilesOutsideVendor
+     */
+    public function testNewPhpstanPatternMatchesNeonFilesOutsideVendor(string $path): void
+    {
+        $this->assertTrue(
+            $this->patternMatches(self::NEW_PHPSTAN_PATTERN, $path),
+            "Expected new phpstan pattern to match '{$path}' (should be excluded from release)"
+        );
+    }
+
+    public static function providePhpstanNeonFilesOutsideVendor(): array
+    {
+        return [
+            'phpstan.neon at root'                              => ['phpstan.neon'],
+            'phpstan.neon.dist (partial hit on .neon)'          => ['phpstan.neon.dist'],
+            'phpstan-custom.neon'                               => ['phpstan-custom.neon'],
+            'phpstan-strict.neon'                               => ['phpstan-strict.neon'],
+            'phpstan.neon in subdirectory'                      => ['config/phpstan.neon'],
+            'phpstan.neon via absolute path without vendor'     => ['/tmp/build/prestashop/phpstan.neon'],
+            'phpstan.neon via absolute path in subdir'          => ['/tmp/build/prestashop/config/phpstan.neon'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // New pattern — vendor .neon files that SHOULD NOT be excluded
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider providePhpstanNeonFilesInsideVendor
+     */
+    public function testNewPhpstanPatternDoesNotMatchVendorNeonFiles(string $path): void
+    {
+        $this->assertFalse(
+            $this->patternMatches(self::NEW_PHPSTAN_PATTERN, $path),
+            "Expected new phpstan pattern NOT to match '{$path}' (vendor files must be kept)"
+        );
+    }
+
+    public static function providePhpstanNeonFilesInsideVendor(): array
+    {
+        return [
+            'vendor/phpstan/phpstan/phpstan.neon'              => ['vendor/phpstan/phpstan/phpstan.neon'],
+            'vendor/phpstan/phpstan-strict-rules/rules.neon'   => ['vendor/phpstan/phpstan-strict-rules/rules.neon'],
+            'vendor/phpstan/extension-installer/phpstan.neon'  => ['vendor/phpstan/extension-installer/phpstan.neon'],
+            'vendor/foo/bar/phpstan.neon'                      => ['vendor/foo/bar/phpstan.neon'],
+            'absolute path with vendor'                        => ['/tmp/build/prestashop/vendor/phpstan/phpstan.neon'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // New pattern — non-.neon phpstan artifacts that SHOULD NOT be excluded
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider provideNonNeonPhpstanFiles
+     */
+    public function testNewPhpstanPatternDoesNotMatchNonNeonFiles(string $path): void
+    {
+        $this->assertFalse(
+            $this->patternMatches(self::NEW_PHPSTAN_PATTERN, $path),
+            "Expected new phpstan pattern NOT to match '{$path}' (only .neon files should be excluded)"
+        );
+    }
+
+    public static function provideNonNeonPhpstanFiles(): array
+    {
+        return [
+            'phpstan.phar'     => ['phpstan.phar'],
+            'phpstan (binary)' => ['phpstan'],
+            'phpstan.php'      => ['phpstan.php'],
+            'phpstan.xml'      => ['phpstan.xml'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Regression: old pattern was too broad
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider provideNonNeonPhpstanFiles
+     */
+    public function testOldPhpstanPatternWronglyMatchedNonNeonFiles(string $path): void
+    {
+        $this->assertTrue(
+            $this->patternMatches(self::OLD_PHPSTAN_PATTERN, $path),
+            "Old pattern matched '{$path}' — too broad, this is the bug being fixed"
+        );
+    }
+
+    /**
+     * @dataProvider providePhpstanNeonFilesInsideVendor
+     */
+    public function testOldPhpstanPatternWronglyMatchedVendorFiles(string $path): void
+    {
+        $this->assertTrue(
+            $this->patternMatches(self::OLD_PHPSTAN_PATTERN, $path),
+            "Old pattern matched '{$path}' — vendor files should have been kept"
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The phpstan exclusion pattern used by `ReleaseCreator` was too broad (`phpstan(.*)?`). It matched all phpstan files, causing phpstan extensions shipped in the vendor directory to be incorrectly stripped from release packages. The new pattern (`phpstan.*\.neon) restricts exclusion to `.neon` files. Unit tests are added to document the old bug and verify the new behavior.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the new unit tests: `cd tools/build && php vendor/bin/phpunit tests/Unit/Library/ReleaseCreatorTest.php`. All test cases should pass. To verify manually, generate a release archive and confirm that `vendor/phpstan/` files are present and that root-level `phpstan.neon` / `phpstan.neon.dist` files are absent.
| UI Tests          | https://github.com/cnavarro-prestashop/ga.tests.ui.pr/actions/runs/27826794969
| Sponsor company   | PrestaShop
