### PR TITLE
Prevent object hydratation to corrupt object lang state

### DIFF
--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -15,9 +15,6 @@ class AddressFormatCore extends ObjectModel
     /** @var int Address format */
     public $id_address_format;
 
-    /** @var int Country ID */
-    public $id_country;
-
     /** @var string Format */
     public $format;
 
@@ -31,7 +28,6 @@ class AddressFormatCore extends ObjectModel
         'primary' => 'id_country',
         'fields' => [
             'format' => ['type' => self::TYPE_HTML, 'validate' => 'isGenericName', 'required' => true, 'size' => 255],
-            'id_country' => ['type' => self::TYPE_INT],
         ],
     ];
 
@@ -589,8 +585,8 @@ class AddressFormatCore extends ObjectModel
         $idCountry = (int) $idCountry;
 
         $tmpObj = new AddressFormat();
-        $tmpObj->id_country = $idCountry;
-        $out = $tmpObj->getFormat($tmpObj->id_country);
+        $tmpObj->id = $idCountry;
+        $out = $tmpObj->getFormat($idCountry);
         unset($tmpObj);
 
         return $out;

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -2056,10 +2056,10 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
         $this->id_lang = $id_lang;
         if (isset($data[$this->def['primary']])) {
             $this->id = (int) $data[$this->def['primary']];
-            unset($data['primary']);
+            unset($data[$this->def['primary']]);
         }
 
-        if (!empty(static::$definition['multilang'])) {
+        if (!empty($this->def['multilang'])) {
             unset($data['id_lang']);
         }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -2056,6 +2056,11 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
         $this->id_lang = $id_lang;
         if (isset($data[$this->def['primary']])) {
             $this->id = (int) $data[$this->def['primary']];
+            unset($data['primary']);
+        }
+
+        if (!empty(static::$definition['multilang'])) {
+            unset($data['id_lang']);
         }
 
         foreach ($data as $key => $value) {

--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -420,11 +420,15 @@ class AdminCountriesControllerCore extends AdminController
         $country = parent::processSave();
 
         if (!count($this->errors)) {
-            if (null === $tmp_addr_format->id_country) {
-                $tmp_addr_format->id_country = $country->id;
+            if (null === $tmp_addr_format->id) {
+                $tmp_addr_format->id = $country->id;
+                $tmp_addr_format->force_id = true;
+                $result = $tmp_addr_format->add();
+            } else {
+                $result = $tmp_addr_format->save();
             }
 
-            if (!$tmp_addr_format->save()) {
+            if (!$result) {
                 $this->errors[] = $this->trans('Invalid address layout %s', [Db::getInstance()->getMsgError()], 'Admin.International.Notification');
             }
         }

--- a/src/Adapter/Country/CommandHandler/AddCountryHandler.php
+++ b/src/Adapter/Country/CommandHandler/AddCountryHandler.php
@@ -85,10 +85,11 @@ class AddCountryHandler implements AddCountryHandlerInterface
     private function saveAddressFormat(int $countryId, string $format): void
     {
         $addressFormatModel = new AddressFormat();
-        $addressFormatModel->id_country = $countryId;
+        $addressFormatModel->force_id = true;
+        $addressFormatModel->id = $countryId;
         $addressFormatModel->format = $format;
 
-        if (!$addressFormatModel->save()) {
+        if (!$addressFormatModel->add()) {
             throw new CannotAddCountryException(sprintf('Failed to save address format for country %d', $countryId));
         }
 

--- a/src/Adapter/Country/CommandHandler/EditCountryHandler.php
+++ b/src/Adapter/Country/CommandHandler/EditCountryHandler.php
@@ -110,12 +110,17 @@ class EditCountryHandler implements EditCountryHandlerInterface
     private function saveAddressFormat(int $countryId, string $format): void
     {
         $addressFormatModel = new AddressFormat($countryId);
-        if (null === $addressFormatModel->id_country || 0 === (int) $addressFormatModel->id_country) {
-            $addressFormatModel->id_country = $countryId;
-        }
         $addressFormatModel->format = $format;
 
-        if (!$addressFormatModel->save()) {
+        if (null === $addressFormatModel->id || 0 === (int) $addressFormatModel->id) {
+            $addressFormatModel->force_id = true;
+            $addressFormatModel->id = $countryId;
+            $result = $addressFormatModel->add();
+        } else {
+            $result = $addressFormatModel->update();
+        }
+
+        if (!$result) {
             throw new CannotEditCountryException(sprintf('Failed to save address format for country %d', $countryId));
         }
 

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -8,6 +8,7 @@ namespace PrestaShopBundle\Install;
 
 use Country;
 use Module;
+use ObjectModel;
 use PrestaShop\PrestaShop\Adapter\Entity\Db;
 use PrestaShop\PrestaShop\Adapter\Entity\DbQuery;
 use PrestaShop\PrestaShop\Adapter\Entity\Image;
@@ -505,10 +506,14 @@ class XmlLoader
         if ($classname) {
             $classname = '\\' . $classname;
             // Create entity with ObjectModel class
+            /** @var ObjectModel $object */
             $object = new $classname();
             $object->hydrate($data);
             if ($data_lang) {
                 $object->hydrate($data_lang);
+            }
+            if (!empty($object->id)) {
+                $object->force_id = true;
             }
             $object->add(true, isset($xml->fields['null']));
             $entity_id = $object->id;

--- a/tests/Integration/Classes/ObjectModelTest.php
+++ b/tests/Integration/Classes/ObjectModelTest.php
@@ -624,6 +624,35 @@ class ObjectModelTest extends TestCase
     }
 
     /**
+     * Object hydratation must not override internal properties
+     */
+    public function testHydrate()
+    {
+        $hydratePayload = [
+            'id_testable_object' => 42,
+            'id_lang' => 2, // id_lang field can be pulled from DB
+            'name' => [
+                1 => 'Test',
+                2 => 'Test',
+            ],
+            'quantity' => 36,
+            'enabled' => 0,
+        ];
+
+        // Multilang loaded object must have id_lang set as null
+        $hydratedObject = new TestableObjectModel();
+        $hydratedObject->hydrate($hydratePayload, null);
+
+        $this->assertNull($hydratedObject->getIdLang());
+
+        // Single lang loaded object must reflect proper id_lang
+        $hydratedObject = new TestableObjectModel();
+        $hydratedObject->hydrate($hydratePayload, 1);
+
+        $this->assertSame(1, $hydratedObject->getIdLang());
+    }
+
+    /**
      * @param TestableObjectModel $object
      * @param array $expectedProperties
      */

--- a/tests/Resources/classes/TestableObjectModel.php
+++ b/tests/Resources/classes/TestableObjectModel.php
@@ -60,4 +60,9 @@ class TestableObjectModel extends ObjectModel
         Shop::addTableAssociation('testable_object_lang', ['type' => 'fk_shop']);
         parent::__construct($id, $id_lang, $id_shop);
     }
+
+    public function getIdLang(): ?int
+    {
+        return $this->id_lang;
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix #41791 where `ObjectModel::hydrate(`) may corrupt object state + prevent confusing primary field being created
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Use the provided method in issue #41791 
| UI Tests          | No changes
| Fixed issue or discussion?     | Fixes #41791 
| Related PRs       | None
| Sponsor company   | Novius

**Question**
Should hydrate exclude also every protected field? This could lead to some BC.