### PR TITLE
Add import Behat coverage for the 6 remaining entity types and multistore (Story 1, part 2)

### DIFF
--- a/src/Adapter/Import/CommandHandler/ImportCsvFromFileHandler.php
+++ b/src/Adapter/Import/CommandHandler/ImportCsvFromFileHandler.php
@@ -17,6 +17,7 @@ use PrestaShop\PrestaShop\Core\Import\Configuration\ImportConfig;
 use PrestaShop\PrestaShop\Core\Import\Configuration\ImportRuntimeConfig;
 use PrestaShop\PrestaShop\Core\Import\Exception\NotSupportedImportTypeException;
 use PrestaShop\PrestaShop\Core\Import\Handler\ImportHandlerFinderInterface;
+use PrestaShop\PrestaShop\Core\Import\Handler\ImportHandlerInterface;
 use PrestaShop\PrestaShop\Core\Import\ImporterInterface;
 use PrestaShop\PrestaShop\Core\Import\ImportSettings;
 
@@ -64,7 +65,7 @@ final class ImportCsvFromFileHandler implements ImportCsvFromFileHandlerInterfac
         return $this->runModernImport($command, $importHandler);
     }
 
-    private function runModernImport(ImportCsvFromFileCommand $command, $importHandler): ImportResult
+    private function runModernImport(ImportCsvFromFileCommand $command, ImportHandlerInterface $importHandler): ImportResult
     {
         $importConfig = $this->buildImportConfig($command);
         $mapping = $command->getDataMapping();

--- a/src/Adapter/Import/CommandHandler/ImportCsvFromFileHandler.php
+++ b/src/Adapter/Import/CommandHandler/ImportCsvFromFileHandler.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Import\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Import\LegacyImportExecutor;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Import\Command\ImportCsvFromFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Import\CommandHandler\ImportCsvFromFileHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
+use PrestaShop\PrestaShop\Core\Import\Configuration\ImportConfig;
+use PrestaShop\PrestaShop\Core\Import\Configuration\ImportRuntimeConfig;
+use PrestaShop\PrestaShop\Core\Import\Exception\NotSupportedImportTypeException;
+use PrestaShop\PrestaShop\Core\Import\Handler\ImportHandlerFinderInterface;
+use PrestaShop\PrestaShop\Core\Import\ImporterInterface;
+use PrestaShop\PrestaShop\Core\Import\ImportSettings;
+
+/**
+ * Façade handler routing a CSV import either to the modern Importer (for entity
+ * types that own a handler) or to the legacy AdminImportController (for the rest),
+ * returning a single executor-agnostic ImportResult.
+ *
+ * This is the only production wiring added by the import safety-net story; the
+ * interface stays stable so a later story can swap the internals for the
+ * ImportRun aggregate without touching the callers or the Behat scenarios.
+ *
+ * @internal
+ */
+#[AsCommandHandler]
+final class ImportCsvFromFileHandler implements ImportCsvFromFileHandlerInterface
+{
+    /**
+     * Number of rows processed per Importer iteration; the loop advances the
+     * offset until the import reports completion.
+     */
+    private const BATCH_SIZE = 100;
+
+    /**
+     * Safety bound to avoid an infinite loop if the import never completes.
+     */
+    private const MAX_ITERATIONS = 100000;
+
+    public function __construct(
+        private readonly ImporterInterface $importer,
+        private readonly ImportHandlerFinderInterface $importHandlerFinder,
+        private readonly LegacyImportExecutor $legacyImportExecutor,
+    ) {
+    }
+
+    public function handle(ImportCsvFromFileCommand $command): ImportResult
+    {
+        try {
+            $importHandler = $this->importHandlerFinder->find($command->getEntityType());
+        } catch (NotSupportedImportTypeException) {
+            // No modern handler for this entity type: fall back to the legacy controller.
+            return $this->legacyImportExecutor->execute($command);
+        }
+
+        return $this->runModernImport($command, $importHandler);
+    }
+
+    private function runModernImport(ImportCsvFromFileCommand $command, $importHandler): ImportResult
+    {
+        $importConfig = $this->buildImportConfig($command);
+        $mapping = $command->getDataMapping();
+
+        $errors = [];
+        $warnings = [];
+        $notices = [];
+        $doneCount = 0;
+        $totalCount = 0;
+        $sharedData = [];
+        $offset = 0;
+        $finished = false;
+        $iteration = 0;
+
+        do {
+            $runtimeConfig = new ImportRuntimeConfig(
+                $command->isValidateOnly(),
+                $offset,
+                self::BATCH_SIZE,
+                $sharedData,
+                $mapping
+            );
+
+            $this->importer->import($importConfig, $runtimeConfig, $importHandler);
+
+            $report = $runtimeConfig->toArray();
+            $sharedData = $runtimeConfig->getSharedData();
+            $errors = $report['errors'] ?? [];
+            $warnings = $report['warnings'] ?? [];
+            $notices = $report['notices'] ?? [];
+            $doneCount = (int) ($report['doneCount'] ?? $doneCount);
+            $totalCount = max($totalCount, (int) ($report['totalCount'] ?? 0), $doneCount);
+
+            $finished = $runtimeConfig->isFinished();
+            $offset = $doneCount;
+        } while (!$finished && ++$iteration < self::MAX_ITERATIONS);
+
+        return new ImportResult(
+            $this->normalizeMessages($errors),
+            $this->normalizeMessages($warnings),
+            $this->normalizeMessages($notices),
+            $doneCount,
+            $totalCount
+        );
+    }
+
+    private function buildImportConfig(ImportCsvFromFileCommand $command): ImportConfig
+    {
+        $options = $command->getOptions();
+
+        return new ImportConfig(
+            $command->getFilename(),
+            $command->getEntityType(),
+            $command->getLangIso(),
+            $options['separator'] ?? ImportSettings::DEFAULT_SEPARATOR,
+            $options['multiple_value_separator'] ?? ImportSettings::DEFAULT_MULTIVALUE_SEPARATOR,
+            !empty($options['truncate']),
+            !empty($options['regenerate']),
+            !empty($options['match_ref']),
+            !empty($options['forceIDs']),
+            false,
+            (int) ($options['skip'] ?? 0)
+        );
+    }
+
+    /**
+     * @param mixed $messages
+     *
+     * @return string[]
+     */
+    private function normalizeMessages($messages): array
+    {
+        if (!is_array($messages)) {
+            return [];
+        }
+
+        return array_values(array_map(static fn ($message): string => (string) $message, $messages));
+    }
+}

--- a/src/Adapter/Import/LegacyImportExecutor.php
+++ b/src/Adapter/Import/LegacyImportExecutor.php
@@ -14,6 +14,7 @@ use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Domain\Import\Command\ImportCsvFromFileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
 use PrestaShop\PrestaShop\Core\Import\ImportSettings;
+use ReflectionClass;
 use ReflectionProperty;
 
 /**
@@ -50,6 +51,7 @@ final class LegacyImportExecutor
             'get' => $_GET,
         ];
 
+        $this->resetLegacyStaticState();
         $this->applyRequestParameters($command);
 
         try {
@@ -115,6 +117,22 @@ final class LegacyImportExecutor
             $_POST = $backup['post'];
             $_GET = $backup['get'];
         }
+    }
+
+    /**
+     * The legacy controller keeps its column mapping, validators and default values in public static
+     * properties that the constructor only adds to (never fully resets). When several entity types are
+     * imported in the same process they would otherwise leak into each other (e.g. the store-contact
+     * import marking "address1" as a multilang field, which then breaks the address import). Restore the
+     * declared defaults before each run.
+     */
+    private function resetLegacyStaticState(): void
+    {
+        $defaults = (new ReflectionClass(AdminImportController::class))->getDefaultProperties();
+
+        AdminImportController::$validators = $defaults['validators'];
+        AdminImportController::$default_values = $defaults['default_values'];
+        AdminImportController::$column_mask = $defaults['column_mask'];
     }
 
     private function injectContainer(AdminImportController $controller): void

--- a/src/Adapter/Import/LegacyImportExecutor.php
+++ b/src/Adapter/Import/LegacyImportExecutor.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Import;
+
+use AdminImportController;
+use Controller;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Domain\Import\Command\ImportCsvFromFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
+use PrestaShop\PrestaShop\Core\Import\ImportSettings;
+use ReflectionProperty;
+
+/**
+ * Drives the legacy AdminImportController for the entity types that do not own a
+ * modern import handler yet (customers, addresses, manufacturers, suppliers,
+ * combinations, aliases, store contacts).
+ *
+ * The legacy controller is entirely request/context driven: it reads its inputs
+ * through Tools::getValue() and accumulates messages on its public $errors /
+ * $warnings / $informations properties. This adapter isolates that coupling so
+ * the command handler stays clean, and maps the outcome onto an ImportResult.
+ *
+ * Nothing in the legacy controller is modified — it is invoked as-is.
+ */
+final class LegacyImportExecutor
+{
+    /**
+     * Number of rows handled per importByGroups() call. The loop below keeps
+     * advancing the offset until the controller reports the import is finished,
+     * so this only controls batch granularity, not the total imported.
+     */
+    private const BATCH_SIZE = 100;
+
+    /**
+     * Safety bound to avoid an infinite loop if the controller never reports
+     * completion (e.g. an unreadable file).
+     */
+    private const MAX_ITERATIONS = 100000;
+
+    public function execute(ImportCsvFromFileCommand $command): ImportResult
+    {
+        $backup = [
+            'post' => $_POST,
+            'get' => $_GET,
+        ];
+
+        $this->applyRequestParameters($command);
+
+        try {
+            // The constructor reads "entity"/"separator" to build the field map,
+            // so the request parameters must be applied beforehand.
+            $controller = new AdminImportController();
+            // The controller's row methods resolve services through its container, which is normally
+            // wired by init(). We invoke importByGroups() directly, so inject the container ourselves.
+            $this->injectContainer($controller);
+
+            $doneCount = 0;
+            $totalCount = 0;
+            $offset = 0;
+            $moreStep = 0;
+            $crossStepsVariables = [];
+            $finished = false;
+            $iteration = 0;
+
+            do {
+                $_POST['offset'] = $offset;
+                $_POST['moreStep'] = $moreStep;
+                $_POST['crossStepsVars'] = json_encode($crossStepsVariables);
+
+                $results = [];
+                $controller->importByGroups(
+                    $offset,
+                    self::BATCH_SIZE,
+                    $results,
+                    $command->isValidateOnly(),
+                    $moreStep
+                );
+
+                if (isset($results['crossStepsVariables'])) {
+                    $crossStepsVariables = $results['crossStepsVariables'];
+                }
+                if (isset($results['totalCount'])) {
+                    $totalCount = (int) $results['totalCount'];
+                }
+
+                $finished = !empty($results['isFinished']);
+
+                if ($finished && isset($results['oneMoreStep'])) {
+                    // The controller requested an additional pass (e.g. linking
+                    // accessories): restart from the beginning for that step.
+                    $moreStep = (int) $results['oneMoreStep'];
+                    $offset = 0;
+                    $finished = false;
+                } elseif ($finished) {
+                    $doneCount = (int) ($results['doneCount'] ?? $offset);
+                } else {
+                    $offset = (int) ($results['doneCount'] ?? ($offset + self::BATCH_SIZE));
+                }
+            } while (!$finished && ++$iteration < self::MAX_ITERATIONS);
+
+            return new ImportResult(
+                $this->normalizeMessages($controller->errors),
+                $this->normalizeMessages($controller->warnings),
+                $this->normalizeMessages($controller->informations),
+                $doneCount,
+                $totalCount
+            );
+        } finally {
+            $_POST = $backup['post'];
+            $_GET = $backup['get'];
+        }
+    }
+
+    private function injectContainer(AdminImportController $controller): void
+    {
+        if (null !== $controller->getContainer()) {
+            return;
+        }
+
+        $property = new ReflectionProperty(Controller::class, 'container');
+        $property->setValue($controller, SymfonyContainer::getInstance());
+    }
+
+    /**
+     * Populates the request parameters the legacy controller reads through
+     * Tools::getValue(). In the test environment Tools::getValue() falls back to
+     * the $_POST/$_GET superglobals, which is what the Behat safety net relies on.
+     */
+    private function applyRequestParameters(ImportCsvFromFileCommand $command): void
+    {
+        $options = $command->getOptions();
+
+        $parameters = [
+            'entity' => $command->getEntityType(),
+            'csv' => $command->getFilename(),
+            'iso_lang' => $command->getLangIso(),
+            'separator' => $options['separator'] ?? ImportSettings::DEFAULT_SEPARATOR,
+            'multiple_value_separator' => $options['multiple_value_separator'] ?? ImportSettings::DEFAULT_MULTIVALUE_SEPARATOR,
+            'truncate' => !empty($options['truncate']) ? 1 : 0,
+            'forceIDs' => !empty($options['forceIDs']) ? 1 : 0,
+            'match_ref' => !empty($options['match_ref']) ? 1 : 0,
+            'regenerate' => !empty($options['regenerate']) ? 1 : 0,
+            'skip' => (int) ($options['skip'] ?? 0),
+            'type_value' => $command->getDataMapping(),
+            'validateOnly' => $command->isValidateOnly() ? 1 : 0,
+        ];
+
+        foreach ($parameters as $key => $value) {
+            $_POST[$key] = $value;
+            $_GET[$key] = $value;
+        }
+    }
+
+    /**
+     * @param mixed $messages
+     *
+     * @return string[]
+     */
+    private function normalizeMessages($messages): array
+    {
+        if (!is_array($messages)) {
+            return [];
+        }
+
+        return array_values(array_map(static fn ($message): string => (string) $message, $messages));
+    }
+}

--- a/src/Core/Domain/Import/Command/ImportCsvFromFileCommand.php
+++ b/src/Core/Domain/Import/Command/ImportCsvFromFileCommand.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Import\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Import\Exception\ImportException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Import\Entity;
+
+/**
+ * Thin façade command running a full CSV import for a given entity type.
+ *
+ * It hides which executor runs underneath (the modern Importer for entity types
+ * that own a handler, or the legacy AdminImportController row methods for the
+ * others) so that consumers never need to know about that split.
+ */
+final class ImportCsvFromFileCommand
+{
+    /**
+     * @var string name of the CSV file located in the import directory
+     */
+    private $filename;
+
+    /**
+     * @var int one of Entity::TYPE_*
+     */
+    private $entityType;
+
+    /**
+     * @var string language ISO code used for multilingual fields
+     */
+    private $langIso;
+
+    /**
+     * @var array<string, mixed> import options, e.g.:
+     *                           - data_mapping: array<int, string> column index => entity field name
+     *                           - truncate: bool
+     *                           - match_ref: bool
+     *                           - forceIDs: bool
+     *                           - regenerate: bool
+     *                           - separator: string
+     *                           - multiple_value_separator: string
+     *                           - skip: int
+     */
+    private $options;
+
+    /**
+     * @var bool when true, the import only validates rows and persists nothing
+     */
+    private $validateOnly;
+
+    /**
+     * @var ShopConstraint|null shop context the import runs against (null inherits the BO context)
+     */
+    private $shopConstraint;
+
+    /**
+     * @param string $filename
+     * @param int $entityType
+     * @param string $langIso
+     * @param array<string, mixed> $options
+     * @param bool $validateOnly
+     * @param ShopConstraint|null $shopConstraint
+     *
+     * @throws ImportException when the entity type is not supported
+     */
+    public function __construct(
+        string $filename,
+        int $entityType,
+        string $langIso,
+        array $options = [],
+        bool $validateOnly = false,
+        ?ShopConstraint $shopConstraint = null
+    ) {
+        if (!in_array($entityType, Entity::AVAILABLE_TYPES, true)) {
+            throw new ImportException(sprintf('Import entity type "%d" is not supported.', $entityType));
+        }
+
+        $this->filename = $filename;
+        $this->entityType = $entityType;
+        $this->langIso = $langIso;
+        $this->options = $options;
+        $this->validateOnly = $validateOnly;
+        $this->shopConstraint = $shopConstraint;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    public function getEntityType(): int
+    {
+        return $this->entityType;
+    }
+
+    public function getLangIso(): string
+    {
+        return $this->langIso;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOption(string $name, $default = null)
+    {
+        return $this->options[$name] ?? $default;
+    }
+
+    /**
+     * @return array<int, string> column index => entity field name
+     */
+    public function getDataMapping(): array
+    {
+        return (array) $this->getOption('data_mapping', []);
+    }
+
+    public function isValidateOnly(): bool
+    {
+        return $this->validateOnly;
+    }
+
+    public function getShopConstraint(): ?ShopConstraint
+    {
+        return $this->shopConstraint;
+    }
+}

--- a/src/Core/Domain/Import/CommandHandler/ImportCsvFromFileHandlerInterface.php
+++ b/src/Core/Domain/Import/CommandHandler/ImportCsvFromFileHandlerInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Import\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Import\Command\ImportCsvFromFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
+
+/**
+ * Defines the contract for running a CSV import through the façade command.
+ *
+ * The interface stays stable across the import migration: today the concrete
+ * handler wires the existing Importer / legacy controller, later stories will
+ * dispatch the ImportRun aggregate behind the very same method.
+ */
+interface ImportCsvFromFileHandlerInterface
+{
+    public function handle(ImportCsvFromFileCommand $command): ImportResult;
+}

--- a/src/Core/Domain/Import/CommandHandler/ImportCsvFromFileHandlerInterface.php
+++ b/src/Core/Domain/Import/CommandHandler/ImportCsvFromFileHandlerInterface.php
@@ -17,6 +17,11 @@ use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
  * The interface stays stable across the import migration: today the concrete
  * handler wires the existing Importer / legacy controller, later stories will
  * dispatch the ImportRun aggregate behind the very same method.
+ *
+ * Assumed deviation from the usual "commands return void/an id" rule: this command
+ * intentionally returns an ImportResult. The report (errors/warnings/notices/counts)
+ * is the façade's contract — it is what the safety-net scenarios assert against and
+ * what the UI needs back from a run — so it is returned synchronously here.
  */
 interface ImportCsvFromFileHandlerInterface
 {

--- a/src/Core/Domain/Import/Exception/ImportException.php
+++ b/src/Core/Domain/Import/Exception/ImportException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Import\Exception;
+
+use Exception;
+
+/**
+ * Base exception for the Import domain.
+ */
+class ImportException extends Exception
+{
+}

--- a/src/Core/Domain/Import/Result/ImportResult.php
+++ b/src/Core/Domain/Import/Result/ImportResult.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Import\Result;
+
+/**
+ * Executor-agnostic report returned by ImportCsvFromFileHandler.
+ *
+ * Both the modern Importer and the legacy AdminImportController paths are mapped
+ * into this shape so that consumers (and the Behat safety net) assert against a
+ * stable contract regardless of which executor ran.
+ */
+final class ImportResult
+{
+    /**
+     * @var string[]
+     */
+    private $errors;
+
+    /**
+     * @var string[]
+     */
+    private $warnings;
+
+    /**
+     * @var string[]
+     */
+    private $notices;
+
+    /**
+     * @var int number of rows actually processed
+     */
+    private $doneCount;
+
+    /**
+     * @var int total number of importable rows in the file
+     */
+    private $totalCount;
+
+    /**
+     * @param string[] $errors
+     * @param string[] $warnings
+     * @param string[] $notices
+     * @param int $doneCount
+     * @param int $totalCount
+     */
+    public function __construct(
+        array $errors = [],
+        array $warnings = [],
+        array $notices = [],
+        int $doneCount = 0,
+        int $totalCount = 0
+    ) {
+        $this->errors = array_values($errors);
+        $this->warnings = array_values($warnings);
+        $this->notices = array_values($notices);
+        $this->doneCount = $doneCount;
+        $this->totalCount = $totalCount;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getWarnings(): array
+    {
+        return $this->warnings;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNotices(): array
+    {
+        return $this->notices;
+    }
+
+    public function hasErrors(): bool
+    {
+        return [] !== $this->errors;
+    }
+
+    public function getDoneCount(): int
+    {
+        return $this->doneCount;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->totalCount;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/import.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/import.yml
@@ -91,3 +91,12 @@ services:
       - '@PrestaShop\PrestaShop\Adapter\Tools'
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
       - '@prestashop.core.hook.dispatcher'
+
+  PrestaShop\PrestaShop\Adapter\Import\LegacyImportExecutor: ~
+
+  PrestaShop\PrestaShop\Adapter\Import\CommandHandler\ImportCsvFromFileHandler:
+    autoconfigure: true
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Import\ImporterInterface'
+      - '@PrestaShop\PrestaShop\Core\Import\Handler\ImportHandlerFinderInterface'
+      - '@PrestaShop\PrestaShop\Adapter\Import\LegacyImportExecutor'

--- a/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
@@ -14,6 +14,7 @@ use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
 use PrestaShop\PrestaShop\Core\Import\Entity;
 use PrestaShop\PrestaShop\Core\Import\ImportSettings;
 use RuntimeException;
+use Shop;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -185,6 +186,26 @@ class ImportFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then product with reference :reference should be associated to shops :shopReferences
+     */
+    public function productShouldBeAssociatedToShops(string $reference, string $shopReferences): void
+    {
+        foreach (explode(',', $shopReferences) as $shopReference) {
+            $shopReference = trim($shopReference);
+            Assert::assertSame(
+                1,
+                $this->count(
+                    'SELECT COUNT(*) FROM ' . $this->prefix() . 'product_shop ps'
+                    . ' INNER JOIN ' . $this->prefix() . 'product p ON p.id_product = ps.id_product'
+                    . ' WHERE p.reference = :reference AND ps.id_shop = :shopId',
+                    ['reference' => $reference, 'shopId' => $this->referenceToId($shopReference)]
+                ),
+                sprintf('Expected product "%s" to be associated to shop "%s".', $reference, $shopReference)
+            );
+        }
+    }
+
+    /**
      * @Then product :name should exist
      */
     public function productShouldExist(string $name): void
@@ -246,6 +267,44 @@ class ImportFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then category :name should be associated to shops :shopReferences
+     */
+    public function categoryShouldBeAssociatedToShops(string $name, string $shopReferences): void
+    {
+        foreach (explode(',', $shopReferences) as $shopReference) {
+            $shopReference = trim($shopReference);
+            Assert::assertGreaterThanOrEqual(
+                1,
+                $this->count(
+                    'SELECT COUNT(*) FROM ' . $this->prefix() . 'category_shop cs'
+                    . ' INNER JOIN ' . $this->prefix() . 'category_lang cl ON cl.id_category = cs.id_category AND cl.id_lang = :langId'
+                    . ' WHERE cl.name = :name AND cs.id_shop = :shopId',
+                    ['name' => $name, 'langId' => $this->resolveLangId('en'), 'shopId' => $this->referenceToId($shopReference)]
+                ),
+                sprintf('Expected category "%s" to be associated to shop "%s".', $name, $shopReference)
+            );
+        }
+    }
+
+    /**
+     * @Then product with reference :reference should have a combination associated to shop :shopReference
+     */
+    public function combinationShouldBeAssociatedToShop(string $reference, string $shopReference): void
+    {
+        Assert::assertGreaterThan(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'product_attribute_shop pas'
+                . ' INNER JOIN ' . $this->prefix() . 'product_attribute pa ON pa.id_product_attribute = pas.id_product_attribute'
+                . ' INNER JOIN ' . $this->prefix() . 'product p ON p.id_product = pa.id_product'
+                . ' WHERE p.reference = :reference AND pas.id_shop = :shopId',
+                ['reference' => $reference, 'shopId' => $this->referenceToId($shopReference)]
+            ),
+            sprintf('Expected product "%s" to have a combination associated to shop "%s".', $reference, $shopReference)
+        );
+    }
+
+    /**
      * @Then category :name should not exist
      */
     public function categoryShouldNotExist(string $name): void
@@ -257,6 +316,94 @@ class ImportFeatureContext extends AbstractDomainFeatureContext
                 ['name' => $name, 'langId' => $this->resolveLangId('en')]
             ),
             sprintf('Expected category "%s" not to exist.', $name)
+        );
+    }
+
+    /**
+     * @Then manufacturer :name should exist
+     */
+    public function manufacturerShouldExist(string $name): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'manufacturer WHERE name = :name', ['name' => $name]),
+            sprintf('Expected exactly one manufacturer "%s".', $name)
+        );
+    }
+
+    /**
+     * @Then supplier :name should exist
+     */
+    public function supplierShouldExist(string $name): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'supplier WHERE name = :name', ['name' => $name]),
+            sprintf('Expected exactly one supplier "%s".', $name)
+        );
+    }
+
+    /**
+     * @Then alias :alias should exist with search :search
+     */
+    public function aliasShouldExist(string $alias, string $search): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'alias WHERE alias = :alias AND search = :search',
+                ['alias' => $alias, 'search' => $search]
+            ),
+            sprintf('Expected alias "%s" with search "%s".', $alias, $search)
+        );
+    }
+
+    /**
+     * @Then store :name should exist
+     */
+    public function storeShouldExist(string $name): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'store_lang WHERE name = :name AND id_lang = :langId',
+                ['name' => $name, 'langId' => $this->resolveLangId('en')]
+            ),
+            sprintf('Expected exactly one store "%s".', $name)
+        );
+    }
+
+    /**
+     * @Then address :alias should exist for customer :email
+     */
+    public function addressShouldExistForCustomer(string $alias, string $email): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'address a'
+                . ' INNER JOIN ' . $this->prefix() . 'customer c ON c.id_customer = a.id_customer'
+                . ' WHERE a.alias = :alias AND c.email = :email AND a.deleted = 0',
+                ['alias' => $alias, 'email' => $email]
+            ),
+            sprintf('Expected address "%s" for customer "%s".', $alias, $email)
+        );
+    }
+
+    /**
+     * @Then product with reference :reference should have a combination with reference :combinationReference
+     */
+    public function productShouldHaveCombination(string $reference, string $combinationReference): void
+    {
+        Assert::assertGreaterThan(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'product_attribute pa'
+                . ' INNER JOIN ' . $this->prefix() . 'product p ON p.id_product = pa.id_product'
+                . ' WHERE p.reference = :reference AND pa.reference = :combinationReference',
+                ['reference' => $reference, 'combinationReference' => $combinationReference]
+            ),
+            sprintf('Expected product "%s" to have a combination with reference "%s".', $reference, $combinationReference)
         );
     }
 
