### PR TITLE
Fix race condition on invoice number generation

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1263,28 +1263,44 @@ class OrderCore extends ObjectModel
             return false;
         }
 
-        $number = Configuration::get('PS_INVOICE_START_NUMBER', null, null, $id_shop);
-        // If invoice start number has been set, you clean the value of this configuration
-        if ($number) {
-            Configuration::updateValue('PS_INVOICE_START_NUMBER', false, false, null, $id_shop);
+        $db = Db::getInstance();
+
+        // Transaction + standalone SELECT ... FOR UPDATE so concurrent order validations
+        // cannot read the same MAX(number) and assign duplicate invoice numbers.
+        try {
+            $db->execute('START TRANSACTION', false);
+
+            $number = Configuration::get('PS_INVOICE_START_NUMBER', null, null, $id_shop);
+            if ($number) {
+                Configuration::updateValue('PS_INVOICE_START_NUMBER', false, false, null, $id_shop);
+                $newInvoiceNumber = (int) $number;
+            } else {
+                $whereYear = Configuration::get('PS_INVOICE_RESET')
+                    ? ' WHERE DATE_FORMAT(`date_add`, "%Y") = ' . (int) date('Y')
+                    : '';
+                // executeS(), not getValue()/getRow(): the latter append "LIMIT 1", which is
+                // invalid after FOR UPDATE.
+                $rows = $db->executeS(
+                    'SELECT MAX(`number`) AS max_number FROM `' . _DB_PREFIX_ . 'order_invoice`' . $whereYear . ' FOR UPDATE',
+                    true,
+                    false
+                );
+                $newInvoiceNumber = (int) ($rows[0]['max_number'] ?? 0) + 1;
+            }
+
+            $result = $db->execute(
+                'UPDATE `' . _DB_PREFIX_ . 'order_invoice` SET number = ' . $newInvoiceNumber
+                . ' WHERE `id_order_invoice` = ' . (int) $order_invoice_id
+            );
+
+            $db->execute('COMMIT', false);
+
+            return $result;
+        } catch (Exception $e) {
+            $db->execute('ROLLBACK', false);
+
+            throw $e;
         }
-
-        $sql = 'UPDATE `' . _DB_PREFIX_ . 'order_invoice` SET number =';
-
-        if ($number) {
-            $sql .= (int) $number;
-        } else {
-            $getNumberSql = '(SELECT new_number FROM (SELECT (MAX(`number`) + 1) AS new_number
-                FROM `' . _DB_PREFIX_ . 'order_invoice`' . (Configuration::get('PS_INVOICE_RESET') ?
-                ' WHERE DATE_FORMAT(`date_add`, "%Y") = ' . (int) date('Y') : '') . ') AS result)';
-            $getNumberSqlRow = Db::getInstance()->getRow($getNumberSql);
-            $newInvoiceNumber = $getNumberSqlRow['new_number'];
-            $sql .= $newInvoiceNumber;
-        }
-
-        $sql .= ' WHERE `id_order_invoice` = ' . (int) $order_invoice_id;
-
-        return Db::getInstance()->execute($sql);
     }
 
     public function getInvoiceNumber($order_invoice_id)

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -480,11 +480,9 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         }
 
         $invoice->id_order = $order->id;
-        if ($invoice->number) {
-            Configuration::updateValue('PS_INVOICE_START_NUMBER', false, false, null, $order->id_shop);
-        } else {
-            $invoice->number = Order::getLastInvoiceNumber() + 1;
-        }
+        // Number is assigned after insert by Order::setLastInvoiceNumber() (locked read),
+        // not computed here, to avoid a duplicate-number race.
+        $invoice->number = 0;
 
         $invoice_address = new Address(
             (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)}
@@ -509,6 +507,10 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         $invoice->total_wrapping_tax_incl = abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING, $newProducts));
         $invoice->shipping_tax_computation_method = (int) $taxCalculator->computation_method;
         $invoice->add();
+
+        // Assign the number on the inserted row, then reload it into the stale object.
+        Order::setLastInvoiceNumber($invoice->id, $order->id_shop);
+        $invoice->number = (int) $order->getInvoiceNumber($invoice->id);
 
         $invoice->saveCarrierTaxCalculator($taxCalculator->getTaxesAmount($invoice->total_shipping_tax_excl));
 

