### PR TITLE
Fix meta title appended to CMS page, CMS category, manufacturer, and supplier URLs

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -562,8 +562,7 @@ class LinkCore
         $params['id'] = $cms->id;
         $params['rewrite'] = (!$alias) ? (is_array($cms->link_rewrite) ? $cms->link_rewrite[(int) $idLang] : $cms->link_rewrite) : $alias;
 
-        $params['meta_title'] = '';
-        if (isset($cms->meta_title) && !empty($cms->meta_title)) {
+        if ($dispatcher->hasKeyword('cms_rule', $idLang, 'meta_title', $idShop)) {
             $params['meta_title'] = is_array($cms->meta_title) ? Tools::str2url($cms->meta_title[(int) $idLang]) : Tools::str2url($cms->meta_title);
         }
 
@@ -656,7 +655,10 @@ class LinkCore
         $params = [];
         $params['id'] = $manufacturer->id;
         $params['rewrite'] = (!$alias) ? $manufacturer->link_rewrite : $alias;
-        $params['meta_title'] = Tools::str2url($manufacturer->meta_title);
+
+        if ($dispatcher->hasKeyword('manufacturer_rule', $idLang, 'meta_title', $idShop)) {
+            $params['meta_title'] = Tools::str2url($manufacturer->meta_title);
+        }
 
         return $url . $dispatcher->createUrl('manufacturer_rule', $idLang, $params, $this->allow, '', $idShop);
     }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -518,7 +518,10 @@ class LinkCore
         $params = [];
         $params['id'] = $cmsCategory->id;
         $params['rewrite'] = (!$alias) ? $cmsCategory->link_rewrite : $alias;
-        $params['meta_title'] = Tools::str2url($cmsCategory->meta_title);
+
+        if ($dispatcher->hasKeyword('cms_category_rule', $idLang, 'meta_title', $idShop)) {
+            $params['meta_title'] = Tools::str2url($cmsCategory->meta_title);
+        }
 
         return $url . $dispatcher->createUrl('cms_category_rule', $idLang, $params, $this->allow, '', $idShop);
     }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -617,7 +617,10 @@ class LinkCore
         $params = [];
         $params['id'] = $supplier->id;
         $params['rewrite'] = (!$alias) ? $supplier->link_rewrite : $alias;
-        $params['meta_title'] = Tools::str2url($supplier->meta_title);
+
+        if ($dispatcher->hasKeyword('supplier_rule', $idLang, 'meta_title', $idShop)) {
+            $params['meta_title'] = Tools::str2url($supplier->meta_title);
+        }
 
         return $url . $dispatcher->createUrl('supplier_rule', $idLang, $params, $this->allow, '', $idShop);
     }

--- a/tests/Integration/Classes/LinkTest.php
+++ b/tests/Integration/Classes/LinkTest.php
@@ -12,9 +12,34 @@ use Context;
 use Dispatcher;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionProperty;
 
 class LinkTest extends TestCase
 {
+    private $originalUseRoutes;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalUseRoutes = $this->getUseRoutesProperty()->getValue(Dispatcher::getInstance());
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore the Dispatcher singleton state mutated by the tests, otherwise the forced
+        // use_routes value leaks into other test classes and changes their generated URLs.
+        $this->getUseRoutesProperty()->setValue(Dispatcher::getInstance(), $this->originalUseRoutes);
+        parent::tearDown();
+    }
+
+    private function getUseRoutesProperty(): ReflectionProperty
+    {
+        $property = (new ReflectionClass('Dispatcher'))->getProperty('use_routes');
+        $property->setAccessible(true);
+
+        return $property;
+    }
+
     private function getProductLink(bool $statusUseRoutes, int $id_product, ?int $id_product_attribute): array
     {
         $reflectionDispatcher = new ReflectionClass('Dispatcher');

--- a/tests/Integration/Classes/LinkTest.php
+++ b/tests/Integration/Classes/LinkTest.php
@@ -67,4 +67,17 @@ class LinkTest extends TestCase
         $this->assertEquals(1, $query['id_product']);
         $this->assertArrayNotHasKey('id_product_attribute', $query);
     }
+
+    public function testSupplierUrlOmitsMetaTitleWhenRouteHasNoMetaTitleKeyword(): void
+    {
+        $reflectionDispatcher = new ReflectionClass('Dispatcher');
+        $property = $reflectionDispatcher->getProperty('use_routes');
+        $property->setAccessible(true);
+        $property->setValue(Dispatcher::getInstance(), true);
+
+        $url = Context::getContext()->link->getSupplierLink(1);
+        parse_str(parse_url($url)['query'] ?? '', $query);
+
+        $this->assertArrayNotHasKey('meta_title', $query);
+    }
 }

--- a/tests/Integration/Classes/LinkTest.php
+++ b/tests/Integration/Classes/LinkTest.php
@@ -40,8 +40,12 @@ class LinkTest extends TestCase
         return $property;
     }
 
-    private function getProductLink(bool $statusUseRoutes, int $id_product, ?int $id_product_attribute): array
-    {
+    private function getProductLink(
+        bool $statusUseRoutes,
+        int $id_product,
+        ?int $id_product_attribute,
+        ?string $ean13 = null
+    ): array {
         $reflectionDispatcher = new ReflectionClass('Dispatcher');
         $property = $reflectionDispatcher->getProperty('use_routes');
         $property->setAccessible(true);
@@ -51,7 +55,7 @@ class LinkTest extends TestCase
             $id_product,
             null,
             null,
-            null,
+            $ean13,
             Context::getContext()->language->id,
             null,
             $id_product_attribute,
@@ -104,5 +108,15 @@ class LinkTest extends TestCase
         parse_str(parse_url($url)['query'] ?? '', $query);
 
         $this->assertArrayNotHasKey('meta_title', $query);
+    }
+
+    public function testProductUrlOmitsEan13WhenRouteHasNoEan13Keyword(): void
+    {
+        parse_str(
+            $this->getProductLink(true, 1, null, '1234567890128')['query'] ?? '',
+            $query
+        );
+
+        $this->assertArrayNotHasKey('ean13', $query);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix a minor issue introduced in #41386: the `meta_title` parameter is always added to CMS page, CMS category, manufacturer, and supplier URLs.
| Type?             | bug fix
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to the manufacturer list and click on a manufacturer.<br/>- Check that the URL does not contain `meta_title=`.<br/><br/>2. Go to the supplier list and click on a supplier.<br/>- Check that the URL does not contain `meta_title=`.<br/><br/>3. Open a CMS page.<br/>- Check that the URL does not contain `meta_title=`.<br/><br/>4. Open a CMS category.<br/>- Check that the URL does not contain `meta_title=`.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/28058275760
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/pull/41386#issuecomment-4783631495
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41386 https://github.com/PrestaShop/PrestaShop/pull/41750
| Sponsor company   | Codencode snc