@@ -296,6 +443,47 @@ class ImportFeatureContext extends AbstractDomainFeatureContext
 
         Assert::assertNotFalse($actual, sprintf('Customer "%s" not found.', $email));
         Assert::assertSame($lastName, $actual);
+    }
+
+    /**
+     * @Given the shop group :groupReference shares its customers
+     */
+    public function shopGroupSharesCustomers(string $groupReference): void
+    {
+        $this->getConnection()->executeStatement(
+            'UPDATE ' . $this->prefix() . 'shop_group SET share_customer = 1 WHERE id_shop_group = :id',
+            ['id' => $this->referenceToId($groupReference)]
+        );
+
+        Shop::resetStaticCache();
+    }
+
+    /**
+     * @Then customer with email :email should be in shop :shopReference
+     */
+    public function customerShouldBeInShop(string $email, string $shopReference): void
+    {
+        $actual = $this->getConnection()->executeQuery(
+            'SELECT id_shop FROM ' . $this->prefix() . 'customer WHERE email = :email',
+            ['email' => $email]
+        )->fetchOne();
+
+        Assert::assertNotFalse($actual, sprintf('Customer "%s" not found.', $email));
+        Assert::assertSame($this->referenceToId($shopReference), (int) $actual);
+    }
+
+    /**
+     * @Then customer with email :email should be shared in shop group :groupReference
+     */
+    public function customerShouldBeSharedInGroup(string $email, string $groupReference): void
+    {
+        $actual = $this->getConnection()->executeQuery(
+            'SELECT id_shop_group FROM ' . $this->prefix() . 'customer WHERE email = :email',
+            ['email' => $email]
+        )->fetchOne();
+
+        Assert::assertNotFalse($actual, sprintf('Customer "%s" not found.', $email));
+        Assert::assertSame($this->referenceToId($groupReference), (int) $actual);
     }
 
     private function runImport(string $entityType, string $fixture, string $langIso, bool $validateOnly, array $rawOptions): void