--- a/tests/Integration/Classes/Order/SetLastInvoiceNumberTest.php
+++ b/tests/Integration/Classes/Order/SetLastInvoiceNumberTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Configuration;
+use Db;
+use Order;
+use PDO;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Proves that the SELECT ... FOR UPDATE used by Order::setLastInvoiceNumber() actually
+ * serializes concurrent readers, so two orders validated at the same time cannot read the
+ * same MAX(number) and end up with the same invoice number.
+ */
+class SetLastInvoiceNumberTest extends TestCase
+{
+    private const READ_SQL = 'SELECT MAX(`number`) FROM `' . _DB_PREFIX_ . 'order_invoice` FOR UPDATE';
+
+    /** @var PDO */
+    private $connectionA;
+
+    /** @var PDO */
+    private $connectionB;
+
+    /** @var int */
+    private $seededInvoiceId;
+
+    protected function setUp(): void
+    {
+        $this->connectionA = $this->newConnection();
+        $this->connectionB = $this->newConnection();
+
+        // FOR UPDATE only locks rows it scans, so a row must exist to be locked.
+        $this->connectionA->exec(
+            'INSERT INTO `' . _DB_PREFIX_ . 'order_invoice` (`id_order`, `number`, `delivery_number`, `shipping_tax_computation_method`, `date_add`)'
+            . ' VALUES (0, 1, 0, 0, NOW())'
+        );
+        $this->seededInvoiceId = (int) $this->connectionA->lastInsertId();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->connectionA, $this->connectionB] as $connection) {
+            try {
+                $connection->exec('ROLLBACK');
+            } catch (PDOException $e) {
+            }
+        }
+
+        $this->newConnection()->exec(
+            'DELETE FROM `' . _DB_PREFIX_ . 'order_invoice` WHERE `id_order_invoice` = ' . $this->seededInvoiceId
+        );
+    }
+
+    public function testForUpdateBlocksConcurrentReader(): void
+    {
+        $this->connectionA->exec('START TRANSACTION');
+        $this->connectionA->query(self::READ_SQL);
+
+        $this->connectionB->exec('SET SESSION innodb_lock_wait_timeout = 1');
+        $this->connectionB->exec('START TRANSACTION');
+
+        try {
+            $this->connectionB->query(self::READ_SQL);
+            $this->fail('Second reader should have been blocked by the FOR UPDATE lock held by the first transaction.');
+        } catch (PDOException $e) {
+            // 1205 = lock wait timeout: the row range is held by connection A as expected.
+            $this->assertSame('1205', (string) $e->errorInfo[1]);
+        }
+
+        $this->connectionA->exec('COMMIT');
+
+        // Once A commits the lock is released and B can read again.
+        $this->assertNotFalse($this->connectionB->query(self::READ_SQL));
+    }
+
+    /**
+     * Runs the real method through the legacy Db layer to guard against the locked read being
+     * built with getValue()/getRow() (which append "LIMIT 1" after FOR UPDATE -> SQL error).
+     */
+    public function testSetLastInvoiceNumberAssignsANumber(): void
+    {
+        Configuration::updateValue('PS_INVOICE_START_NUMBER', false, false, null, (int) Configuration::get('PS_SHOP_DEFAULT'));
+
+        $assigned = Order::setLastInvoiceNumber($this->seededInvoiceId, (int) Configuration::get('PS_SHOP_DEFAULT'));
+
+        $this->assertTrue($assigned);
+        $this->assertGreaterThan(
+            0,
+            (int) Db::getInstance()->getValue(
+                'SELECT `number` FROM `' . _DB_PREFIX_ . 'order_invoice` WHERE `id_order_invoice` = ' . $this->seededInvoiceId
+            )
+        );
+    }
+
+    private function newConnection(): PDO
+    {
+        [$host, $port] = array_pad(explode(':', _DB_SERVER_, 2), 2, null);
+
+        $dsn = 'mysql:host=' . $host . ';dbname=' . _DB_NAME_;
+        if ($port) {
+            $dsn .= ';port=' . $port;
+        }
+
+        return new PDO($dsn, _DB_USER_, _DB_PASSWD_, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    }
+}


