### PR TITLE
Fix SqlTranslationLoader missing theme translations in PS9 (#41232)

### DIFF
--- a/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
@@ -60,15 +60,12 @@ class SqlTranslationLoader implements LoaderInterface
             throw new NotFoundResourceException(sprintf('Language not found in database: %s', $locale));
         }
 
-        // If we get translations for a theme, realistically we need to get translations
-        // for all active themes from the database, since different stores can use different themes.
-        // If we don't do that, the first store's theme you visit after the cache is cleared will
-        // be the only one that has translations.
         $selectTranslationsQuery = '
             SELECT `key`, `translation`, `domain`
             FROM `' . _DB_PREFIX_ . 'translation`
             WHERE `id_lang` = ' . $localeResults[$locale]['id_lang'] . '
-            AND theme ' . ($this->theme !== null ? ' IN (SELECT `theme` FROM `' . _DB_PREFIX_ . 'shop` WHERE `active` = 1)' : 'IS NULL');
+            AND ' . $this->buildThemeCondition() . '
+            ORDER BY theme IS NOT NULL';
 
         $translations = Db::getInstance()->executeS($selectTranslationsQuery) ?: [];
 
@@ -76,6 +73,30 @@ class SqlTranslationLoader implements LoaderInterface
         $this->addTranslationsToCatalogue($translations, $catalogue);
 
         return $catalogue;