@@ -398,12 +586,30 @@ class ImportFeatureContext extends AbstractDomainFeatureContext
             throw new RuntimeException(sprintf('Unable to create import directory "%s".', $directory));
         }
 
+        $content = file_get_contents($source);
+        if (false === $content) {
+            throw new RuntimeException(sprintf('Unable to read import fixture "%s".', $fixture));
+        }
+
         $destination = $directory . $fixture;
-        if (!copy($source, $destination)) {
-            throw new RuntimeException(sprintf('Unable to copy import fixture "%s" to %s.', $fixture, $destination));
+        if (false === file_put_contents($destination, $this->replaceReferences($content))) {
+            throw new RuntimeException(sprintf('Unable to write import fixture "%s" to %s.', $fixture, $destination));
         }
 
         $this->copiedFixtures[$destination] = $destination;
+    }
+
+    /**
+     * Replaces {{reference}} placeholders in a fixture with the matching id from shared storage.
+     * Used by multistore fixtures whose shop/group ids are only known at runtime.
+     */
+    private function replaceReferences(string $content): string
+    {
+        return preg_replace_callback(
+            '/\{\{([a-zA-Z0-9_]+)\}\}/',
+            fn (array $matches): string => (string) $this->referenceToId($matches[1]),
+            $content
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
@@ -22,10 +22,15 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
  * Exercises the import safety net through the ImportCsvFromFileCommand façade.
  *
  * Every scenario dispatches the command via the bus and asserts either against
- * the returned ImportResult or against the persisted data (queried through the
- * Doctrine DBAL connection, never through ObjectModel). The same command covers
+ * the returned ImportResult or against the persisted data. The same command covers
  * both executors: entity types with a modern handler (products, categories) run
  * through the Importer, the others fall back to the legacy controller.
+ *
+ * Assumed deviation: persisted data is read through the Doctrine DBAL connection
+ * rather than the domain repositories. This is deliberate — the repositories only
+ * expose get($id) lookups, not the by-name / by-reference / by-email lookups these
+ * assertions need — and it still respects the rule of never asserting through
+ * ObjectModel.
  */
 class ImportFeatureContext extends AbstractDomainFeatureContext
 {

--- a/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ImportFeatureContext.php
@@ -1,0 +1,455 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain;
+
+use Behat\Gherkin\Node\TableNode;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Import\Command\ImportCsvFromFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Import\Result\ImportResult;
+use PrestaShop\PrestaShop\Core\Import\Entity;
+use PrestaShop\PrestaShop\Core\Import\ImportSettings;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * Exercises the import safety net through the ImportCsvFromFileCommand façade.
+ *
+ * Every scenario dispatches the command via the bus and asserts either against
+ * the returned ImportResult or against the persisted data (queried through the
+ * Doctrine DBAL connection, never through ObjectModel). The same command covers
+ * both executors: entity types with a modern handler (products, categories) run
+ * through the Importer, the others fall back to the legacy controller.
+ */
+class ImportFeatureContext extends AbstractDomainFeatureContext
+{
+    /**
+     * Boolean-like options that must be cast from their Gherkin string form.
+     */
+    private const BOOLEAN_OPTIONS = ['truncate', 'match_ref', 'forceIDs', 'regenerate'];
+
+    /**
+     * @var ImportResult|null
+     */
+    private $lastImportResult;
+
+    /**
+     * @var string[] absolute paths of fixtures copied into the import directory, cleaned up after each scenario
+     */
+    private $copiedFixtures = [];
+
+    /**
+     * @AfterScenario
+     */
+    public function removeCopiedFixtures(): void
+    {
+        foreach ($this->copiedFixtures as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
+
+        $this->copiedFixtures = [];
+    }
+
+    /**
+     * @When I import :entityType from CSV file :fixture in language :langIso
+     */
+    public function importFile(string $entityType, string $fixture, string $langIso): void
+    {
+        $this->runImport($entityType, $fixture, $langIso, false, []);
+    }
+
+    /**
+     * @When I import :entityType from CSV file :fixture in language :langIso with options:
+     */
+    public function importFileWithOptions(string $entityType, string $fixture, string $langIso, TableNode $options): void
+    {
+        $this->runImport($entityType, $fixture, $langIso, false, $options->getRowsHash());
+    }
+
+    /**
+     * @When I validate the import of :entityType from CSV file :fixture in language :langIso
+     */
+    public function validateImportFile(string $entityType, string $fixture, string $langIso): void
+    {
+        $this->runImport($entityType, $fixture, $langIso, true, []);
+    }
+
+    /**
+     * @When I validate the import of :entityType from CSV file :fixture in language :langIso with options:
+     */
+    public function validateImportFileWithOptions(string $entityType, string $fixture, string $langIso, TableNode $options): void
+    {
+        $this->runImport($entityType, $fixture, $langIso, true, $options->getRowsHash());
+    }
+
+    /**
+     * @Then the import should succeed
+     */
+    public function theImportShouldSucceed(): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        Assert::assertFalse(
+            $this->lastImportResult->hasErrors(),
+            sprintf('Import reported errors: %s', implode(' | ', $this->lastImportResult->getErrors()))
+        );
+    }
+
+    /**
+     * @Then the import should report :count error(s)
+     */
+    public function theImportShouldReportErrors(int $count): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        Assert::assertCount(
+            $count,
+            $this->lastImportResult->getErrors(),
+            sprintf('Reported errors: %s', implode(' | ', $this->lastImportResult->getErrors()))
+        );
+    }
+
+    /**
+     * @Then the import should report at least :count error(s)
+     */
+    public function theImportShouldReportAtLeastErrors(int $count): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        Assert::assertGreaterThanOrEqual(
+            $count,
+            count($this->lastImportResult->getErrors()),
+            sprintf('Reported errors: %s', implode(' | ', $this->lastImportResult->getErrors()))
+        );
+    }
+
+    /**
+     * @Then the import report should contain error :text
+     */
+    public function theImportReportShouldContainError(string $text): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        foreach ($this->lastImportResult->getErrors() as $error) {
+            if (str_contains($error, $text)) {
+                return;
+            }
+        }
+        Assert::fail(sprintf(
+            'No reported error contains "%s". Errors: %s',
+            $text,
+            implode(' | ', $this->lastImportResult->getErrors())
+        ));
+    }
+
+    /**
+     * @Then :count rows should have been processed
+     */
+    public function rowsShouldHaveBeenProcessed(int $count): void
+    {
+        Assert::assertNotNull($this->lastImportResult, 'No import was run.');
+        Assert::assertSame($count, $this->lastImportResult->getDoneCount());
+    }
+
+    /**
+     * @Then product with reference :reference should exist
+     */
+    public function productWithReferenceShouldExist(string $reference): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'product WHERE reference = :reference', ['reference' => $reference]),
+            sprintf('Expected exactly one product with reference "%s".', $reference)
+        );
+    }
+
+    /**
+     * @Then product with id :id should exist
+     */
+    public function productWithIdShouldExist(int $id): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'product WHERE id_product = :id', ['id' => $id]),
+            sprintf('Expected product with id %d to exist.', $id)
+        );
+    }
+
+    /**
+     * @Then product :name should exist
+     */
+    public function productShouldExist(string $name): void
+    {
+        Assert::assertGreaterThan(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'product_lang WHERE name = :name AND id_lang = :langId',
+                ['name' => $name, 'langId' => $this->resolveLangId('en')]
+            ),
+            sprintf('Expected product "%s" to exist.', $name)
+        );
+    }
+
+    /**
+     * @Then product :name should not exist
+     */
+    public function productShouldNotExist(string $name): void
+    {
+        Assert::assertSame(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'product_lang WHERE name = :name AND id_lang = :langId',
+                ['name' => $name, 'langId' => $this->resolveLangId('en')]
+            ),
+            sprintf('Expected product "%s" not to exist.', $name)
+        );
+    }
+
+    /**
+     * @Then product :name should have price :price
+     */
+    public function productShouldHavePrice(string $name, string $price): void
+    {
+        $actual = $this->getConnection()->executeQuery(
+            'SELECT p.price FROM ' . $this->prefix() . 'product p'
+            . ' INNER JOIN ' . $this->prefix() . 'product_lang pl ON pl.id_product = p.id_product'
+            . ' WHERE pl.name = :name AND pl.id_lang = :langId',
+            ['name' => $name, 'langId' => $this->resolveLangId('en')]
+        )->fetchOne();
+
+        Assert::assertNotFalse($actual, sprintf('Product "%s" not found.', $name));
+        Assert::assertEqualsWithDelta((float) $price, (float) $actual, 0.001);
+    }
+
+    /**
+     * @Then category :name should exist
+     */
+    public function categoryShouldExist(string $name): void
+    {
+        Assert::assertGreaterThan(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'category_lang WHERE name = :name AND id_lang = :langId',
+                ['name' => $name, 'langId' => $this->resolveLangId('en')]
+            ),
+            sprintf('Expected category "%s" to exist.', $name)
+        );
+    }
+
+    /**
+     * @Then category :name should not exist
+     */
+    public function categoryShouldNotExist(string $name): void
+    {
+        Assert::assertSame(
+            0,
+            $this->count(
+                'SELECT COUNT(*) FROM ' . $this->prefix() . 'category_lang WHERE name = :name AND id_lang = :langId',
+                ['name' => $name, 'langId' => $this->resolveLangId('en')]
+            ),
+            sprintf('Expected category "%s" not to exist.', $name)
+        );
+    }
+
+    /**
+     * @Then customer with email :email should exist
+     */
+    public function customerWithEmailShouldExist(string $email): void
+    {
+        Assert::assertSame(
+            1,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'customer WHERE email = :email', ['email' => $email]),
+            sprintf('Expected exactly one customer with email "%s".', $email)
+        );
+    }
+
+    /**
+     * @Then customer with email :email should not exist
+     */
+    public function customerWithEmailShouldNotExist(string $email): void
+    {
+        Assert::assertSame(
+            0,
+            $this->count('SELECT COUNT(*) FROM ' . $this->prefix() . 'customer WHERE email = :email', ['email' => $email]),
+            sprintf('Expected no customer with email "%s".', $email)
+        );
+    }
+
+    /**
+     * @Then customer with email :email should have last name :lastName
+     */
+    public function customerShouldHaveLastName(string $email, string $lastName): void
+    {
+        $actual = $this->getConnection()->executeQuery(
+            'SELECT lastname FROM ' . $this->prefix() . 'customer WHERE email = :email',
+            ['email' => $email]
+        )->fetchOne();
+
+        Assert::assertNotFalse($actual, sprintf('Customer "%s" not found.', $email));
+        Assert::assertSame($lastName, $actual);
+    }
+
+    private function runImport(string $entityType, string $fixture, string $langIso, bool $validateOnly, array $rawOptions): void
+    {
+        $this->ensureRequestWithSession();
+        $this->copyFixtureToImportDirectory($fixture);
+
+        $options = $this->normalizeOptions($rawOptions);
+        $separator = $options['separator'] ?? ImportSettings::DEFAULT_SEPARATOR;
+        $options['data_mapping'] = $this->buildMappingFromHeader($fixture, $separator);
+        // The fixtures carry a header row naming each field, so skip it by default.
+        $options['skip'] = isset($options['skip']) ? (int) $options['skip'] : 1;
+
+        $command = new ImportCsvFromFileCommand(
+            $fixture,
+            Entity::getFromName($entityType),
+            $langIso,
+            $options,
+            $validateOnly
+        );
+
+        $this->lastImportResult = $this->dispatchSwallowingLegacyWarnings($command);
+    }
+
+    /**
+     * The legacy import code (and the partially migrated handlers it shares helpers with) emit PHP
+     * warnings/notices that are harmless at runtime — production suppresses them — but the test kernel's
+     * debug error handler promotes them to exceptions. Since this safety net locks the import OUTCOME,
+     * not the notice-cleanliness of code we are explicitly not allowed to touch, warnings are swallowed
+     * for the duration of the dispatch only.
+     */
+    private function dispatchSwallowingLegacyWarnings(ImportCsvFromFileCommand $command): ImportResult
+    {
+        set_error_handler(
+            static fn (int $severity): bool => in_array($severity, [E_WARNING, E_NOTICE, E_DEPRECATED, E_USER_DEPRECATED], true)
+        );
+
+        try {
+            return $this->getCommandBus()->handle($command);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * @param array<string, string> $rawOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeOptions(array $rawOptions): array
+    {
+        $options = $rawOptions;
+        foreach (self::BOOLEAN_OPTIONS as $key) {
+            if (isset($options[$key])) {
+                $options[$key] = filter_var($options[$key], FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Reads the fixture header row and turns it into a column index => field name mapping,
+     * matching the "type_value" format consumed by both the modern and legacy executors.
+     *
+     * @return array<int, string>
+     */
+    private function buildMappingFromHeader(string $fixture, string $separator): array
+    {
+        $handle = fopen($this->getImportDirectory() . $fixture, 'rb');
+        if (false === $handle) {
+            throw new RuntimeException(sprintf('Unable to read import fixture "%s".', $fixture));
+        }
+
+        $header = fgetcsv($handle, 0, $separator, '"', '');
+        fclose($handle);
+
+        if (false === $header) {
+            throw new RuntimeException(sprintf('Import fixture "%s" has no header row.', $fixture));
+        }
+
+        $mapping = [];
+        foreach ($header as $index => $field) {
+            $field = trim((string) $field);
+            $mapping[$index] = '' === $field ? 'no' : $field;
+        }
+
+        return $mapping;
+    }
+
+    private function copyFixtureToImportDirectory(string $fixture): void
+    {
+        $source = dirname(__DIR__, 5) . '/Resources/import/' . $fixture;
+        if (!is_file($source)) {
+            throw new RuntimeException(sprintf('Import fixture "%s" not found at %s.', $fixture, $source));
+        }
+
+        $directory = $this->getImportDirectory();
+        if (!is_dir($directory) && !mkdir($directory, 0777, true) && !is_dir($directory)) {
+            throw new RuntimeException(sprintf('Unable to create import directory "%s".', $directory));
+        }
+
+        $destination = $directory . $fixture;
+        if (!copy($source, $destination)) {
+            throw new RuntimeException(sprintf('Unable to copy import fixture "%s" to %s.', $fixture, $destination));
+        }
+
+        $this->copiedFixtures[$destination] = $destination;
+    }
+
+    /**
+     * The modern CSV reader pulls its separator from the session at build time, so a request
+     * carrying a session must be on the stack before the Importer is instantiated. The CLI/Behat
+     * runtime has none, so we push a minimal one (the legacy executor is unaffected: it reads $_POST).
+     */
+    private function ensureRequestWithSession(): void
+    {
+        $requestStack = $this->getContainer()->get('request_stack');
+        if (null !== $requestStack->getCurrentRequest()) {
+            return;
+        }
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('separator', ImportSettings::DEFAULT_SEPARATOR);
+        $session->set('multiple_value_separator', ImportSettings::DEFAULT_MULTIVALUE_SEPARATOR);
+
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack->push($request);
+    }
+
+    private function getImportDirectory(): string
+    {
+        return (string) $this->getContainer()->get('prestashop.core.import.dir');
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->getContainer()->get('doctrine.dbal.default_connection');
+    }
+
+    private function prefix(): string
+    {
+        return (string) $this->getContainer()->getParameter('database_prefix');
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function count(string $sql, array $params): int
+    {
+        return (int) $this->getConnection()->executeQuery($sql, $params)->fetchOne();
+    }
+
+    private function resolveLangId(string $iso): int
+    {
+        return (int) $this->getConnection()->executeQuery(
+            'SELECT id_lang FROM ' . $this->prefix() . 'lang WHERE iso_code = :iso',
+            ['iso' => $iso]
+        )->fetchOne();
+    }
+}

--- a/tests/Integration/Behaviour/Features/Scenario/Import/address.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/address.feature
@@ -1,0 +1,11 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+Feature: Import addresses from a CSV file
+  As an employee
+  I must be able to import customer addresses through the import façade
+  This entity type has no modern handler yet: it is executed by the legacy controller
+
+  Scenario: Insert a new address for an existing customer
+    When I import "addresses" from CSV file "addresses_insert.csv" in language "en"
+    Then the import should succeed
+    And address "Behat Home" should exist for customer "pub@prestashop.com"

--- a/tests/Integration/Behaviour/Features/Scenario/Import/alias.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/alias.feature
@@ -1,0 +1,12 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+Feature: Import search aliases from a CSV file
+  As an employee
+  I must be able to import search aliases through the import façade
+  This entity type has no modern handler yet: it is executed by the legacy controller
+
+  Scenario: Insert new aliases
+    When I import "alias" from CSV file "aliases_insert.csv" in language "en"
+    Then the import should succeed
+    And alias "behatalias" should exist with search "behatsearch"
+    And alias "behatalias2" should exist with search "behatsearch2"

--- a/tests/Integration/Behaviour/Features/Scenario/Import/category.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/category.feature
@@ -1,0 +1,33 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s import tests/Integration/Behaviour/Features/Scenario/Import/category.feature
+Feature: Import categories from a CSV file
+  As an employee
+  I must be able to import categories from a CSV file through the import façade
+  This entity type is executed by the modern Importer
+
+  Scenario: Insert new categories
+    When I import "categories" from CSV file "categories_insert.csv" in language "en"
+    Then the import should succeed
+    And category "Behat Category A" should exist
+    And category "Behat Category B" should exist
+    And category "Behat Category C" should exist
+
+  Scenario: Validate-only mode persists nothing
+    When I validate the import of "categories" from CSV file "categories_insert.csv" in language "en"
+    Then the import should succeed
+    And category "Behat Category A" should not exist
+
+  Scenario: Truncate then import replaces the existing categories
+    When I import "categories" from CSV file "categories_insert.csv" in language "en"
+    And I import "categories" from CSV file "categories_truncate.csv" in language "en" with options:
+      | truncate | true |
+    Then category "Behat Category A" should not exist
+    And category "Behat Truncated X" should exist
+    And category "Behat Truncated Y" should exist
+
+  Scenario: A malformed row is reported and the neighbouring rows still import
+    When I import "categories" from CSV file "categories_malformed.csv" in language "en"
+    Then the import should report at least 1 error
+    And category "Behat Valid One" should exist
+    And category "Behat Valid Two" should exist

--- a/tests/Integration/Behaviour/Features/Scenario/Import/combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/combination.feature
@@ -1,0 +1,13 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+Feature: Import combinations from a CSV file
+  As an employee
+  I must be able to import product combinations through the import façade
+  This entity type has no modern handler yet: it is executed by the legacy controller
+
+  Scenario: Insert a new combination on an existing product
+    Given I import "products" from CSV file "products_for_combinations.csv" in language "en"
+    When I import "combinations" from CSV file "combinations_insert.csv" in language "en" with options:
+      | match_ref | true |
+    Then the import should succeed
+    And product with reference "BEHAT-COMBO" should have a combination with reference "BEHAT-COMBO-XL"

--- a/tests/Integration/Behaviour/Features/Scenario/Import/customer.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/customer.feature
@@ -1,0 +1,25 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s import tests/Integration/Behaviour/Features/Scenario/Import/customer.feature
+Feature: Import customers from a CSV file
+  As an employee
+  I must be able to import customers from a CSV file through the import façade
+  This entity type has no modern handler yet: it is executed by the legacy controller
+
+  Scenario: Insert new customers
+    When I import "customers" from CSV file "customers_insert.csv" in language "en"
+    Then the import should succeed
+    And customer with email "behat.customer.a@example.com" should exist
+    And customer with email "behat.customer.b@example.com" should exist
+
+  Scenario: Force the row id
+    When I import "customers" from CSV file "customers_forceids.csv" in language "en" with options:
+      | forceIDs | true |
+    Then the import should succeed
+    And customer with email "behat.customer.forced@example.com" should exist
+    And customer with email "behat.customer.forced@example.com" should have last name "Forced"
+
+  Scenario: Validate-only mode persists nothing
+    When I validate the import of "customers" from CSV file "customers_insert.csv" in language "en"
+    Then the import should succeed
+    And customer with email "behat.customer.a@example.com" should not exist

--- a/tests/Integration/Behaviour/Features/Scenario/Import/manufacturer.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/manufacturer.feature
@@ -1,0 +1,12 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+Feature: Import manufacturers from a CSV file
+  As an employee
+  I must be able to import manufacturers (brands) through the import façade
+  This entity type has no modern handler yet: it is executed by the legacy controller
+
+  Scenario: Insert new manufacturers
+    When I import "manufacturers" from CSV file "manufacturers_insert.csv" in language "en"
+    Then the import should succeed
+    And manufacturer "Behat Brand A" should exist
+    And manufacturer "Behat Brand B" should exist

--- a/tests/Integration/Behaviour/Features/Scenario/Import/multistore_catalog.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/multistore_catalog.feature
@@ -1,0 +1,35 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+@reboot-kernel-before-scenario
+@reboot-kernel-after-feature
+@clear-cache-before-feature
+Feature: Import catalog entities in a multistore context
+  As an employee
+  I must be able to import catalog entities and associate them to the shops named in the CSV
+  Products and categories run through the modern Importer, combinations through the legacy controller
+
+  Background:
+    Given I enable multishop feature
+    And shop "shop1" with name "test_shop" exists
+    And I add a shop group "import_group" with name "Import Group"
+    And I add a shop "shop2" with name "Import Shop 2" and color "red" for the group "import_group"
+    And I copy "country" shop data from "test_shop" to "Import Shop 2"
+    And I copy "currency" shop data from "test_shop" to "Import Shop 2"
+    And multiple shop context is loaded
+
+  Scenario: Import a product associated to the shops listed in the shop column
+    When I import "products" from CSV file "products_multishop.csv" in language "en"
+    Then the import should succeed
+    And product with reference "BEHAT-MS" should be associated to shops "shop1,shop2"
+
+  Scenario: Import a category associated to the shops listed in the shop column
+    When I import "categories" from CSV file "categories_multishop.csv" in language "en"
+    Then the import should succeed
+    And category "Behat MS Category" should be associated to shops "shop1,shop2"
+
+  Scenario: Import a combination associated to the shop listed in the shop column
+    Given I import "products" from CSV file "products_for_combinations.csv" in language "en"
+    When I import "combinations" from CSV file "combinations_multishop.csv" in language "en" with options:
+      | match_ref | true |
+    Then the import should succeed
+    And product with reference "BEHAT-COMBO" should have a combination associated to shop "shop2"

--- a/tests/Integration/Behaviour/Features/Scenario/Import/multistore_customer.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/multistore_customer.feature
@@ -1,0 +1,25 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+@reboot-kernel-after-feature
+@clear-cache-before-feature
+Feature: Import customers in a multistore context
+  As an employee
+  I must be able to import customers into specific shops and shop groups
+  This entity type is executed by the legacy controller
+
+  Background:
+    Given I enable multishop feature
+    And I add a shop group "import_group" with name "Import Group"
+    And I add a shop "shop2" with name "Import Shop 2" and color "red" for the group "import_group"
+
+  Scenario: Customer is imported into a specific shop through the id_shop column
+    When I import "customers" from CSV file "customers_multishop.csv" in language "en"
+    Then the import should succeed
+    And customer with email "behat.multishop@example.com" should exist
+    And customer with email "behat.multishop@example.com" should be in shop "shop2"
+
+  Scenario: Customer is shared across a shop group when share_customer is enabled
+    Given the shop group "import_group" shares its customers
+    When I import "customers" from CSV file "customers_shared.csv" in language "en"
+    Then the import should succeed
+    And customer with email "behat.shared@example.com" should be shared in shop group "import_group"

--- a/tests/Integration/Behaviour/Features/Scenario/Import/product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/product.feature
@@ -1,0 +1,46 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s import tests/Integration/Behaviour/Features/Scenario/Import/product.feature
+Feature: Import products from a CSV file
+  As an employee
+  I must be able to import products from a CSV file through the import façade
+  This entity type is executed by the modern Importer
+
+  Scenario: Insert new products
+    When I import "products" from CSV file "products_insert.csv" in language "en"
+    Then the import should succeed
+    And product "Behat Product A" should exist
+    And product "Behat Product B" should exist
+    And product with reference "BEHAT-A" should exist
+
+  Scenario: Update existing products matched by reference
+    When I import "products" from CSV file "products_insert.csv" in language "en"
+    And I import "products" from CSV file "products_update_by_reference.csv" in language "en" with options:
+      | match_ref | true |
+    Then the import should succeed
+    And product "Behat Product A" should have price 15.50
+
+  Scenario: Force the row id
+    When I import "products" from CSV file "products_forceids.csv" in language "en" with options:
+      | forceIDs | true |
+    Then the import should succeed
+    And product with id 9991 should exist
+
+  Scenario: Update an existing product matched by id
+    When I import "products" from CSV file "products_forceids.csv" in language "en" with options:
+      | forceIDs | true |
+    And I import "products" from CSV file "products_update_by_id.csv" in language "en"
+    Then the import should succeed
+    And product "Behat Forced Product" should have price 25.00
+
+  Scenario: Validate-only mode does not update an existing product
+    When I import "products" from CSV file "products_insert.csv" in language "en"
+    And I validate the import of "products" from CSV file "products_update_by_reference.csv" in language "en" with options:
+      | match_ref | true |
+    Then the import should succeed
+    And product "Behat Product A" should have price 10.00
+
+  Scenario: A malformed row is skipped and the neighbouring rows still import
+    When I import "products" from CSV file "products_malformed.csv" in language "en"
+    Then product "Behat Product Valid One" should exist
+    And product "Behat Product Valid Two" should exist

--- a/tests/Integration/Behaviour/Features/Scenario/Import/store_contact.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/store_contact.feature
@@ -1,0 +1,12 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+Feature: Import store contacts from a CSV file
+  As an employee
+  I must be able to import store contacts through the import façade
+  This entity type has no modern handler yet: it is executed by the legacy controller
+
+  Scenario: Insert new store contacts
+    When I import "contacts" from CSV file "contacts_insert.csv" in language "en"
+    Then the import should succeed
+    And store "Behat Store A" should exist
+    And store "Behat Store B" should exist

--- a/tests/Integration/Behaviour/Features/Scenario/Import/supplier.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Import/supplier.feature
@@ -1,0 +1,12 @@
+@restore-all-tables-before-feature
+@reset-all-tables-before-scenario
+Feature: Import suppliers from a CSV file
+  As an employee
+  I must be able to import suppliers through the import façade
+  This entity type has no modern handler yet: it is executed by the legacy controller
+
+  Scenario: Insert new suppliers
+    When I import "suppliers" from CSV file "suppliers_insert.csv" in language "en"
+    Then the import should succeed
+    And supplier "Behat Supplier A" should exist
+    And supplier "Behat Supplier B" should exist

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -65,6 +65,12 @@ default:
       contexts:
         - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\EmailBodyTranslationFeatureContext
+    import:
+      paths:
+        - "%paths.base%/Features/Scenario/Import"
+      contexts:
+        - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\Domain\ImportFeatureContext
     customer:
       paths:
         - "%paths.base%/Features/Scenario/Customer"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -70,6 +70,7 @@ default:
         - "%paths.base%/Features/Scenario/Import"
       contexts:
         - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\ImportFeatureContext
     customer:
       paths:

--- a/tests/Resources/import/addresses_insert.csv
+++ b/tests/Resources/import/addresses_insert.csv
@@ -1,0 +1,2 @@
+alias;lastname;firstname;address1;city;postcode;country;customer_email
+Behat Home;Doe;John;10 Test Avenue;Paris;75001;France;pub@prestashop.com

--- a/tests/Resources/import/aliases_insert.csv
+++ b/tests/Resources/import/aliases_insert.csv
@@ -1,0 +1,3 @@
+alias;search;active
+behatalias;behatsearch;1
+behatalias2;behatsearch2;1

--- a/tests/Resources/import/categories_insert.csv
+++ b/tests/Resources/import/categories_insert.csv
@@ -1,0 +1,4 @@
+name;active;parent
+Behat Category A;1;Home
+Behat Category B;1;Home
+Behat Category C;1;Home

--- a/tests/Resources/import/categories_malformed.csv
+++ b/tests/Resources/import/categories_malformed.csv
@@ -1,0 +1,4 @@
+name;active;parent
+Behat Valid One;1;Home
+Behat Valid Two;1;Home
+;1;Home

--- a/tests/Resources/import/categories_multishop.csv
+++ b/tests/Resources/import/categories_multishop.csv
@@ -1,0 +1,2 @@
+name;active;parent;shop
+Behat MS Category;1;Home;{{shop1}},{{shop2}}

--- a/tests/Resources/import/categories_truncate.csv
+++ b/tests/Resources/import/categories_truncate.csv
@@ -1,0 +1,3 @@
+name;active;parent
+Behat Truncated X;1;Home
+Behat Truncated Y;1;Home

--- a/tests/Resources/import/combinations_insert.csv
+++ b/tests/Resources/import/combinations_insert.csv
@@ -1,0 +1,2 @@
+product_reference;group;attribute;reference;quantity
+BEHAT-COMBO;Behat Size:select:0;Behat XL:0;BEHAT-COMBO-XL;10

--- a/tests/Resources/import/combinations_multishop.csv
+++ b/tests/Resources/import/combinations_multishop.csv
@@ -1,0 +1,2 @@
+product_reference;group;attribute;reference;quantity;shop
+BEHAT-COMBO;Behat Size:select:0;Behat XL:0;BEHAT-COMBO-XL;10;{{shop2}}

--- a/tests/Resources/import/contacts_insert.csv
+++ b/tests/Resources/import/contacts_insert.csv
@@ -1,0 +1,3 @@
+name;address1;city;country;latitude;longitude;active
+Behat Store A;1 Test Street;Paris;France;48.8566;2.3522;1
+Behat Store B;2 Test Street;Lyon;France;45.7640;4.8357;1

--- a/tests/Resources/import/customers_forceids.csv
+++ b/tests/Resources/import/customers_forceids.csv
@@ -1,0 +1,2 @@
+id;email;passwd;lastname;firstname;active
+9981;behat.customer.forced@example.com;Azerty123;Forced;Carl;1

--- a/tests/Resources/import/customers_insert.csv
+++ b/tests/Resources/import/customers_insert.csv
@@ -1,0 +1,3 @@
+email;passwd;lastname;firstname;active
+behat.customer.a@example.com;Azerty123;Doe;John;1
+behat.customer.b@example.com;Azerty123;Roe;Jane;1

--- a/tests/Resources/import/customers_multishop.csv
+++ b/tests/Resources/import/customers_multishop.csv
@@ -1,0 +1,2 @@
+email;passwd;lastname;firstname;active;id_shop
+behat.multishop@example.com;Azerty123;Multi;Shop;1;{{shop2}}

--- a/tests/Resources/import/customers_shared.csv
+++ b/tests/Resources/import/customers_shared.csv
@@ -1,0 +1,2 @@
+email;passwd;lastname;firstname;active;id_shop
+behat.shared@example.com;Azerty123;Shared;Cust;1;{{shop2}}

--- a/tests/Resources/import/manufacturers_insert.csv
+++ b/tests/Resources/import/manufacturers_insert.csv
@@ -1,0 +1,3 @@
+name;active;description
+Behat Brand A;1;Brand A description
+Behat Brand B;1;Brand B description

--- a/tests/Resources/import/products_for_combinations.csv
+++ b/tests/Resources/import/products_for_combinations.csv
@@ -1,0 +1,2 @@
+name;reference;price_tex;quantity;active;category
+Behat Combo Product;BEHAT-COMBO;30.00;100;1;Home

--- a/tests/Resources/import/products_forceids.csv
+++ b/tests/Resources/import/products_forceids.csv
@@ -1,0 +1,2 @@
+id;name;reference;price_tex;quantity;active;category
+9991;Behat Forced Product;BEHAT-FORCED;12.00;30;1;Home

--- a/tests/Resources/import/products_insert.csv
+++ b/tests/Resources/import/products_insert.csv
@@ -1,0 +1,3 @@
+name;reference;price_tex;quantity;active;category
+Behat Product A;BEHAT-A;10.00;100;1;Home
+Behat Product B;BEHAT-B;20.00;50;1;Home

--- a/tests/Resources/import/products_malformed.csv
+++ b/tests/Resources/import/products_malformed.csv
@@ -1,0 +1,4 @@
+name;reference;price_tex;quantity;active;category
+Behat Product Valid One;BEHAT-V1;10.00;100;1;Home
+Behat Product Valid Two;BEHAT-V2;30.00;25;1;Home
+;BEHAT-INVALID;20.00;50;1;Home

--- a/tests/Resources/import/products_multishop.csv
+++ b/tests/Resources/import/products_multishop.csv
@@ -1,0 +1,2 @@
+name;reference;price_tex;quantity;active;category;shop
+Behat Multishop Product;BEHAT-MS;10.00;100;1;Home;{{shop1}},{{shop2}}

--- a/tests/Resources/import/products_update_by_id.csv
+++ b/tests/Resources/import/products_update_by_id.csv
@@ -1,0 +1,2 @@
+id;name;reference;price_tex;quantity;active;category
+9991;Behat Forced Product;BEHAT-FORCED;25.00;30;1;Home

--- a/tests/Resources/import/products_update_by_reference.csv
+++ b/tests/Resources/import/products_update_by_reference.csv
@@ -1,0 +1,2 @@
+name;reference;price_tex;quantity;active;category
+Behat Product A;BEHAT-A;15.50;100;1;Home

--- a/tests/Resources/import/suppliers_insert.csv
+++ b/tests/Resources/import/suppliers_insert.csv
@@ -1,0 +1,3 @@
+name;active;description
+Behat Supplier A;1;Supplier A description
+Behat Supplier B;1;Supplier B description


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Story 1 of the Import admin page migration (#41321), part 2. Builds on #41814 (the `ImportCsvFromFileCommand` façade + Behat safety net for products/categories/customers) by adding Behat regression coverage for the **6 remaining entity types** and the **multistore** scenarios. All six remaining types run through the legacy `AdminImportController` (no modern handler yet); products/categories run through the modern `Importer`. No new production feature: the only production change is making the legacy executor reset the controller's public static state between runs.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Provision the test DB (`composer create-test-db`) then run the suite:<br>`./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s import`<br>All 24 scenarios (119 steps) must be green.<br>New coverage in this PR:<br>• **Legacy executor** — `manufacturer`, `supplier`, `alias`, `store_contact`, `address`, `combination` feature files (insert; combination matched by product reference).<br>• **Multistore (legacy)** — `multistore_customer.feature`: customer imported into a specific shop via the `id_shop` column, and customer shared across a shop group when `share_customer` is enabled.<br>• **Multistore (modern + legacy)** — `multistore_catalog.feature`: products, categories and combinations associated to the shops named in the `shop` column.
| UI Tests          | N/A (Behat only; Playwright campaigns come in the next PR of this story)
| Fixed issue or discussion?     | Part of #41798
| Related PRs       | Depends on #41814 (PR 1 of this story) — until it is merged, this PR's diff also shows #41814's commit. Playwright campaigns will follow in PR 3.
| Sponsor company   | @PrestaShopCorp

### Notes

The only production change is in `LegacyImportExecutor`: it now restores the legacy controller's public static properties (`$validators`, `$column_mask`, `$default_values`) to their declared defaults before each run. The controller only ever *adds* to these in its constructor, so importing several entity types in one process would otherwise leak state between them (e.g. the store-contact import marking `address1` as a multilang field, which then breaks the following address import).

Behaviours locked as-is, worth knowing for the later refactor:
- **Multistore catalog imports run with a kernel reboot per scenario** (`@reboot-kernel-before-scenario`), because the modern import handlers capture their shop context at service-construction time. The multistore features also reboot the kernel after themselves so they don't leak a multishop handler into later single-shop features.
- **Category multistore association inserts duplicate `category_shop` rows** (one category, but the shop link is written more than once) — the assertion checks association presence, not row count.
- **`id_shop` in the customer CSV must be a numeric shop id** (the legacy controller does `new Shop((int) $id_shop)`), so multistore fixtures use a `{{shop_reference}}` placeholder that the Behat context resolves to the runtime shop id.

Deferred (needs a deeper change to let the modern handler re-read the shop context, out of scope here): the 3 product scenarios for an **empty `shop` column inheriting the BO context** (`CONTEXT_ALL` / `CONTEXT_GROUP` / `CONTEXT_SHOP`).

### Known tradeoffs

Beyond the locked behaviours above, this PR inherits the façade tradeoffs from #41814:
- the Behat context reads persisted data via the Doctrine DBAL connection (the repositories lack by-name/reference/email lookups) — never through ObjectModel;
- `LegacyImportExecutor` drives the legacy controller via `$_POST`/`$_GET` + a reflection call (deliberate bridge; the legacy controller is untouched).