### PR DESCRIPTION
| Questions                  | Answers                                                                 |
| -------------------------- | ----------------------------------------------------------------------- |
| Branch?                    | develop                                                                 |
| Description?               | Fixes a race condition in invoice number generation. `Order::setLastInvoiceNumber()` read `MAX(number) + 1` and wrote it back in two unsynchronized statements, so two orders validated concurrently could read the same MAX and be assigned the same invoice number — a customer could then see another customer's invoice (confidentiality issue). The read is now locked with a standalone `SELECT ... FOR UPDATE` inside an explicit transaction. |
| Type?                      | bug fix                                                                 |
| Category?                  | BO                                                                      |
| BC breaks?                 | no                                                                      |
| Deprecations?              | no                                                                      |
| How to test?               | See "How to test" below.                                                |
| UI Tests                   | N/A — server-side concurrency fix, no UI surface. Covered by an integration test instead. |
| Fixed issue or discussion? | https://github.com/PrestaShop/PrestaShop/issues/28757                   |
| Related PRs                | https://github.com/PrestaShop/PrestaShop/pull/6915                      |
| Sponsor company            |  creabilis.com                                                                       |

### The problem

`Order::setLastInvoiceNumber()` computes the next invoice number as `MAX(number) + 1` and then writes it back in a **separate** `UPDATE` statement. There is no synchronization between the read and the write, so two orders validated at the same moment can both read the same `MAX(number)` and both be assigned the **same invoice number**.

The visible consequence is a confidentiality bug: two orders share an invoice number, and a customer can end up seeing another customer's invoice.

The same flawed `MAX(number) + 1`-in-PHP pattern was also used by `AddProductToOrderHandler` when creating a new invoice for an existing order.

### The fix

Keep the two-statement structure (separate read, then `UPDATE`) — it was introduced on purpose by #6915 to avoid MySQL error 1093 — but add the missing synchronization between the two:

- Wrap both statements in an explicit transaction.
- Lock the read with a **standalone** `SELECT MAX(number) ... FOR UPDATE`. The InnoDB lock is held until `COMMIT`, so a concurrent transaction blocks on the read and then sees the freshly written number instead of a stale one.

The lock is a standalone statement, **not** nested inside the `UPDATE`. This is deliberate:

- It does not reintroduce MySQL error 1093 (the reason #6915 split the query in the first place).
- `FOR UPDATE` inside an `UPDATE`/`INSERT` subquery requires MySQL 8.0.1+, whereas PrestaShop 9 supports **MySQL 5.7+ / MariaDB 10.2+**. A standalone `SELECT ... FOR UPDATE` works on those minimum versions.

`AddProductToOrderHandler::createNewInvoice()` no longer computes the number in PHP. It inserts the invoice row first, calls `Order::setLastInvoiceNumber()` (the locked path), then reloads `number` from the database (the in-memory object would otherwise keep the placeholder value).

### Why not `GET_LOCK()` / a sequence table?

- **InnoDB row locking** (`FOR UPDATE`) reuses the engine the data already lives in: automatic deadlock detection and guaranteed release on `COMMIT`/`ROLLBACK`. An advisory `GET_LOCK()` has to be released explicitly and leaks on a fatal error.
- `CREATE SEQUENCE` is MySQL 8.0.3+ / MariaDB 10.3+ only — below the supported floor.

### Known limitation (out of scope)

This PR fixes the **duplicate-number** race. It does **not** address #23356 (duplication of an entire `OrderInvoice` row, not just the number) — that is a different bug and is intentionally left for a separate PR.

A `UNIQUE` index on `order_invoice.number` would be a useful belt-and-braces guard, but it is also **out of scope**: it requires an upgrade script to clean up pre-existing duplicates in production databases before the constraint can be added. This will be a follow-up PR.

### How to test

Automated: `tests/Integration/Classes/Order/SetLastInvoiceNumberTest.php` opens two separate database connections and proves the `FOR UPDATE` lock serializes them — while connection A holds the lock, connection B's identical `SELECT ... FOR UPDATE` hits a lock-wait timeout (error 1205); once A commits, B reads again.

```
php vendor/bin/phpunit tests/Integration/Classes/Order/SetLastInvoiceNumberTest.php
```

Manual: validate two orders as close to simultaneously as possible (e.g. two parallel requests) on a shop with `PS_INVOICE` enabled, and confirm they receive distinct, consecutive invoice numbers.

### Related issues

- https://github.com/PrestaShop/PrestaShop/issues/28757 (main, unresolved)
- https://github.com/PrestaShop/PrestaShop/issues/12660 (same bug, never fixed)
- https://github.com/PrestaShop/PrestaShop/issues/11115 (closed for unclear scope — this PR stays focused on one reproducible bug)
- https://github.com/PrestaShop/PrestaShop/issues/23356 (different, related bug — out of scope, see above)
- https://github.com/PrestaShop/PrestaShop/pull/6915 (2016: split MAX+1 from the UPDATE to fix error 1093 — preserved here)
