### PR TITLE
Fix structured data for manufacturer list

### DIFF
--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -15,7 +15,6 @@ class ManufacturerControllerCore extends ProductListingFrontController
 
     /** @var Manufacturer|null */
     protected $manufacturer;
-    protected $label;
 
     /** @var ManufacturerPresenter */
     protected $manufacturerPresenter;
@@ -79,24 +78,12 @@ class ManufacturerControllerCore extends ProductListingFrontController
 
             if (Validate::isLoadedObject($this->manufacturer) && $this->manufacturer->active && $this->manufacturer->isAssociatedToShop()) {
                 $this->assignManufacturer();
-                $this->label = $this->trans(
-                    'List of products by brand %brand_name%',
-                    [
-                        '%brand_name%' => $this->manufacturer->name,
-                    ],
-                    'Shop.Theme.Catalog'
-                );
                 $this->doProductSearch(
                     'catalog/listing/manufacturer',
                     ['entity' => 'manufacturer', 'id' => $this->manufacturer->id]
                 );
             } else {
                 $this->assignAll();
-                $this->label = $this->trans(
-                    'List of all brands',
-                    [],
-                    'Shop.Theme.Catalog'
-                );
                 $this->setTemplate('catalog/manufacturers', ['entity' => 'manufacturers']);
             }
         } else {
@@ -214,7 +201,11 @@ class ManufacturerControllerCore extends ProductListingFrontController
 
     public function getListingLabel(): string
     {
-        return $this->label;
+        if (Validate::isLoadedObject($this->manufacturer) && $this->manufacturer->active && $this->manufacturer->isAssociatedToShop()) {
+            return $this->trans('List of products by brand %brand_name%', ['%brand_name%' => $this->manufacturer->name], 'Shop.Theme.Catalog');
+        } else {
+            return $this->trans('List of all brands', [], 'Shop.Theme.Catalog');
+        }
     }
 
     public function getBreadcrumbLinks(): array
@@ -233,6 +224,22 @@ class ManufacturerControllerCore extends ProductListingFrontController
         }
 
         return $breadcrumb;
+    }
+
+    /**
+     * Generates structured data this page, depending on if we are displaying a manufacturer or a list of manufacturers.
+     *
+     * @return array
+     */
+    public function getStructuredData(): array
+    {
+        // If we are displaying a manufacturer, we will use the product listing structured data
+        if (Validate::isLoadedObject($this->manufacturer) && $this->manufacturer->active && $this->manufacturer->isAssociatedToShop()) {
+            return parent::getStructuredData();
+        }
+
+        // Otherwise, we will display the basic data, the same as in FrontController
+        return FrontController::getStructuredData();
     }
 
     /**

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -15,7 +15,6 @@ class SupplierControllerCore extends ProductListingFrontController
 
     /** @var Supplier|null */
     protected $supplier;
-    protected $label;
 
     /** @var SupplierPresenter */
     protected $supplierPresenter;
@@ -79,24 +78,12 @@ class SupplierControllerCore extends ProductListingFrontController
 
             if (Validate::isLoadedObject($this->supplier) && $this->supplier->active && $this->supplier->isAssociatedToShop()) {
                 $this->assignSupplier();
-                $this->label = $this->trans(
-                    'List of products by supplier %supplier_name%',
-                    [
-                        '%supplier_name%' => $this->supplier->name,
-                    ],
-                    'Shop.Theme.Catalog'
-                );
                 $this->doProductSearch(
                     'catalog/listing/supplier',
                     ['entity' => 'supplier', 'id' => $this->supplier->id]
                 );
             } else {
                 $this->assignAll();
-                $this->label = $this->trans(
-                    'List of all suppliers',
-                    [],
-                    'Shop.Theme.Catalog'
-                );
                 $this->setTemplate('catalog/suppliers', ['entity' => 'suppliers']);
             }
         } else {
@@ -212,7 +199,11 @@ class SupplierControllerCore extends ProductListingFrontController
 
     public function getListingLabel(): string
     {
-        return $this->label;
+        if (Validate::isLoadedObject($this->supplier) && $this->supplier->active && $this->supplier->isAssociatedToShop()) {
+            return $this->trans('List of products by supplier %supplier_name%', ['%supplier_name%' => $this->supplier->name], 'Shop.Theme.Catalog');
+        } else {
+            return $this->trans('List of all suppliers', [], 'Shop.Theme.Catalog');
+        }
     }
 
     public function getBreadcrumbLinks(): array
@@ -231,6 +222,22 @@ class SupplierControllerCore extends ProductListingFrontController
         }
 
         return $breadcrumb;
+    }
+
+    /**
+     * Generates structured data this page, depending on if we are displaying a supplier or a list of suppliers.
+     *
+     * @return array
+     */
+    public function getStructuredData(): array
+    {
+        // If we are displaying a supplier, we will use the product listing structured data
+        if (Validate::isLoadedObject($this->supplier) && $this->supplier->active && $this->supplier->isAssociatedToShop()) {
+            return parent::getStructuredData();
+        }
+
+        // Otherwise, we will display the basic data, the same as in FrontController
+        return FrontController::getStructuredData();
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes structured data for manufacturer and supplier list. See https://github.com/PrestaShop/PrestaShop/pull/37552#issuecomment-4781190874
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | 
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/pull/37552#issuecomment-4781190874
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### How to test
Make sure you have the data displayed in the head:

```smarty
<!-- new structured data start -->
{if !empty($structured_data)}
{foreach from=$structured_data item="element"}
<script type="application/ld+json">{$element|@json_encode:320 nofilter}</script>
{/foreach}
{/if}
<!-- new structured data end -->
```

Check this:
- Check homepage - base structured data only.
- Check category - listing data added.
- Check product - product data added.
- Check manufacturer brand list - base structured data only, no error.
- Check single manufacturer - listing data added.