+    }
+
+    /**
+     * Builds the WHERE sub-condition that restricts which ps_translation rows are loaded.
+     *
+     * Always covers both core rows (theme IS NULL) and theme-specific rows for every
+     * active shop. This is required because in PS9 the Symfony container is always active,
+     * so getTranslator() never calls TranslatorLanguageLoader::loadLanguage() and setTheme()
+     * is never invoked. A single loader instance must therefore handle both row types.
+     *
+     * In the PS8 legacy path, TranslatorLanguageLoader registers two separate instances
+     * (a plain 'db' loader and a 'db.theme' loader with setTheme() called). With the
+     * unified condition both instances load the same rows; the second pass is redundant
+     * but harmless.
+     *
+     * ORDER BY theme IS NOT NULL in the caller ensures theme=NULL rows are processed first
+     * inside addTranslationsToCatalogue(), so shop-specific overrides win on duplicate keys.
+     *
+     * The correct column is ps_shop.theme_name — ps_shop.theme has never existed; referencing
+     * it causes MySQL/MariaDB to silently return an empty result set (issue #41232, Bug A).
+     */
+    protected function buildThemeCondition(): string
+    {
+        return '(theme IS NULL OR theme IN (SELECT `theme_name` FROM `' . _DB_PREFIX_ . 'shop` WHERE `active` = 1))';
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Translation/Loader/SqlTranslationLoaderTest.php
+++ b/tests/Integration/PrestaShopBundle/Translation/Loader/SqlTranslationLoaderTest.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Translation\Loader;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShopBundle\Translation\Loader\SqlTranslationLoader;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * Integration regression suite for SqlTranslationLoader (issue #41232).
+ *
+ * Scenarios covered:
+ *   1. Core (theme IS NULL) translations always loaded
+ *   2. Theme-exclusive translations loaded without theme context (PS9 Symfony-container path —
+ *      setTheme() is never called; this is the primary cold-cache bug)
+ *   3. Theme-exclusive translations loaded when theme is explicitly set
+ *   4. Shop-theme override wins over core entry for the same key, no theme context
+ *   5. Shop-theme override wins over core entry for the same key, theme set
+ *   6. Multishop: all active shop themes loaded in a single query regardless of theme context
+ *   7. Inactive shop theme rows are never included in the catalogue
+ *
+ * Run:
+ *   docker compose exec prestashop-git php ./vendor/phpunit/phpunit/phpunit \
+ *     -c tests/Integration/phpunit.xml \
+ *     tests/Integration/PrestaShopBundle/Translation/Loader/SqlTranslationLoaderTest.php
+ */
+class SqlTranslationLoaderTest extends TestCase
+{
+    private const DOMAIN_GLOBAL = 'Shop.Theme.Global';
+    private const DOMAIN_CHECKOUT = 'Shop.Theme.Checkout';
+
+    // Unique keys — prefixed to avoid any collision with real fixture data
+    private const KEY_CORE_ONLY = '__test_sql_loader__core_only__';
+    private const KEY_WITH_OVERRIDE = '__test_sql_loader__with_override__';
+    private const KEY_THEME_A_EXCLUSIVE = '__test_sql_loader__theme_a_exclusive__';
+    private const KEY_THEME_B_EXCLUSIVE = '__test_sql_loader__theme_b_exclusive__';
+    private const KEY_INACTIVE_THEME = '__test_sql_loader__inactive_theme__';
+
+    private const THEME_B_NAME = '__test_sql_loader_theme_b__';
+    private const INACTIVE_THEME_NAME = '__test_sql_loader_inactive__';
+
+    private static int $langId;
+    private static string $locale;
+    private static string $themeNameA;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $lang = Db::getInstance()->getRow(
+            'SELECT `id_lang`, `locale` FROM `' . _DB_PREFIX_ . 'lang` WHERE `active` = 1'
+        );
+        self::$langId = (int) $lang['id_lang'];
+        self::$locale = $lang['locale'];
+
+        $shop = Db::getInstance()->getRow(
+            'SELECT `theme_name`, `id_shop_group`, `id_category`
+             FROM `' . _DB_PREFIX_ . 'shop`
+             WHERE `active` = 1'
+        );
+        self::$themeNameA = $shop['theme_name'];
+
+        // Second active shop with a different theme — used in multishop scenario
+        Db::getInstance()->insert('shop', [
+            'id_shop_group' => (int) $shop['id_shop_group'],
+            'name' => 'Test Shop B (SqlTranslationLoaderTest)',
+            'color' => '',
+            'id_category' => (int) $shop['id_category'],
+            'theme_name' => self::THEME_B_NAME,
+            'active' => 1,
+            'deleted' => 0,
+        ]);
+
+        self::seedTranslations();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['translation', 'shop']);
+    }
+
+    // ── scenario 1 ────────────────────────────────────────────────────────────
+
+    public function testCoreTranslationAlwaysLoadedWithoutThemeContext(): void
+    {
+        $loader = new SqlTranslationLoader();
+        $catalogue = $loader->load('', self::$locale);
+
+        $this->assertTrue(
+            $catalogue->defines(self::KEY_CORE_ONLY, self::DOMAIN_GLOBAL),
+            'Core (theme IS NULL) translation must always be present'
+        );
+        $this->assertSame('Core only value', $catalogue->get(self::KEY_CORE_ONLY, self::DOMAIN_GLOBAL));
+    }
+
+    public function testCoreTranslationAlwaysLoadedWithThemeContext(): void
+    {
+        $loader = (new SqlTranslationLoader())->setTheme($this->mockTheme());
+        $catalogue = $loader->load('', self::$locale);
+
+        $this->assertTrue($catalogue->defines(self::KEY_CORE_ONLY, self::DOMAIN_GLOBAL));
+        $this->assertSame('Core only value', $catalogue->get(self::KEY_CORE_ONLY, self::DOMAIN_GLOBAL));
+    }
+
+    // ── scenario 2 — primary cold-cache bug ───────────────────────────────────
+
+    public function testThemeExclusiveKeyLoadedWithoutThemeContext(): void
+    {
+        $loader = new SqlTranslationLoader();
+        $catalogue = $loader->load('', self::$locale);
+
+        $this->assertTrue(
+            $catalogue->defines(self::KEY_THEME_A_EXCLUSIVE, self::DOMAIN_CHECKOUT),
+            'Theme-exclusive key must be in the catalogue even when setTheme() was never called — '
+            . 'in PS9 the Symfony container is always used and setTheme() is never invoked; '
+            . 'failing here means a cold-cache request will serve English fallbacks to all visitors'
+        );
+        $this->assertSame('Theme A only value', $catalogue->get(self::KEY_THEME_A_EXCLUSIVE, self::DOMAIN_CHECKOUT));
+    }
+
+    // ── scenario 3 — Bug A (wrong column name) ────────────────────────────────
+
+    public function testThemeExclusiveKeyLoadedWithThemeSet(): void
+    {
+        $loader = (new SqlTranslationLoader())->setTheme($this->mockTheme());
+        $catalogue = $loader->load('', self::$locale);
+
+        $this->assertTrue(
+            $catalogue->defines(self::KEY_THEME_A_EXCLUSIVE, self::DOMAIN_CHECKOUT),
+            'Theme-exclusive key must be present when setTheme() is called — '
+            . 'the IN subquery must reference ps_shop.theme_name, not the non-existent ps_shop.theme column'
+        );
+        $this->assertSame('Theme A only value', $catalogue->get(self::KEY_THEME_A_EXCLUSIVE, self::DOMAIN_CHECKOUT));
+    }
+
+    // ── scenario 4 & 5 — override precedence ─────────────────────────────────
+
+    public function testThemeOverrideWinsOverCoreWithoutThemeContext(): void
+    {
+        $loader = new SqlTranslationLoader();
+        $catalogue = $loader->load('', self::$locale);
+
+        $this->assertSame(
+            'Theme A override',
+            $catalogue->get(self::KEY_WITH_OVERRIDE, self::DOMAIN_GLOBAL),
+            'When the same key exists in both core (theme IS NULL) and a shop theme, '
+            . 'the shop-theme value must win regardless of theme context'
+        );
+    }
+
+    public function testThemeOverrideWinsOverCoreWithThemeSet(): void
+    {
+        $loader = (new SqlTranslationLoader())->setTheme($this->mockTheme());
+        $catalogue = $loader->load('', self::$locale);
+
+        $this->assertSame(
+            'Theme A override',
+            $catalogue->get(self::KEY_WITH_OVERRIDE, self::DOMAIN_GLOBAL)
+        );
+    }
+
+    // ── scenario 6 — multishop ────────────────────────────────────────────────
+
+    public function testAllActiveShopThemesLoadedWithoutThemeContext(): void
+    {
+        $loader = new SqlTranslationLoader();
+        $catalogue = $loader->load('', self::$locale);
+
+        $this->assertTrue(
+            $catalogue->defines(self::KEY_THEME_A_EXCLUSIVE, self::DOMAIN_CHECKOUT),
+            'Theme A translations must be present (multishop)'
+        );
+        $this->assertTrue(
+            $catalogue->defines(self::KEY_THEME_B_EXCLUSIVE, self::DOMAIN_CHECKOUT),
+            'Theme B translations must be present even though theme B is a different active shop — '
+            . 'the loader must cover all active shop themes in one query'
+        );
+    }
+
+    public function testAllActiveShopThemesLoadedWithThemeSet(): void
+    {
+        $loader = (new SqlTranslationLoader())->setTheme($this->mockTheme());
+        $catalogue = $loader->load('', self::$locale);
+
+        $this->assertTrue($catalogue->defines(self::KEY_THEME_A_EXCLUSIVE, self::DOMAIN_CHECKOUT));
+        $this->assertTrue(
+            $catalogue->defines(self::KEY_THEME_B_EXCLUSIVE, self::DOMAIN_CHECKOUT),
+            'Even when a specific theme is set the loader must still include all active shop themes; '
+            . 'different shops in the same install may run different themes'
+        );
+    }
+
+    // ── scenario 7 — inactive shop theme excluded ─────────────────────────────
+
+    public function testInactiveShopThemeRowsNotLoaded(): void
+    {
+        $loader = new SqlTranslationLoader();
+        $catalogue = $loader->load('', self::$locale);
+
+        $this->assertFalse(
+            $catalogue->defines(self::KEY_INACTIVE_THEME, self::DOMAIN_GLOBAL),
+            'Translations for a theme that belongs to no active shop must not be loaded'
+        );
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private function mockTheme(): Theme
+    {
+        // buildThemeCondition() only checks $this->theme !== null; getName() is never called
+        return $this->createMock(Theme::class);
+    }
+
+    private static function seedTranslations(): void
+    {
+        $rows = [
+            // Scenario 1 — core-only entry
+            [self::KEY_CORE_ONLY, 'Core only value', self::DOMAIN_GLOBAL, null],
+
+            // Scenarios 4 & 5 — same key in core + theme A; theme A must win
+            [self::KEY_WITH_OVERRIDE, 'Core fallback', self::DOMAIN_GLOBAL, null],
+            [self::KEY_WITH_OVERRIDE, 'Theme A override', self::DOMAIN_GLOBAL, self::$themeNameA],
+
+            // Scenarios 2, 3, 6 — theme-exclusive entries (no core counterpart)
+            [self::KEY_THEME_A_EXCLUSIVE, 'Theme A only value', self::DOMAIN_CHECKOUT, self::$themeNameA],
+            [self::KEY_THEME_B_EXCLUSIVE, 'Theme B only value', self::DOMAIN_CHECKOUT, self::THEME_B_NAME],
+
+            // Scenario 7 — inactive-shop theme must be silently excluded
+            [self::KEY_INACTIVE_THEME, 'Should never appear', self::DOMAIN_GLOBAL, self::INACTIVE_THEME_NAME],
+        ];
+
+        $db = Db::getInstance();
+        $prefix = _DB_PREFIX_;
+
+        foreach ($rows as [$key, $translation, $domain, $theme]) {
+            $themeSQL = $theme !== null ? '"' . $db->escape($theme) . '"' : 'NULL';
+            $db->execute(
+                'INSERT INTO `' . $prefix . 'translation`
+                    (`id_lang`, `key`, `translation`, `domain`, `theme`)
+                 VALUES
+                    (' . self::$langId . ',
+                     "' . $db->escape($key) . '",
+                     "' . $db->escape($translation) . '",
+                     "' . $db->escape($domain) . '",
+                     ' . $themeSQL . ')'
+            );
+        }
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Translation/Loader/SqlTranslationLoaderTest.php
+++ b/tests/Unit/PrestaShopBundle/Translation/Loader/SqlTranslationLoaderTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Translation\Loader;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShopBundle\Translation\Loader\SqlTranslationLoader;
+
+if (!defined('_DB_PREFIX_')) {
+    define('_DB_PREFIX_', 'ps_');
+}
+
+/**
+ * Unit regression tests for SqlTranslationLoader (issue #41232).
+ *
+ * Tests the WHERE condition built by buildThemeCondition() — the pure-logic part of the
+ * loader that has no DB dependency and can be verified without a running database.
+ *
+ * Two bugs the condition must fix:
+ *
+ *   Bug A — wrong column: the original IN subquery referenced ps_shop.theme which has never
+ *   existed; the correct column is ps_shop.theme_name. MySQL silently returns empty results.
+ *
+ *   Bug B — split-loader assumption: in PS8 two separate loader instances were registered
+ *   (one for theme IS NULL rows, one for theme rows). In PS9 the Symfony container is always
+ *   active and only a single loader instance is used, so it must cover both row types in one
+ *   query regardless of whether setTheme() was called.
+ *
+ * The full behavioural suite (with a real DB) lives in
+ * tests/Integration/PrestaShopBundle/Translation/Loader/SqlTranslationLoaderTest.php.
+ */
+final class SqlTranslationLoaderTest extends TestCase
+{
+    public function testConditionAlwaysIncludesCoreRows(): void
+    {
+        $condition = (new ExposedSqlTranslationLoader())->getThemeCondition();
+
+        $this->assertStringContainsString(
+            'theme IS NULL',
+            $condition,
+            'Core (theme IS NULL) rows must always be included — they hold admin-customised core translations'
+        );
+    }
+
+    public function testConditionAlwaysIncludesActiveShopThemeRows(): void
+    {
+        $condition = (new ExposedSqlTranslationLoader())->getThemeCondition();
+
+        $this->assertStringContainsString(
+            '`theme_name`',
+            $condition,
+            'Active-shop theme rows must always be included — ps_shop.theme_name is the correct column'
+        );
+        $this->assertStringNotContainsString(
+            'SELECT `theme`',
+            $condition,
+            'ps_shop.theme is not a valid column and causes the query to fail silently'
+        );
+    }
+
+    public function testConditionIsUnchangedWhenThemeIsSet(): void
+    {
+        $loader = new ExposedSqlTranslationLoader();
+        $loader->setTheme($this->createMock(Theme::class));
+
+        $condition = $loader->getThemeCondition();
+
+        $this->assertStringContainsString('theme IS NULL', $condition,
+            'Core rows must still be loaded even when a theme context is available — '
+            . 'in PS9 a single loader instance handles both row types'
+        );
+        $this->assertStringContainsString('`theme_name`', $condition);
+    }
+}
+
+/**
+ * Exposes the protected buildThemeCondition() method for assertion.
+ */
+final class ExposedSqlTranslationLoader extends SqlTranslationLoader
+{
+    public function getThemeCondition(): string
+    {
+        return $this->buildThemeCondition();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `SqlTranslationLoader` has two compounding bugs that cause shop-theme translations from the database to silently fall back to English on the front office in PS9.<br><br>**Bug A — wrong column name:** The IN subquery introduced in e22c7a7 references `ps_shop.theme`, a column that has never existed. The correct column is `ps_shop.theme_name`. MySQL/MariaDB silently returns an empty result set, so no DB theme translation is ever loaded when a theme context is set.<br><br>**Bug B — split-loader assumption broken in PS9:** The original code branched on `$this->theme !== null`, following the PS8 convention where `TranslatorLanguageLoader` registers two separate instances — a plain `db` loader (loads `theme IS NULL` rows) and a `db.theme` loader with `setTheme()` called (loads theme rows). In PS9 the Symfony container is always active, so `TranslatorLanguageLoader::loadLanguage()` is never called and `setTheme()` is never invoked. The single DI-registered loader always fell into the `IS NULL` branch and missed all shop-theme DB translations entirely.<br><br>**Fix:** Extract `buildThemeCondition()` and unify the query to always cover both core rows (`theme IS NULL`) and all active-shop theme rows in a single pass, with `ORDER BY theme IS NOT NULL` so shop-specific overrides win on duplicate keys. In the PS8 two-loader path both instances now load the same rows; the second pass is redundant but harmless.
| Type?             | bug fix
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The bug affects translations saved via BO > International > Translations that are stored in `ps_translation` with a theme value. Reliable reproduction: run the integration test suite added in this PR (`tests/Integration/PrestaShopBundle/Translation/Loader/SqlTranslationLoaderTest.php`) against the unfixed code — 4 tests fail. After the fix all 9 pass. Manual check: on PS9 with a custom theme, save a front-office translation override in BO, clear `var/cache/`, and reload the front office. Note: the bug is intermittent in production because it depends on whether a valid translation cache already exists — a warm cache will serve correct translations until it expires or is cleared.
| UI Tests          | https://github.com/tswfi/ga.tests.ui.pr/actions/runs/28087238114
| Fixed issue or discussion? | Fixes #41232, Fixes #36036<br><br>Possibly also fixes #40564 (symptoms match Bug B — translations saved to DB but never loaded on FO).<br><br>Related but out of scope: #40571 (XLF file-based theme translations also ignored via Symfony container — separate remaining issue in `Context::getTranslator`).
| Related PRs       | —
| Sponsor company   | Vilkas Group Oy