### PR TITLE
Fix extra query parameters for customized routes

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -1087,7 +1087,9 @@ class DispatcherCore
 
             foreach ($params as $key => $value) {
                 if (!isset($routeDefinition['keywords'][$key])) {
-                    $add_param[$key] = $value;
+                    if (!isset($this->default_routes[$routeName]['keywords'][$key])) {
+                        $add_param[$key] = $value;
+                    }
                 } else {
                     if ($params[$key]) {
                         $parameter = $params[$key];

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -181,12 +181,11 @@ class LinkCore
         }
         $params['rewrite'] = (!$alias) ? $product->getFieldByLang('link_rewrite') : $alias;
 
-        if ($dispatcher->hasKeyword('product_rule', $idLang, 'ean13', $idShop)) {
-            if (!$ean13) {
-                $product = $this->getProductObject($product, $idLang, $idShop);
-            }
-            $params['ean13'] = (!$ean13) ? $product->ean13 : $ean13;
+        if (!$ean13) {
+            $product = $this->getProductObject($product, $idLang, $idShop);
         }
+        $params['ean13'] = (!$ean13) ? $product->ean13 : $ean13;
+
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'meta_title', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['meta_title'] = Tools::str2url($product->getFieldByLang('meta_title'));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes the handling of additional query parameters when generating URLs for customized routes.<br/>The issue was originally introduced by #41386.<br/>That PR changed the URL generation behavior so that parameters not defined as keywords in the currently configured route were added to the query string.<br/>However, a customized route may intentionally omit some keywords that are still part of the corresponding default route. Those parameters should not be considered additional query parameters.<br/>As a consequence, route keywords such as `ean13`, `meta_title`, and potentially other parameters could incorrectly appear in the generated URL query string.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to the manufacturer list and click on a manufacturer and check that the URL does not contain `meta_title=`.<br/>2. Open a CMS page and check that the URL does not contain `meta_title=`.<br/>3. Open a CMS category and check that the URL does not contain `meta_title=`.<br/>4. Go to Admin > Shop Parameters > Traffic & SEO and set `Route to products` to `{id}{-:id_product_attribute}{-:ean13}-{rewrite}.html`<br/>5. Open a product with an EAN-13 value and verify that the generated URL is similar to https://yourshopurl.com/18-38-1234567891234-carnet-de-notes-colibri.html
| UI Tests          | https://github.com/Codencode/ga.tests.ui.pr/actions/runs/28079560429
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/pull/41386#issuecomment-4783631495
| Related PRs       | - #41386 introduced the behavior that caused default route keywords to be treated as additional query parameters.<br/>- #41750 partially fixed the issue for the `ean13` product route keyword.<br/>- #41808 attempted to fix the same issue for `meta_title` in CMS and manufacturer URLs.
| Sponsor company   | Codencode snc

---

@Hlavtox @hadjedjvincent @kpodemski, could you please share your thoughts on this approach?

* @Hlavtox originally introduced the related changes in #41386.
* @hadjedjvincent implemented the partial fix in #41750.
* @kpodemski suggested that the issue was probably located further upstream.

This PR fixes the problem directly in `Dispatcher::createUrl()` by checking both the customized route keywords and the corresponding default route keywords before treating a parameter as an additional query parameter.

With this change, the issue addressed by #41750 is also handled at the dispatcher level.

Do you think the changes introduced in #41750 should now be removed to avoid keeping redundant, route-specific logic in `Link.php`?

If you agree, I can include their removal in this PR so that the whole fix remains centralized in the dispatcher.
