### PR TITLE
Bump GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -85,7 +85,7 @@ jobs:
           SYMFONY_DEPRECATIONS_HELPER: disabled
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: failure()
         with:
           name: behaviour-${{ matrix.php }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -43,7 +43,7 @@ jobs:
             --distribution=open_source
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: open-source-archive
           path: |

--- a/.github/workflows/create_diff_for_autoupgrade_pr_label.yml
+++ b/.github/workflows/create_diff_for_autoupgrade_pr_label.yml
@@ -75,7 +75,7 @@ jobs:
           docker compose run --rm mysql sh -c "exec mysqldump -hmysql -uroot --no-create-info --compact -pprestashop presta_${{ matrix.branch }} ${{ env.DUMP_TABLES_FOR_DIFF }}" >> dump_${{ matrix.branch }}.sql
 
       - name: Upload dump
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dump_${{ matrix.branch }}
           path: |
@@ -86,7 +86,7 @@ jobs:
     needs: [ install_prestashop_and_dump ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
 
       - name: Create diff
         run: git diff ./dump_head/dump_head.sql ./dump_base/dump_base.sql > sql-diff.txt | true
@@ -97,7 +97,7 @@ jobs:
           echo ${{ github.event.number }} > ./pr_number
 
       - name: Upload diff
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sql_diff
           path: |

--- a/.github/workflows/cron_nightly_tests_reusable.yml
+++ b/.github/workflows/cron_nightly_tests_reusable.yml
@@ -232,7 +232,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ env.GH_BRANCH }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         name: Download reports
         with:
           path: ${{ env.REPORTS_DIR }}

--- a/.github/workflows/notify_for_autoupgrade_pr_label.yml
+++ b/.github/workflows/notify_for_autoupgrade_pr_label.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - id: download_artifact
         name: Download artifact
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -70,7 +70,7 @@ jobs:
           docker logs ${{ inputs.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log
 
       - name: Upload Screenshots and logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: failure()
         with:
           name: sanity-${{ matrix.php }}-${{ matrix.browser }}-${{ matrix.db }}

--- a/.github/workflows/validate-pr-metadata.yml
+++ b/.github/workflows/validate-pr-metadata.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Set milestone based on target branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/verify_autoupgrade_label_and_approvals.yml
+++ b/.github/workflows/verify_autoupgrade_label_and_approvals.yml
@@ -43,7 +43,7 @@ jobs:
           echo $PR_AUTHOR > ./author
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: approval_count
           path: |

--- a/.github/workflows/verify_diff_for_autoupgrade_pr_label.yml
+++ b/.github/workflows/verify_diff_for_autoupgrade_pr_label.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Several GitHub Actions used in the workflows still target the **Node 20** runtime, which GitHub has deprecated and is now force-running on Node 24 (with a deprecation warning on every run). This PR bumps those actions to the major versions that natively target Node 24.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | none
| How to test?      | Trigger / re-run the affected workflows and confirm the "Node.js 20 is deprecated" warning no longer appears in the logs.

### Changes

- `actions/upload-artifact` `v4` → `v5`
- `actions/download-artifact` `v4` → `v5`
- `actions/github-script` `v6`/`v7` → `v8`

Affected workflows: `behaviour.yml`, `build-release.yml`, `sanity.yml`, `cron_nightly_tests_reusable.yml`, `validate-pr-metadata.yml`, `notify_for_autoupgrade_pr_label.yml`, `verify_autoupgrade_label_and_approvals.yml`, `create_diff_for_autoupgrade_pr_label.yml`, `verify_diff_for_autoupgrade_pr_label.yml`.

The `github-script` public API (`github`, `context`, `core`) is stable across v6→v8, so the inline scripts are unchanged. `cron_nightly_tests_reusable.yml` already uses `upload-artifact@v6` in one step and was left as-is.

> Out of scope (left for a dedicated PR): the very widespread `actions/checkout@v4`, `actions/cache@v4`, `actions/setup-node@v4` and `actions/setup-python@v5` bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)