### PR TITLE
Add import CSV façade command and Behat safety net (Story 1 - part 1)

### DIFF
--- a/src/Adapter/Import/CommandHandler/ImportCsvFromFileHandler.php
+++ b/src/Adapter/Import/CommandHandler/ImportCsvFromFileHandler.php
@@ -17,6 +17,7 @@ use PrestaShop\PrestaShop\Core\Import\Configuration\ImportConfig;
 use PrestaShop\PrestaShop\Core\Import\Configuration\ImportRuntimeConfig;
 use PrestaShop\PrestaShop\Core\Import\Exception\NotSupportedImportTypeException;
 use PrestaShop\PrestaShop\Core\Import\Handler\ImportHandlerFinderInterface;
+use PrestaShop\PrestaShop\Core\Import\Handler\ImportHandlerInterface;
 use PrestaShop\PrestaShop\Core\Import\ImporterInterface;
 use PrestaShop\PrestaShop\Core\Import\ImportSettings;
 
@@ -64,7 +65,7 @@ final class ImportCsvFromFileHandler implements ImportCsvFromFileHandlerInterfac
         return $this->runModernImport($command, $importHandler);
     }
 
-    private function runModernImport(ImportCsvFromFileCommand $command, $importHandler): ImportResult
+    private function runModernImport(ImportCsvFromFileCommand $command, ImportHandlerInterface $importHandler): ImportResult
     {
         $importConfig = $this->buildImportConfig($command);
         $mapping = $command->getDataMapping();

--- a/src/Adapter/Import/CommandHandler/ImportCsvFromFileHandler.php
+++ b/src/Adapter/Import/CommandHandler/ImportCsvFromFileHandler.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Import\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Import\LegacyImportExecutor;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Import\Command\ImportCsvFromFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Import\CommandHandler\ImportCsvFromFileHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
+use PrestaShop\PrestaShop\Core\Import\Configuration\ImportConfig;
+use PrestaShop\PrestaShop\Core\Import\Configuration\ImportRuntimeConfig;
+use PrestaShop\PrestaShop\Core\Import\Exception\NotSupportedImportTypeException;
+use PrestaShop\PrestaShop\Core\Import\Handler\ImportHandlerFinderInterface;
+use PrestaShop\PrestaShop\Core\Import\ImporterInterface;
+use PrestaShop\PrestaShop\Core\Import\ImportSettings;
+
+/**
+ * Façade handler routing a CSV import either to the modern Importer (for entity
+ * types that own a handler) or to the legacy AdminImportController (for the rest),
+ * returning a single executor-agnostic ImportResult.
+ *
+ * This is the only production wiring added by the import safety-net story; the
+ * interface stays stable so a later story can swap the internals for the
+ * ImportRun aggregate without touching the callers or the Behat scenarios.
+ *
+ * @internal
+ */
+#[AsCommandHandler]
+final class ImportCsvFromFileHandler implements ImportCsvFromFileHandlerInterface
+{
+    /**
+     * Number of rows processed per Importer iteration; the loop advances the
+     * offset until the import reports completion.
+     */
+    private const BATCH_SIZE = 100;
+
+    /**
+     * Safety bound to avoid an infinite loop if the import never completes.
+     */
+    private const MAX_ITERATIONS = 100000;
+
+    public function __construct(
+        private readonly ImporterInterface $importer,
+        private readonly ImportHandlerFinderInterface $importHandlerFinder,
+        private readonly LegacyImportExecutor $legacyImportExecutor,
+    ) {
+    }
+
+    public function handle(ImportCsvFromFileCommand $command): ImportResult
+    {
+        try {
+            $importHandler = $this->importHandlerFinder->find($command->getEntityType());
+        } catch (NotSupportedImportTypeException) {
+            // No modern handler for this entity type: fall back to the legacy controller.
+            return $this->legacyImportExecutor->execute($command);
+        }
+
+        return $this->runModernImport($command, $importHandler);
+    }
+
+    private function runModernImport(ImportCsvFromFileCommand $command, $importHandler): ImportResult
+    {
+        $importConfig = $this->buildImportConfig($command);
+        $mapping = $command->getDataMapping();
+
+        $errors = [];
+        $warnings = [];
+        $notices = [];
+        $doneCount = 0;
+        $totalCount = 0;
+        $sharedData = [];
+        $offset = 0;
+        $finished = false;
+        $iteration = 0;
+
+        do {
+            $runtimeConfig = new ImportRuntimeConfig(
+                $command->isValidateOnly(),
+                $offset,
+                self::BATCH_SIZE,
+                $sharedData,
+                $mapping
+            );
+
+            $this->importer->import($importConfig, $runtimeConfig, $importHandler);
+
+            $report = $runtimeConfig->toArray();
+            $sharedData = $runtimeConfig->getSharedData();
+            $errors = $report['errors'] ?? [];
+            $warnings = $report['warnings'] ?? [];
+            $notices = $report['notices'] ?? [];
+            $doneCount = (int) ($report['doneCount'] ?? $doneCount);
+            $totalCount = max($totalCount, (int) ($report['totalCount'] ?? 0), $doneCount);
+
+            $finished = $runtimeConfig->isFinished();
+            $offset = $doneCount;
+        } while (!$finished && ++$iteration < self::MAX_ITERATIONS);
+
+        return new ImportResult(
+            $this->normalizeMessages($errors),
+            $this->normalizeMessages($warnings),
+            $this->normalizeMessages($notices),
+            $doneCount,
+            $totalCount
+        );
+    }
+
+    private function buildImportConfig(ImportCsvFromFileCommand $command): ImportConfig
+    {
+        $options = $command->getOptions();
+
+        return new ImportConfig(
+            $command->getFilename(),
+            $command->getEntityType(),
+            $command->getLangIso(),
+            $options['separator'] ?? ImportSettings::DEFAULT_SEPARATOR,
+            $options['multiple_value_separator'] ?? ImportSettings::DEFAULT_MULTIVALUE_SEPARATOR,
+            !empty($options['truncate']),
+            !empty($options['regenerate']),
+            !empty($options['match_ref']),
+            !empty($options['forceIDs']),
+            false,
+            (int) ($options['skip'] ?? 0)
+        );
+    }
+
+    /**
+     * @param mixed $messages
+     *
+     * @return string[]
+     */
+    private function normalizeMessages($messages): array
+    {
+        if (!is_array($messages)) {
+            return [];
+        }
+
+        return array_values(array_map(static fn ($message): string => (string) $message, $messages));
+    }
+}

--- a/src/Adapter/Import/LegacyImportExecutor.php
+++ b/src/Adapter/Import/LegacyImportExecutor.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Import;
+
+use AdminImportController;
+use Controller;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Domain\Import\Command\ImportCsvFromFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
+use PrestaShop\PrestaShop\Core\Import\ImportSettings;
+use ReflectionProperty;
+
+/**
+ * Drives the legacy AdminImportController for the entity types that do not own a
+ * modern import handler yet (customers, addresses, manufacturers, suppliers,
+ * combinations, aliases, store contacts).
+ *
+ * The legacy controller is entirely request/context driven: it reads its inputs
+ * through Tools::getValue() and accumulates messages on its public $errors /
+ * $warnings / $informations properties. This adapter isolates that coupling so
+ * the command handler stays clean, and maps the outcome onto an ImportResult.
+ *
+ * Nothing in the legacy controller is modified — it is invoked as-is.
+ */
+final class LegacyImportExecutor
+{
+    /**
+     * Number of rows handled per importByGroups() call. The loop below keeps
+     * advancing the offset until the controller reports the import is finished,
+     * so this only controls batch granularity, not the total imported.
+     */
+    private const BATCH_SIZE = 100;
+
+    /**
+     * Safety bound to avoid an infinite loop if the controller never reports
+     * completion (e.g. an unreadable file).
+     */
+    private const MAX_ITERATIONS = 100000;
+
+    public function execute(ImportCsvFromFileCommand $command): ImportResult
+    {
+        $backup = [
+            'post' => $_POST,
+            'get' => $_GET,
+        ];
+
+        $this->applyRequestParameters($command);
+
+        try {
+            // The constructor reads "entity"/"separator" to build the field map,
+            // so the request parameters must be applied beforehand.
+            $controller = new AdminImportController();
+            // The controller's row methods resolve services through its container, which is normally
+            // wired by init(). We invoke importByGroups() directly, so inject the container ourselves.
+            $this->injectContainer($controller);
+
+            $doneCount = 0;
+            $totalCount = 0;
+            $offset = 0;
+            $moreStep = 0;
+            $crossStepsVariables = [];
+            $finished = false;
+            $iteration = 0;
+
+            do {
+                $_POST['offset'] = $offset;
+                $_POST['moreStep'] = $moreStep;
+                $_POST['crossStepsVars'] = json_encode($crossStepsVariables);
+
+                $results = [];
+                $controller->importByGroups(
+                    $offset,
+                    self::BATCH_SIZE,
+                    $results,
+                    $command->isValidateOnly(),
+                    $moreStep
+                );
+
+                if (isset($results['crossStepsVariables'])) {
+                    $crossStepsVariables = $results['crossStepsVariables'];
+                }
+                if (isset($results['totalCount'])) {
+                    $totalCount = (int) $results['totalCount'];
+                }
+
+                $finished = !empty($results['isFinished']);
+
+                if ($finished && isset($results['oneMoreStep'])) {
+                    // The controller requested an additional pass (e.g. linking
+                    // accessories): restart from the beginning for that step.
+                    $moreStep = (int) $results['oneMoreStep'];
+                    $offset = 0;
+                    $finished = false;
+                } elseif ($finished) {
+                    $doneCount = (int) ($results['doneCount'] ?? $offset);
+                } else {
+                    $offset = (int) ($results['doneCount'] ?? ($offset + self::BATCH_SIZE));
+                }
+            } while (!$finished && ++$iteration < self::MAX_ITERATIONS);
+
+            return new ImportResult(
+                $this->normalizeMessages($controller->errors),
+                $this->normalizeMessages($controller->warnings),
+                $this->normalizeMessages($controller->informations),
+                $doneCount,
+                $totalCount
+            );
+        } finally {
+            $_POST = $backup['post'];
+            $_GET = $backup['get'];
+        }
+    }
+
+    private function injectContainer(AdminImportController $controller): void
+    {
+        if (null !== $controller->getContainer()) {
+            return;
+        }
+
+        $property = new ReflectionProperty(Controller::class, 'container');
+        $property->setValue($controller, SymfonyContainer::getInstance());
+    }
+
+    /**
+     * Populates the request parameters the legacy controller reads through
+     * Tools::getValue(). In the test environment Tools::getValue() falls back to
+     * the $_POST/$_GET superglobals, which is what the Behat safety net relies on.
+     */
+    private function applyRequestParameters(ImportCsvFromFileCommand $command): void
+    {
+        $options = $command->getOptions();
+
+        $parameters = [
+            'entity' => $command->getEntityType(),
+            'csv' => $command->getFilename(),
+            'iso_lang' => $command->getLangIso(),
+            'separator' => $options['separator'] ?? ImportSettings::DEFAULT_SEPARATOR,
+            'multiple_value_separator' => $options['multiple_value_separator'] ?? ImportSettings::DEFAULT_MULTIVALUE_SEPARATOR,
+            'truncate' => !empty($options['truncate']) ? 1 : 0,
+            'forceIDs' => !empty($options['forceIDs']) ? 1 : 0,
+            'match_ref' => !empty($options['match_ref']) ? 1 : 0,
+            'regenerate' => !empty($options['regenerate']) ? 1 : 0,
+            'skip' => (int) ($options['skip'] ?? 0),
+            'type_value' => $command->getDataMapping(),
+            'validateOnly' => $command->isValidateOnly() ? 1 : 0,
+        ];
+
+        foreach ($parameters as $key => $value) {
+            $_POST[$key] = $value;
+            $_GET[$key] = $value;
+        }
+    }
+
+    /**
+     * @param mixed $messages
+     *
+     * @return string[]
+     */
+    private function normalizeMessages($messages): array
+    {
+        if (!is_array($messages)) {
+            return [];
+        }
+
+        return array_values(array_map(static fn ($message): string => (string) $message, $messages));
+    }
+}

--- a/src/Core/Domain/Import/Command/ImportCsvFromFileCommand.php
+++ b/src/Core/Domain/Import/Command/ImportCsvFromFileCommand.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Import\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Import\Exception\ImportException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Import\Entity;
+
+/**
+ * Thin façade command running a full CSV import for a given entity type.
+ *
+ * It hides which executor runs underneath (the modern Importer for entity types
+ * that own a handler, or the legacy AdminImportController row methods for the
+ * others) so that consumers never need to know about that split.
+ */
+final class ImportCsvFromFileCommand
+{
+    /**
+     * @var string name of the CSV file located in the import directory
+     */
+    private $filename;
+
+    /**
+     * @var int one of Entity::TYPE_*
+     */
+    private $entityType;
+
+    /**
+     * @var string language ISO code used for multilingual fields
+     */
+    private $langIso;
+
+    /**
+     * @var array<string, mixed> import options, e.g.:
+     *                           - data_mapping: array<int, string> column index => entity field name
+     *                           - truncate: bool
+     *                           - match_ref: bool
+     *                           - forceIDs: bool
+     *                           - regenerate: bool
+     *                           - separator: string
+     *                           - multiple_value_separator: string
+     *                           - skip: int
+     */
+    private $options;
+
+    /**
+     * @var bool when true, the import only validates rows and persists nothing
+     */
+    private $validateOnly;
+
+    /**
+     * @var ShopConstraint|null shop context the import runs against (null inherits the BO context)
+     */
+    private $shopConstraint;
+
+    /**
+     * @param string $filename
+     * @param int $entityType
+     * @param string $langIso
+     * @param array<string, mixed> $options
+     * @param bool $validateOnly
+     * @param ShopConstraint|null $shopConstraint
+     *
+     * @throws ImportException when the entity type is not supported
+     */
+    public function __construct(
+        string $filename,
+        int $entityType,
+        string $langIso,
+        array $options = [],
+        bool $validateOnly = false,
+        ?ShopConstraint $shopConstraint = null
+    ) {
+        if (!in_array($entityType, Entity::AVAILABLE_TYPES, true)) {
+            throw new ImportException(sprintf('Import entity type "%d" is not supported.', $entityType));
+        }
+
+        $this->filename = $filename;
+        $this->entityType = $entityType;
+        $this->langIso = $langIso;
+        $this->options = $options;
+        $this->validateOnly = $validateOnly;
+        $this->shopConstraint = $shopConstraint;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    public function getEntityType(): int
+    {
+        return $this->entityType;
+    }
+
+    public function getLangIso(): string
+    {
+        return $this->langIso;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOption(string $name, $default = null)
+    {
+        return $this->options[$name] ?? $default;
+    }
+
+    /**
+     * @return array<int, string> column index => entity field name
+     */
+    public function getDataMapping(): array
+    {
+        return (array) $this->getOption('data_mapping', []);
+    }
+
+    public function isValidateOnly(): bool
+    {
+        return $this->validateOnly;
+    }
+
+    public function getShopConstraint(): ?ShopConstraint
+    {
+        return $this->shopConstraint;
+    }
+}

--- a/src/Core/Domain/Import/CommandHandler/ImportCsvFromFileHandlerInterface.php
+++ b/src/Core/Domain/Import/CommandHandler/ImportCsvFromFileHandlerInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Import\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Import\Command\ImportCsvFromFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
+
+/**
+ * Defines the contract for running a CSV import through the façade command.
+ *
+ * The interface stays stable across the import migration: today the concrete
+ * handler wires the existing Importer / legacy controller, later stories will
+ * dispatch the ImportRun aggregate behind the very same method.
+ */
+interface ImportCsvFromFileHandlerInterface
+{
+    public function handle(ImportCsvFromFileCommand $command): ImportResult;
+}

--- a/src/Core/Domain/Import/CommandHandler/ImportCsvFromFileHandlerInterface.php
+++ b/src/Core/Domain/Import/CommandHandler/ImportCsvFromFileHandlerInterface.php
@@ -17,6 +17,11 @@ use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
  * The interface stays stable across the import migration: today the concrete
  * handler wires the existing Importer / legacy controller, later stories will
  * dispatch the ImportRun aggregate behind the very same method.
+ *
+ * Assumed deviation from the usual "commands return void/an id" rule: this command
+ * intentionally returns an ImportResult. The report (errors/warnings/notices/counts)
+ * is the façade's contract — it is what the safety-net scenarios assert against and
+ * what the UI needs back from a run — so it is returned synchronously here.
  */
 interface ImportCsvFromFileHandlerInterface
 {

--- a/src/Core/Domain/Import/Exception/ImportException.php
+++ b/src/Core/Domain/Import/Exception/ImportException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Import\Exception;
+
+use Exception;
+
+/**
+ * Base exception for the Import domain.
+ */
+class ImportException extends Exception
+{
+}

--- a/src/Core/Domain/Import/Result/ImportResult.php
+++ b/src/Core/Domain/Import/Result/ImportResult.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Import\Result;
+
+/**
+ * Executor-agnostic report returned by ImportCsvFromFileHandler.
+ *
+ * Both the modern Importer and the legacy AdminImportController paths are mapped
+ * into this shape so that consumers (and the Behat safety net) assert against a
+ * stable contract regardless of which executor ran.
+ */
+final class ImportResult
+{
+    /**
+     * @var string[]
+     */
+    private $errors;
+
+    /**
+     * @var string[]
+     */
+    private $warnings;
+
+    /**
+     * @var string[]
+     */
+    private $notices;
+
+    /**
+     * @var int number of rows actually processed
+     */
+    private $doneCount;
+
+    /**
+     * @var int total number of importable rows in the file
+     */
+    private $totalCount;
+
+    /**
+     * @param string[] $errors
+     * @param string[] $warnings
+     * @param string[] $notices
+     * @param int $doneCount
+     * @param int $totalCount
+     */
+    public function __construct(
+        array $errors = [],
+        array $warnings = [],
+        array $notices = [],
+        int $doneCount = 0,
+        int $totalCount = 0
+    ) {
+        $this->errors = array_values($errors);
+        $this->warnings = array_values($warnings);
+        $this->notices = array_values($notices);
+        $this->doneCount = $doneCount;
+        $this->totalCount = $totalCount;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getWarnings(): array
+    {
+        return $this->warnings;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNotices(): array
+    {
+        return $this->notices;
+    }
+
+    public function hasErrors(): bool
+    {
+        return [] !== $this->errors;
+    }
+
+    public function getDoneCount(): int
+    {
+        return $this->doneCount;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->totalCount;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/import.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/import.yml
@@ -91,3 +91,12 @@ services:
       - '@PrestaShop\PrestaShop\Adapter\Tools'
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
       - '@prestashop.core.hook.dispatcher'
+
+  PrestaShop\PrestaShop\Adapter\Import\LegacyImportExecutor: ~
+
+  PrestaShop\PrestaShop\Adapter\Import\CommandHandler\ImportCsvFromFileHandler:
+    autoconfigure: true
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Import\ImporterInterface'
+      - '@PrestaShop\PrestaShop\Core\Import\Handler\ImportHandlerFinderInterface'
+      - '@PrestaShop\PrestaShop\Adapter\Import\LegacyImportExecutor'

--- a/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
@@ -22,10 +22,15 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
  * Exercises the import safety net through the ImportCsvFromFileCommand façade.
  *
  * Every scenario dispatches the command via the bus and asserts either against
- * the returned ImportResult or against the persisted data (queried through the
- * Doctrine DBAL connection, never through ObjectModel). The same command covers
+ * the returned ImportResult or against the persisted data. The same command covers
  * both executors: entity types with a modern handler (products, categories) run
  * through the Importer, the others fall back to the legacy controller.
+ *
+ * Assumed deviation: persisted data is read through the Doctrine DBAL connection
+ * rather than the domain repositories. This is deliberate — the repositories only
+ * expose get($id) lookups, not the by-name / by-reference / by-email lookups these
+ * assertions need — and it still respects the rule of never asserting through
+ * ObjectModel.
  */
 class ImportFeatureContext extends AbstractDomainFeatureContext
 {

--- a/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
@@ -1,0 +1,455 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain;
+
+use Behat\Gherkin\Node\TableNode;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Import\Command\ImportCsvFromFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
+use PrestaShop\PrestaShop\Core\Import\Entity;
+use PrestaShop\PrestaShop\Core\Import\ImportSettings;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * Exercises the import safety net through the ImportCsvFromFileCommand façade.
+ *
+ * Every scenario dispatches the command via the bus and asserts either against
+ * the returned ImportResult or against the persisted data (queried through the
+ * Doctrine DBAL connection, never through ObjectModel). The same command covers
+ * both executors: entity types with a modern handler (products, categories) run
+ * through the Importer, the others fall back to the legacy controller.
+ */
+class ImportFeatureContext extends AbstractDomainFeatureContext
+{
+    /**
+     * Boolean-like options that must be cast from their Gherkin string form.
+     */
+    private const BOOLEAN_OPTIONS = ['truncate', 'match_ref', 'forceIDs', 'regenerate'];
+
+    /**
+     * @var ImportResult|null
+     */
+    private $lastImportResult;
+
+    /**
+     * @var string[] absolute paths of fixtures copied into the import directory, cleaned up after each scenario
+     */
+    private $copiedFixtures = [];
+
+    /**
+     * @AfterScenario
+     */
+    public function removeCopiedFixtures(): void
+    {
+        foreach ($this->copiedFixtures as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
+
+        $this->copiedFixtures = [];
+    }
+
+    /**
+     * @When I import :entityType from CSV file :fixture in language :langIso
+     */
+    public function importFile(string $entityType, string $fixture, string $langIso): void
+    {
+        $this->runImport($entityType, $fixture, $langIso, false, []);
+    }
+
+    /**
+     * @When I import :entityType from CSV file :fixture in language :langIso with options:
+     */
+    public function importFileWithOptions(string $entityType, string $fixture, string $langIso, TableNode $options): void
+    {
+        $this->runImport($entityType, $fixture, $langIso, false, $options->getRowsHash());
+    }
+
+    /**
+     * @When I validate the import of :entityType from CSV file :fixture in language :langIso
+     */
+    public function validateImportFile(string $entityType, string $fixture, string $langIso): void
+    {
+        $this->runImport($entityType, $fixture, $langIso, true, []);
+    }
+
+    /**
+     * @When I validate the import of :entityType from CSV file :fixture in language :langIso with options:
+     */
+    public function validateImportFileWithOptions(string $entityType, string $fixture, string $langIso, TableNode $options): void
+    {
+        $this->runImport($entityType, $fixture, $langIso, true, $options->getRowsHash());
+    }
+
+    /**
+     * @Then the import should succeed
+     */
+    public function theImportShouldSucceed(): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        Assert::assertFalse(
+            $this->lastImportResult->hasErrors(),
+            sprintf('Import reported errors: %s', implode(' | ', $this->lastImportResult->getErrors()))
+        );
+    }
+
+    /**
+     * @Then the import should report :count error(s)
+     */
+    public function theImportShouldReportErrors(int $count): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        Assert::assertCount(
+            $count,
+            $this->lastImportResult->getErrors(),
+            sprintf('Reported errors: %s', implode(' | ', $this->lastImportResult->getErrors()))
+        );
+    }
+
+    /**
+     * @Then the import should report at least :count error(s)
+     */
+    public function theImportShouldReportAtLeastErrors(int $count): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        Assert::assertGreaterThanOrEqual(
+            $count,
+            count($this->lastImportResult->getErrors()),
+            sprintf('Reported errors: %s', implode(' | ', $this->lastImportResult->getErrors()))
+        );
+    }
+
+    /**
+     * @Then the import report should contain error :text
+     */
+    public function theImportReportShouldContainError(string $text): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        foreach ($this->lastImportResult->getErrors() as $error) {
+            if (str_contains($error, $text)) {
+                return;
+            }
+        }
+        Assert::fail(sprintf(
+            'No reported error contains "%s". Errors: %s',
+            $text,
+            implode(' | ', $this->lastImportResult->getErrors())
+        ));
+    }
+
+    /**
+     * @Then :count rows should have been processed
+     */
+    public function rowsShouldHaveBeenProcessed(int $count): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        Assert::assertSame($count, $this->lastImportResult->getDoneCount());
+    }
+
+    /**
+     * @Then product with reference :reference should exist
+     */
+    public function productWithReferenceShouldExist(string $reference): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'product WHERE reference = :reference', ['reference' => $reference]),
+            sprintf('Expected exactly one product with reference "%s".', $reference)
+        );
+    }
+
+    /**
+     * @Then product with id :id should exist
+     */
+    public function productWithIdShouldExist(int $id): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'product WHERE id_product = :id', ['id' => $id]),
+            sprintf('Expected product with id %d to exist.', $id)
+        );
+    }
+
+    /**
+     * @Then product :name should exist
+     */
+    public function productShouldExist(string $name): void
+    {
+        Assert::assertGreaterThan(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'product_lang WHERE name = :name AND id_lang = :langId',
+                ['name' => $name, 'langId' => $this->resolveLangId('en')]
+            ),
+            sprintf('Expected product "%s" to exist.', $name)
+        );
+    }
+
+    /**
+     * @Then product :name should not exist
+     */
+    public function productShouldNotExist(string $name): void
+    {
+        Assert::assertSame(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'product_lang WHERE name = :name AND id_lang = :langId',
+                ['name' => $name, 'langId' => $this->resolveLangId('en')]
+            ),
+            sprintf('Expected product "%s" not to exist.', $name)
+        );
+    }
+
+    /**
+     * @Then product :name should have price :price
+     */
+    public function productShouldHavePrice(string $name, string $price): void
+    {
+        $actual = $this->getConnection()->executeQuery(
+            'SELECT p.price FROM ' . $this->prefix() . 'product p'
+            . ' INNER JOIN ' . $this->prefix() . 'product_lang pl ON pl.id_product = p.id_product'
+            . ' WHERE pl.name = :name AND pl.id_lang = :langId',
+            ['name' => $name, 'langId' => $this->resolveLangId('en')]
+        )->fetchOne();
+
+        Assert::assertNotFalse($actual, sprintf('Product "%s" not found.', $name));
+        Assert::assertEqualsWithDelta((float) $price, (float) $actual, 0.001);
+    }
+
+    /**
+     * @Then category :name should exist
+     */
+    public function categoryShouldExist(string $name): void
+    {
+        Assert::assertGreaterThan(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'category_lang WHERE name = :name AND id_lang = :langId',
+                ['name' => $name, 'langId' => $this->resolveLangId('en')]
+            ),
+            sprintf('Expected category "%s" to exist.', $name)
+        );
+    }
+
+    /**
+     * @Then category :name should not exist
+     */
+    public function categoryShouldNotExist(string $name): void
+    {
+        Assert::assertSame(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'category_lang WHERE name = :name AND id_lang = :langId',
+                ['name' => $name, 'langId' => $this->resolveLangId('en')]
+            ),
+            sprintf('Expected category "%s" not to exist.', $name)
+        );
+    }
+
+    /**
+     * @Then customer with email :email should exist
+     */
+    public function customerWithEmailShouldExist(string $email): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'customer WHERE email = :email', ['email' => $email]),
+            sprintf('Expected exactly one customer with email "%s".', $email)
+        );
+    }
+
+    /**
+     * @Then customer with email :email should not exist
+     */
+    public function customerWithEmailShouldNotExist(string $email): void
+    {
+        Assert::assertSame(
+            0,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'customer WHERE email = :email', ['email' => $email]),
+            sprintf('Expected no customer with email "%s".', $email)
+        );
+    }
+
+    /**
+     * @Then customer with email :email should have last name :lastName
+     */
+    public function customerShouldHaveLastName(string $email, string $lastName): void
+    {
+        $actual = $this->getConnection()->executeQuery(
+            'SELECT lastname FROM ' . $this->prefix() . 'customer WHERE email = :email',
+            ['email' => $email]
+        )->fetchOne();
+
+        Assert::assertNotFalse($actual, sprintf('Customer "%s" not found.', $email));
+        Assert::assertSame($lastName, $actual);
+    }
+
+    private function runImport(string $entityType, string $fixture, string $langIso, bool $validateOnly, array $rawOptions): void
+    {
+        $this->ensureRequestWithSession();
+        $this->copyFixtureToImportDirectory($fixture);
+
+        $options = $this->normalizeOptions($rawOptions);
+        $separator = $options['separator'] ?? ImportSettings::DEFAULT_SEPARATOR;
+        $options['data_mapping'] = $this->buildMappingFromHeader($fixture, $separator);
+        // The fixtures carry a header row naming each field, so skip it by default.
+        $options['skip'] = isset($options['skip']) ? (int) $options['skip'] : 1;
+
+        $command = new ImportCsvFromFileCommand(
+            $fixture,
+            Entity::getFromName($entityType),
+            $langIso,
+            $options,
+            $validateOnly
+        );
+
+        $this->lastImportResult = $this->dispatchSwallowingLegacyWarnings($command);
+    }
+
+    /**
+     * The legacy import code (and the partially migrated handlers it shares helpers with) emit PHP
+     * warnings/notices that are harmless at runtime — production suppresses them — but the test kernel's
+     * debug error handler promotes them to exceptions. Since this safety net locks the import OUTCOME,
+     * not the notice-cleanliness of code we are explicitly not allowed to touch, warnings are swallowed
+     * for the duration of the dispatch only.
+     */
+    private function dispatchSwallowingLegacyWarnings(ImportCsvFromFileCommand $command): ImportResult
+    {
+        set_error_handler(
+            static fn (int $severity): bool => in_array($severity, [E_WARNING, E_NOTICE, E_DEPRECATED, E_USER_DEPRECATED], true)
+        );
+
+        try {
+            return $this->getCommandBus()->handle($command);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * @param array<string, string> $rawOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeOptions(array $rawOptions): array
+    {
+        $options = $rawOptions;
+        foreach (self::BOOLEAN_OPTIONS as $key) {
+            if (isset($options[$key])) {
+                $options[$key] = filter_var($options[$key], FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Reads the fixture header row and turns it into a column index => field name mapping,
+     * matching the "type_value" format consumed by both the modern and legacy executors.
+     *
+     * @return array<int, string>
+     */
+    private function buildMappingFromHeader(string $fixture, string $separator): array
+    {
+        $handle = fopen($this->getImportDirectory() . $fixture, 'rb');
+        if (false === $handle) {
+            throw new RuntimeException(sprintf('Unable to read import fixture "%s".', $fixture));
+        }
+
+        $header = fgetcsv($handle, 0, $separator, '"', '');
+        fclose($handle);
+
+        if (false === $header) {
+            throw new RuntimeException(sprintf('Import fixture "%s" has no header row.', $fixture));
+        }
+
+        $mapping = [];
+        foreach ($header as $index => $field) {
+            $field = trim((string) $field);
+            $mapping[$index] = '' === $field ? 'no' : $field;
+        }
+
+        return $mapping;
+    }
+
+    private function copyFixtureToImportDirectory(string $fixture): void
+    {
+        $source = dirname(__DIR__, 5) . '/Resources/import/' . $fixture;
+        if (!is_file($source)) {
+            throw new RuntimeException(sprintf('Import fixture "%s" not found at %s.', $fixture, $source));
+        }
+
+        $directory = $this->getImportDirectory();
+        if (!is_dir($directory) && !mkdir($directory, 0777, true) && !is_dir($directory)) {
+            throw new RuntimeException(sprintf('Unable to create import directory "%s".', $directory));
+        }
+
+        $destination = $directory . $fixture;
+        if (!copy($source, $destination)) {
+            throw new RuntimeException(sprintf('Unable to copy import fixture "%s" to %s.', $fixture, $destination));
+        }
+
+        $this->copiedFixtures[$destination] = $destination;
+    }
+
+    /**
+     * The modern CSV reader pulls its separator from the session at build time, so a request
+     * carrying a session must be on the stack before the Importer is instantiated. The CLI/Behat
+     * runtime has none, so we push a minimal one (the legacy executor is unaffected: it reads $_POST).
+     */
+    private function ensureRequestWithSession(): void
+    {
+        $requestStack = $this->getContainer()->get('request_stack');
+        if (null !== $requestStack->getCurrentRequest()) {
+            return;
+        }
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('separator', ImportSettings::DEFAULT_SEPARATOR);
+        $session->set('multiple_value_separator', ImportSettings::DEFAULT_MULTIVALUE_SEPARATOR);
+
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack->push($request);
+    }
+
+    private function getImportDirectory(): string
+    {
+        return (string) $this->getContainer()->get('prestashop.core.import.dir');
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->getContainer()->get('doctrine.dbal.default_connection');
+    }
+
+    private function prefix(): string
+    {
+        return (string) $this->getContainer()->getParameter('database_prefix');
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function count(string $sql, array $params): int
+    {
+        return (int) $this->getConnection()->executeQuery($sql, $params)->fetchOne();
+    }
+
+    private function resolveLangId(string $iso): int
+    {
+        return (int) $this->getConnection()->executeQuery(
+            'SELECT id_lang FROM ' . $this->prefix() . 'lang WHERE iso_code = :iso',
+            ['iso' => $iso]
+        )->fetchOne();
+    }
+}

--- a/tests/Integration/Behaviour/Features/Scenario/Import/category.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/category.feature
@@ -1,0 +1,33 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s import tests/Integration/Behaviour/Features/Scenario/Import/category.feature
+Feature: Import categories from a CSV file
+  As an employee
+  I must be able to import categories from a CSV file through the import façade
+  This entity type is executed by the modern Importer
+
+  Scenario: Insert new categories
+    When I import "categories" from CSV file "categories_insert.csv" in language "en"
+    Then the import should succeed
+    And category "Behat Category A" should exist
+    And category "Behat Category B" should exist
+    And category "Behat Category C" should exist
+
+  Scenario: Validate-only mode persists nothing
+    When I validate the import of "categories" from CSV file "categories_insert.csv" in language "en"
+    Then the import should succeed
+    And category "Behat Category A" should not exist
+
+  Scenario: Truncate then import replaces the existing categories
+    When I import "categories" from CSV file "categories_insert.csv" in language "en"
+    And I import "categories" from CSV file "categories_truncate.csv" in language "en" with options:
+      | truncate | true |
+    Then category "Behat Category A" should not exist
+    And category "Behat Truncated X" should exist
+    And category "Behat Truncated Y" should exist
+
+  Scenario: A malformed row is reported and the neighbouring rows still import
+    When I import "categories" from CSV file "categories_malformed.csv" in language "en"
+    Then the import should report at least 1 error
+    And category "Behat Valid One" should exist
+    And category "Behat Valid Two" should exist

--- a/tests/Integration/Behaviour/Features/Scenario/Import/customer.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/customer.feature
@@ -1,0 +1,25 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s import tests/Integration/Behaviour/Features/Scenario/Import/customer.feature
+Feature: Import customers from a CSV file
+  As an employee
+  I must be able to import customers from a CSV file through the import façade
+  This entity type has no modern handler yet: it is executed by the legacy controller
+
+  Scenario: Insert new customers
+    When I import "customers" from CSV file "customers_insert.csv" in language "en"
+    Then the import should succeed
+    And customer with email "behat.customer.a@example.com" should exist
+    And customer with email "behat.customer.b@example.com" should exist
+
+  Scenario: Force the row id
+    When I import "customers" from CSV file "customers_forceids.csv" in language "en" with options:
+      | forceIDs | true |
+    Then the import should succeed
+    And customer with email "behat.customer.forced@example.com" should exist
+    And customer with email "behat.customer.forced@example.com" should have last name "Forced"
+
+  Scenario: Validate-only mode persists nothing
+    When I validate the import of "customers" from CSV file "customers_insert.csv" in language "en"
+    Then the import should succeed
+    And customer with email "behat.customer.a@example.com" should not exist

--- a/tests/Integration/Behaviour/Features/Scenario/Import/product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/product.feature
@@ -1,0 +1,46 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s import tests/Integration/Behaviour/Features/Scenario/Import/product.feature
+Feature: Import products from a CSV file
+  As an employee
+  I must be able to import products from a CSV file through the import façade
+  This entity type is executed by the modern Importer
+
+  Scenario: Insert new products
+    When I import "products" from CSV file "products_insert.csv" in language "en"
+    Then the import should succeed
+    And product "Behat Product A" should exist
+    And product "Behat Product B" should exist
+    And product with reference "BEHAT-A" should exist
+
+  Scenario: Update existing products matched by reference
+    When I import "products" from CSV file "products_insert.csv" in language "en"
+    And I import "products" from CSV file "products_update_by_reference.csv" in language "en" with options:
+      | match_ref | true |
+    Then the import should succeed
+    And product "Behat Product A" should have price 15.50
+
+  Scenario: Force the row id
+    When I import "products" from CSV file "products_forceids.csv" in language "en" with options:
+      | forceIDs | true |
+    Then the import should succeed
+    And product with id 9991 should exist
+
+  Scenario: Update an existing product matched by id
+    When I import "products" from CSV file "products_forceids.csv" in language "en" with options:
+      | forceIDs | true |
+    And I import "products" from CSV file "products_update_by_id.csv" in language "en"
+    Then the import should succeed
+    And product "Behat Forced Product" should have price 25.00
+
+  Scenario: Validate-only mode does not update an existing product
+    When I import "products" from CSV file "products_insert.csv" in language "en"
+    And I validate the import of "products" from CSV file "products_update_by_reference.csv" in language "en" with options:
+      | match_ref | true |
+    Then the import should succeed
+    And product "Behat Product A" should have price 10.00
+
+  Scenario: A malformed row is skipped and the neighbouring rows still import
+    When I import "products" from CSV file "products_malformed.csv" in language "en"
+    Then product "Behat Product Valid One" should exist
+    And product "Behat Product Valid Two" should exist

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -65,6 +65,12 @@ default:
       contexts:
         - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\EmailBodyTranslationFeatureContext
+    import:
+      paths:
+        - "%paths.base%/Features/Scenario/Import"
+      contexts:
+        - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\Domain\ImportFeatureContext
     customer:
       paths:
         - "%paths.base%/Features/Scenario/Customer"

--- a/tests/Resources/import/categories_insert.csv
+++ b/tests/Resources/import/categories_insert.csv
@@ -1,0 +1,4 @@
+name;active;parent
+Behat Category A;1;Home
+Behat Category B;1;Home
+Behat Category C;1;Home

--- a/tests/Resources/import/categories_malformed.csv
+++ b/tests/Resources/import/categories_malformed.csv
@@ -1,0 +1,4 @@
+name;active;parent
+Behat Valid One;1;Home
+Behat Valid Two;1;Home
+;1;Home

--- a/tests/Resources/import/categories_truncate.csv
+++ b/tests/Resources/import/categories_truncate.csv
@@ -1,0 +1,3 @@
+name;active;parent
+Behat Truncated X;1;Home
+Behat Truncated Y;1;Home

--- a/tests/Resources/import/customers_forceids.csv
+++ b/tests/Resources/import/customers_forceids.csv
@@ -1,0 +1,2 @@
+id;email;passwd;lastname;firstname;active
+9981;behat.customer.forced@example.com;Azerty123;Forced;Carl;1

--- a/tests/Resources/import/customers_insert.csv
+++ b/tests/Resources/import/customers_insert.csv
@@ -1,0 +1,3 @@
+email;passwd;lastname;firstname;active
+behat.customer.a@example.com;Azerty123;Doe;John;1
+behat.customer.b@example.com;Azerty123;Roe;Jane;1

--- a/tests/Resources/import/products_forceids.csv
+++ b/tests/Resources/import/products_forceids.csv
@@ -1,0 +1,2 @@
+id;name;reference;price_tex;quantity;active;category
+9991;Behat Forced Product;BEHAT-FORCED;12.00;30;1;Home

--- a/tests/Resources/import/products_insert.csv
+++ b/tests/Resources/import/products_insert.csv
@@ -1,0 +1,3 @@
+name;reference;price_tex;quantity;active;category
+Behat Product A;BEHAT-A;10.00;100;1;Home
+Behat Product B;BEHAT-B;20.00;50;1;Home

--- a/tests/Resources/import/products_malformed.csv
+++ b/tests/Resources/import/products_malformed.csv
@@ -1,0 +1,4 @@
+name;reference;price_tex;quantity;active;category
+Behat Product Valid One;BEHAT-V1;10.00;100;1;Home
+Behat Product Valid Two;BEHAT-V2;30.00;25;1;Home
+;BEHAT-INVALID;20.00;50;1;Home

--- a/tests/Resources/import/products_update_by_id.csv
+++ b/tests/Resources/import/products_update_by_id.csv
@@ -1,0 +1,2 @@
+id;name;reference;price_tex;quantity;active;category
+9991;Behat Forced Product;BEHAT-FORCED;25.00;30;1;Home

--- a/tests/Resources/import/products_update_by_reference.csv
+++ b/tests/Resources/import/products_update_by_reference.csv
@@ -1,0 +1,2 @@
+name;reference;price_tex;quantity;active;category
+Behat Product A;BEHAT-A;15.50;100;1;Home


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Story 1 of the Import admin page migration (#41321). Adds a thin façade `ImportCsvFromFileCommand` (+ handler interface, concrete handler and an executor-agnostic `ImportResult`) that hides which executor runs underneath, and a Behat regression suite that locks the current import behaviour for the first 3 entity types. No change to the legacy controller. The façade routes products/categories to the modern `Importer` and customers (no modern handler yet) to the legacy `AdminImportController` via a dedicated `LegacyImportExecutor`, so Story 2's executor swap cannot silently break either path.
| Type?             | new feature
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Provision the test DB (`composer create-test-db`) then run the suite:<br>`./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s import`<br>All 13 scenarios (51 steps) must be green. The suite covers **both executors**:<br>• **Modern `Importer`** — `product.feature` (insert, update by reference, force id, update by id, validate-only, malformed row) and `category.feature` (insert, validate-only, truncate, malformed row).<br>• **Legacy `AdminImportController`** — `customer.feature` (insert, force id, validate-only).
| UI Tests          | N/A (Behat only in this PR; Playwright campaigns come in a later PR of this story)
| Fixed issue or discussion?     | Part of #41798
| Related PRs       | Follow-ups of #41798: PR 2 (remaining 6 entity types + multistore + share_customer), PR 3 (Playwright campaigns).
| Sponsor company   | @PrestaShopCorp

### Notes

This is the **only** production-code change of the story: the façade command + handler + legacy executor. The legacy controller is not modified.

A few current behaviours are locked as-is (they differ from a naive expectation and are worth knowing for Story 2):
- **Products in validate-only mode still persist a *new* product** (`ProductImportHandler::loadProductData` calls `$product->add()` unconditionally), so the product validate-only scenario asserts that an *update* is not applied rather than non-persistence.
- **Malformed row handling differs per executor**: categories report an error and the rows *after* the bad one are skipped (the handler gates on `empty($this->getErrors())`); products skip the invalid row silently with no error. Fixtures place the invalid row last accordingly.

Deferred to PR 2 (with the other legacy entities): customer *update by id*, which depends on the legacy customer/shop save branch.

### Known tradeoffs

- **The façade command returns an `ImportResult`** (instead of the usual void/id). The report — errors/warnings/notices/counts — is the façade's contract: it is what the Behat scenarios assert against and what the UI needs back from a run, so it is returned synchronously. Documented on the handler interface.
- **The Behat context reads persisted data through the Doctrine DBAL connection, not the domain repositories.** The repositories only expose `get($id)`, not the by-name / by-reference / by-email lookups the assertions need. This still respects the rule of never asserting through ObjectModel.
- **`LegacyImportExecutor` drives the legacy controller through `$_POST`/`$_GET` and one reflection call** (to inject the container `init()` would normally set). This is the deliberate bridge to the legacy executor for the 7 entity types without a modern handler; the legacy controller itself is untouched.


