### PR TITLE
Fix: Color preview is still displayed after changing an attribute group from color to another type

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/combination/generator/AttributesSelector.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/generator/AttributesSelector.vue
@@ -88,12 +88,12 @@
                 <div class="attribute-item-content">
                   <span
                     class="attribute-item-texture"
-                    v-if="attribute.texture"
+                    v-if="attributeGroup.isColorGroup && attribute.texture"
                     :style="`background: transparent url(${attribute.texture}) no-repeat; background-size: 100% auto;`"
                   />
                   <span
                     class="attribute-item-color"
-                    v-else-if="attribute.color"
+                    v-else-if="attributeGroup.isColorGroup && attribute.color"
                     :style="`background-color: ${attribute.color}`"
                   />
                   <span class="attribute-item-name">{{ attribute.name }}</span>

--- a/admin-dev/themes/new-theme/js/pages/product/combination/types.d.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/types.d.ts
@@ -17,6 +17,7 @@ export interface AttributeGroup {
   id: number;
   name: string;
   publicName: string;
+  isColorGroup: boolean;
   attributes: Array<Attribute>;
 }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -613,6 +613,7 @@ class CombinationController extends PrestaShopAdminController
                 'id' => $attributeGroup->getAttributeGroupId(),
                 'name' => $names[$contextLangId] ?? reset($names),
                 'publicName' => $publicNames[$contextLangId] ?? reset($publicNames),
+                'isColorGroup' => $attributeGroup->isColorGroup(),
                 'attributes' => $attributes,
             ];
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes issue #41796 in the product combinations generator.<br/>When an attribute group is changed from Color to another type, existing attributes may still keep a value in their color field. The combinations generator was using that field alone to decide whether to display a color preview, so non-color groups could still appear with a color swatch.<br/> This change exposes `isColorGroup` from the backend payload and uses it in `AttributesSelector.vue` to display texture/color previews only for actual color groups.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to `Catalog > Attributes & Features`.<br/>2. Create an attribute group with the type set to `Color`.<br/>3. Add at least one attribute to the group and assign it a color, for example `#000000`.<br/>4. Edit the attribute group and change its type from `Color` to `Dropdown list`.<br/>5. Edit and save the attribute without changing its value.<br/>6. Go to a product with combinations.<br/>7. Open the combination generation interface.<br/>8. Expand the attribute group previously modified.<br/>9. Verify that no color or texture preview is displayed next to the attribute.<br/>10. Verify that only the attribute name is displayed.<br/>11. Change the attribute group type back to `Color`.<br/>12. Reopen the combination generation interface.<br/>13. Verify that the color preview is displayed again next to the attribute.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41796
| Related PRs       | 
| Sponsor company   | Codencode snc
