### PR TITLE
Fix: order-with-shipment-display

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -29,7 +29,7 @@
         {{ documentsTitle }}
       </a>
     </li>
-    {% if isImprovedShipmentFeatureFlagEnabled and orderHasShipment == true %}
+    {% if orderHasShipment == true %}
       <li class="nav-item">
         <a class="nav-link" id="orderShipmentsTab" data-toggle="tab" href="#orderShipmentsTabContent" role="tab" aria-controls="orderShipmentsTabContent" aria-expanded="true" aria-selected="false">
           <i class="material-icons">local_shipping</i>
@@ -76,7 +76,7 @@
         {% endblock %}
       {% endembed %}
     </div>
-    {% if isImprovedShipmentFeatureFlagEnabled and orderHasShipment == true %}
+    {% if orderHasShipment == true %}
       <div class="tab-pane d-print-block fade" id="orderShipmentsTabContent" role="tabpanel" aria-labelledby="orderShipmentsTab">
         {% embed '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/details_card.html.twig' %}
           {% block header %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |update condition for shipments tab, in order details view
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see order with shipment, without improved_shipment FF
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/28573926168
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -
