### PR TITLE
Add import Playwright campaigns (Story 1, part 3) [WIP]

### DIFF
--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/03_importCategories.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/03_importCategories.ts
@@ -27,7 +27,8 @@ describe('BO - Advanced Parameters - Import : Import categories', async () => {
   const fileName: string = 'ui_import_categories.csv';
   const firstCategory: string = 'UI Import Category A';
   const secondCategory: string = 'UI Import Category B';
-  const csvContent: string = 'Category ID;Active (0/1);Name *;Parent category;Root category (0/1);Description;Meta title;Meta description;URL rewritten;Image URL\n'
+  const csvContent: string = 'Category ID;Active (0/1);Name *;Parent category;Root category (0/1);'
+    + 'Description;Meta title;Meta description;URL rewritten;Image URL\n'
     + `;1;${firstCategory};Home;0;;;;;\n`
     + `;1;${secondCategory};Home;0;;;;;\n`;
 

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/03_importCategories.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/03_importCategories.ts
@@ -1,0 +1,142 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {expect} from 'chai';
+import {
+  boCategoriesPage,
+  boDashboardPage,
+  boImportPage,
+  boLoginPage,
+  type BrowserContext,
+  type Page,
+  utilsFile,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_advancedParameters_import_importCategories';
+
+/*
+Upload a categories CSV, run the import (validate + import phases) and assert the
+new categories appear on the Categories listing. Exercises the modern Importer
+through the legacy Step-1 -> Step-2 -> progress-modal UI contract.
+ */
+describe('BO - Advanced Parameters - Import : Import categories', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  const fileName: string = 'ui_import_categories.csv';
+  const firstCategory: string = 'UI Import Category A';
+  const secondCategory: string = 'UI Import Category B';
+  const csvContent: string = 'Category ID;Active (0/1);Name *;Parent category;Root category (0/1);Description;Meta title;Meta description;URL rewritten;Image URL\n'
+    + `;1;${firstCategory};Home;0;;;;;\n`
+    + `;1;${secondCategory};Home;0;;;;;\n`;
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+
+    await utilsFile.createFile('.', fileName, csvContent);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+    await utilsFile.deleteFile(fileName);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should go to \'Advanced Parameters > Import\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToImportPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.advancedParametersLink,
+      boDashboardPage.importLink,
+    );
+    await boImportPage.closeSfToolBar(page);
+
+    const pageTitle = await boImportPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boImportPage.pageTitle);
+  });
+
+  it('should upload the categories file', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'uploadFile', baseContext);
+
+    const uploadSuccessText = await boImportPage.uploadImportFile(page, 'Categories', fileName);
+    expect(uploadSuccessText).to.contains(fileName);
+  });
+
+  it('should go to the data-matching step', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'nextStep', baseContext);
+
+    const panelTitle = await boImportPage.goToImportNextStep(page);
+    expect(panelTitle).to.contains(boImportPage.importPanelTitle);
+  });
+
+  it('should start the import', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'startImport', baseContext);
+
+    const modalTitle = await boImportPage.startFileImport(page);
+    expect(modalTitle).to.contains(boImportPage.importModalTitle);
+  });
+
+  it('should check that the import is completed', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'waitForImport', baseContext);
+
+    const isCompleted = await boImportPage.getImportValidationMessage(page);
+    expect(isCompleted, 'The import is not completed!').to.contains('Data imported');
+  });
+
+  it('should close the import progress modal', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeModal', baseContext);
+
+    const isModalClosed = await boImportPage.closeImportModal(page);
+    expect(isModalClosed).to.be.eq(true);
+  });
+
+  it('should go to \'Catalog > Categories\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToCategoriesPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.catalogParentLink,
+      boDashboardPage.categoriesLink,
+    );
+
+    const pageTitle = await boCategoriesPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boCategoriesPage.pageTitle);
+  });
+
+  it('should filter the listing and find the first imported category', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'filterFirstCategory', baseContext);
+
+    await boCategoriesPage.resetFilter(page);
+    await boCategoriesPage.filterCategories(page, 'input', 'name', firstCategory);
+
+    const numberOfCategories = await boCategoriesPage.getNumberOfElementInGrid(page);
+    expect(numberOfCategories).to.be.eq(1);
+
+    const categoryName = await boCategoriesPage.getTextColumnFromTableCategories(page, 1, 'name');
+    expect(categoryName).to.contains(firstCategory);
+  });
+
+  it('should filter the listing and find the second imported category', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'filterSecondCategory', baseContext);
+
+    await boCategoriesPage.resetFilter(page);
+    await boCategoriesPage.filterCategories(page, 'input', 'name', secondCategory);
+
+    const numberOfCategories = await boCategoriesPage.getNumberOfElementInGrid(page);
+    expect(numberOfCategories).to.be.eq(1);
+
+    await boCategoriesPage.resetFilter(page);
+  });
+});

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/04_importProducts.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/04_importProducts.ts
@@ -27,9 +27,10 @@ describe('BO - Advanced Parameters - Import : Import products', async () => {
   const fileName: string = 'ui_import_products.csv';
   const firstProduct: string = 'UI Import Product A';
   const secondProduct: string = 'UI Import Product B';
-  const csvContent: string = 'Active (0/1);Name *;Categories (x,y,z...);Price tax excluded;Reference #;Quantity\n'
-    + `1;${firstProduct};Home;19.99;UI-IMP-A;100\n`
-    + `1;${secondProduct};Home;29.99;UI-IMP-B;50\n`;
+  // Columns must follow the import field order (positional auto-mapping): id, active, name, category, price.
+  const csvContent: string = 'Product ID;Active (0/1);Name *;Categories (x,y,z...);Price tax excluded\n'
+    + `;1;${firstProduct};Home;19.99\n`
+    + `;1;${secondProduct};Home;29.99\n`;
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/04_importProducts.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/04_importProducts.ts
@@ -1,0 +1,143 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {expect} from 'chai';
+import {
+  boDashboardPage,
+  boImportPage,
+  boLoginPage,
+  boProductsPage,
+  type BrowserContext,
+  type Page,
+  utilsFile,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_advancedParameters_import_importProducts';
+
+/*
+Upload a products CSV, run the import and assert the new products appear on the
+Products listing, filtered by reference. Exercises the modern Importer through
+the Step-1 -> Step-2 -> progress-modal UI contract.
+ */
+describe('BO - Advanced Parameters - Import : Import products', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  const fileName: string = 'ui_import_products.csv';
+  const firstReference: string = 'UI-IMP-A';
+  const secondReference: string = 'UI-IMP-B';
+  const csvContent: string = 'Active (0/1);Name *;Categories (x,y,z...);Price tax excluded;Reference #;Quantity\n'
+    + `1;UI Import Product A;Home;19.99;${firstReference};100\n`
+    + `1;UI Import Product B;Home;29.99;${secondReference};50\n`;
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+
+    await utilsFile.createFile('.', fileName, csvContent);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+    await utilsFile.deleteFile(fileName);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should go to \'Advanced Parameters > Import\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToImportPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.advancedParametersLink,
+      boDashboardPage.importLink,
+    );
+    await boImportPage.closeSfToolBar(page);
+
+    const pageTitle = await boImportPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boImportPage.pageTitle);
+  });
+
+  it('should upload the products file', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'uploadFile', baseContext);
+
+    const uploadSuccessText = await boImportPage.uploadImportFile(page, 'Products', fileName);
+    expect(uploadSuccessText).to.contains(fileName);
+  });
+
+  it('should go to the data-matching step', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'nextStep', baseContext);
+
+    const panelTitle = await boImportPage.goToImportNextStep(page);
+    expect(panelTitle).to.contains(boImportPage.importPanelTitle);
+  });
+
+  it('should start the import', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'startImport', baseContext);
+
+    const modalTitle = await boImportPage.startFileImport(page);
+    expect(modalTitle).to.contains(boImportPage.importModalTitle);
+  });
+
+  it('should check that the import is completed', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'waitForImport', baseContext);
+
+    const isCompleted = await boImportPage.getImportValidationMessage(page);
+    expect(isCompleted, 'The import is not completed!').to.contains('Data imported');
+  });
+
+  it('should close the import progress modal', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeModal', baseContext);
+
+    const isModalClosed = await boImportPage.closeImportModal(page);
+    expect(isModalClosed).to.be.eq(true);
+  });
+
+  it('should go to \'Catalog > Products\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.catalogParentLink,
+      boDashboardPage.productsLink,
+    );
+    await boProductsPage.closeSfToolBar(page);
+
+    const pageTitle = await boProductsPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boProductsPage.pageTitle);
+  });
+
+  it('should filter the listing and find the first imported product', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'filterFirstProduct', baseContext);
+
+    await boProductsPage.resetFilter(page);
+    await boProductsPage.filterProducts(page, 'reference', firstReference, 'input');
+
+    const numberOfProducts = await boProductsPage.getNumberOfProductsFromList(page);
+    expect(numberOfProducts).to.be.eq(1);
+
+    const reference = await boProductsPage.getTextColumn(page, 'reference', 1);
+    expect(reference).to.contains(firstReference);
+  });
+
+  it('should filter the listing and find the second imported product', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'filterSecondProduct', baseContext);
+
+    await boProductsPage.resetFilter(page);
+    await boProductsPage.filterProducts(page, 'reference', secondReference, 'input');
+
+    const numberOfProducts = await boProductsPage.getNumberOfProductsFromList(page);
+    expect(numberOfProducts).to.be.eq(1);
+
+    await boProductsPage.resetFilter(page);
+  });
+});

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/04_importProducts.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/04_importProducts.ts
@@ -25,11 +25,11 @@ describe('BO - Advanced Parameters - Import : Import products', async () => {
   let page: Page;
 
   const fileName: string = 'ui_import_products.csv';
-  const firstReference: string = 'UI-IMP-A';
-  const secondReference: string = 'UI-IMP-B';
+  const firstProduct: string = 'UI Import Product A';
+  const secondProduct: string = 'UI Import Product B';
   const csvContent: string = 'Active (0/1);Name *;Categories (x,y,z...);Price tax excluded;Reference #;Quantity\n'
-    + `1;UI Import Product A;Home;19.99;${firstReference};100\n`
-    + `1;UI Import Product B;Home;29.99;${secondReference};50\n`;
+    + `1;${firstProduct};Home;19.99;UI-IMP-A;100\n`
+    + `1;${secondProduct};Home;29.99;UI-IMP-B;50\n`;
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -120,20 +120,20 @@ describe('BO - Advanced Parameters - Import : Import products', async () => {
     await testContext.addContextItem(this, 'testIdentifier', 'filterFirstProduct', baseContext);
 
     await boProductsPage.resetFilter(page);
-    await boProductsPage.filterProducts(page, 'reference', firstReference, 'input');
+    await boProductsPage.filterProducts(page, 'product_name', firstProduct, 'input');
 
     const numberOfProducts = await boProductsPage.getNumberOfProductsFromList(page);
     expect(numberOfProducts).to.be.eq(1);
 
-    const reference = await boProductsPage.getTextColumn(page, 'reference', 1);
-    expect(reference).to.contains(firstReference);
+    const productName = await boProductsPage.getTextColumn(page, 'product_name', 1);
+    expect(productName).to.contains(firstProduct);
   });
 
   it('should filter the listing and find the second imported product', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'filterSecondProduct', baseContext);
 
     await boProductsPage.resetFilter(page);
-    await boProductsPage.filterProducts(page, 'reference', secondReference, 'input');
+    await boProductsPage.filterProducts(page, 'product_name', secondProduct, 'input');
 
     const numberOfProducts = await boProductsPage.getNumberOfProductsFromList(page);
     expect(numberOfProducts).to.be.eq(1);

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/05_importTruncate.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/05_importTruncate.ts
@@ -28,6 +28,7 @@ describe('BO - Advanced Parameters - Import : Import with truncate', async () =>
   const fileName: string = 'ui_import_truncate.csv';
 
   let csvContent: string = 'Active (0/1);Name *;Categories (x,y,z...);Price tax excluded;Reference #;Quantity\n';
+
   for (let i = 1; i <= numberOfProducts; i++) {
     csvContent += `1;UI Truncate Product ${i};Home;${i}.99;UI-TRUNC-${i};10\n`;
   }

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/05_importTruncate.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/05_importTruncate.ts
@@ -27,10 +27,11 @@ describe('BO - Advanced Parameters - Import : Import with truncate', async () =>
   const numberOfProducts: number = 10;
   const fileName: string = 'ui_import_truncate.csv';
 
-  let csvContent: string = 'Active (0/1);Name *;Categories (x,y,z...);Price tax excluded;Reference #;Quantity\n';
+  // Columns must follow the import field order (positional auto-mapping): id, active, name, category, price.
+  let csvContent: string = 'Product ID;Active (0/1);Name *;Categories (x,y,z...);Price tax excluded\n';
 
   for (let i = 1; i <= numberOfProducts; i++) {
-    csvContent += `1;UI Truncate Product ${i};Home;${i}.99;UI-TRUNC-${i};10\n`;
+    csvContent += `;1;UI Truncate Product ${i};Home;${i}.99\n`;
   }
 
   before(async function () {

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/05_importTruncate.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/05_importTruncate.ts
@@ -1,0 +1,130 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {expect} from 'chai';
+import {
+  boDashboardPage,
+  boImportPage,
+  boLoginPage,
+  boProductsPage,
+  type BrowserContext,
+  type Page,
+  utilsFile,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_advancedParameters_import_importTruncate';
+
+/*
+Import 10 products with the "truncate" option enabled and assert the Products
+listing then contains exactly 10 products (all pre-existing products removed).
+Destructive by design - meant to run against a fresh shop.
+ */
+describe('BO - Advanced Parameters - Import : Import with truncate', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  const numberOfProducts: number = 10;
+  const fileName: string = 'ui_import_truncate.csv';
+
+  let csvContent: string = 'Active (0/1);Name *;Categories (x,y,z...);Price tax excluded;Reference #;Quantity\n';
+  for (let i = 1; i <= numberOfProducts; i++) {
+    csvContent += `1;UI Truncate Product ${i};Home;${i}.99;UI-TRUNC-${i};10\n`;
+  }
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+
+    await utilsFile.createFile('.', fileName, csvContent);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+    await utilsFile.deleteFile(fileName);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should go to \'Advanced Parameters > Import\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToImportPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.advancedParametersLink,
+      boDashboardPage.importLink,
+    );
+    await boImportPage.closeSfToolBar(page);
+
+    const pageTitle = await boImportPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boImportPage.pageTitle);
+  });
+
+  it('should upload the products file and enable truncate', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'uploadFile', baseContext);
+
+    const uploadSuccessText = await boImportPage.uploadImportFile(page, 'Products', fileName);
+    expect(uploadSuccessText).to.contains(fileName);
+
+    await boImportPage.setTruncate(page, true);
+  });
+
+  it('should go to the data-matching step', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'nextStep', baseContext);
+
+    const panelTitle = await boImportPage.goToImportNextStep(page);
+    expect(panelTitle).to.contains(boImportPage.importPanelTitle);
+  });
+
+  it('should start the import', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'startImport', baseContext);
+
+    const modalTitle = await boImportPage.startFileImport(page);
+    expect(modalTitle).to.contains(boImportPage.importModalTitle);
+  });
+
+  it('should check that the import is completed', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'waitForImport', baseContext);
+
+    const isCompleted = await boImportPage.getImportValidationMessage(page);
+    expect(isCompleted, 'The import is not completed!').to.contains('Data imported');
+  });
+
+  it('should close the import progress modal', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeModal', baseContext);
+
+    const isModalClosed = await boImportPage.closeImportModal(page);
+    expect(isModalClosed).to.be.eq(true);
+  });
+
+  it('should go to \'Catalog > Products\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.catalogParentLink,
+      boDashboardPage.productsLink,
+    );
+    await boProductsPage.closeSfToolBar(page);
+
+    const pageTitle = await boProductsPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boProductsPage.pageTitle);
+  });
+
+  it('should check that exactly the imported products remain', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkProductsCount', baseContext);
+
+    await boProductsPage.resetFilter(page);
+
+    const productsCount = await boProductsPage.getNumberOfProductsFromHeader(page);
+    expect(productsCount).to.be.eq(numberOfProducts);
+  });
+});

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/05_importTruncate.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/05_importTruncate.ts
@@ -81,6 +81,9 @@ describe('BO - Advanced Parameters - Import : Import with truncate', async () =>
   it('should go to the data-matching step', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'nextStep', baseContext);
 
+    // Enabling truncate adds a "delete all data" confirm dialog on submit; accept it.
+    await boImportPage.dialogListener(page, true);
+
     const panelTitle = await boImportPage.goToImportNextStep(page);
     expect(panelTitle).to.contains(boImportPage.importPanelTitle);
   });

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/06_importMapping.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/06_importMapping.ts
@@ -25,7 +25,8 @@ describe('BO - Advanced Parameters - Import : Save and reload a data matching co
 
   const fileName: string = 'ui_import_mapping.csv';
   const mappingName: string = 'UIImportMapping';
-  const csvContent: string = 'Category ID;Active (0/1);Name *;Parent category;Root category (0/1);Description;Meta title;Meta description;URL rewritten;Image URL\n'
+  const csvContent: string = 'Category ID;Active (0/1);Name *;Parent category;Root category (0/1);'
+    + 'Description;Meta title;Meta description;URL rewritten;Image URL\n'
     + ';1;UI Mapping Category;Home;0;;;;;\n';
 
   before(async function () {

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/06_importMapping.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/06_importMapping.ts
@@ -1,0 +1,144 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {expect} from 'chai';
+import {
+  boDashboardPage,
+  boImportPage,
+  boLoginPage,
+  type BrowserContext,
+  type Page,
+  utilsFile,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_advancedParameters_import_importMapping';
+
+/*
+Save a column-matching configuration on step 2, log out and back in, then check
+the saved configuration is offered again and can be reloaded. Protects the
+Step-1 -> Step-2 data-matching persistence the migration will reshape.
+ */
+describe('BO - Advanced Parameters - Import : Save and reload a data matching configuration', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  const fileName: string = 'ui_import_mapping.csv';
+  const mappingName: string = 'UIImportMapping';
+  const csvContent: string = 'Category ID;Active (0/1);Name *;Parent category;Root category (0/1);Description;Meta title;Meta description;URL rewritten;Image URL\n'
+    + ';1;UI Mapping Category;Home;0;;;;;\n';
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+
+    await utilsFile.createFile('.', fileName, csvContent);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+    await utilsFile.deleteFile(fileName);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should go to \'Advanced Parameters > Import\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToImportPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.advancedParametersLink,
+      boDashboardPage.importLink,
+    );
+    await boImportPage.closeSfToolBar(page);
+
+    const pageTitle = await boImportPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boImportPage.pageTitle);
+  });
+
+  it('should upload the categories file and go to the data-matching step', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'uploadAndNext', baseContext);
+
+    const uploadSuccessText = await boImportPage.uploadImportFile(page, 'Categories', fileName);
+    expect(uploadSuccessText).to.contains(fileName);
+
+    const panelTitle = await boImportPage.goToImportNextStep(page);
+    expect(panelTitle).to.contains(boImportPage.importPanelTitle);
+  });
+
+  it('should save the data matching configuration', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'saveMapping', baseContext);
+
+    await boImportPage.saveDataMatchingConfig(page, mappingName);
+
+    const isVisible = await boImportPage.isLoadDataMatchingConfigVisible(page);
+    expect(isVisible).to.be.eq(true);
+  });
+
+  it('should log out then log back in', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'logoutLogin', baseContext);
+
+    await boDashboardPage.logoutBO(page);
+
+    const pageTitle = await boLoginPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boLoginPage.pageTitle);
+
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const dashboardTitle = await boDashboardPage.getPageTitle(page);
+    expect(dashboardTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should re-upload the file and reach the data-matching step', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'reUpload', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.advancedParametersLink,
+      boDashboardPage.importLink,
+    );
+    await boImportPage.closeSfToolBar(page);
+
+    const uploadSuccessText = await boImportPage.uploadImportFile(page, 'Categories', fileName);
+    expect(uploadSuccessText).to.contains(fileName);
+
+    const panelTitle = await boImportPage.goToImportNextStep(page);
+    expect(panelTitle).to.contains(boImportPage.importPanelTitle);
+  });
+
+  it('should find the saved data matching configuration', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkSavedMapping', baseContext);
+
+    const isVisible = await boImportPage.isLoadDataMatchingConfigVisible(page);
+    expect(isVisible).to.be.eq(true);
+
+    const configs = await boImportPage.getDataMatchingConfigs(page);
+    expect(configs).to.contains(mappingName);
+  });
+
+  it('should reload the saved data matching configuration', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loadMapping', baseContext);
+
+    await boImportPage.loadDataMatchingConfig(page, mappingName);
+
+    const panelTitle = await boImportPage.getPageTitle(page);
+    expect(panelTitle).to.contains(boImportPage.pageTitle);
+  });
+
+  it('should delete the saved data matching configuration', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'deleteMapping', baseContext);
+
+    await boImportPage.deleteDataMatchingConfig(page);
+
+    const configs = await boImportPage.getDataMatchingConfigs(page);
+    expect(configs).to.not.contains(mappingName);
+  });
+});

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/06_importMapping.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/06_importMapping.ts
@@ -78,10 +78,9 @@ describe('BO - Advanced Parameters - Import : Save and reload a data matching co
   it('should save the data matching configuration', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'saveMapping', baseContext);
 
+    // The saved configuration only shows up in the dropdown on a fresh step-2 load,
+    // which is asserted after the log out / log in below.
     await boImportPage.saveDataMatchingConfig(page, mappingName);
-
-    const isVisible = await boImportPage.isLoadDataMatchingConfigVisible(page);
-    expect(isVisible).to.be.eq(true);
   });
 
   it('should log out then log back in', async function () {
@@ -137,9 +136,20 @@ describe('BO - Advanced Parameters - Import : Save and reload a data matching co
   it('should delete the saved data matching configuration', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'deleteMapping', baseContext);
 
+    // Re-select the configuration then delete it (cleanup). Verify on a fresh step-2 load.
+    await boImportPage.loadDataMatchingConfig(page, mappingName);
     await boImportPage.deleteDataMatchingConfig(page);
 
-    const configs = await boImportPage.getDataMatchingConfigs(page);
-    expect(configs).to.not.contains(mappingName);
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.advancedParametersLink,
+      boDashboardPage.importLink,
+    );
+    await boImportPage.closeSfToolBar(page);
+    await boImportPage.uploadImportFile(page, 'Categories', fileName);
+    await boImportPage.goToImportNextStep(page);
+
+    const isVisible = await boImportPage.isLoadDataMatchingConfigVisible(page);
+    expect(isVisible).to.be.eq(false);
   });
 });

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/07_importAbort.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/07_importAbort.ts
@@ -27,6 +27,7 @@ describe('BO - Advanced Parameters - Import : Abort a running import', async () 
   const fileName: string = 'ui_import_abort.csv';
 
   let csvContent: string = 'Active (0/1);Name *;Categories (x,y,z...);Price tax excluded;Reference #;Quantity\n';
+
   for (let i = 1; i <= numberOfProducts; i++) {
     csvContent += `1;UI Abort Product ${i};Home;${i}.99;UI-ABORT-${i};10\n`;
   }

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/07_importAbort.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/07_importAbort.ts
@@ -26,10 +26,11 @@ describe('BO - Advanced Parameters - Import : Abort a running import', async () 
   const numberOfProducts: number = 300;
   const fileName: string = 'ui_import_abort.csv';
 
-  let csvContent: string = 'Active (0/1);Name *;Categories (x,y,z...);Price tax excluded;Reference #;Quantity\n';
+  // Columns must follow the import field order (positional auto-mapping): id, active, name, category, price.
+  let csvContent: string = 'Product ID;Active (0/1);Name *;Categories (x,y,z...);Price tax excluded\n';
 
   for (let i = 1; i <= numberOfProducts; i++) {
-    csvContent += `1;UI Abort Product ${i};Home;${i}.99;UI-ABORT-${i};10\n`;
+    csvContent += `;1;UI Abort Product ${i};Home;${i}.99\n`;
   }
 
   before(async function () {

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/07_importAbort.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/07_importAbort.ts
@@ -1,0 +1,93 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {expect} from 'chai';
+import {
+  boDashboardPage,
+  boImportPage,
+  boLoginPage,
+  type BrowserContext,
+  type Page,
+  utilsFile,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_advancedParameters_import_importAbort';
+
+/*
+Start a long import then click "Abort import": the progress modal must show the
+aborting state and stop cleanly. Protects the progress-modal / AJAX-poller UI
+contract that the migration will reshape.
+ */
+describe('BO - Advanced Parameters - Import : Abort a running import', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  const numberOfProducts: number = 300;
+  const fileName: string = 'ui_import_abort.csv';
+
+  let csvContent: string = 'Active (0/1);Name *;Categories (x,y,z...);Price tax excluded;Reference #;Quantity\n';
+  for (let i = 1; i <= numberOfProducts; i++) {
+    csvContent += `1;UI Abort Product ${i};Home;${i}.99;UI-ABORT-${i};10\n`;
+  }
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+
+    await utilsFile.createFile('.', fileName, csvContent);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+    await utilsFile.deleteFile(fileName);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should go to \'Advanced Parameters > Import\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToImportPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.advancedParametersLink,
+      boDashboardPage.importLink,
+    );
+    await boImportPage.closeSfToolBar(page);
+
+    const pageTitle = await boImportPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boImportPage.pageTitle);
+  });
+
+  it('should upload the products file and go to the data-matching step', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'uploadAndNext', baseContext);
+
+    const uploadSuccessText = await boImportPage.uploadImportFile(page, 'Products', fileName);
+    expect(uploadSuccessText).to.contains(fileName);
+
+    const panelTitle = await boImportPage.goToImportNextStep(page);
+    expect(panelTitle).to.contains(boImportPage.importPanelTitle);
+  });
+
+  it('should start the import', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'startImport', baseContext);
+
+    const modalTitle = await boImportPage.startFileImport(page);
+    expect(modalTitle).to.contains(boImportPage.importModalTitle);
+  });
+
+  it('should abort the running import', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'abortImport', baseContext);
+
+    const isAborting = await boImportPage.abortImport(page);
+    expect(isAborting, 'The aborting state was not shown').to.be.eq(true);
+  });
+});

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/08_importMultistoreShopContext.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/08_importMultistoreShopContext.ts
@@ -1,0 +1,216 @@
+// Import utils
+import testContext from '@utils/testContext';
+import setMultiStoreStatus from '@commonTests/BO/advancedParameters/multistore';
+
+import {expect} from 'chai';
+import {
+  boDashboardPage,
+  boImportPage,
+  boLoginPage,
+  boMultistorePage,
+  boMultistoreShopPage,
+  boMultistoreShopCreatePage,
+  boMultistoreShopUrlCreatePage,
+  boProductsPage,
+  type BrowserContext,
+  FakerShop,
+  type Page,
+  utilsFile,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_advancedParameters_import_importMultistoreShopContext';
+
+/*
+Multistore: with the BO context set to a specific shop, import products whose
+"shop" column is empty. The products must be associated only to the shop that
+was active during the import (the BO context), not to the other shops.
+ */
+describe('BO - Advanced Parameters - Import : Multistore - import in a specific shop context', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+  let shopID: number = 0;
+
+  const createShopData: FakerShop = new FakerShop({name: 'importShop', shopGroup: 'Default', categoryRoot: 'Home'});
+  const fileName: string = 'ui_import_ms_context.csv';
+  const firstProduct: string = 'UI MS Context Product A';
+  const secondProduct: string = 'UI MS Context Product B';
+  const thirdProduct: string = 'UI MS Context Product C';
+  // Columns follow the import field order; the "shop" column is intentionally left out (empty).
+  const csvContent: string = 'Product ID;Active (0/1);Name *;Categories (x,y,z...);Price tax excluded\n'
+    + `;1;${firstProduct};Home;10.00\n`
+    + `;1;${secondProduct};Home;20.00\n`
+    + `;1;${thirdProduct};Home;30.00\n`;
+
+  // Pre-condition: enable multistore
+  setMultiStoreStatus(true, `${baseContext}_preTest`);
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+
+    await utilsFile.createFile('.', fileName, csvContent);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+    await utilsFile.deleteFile(fileName);
+  });
+
+  describe('Create a second shop', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
+    it('should go to \'Advanced Parameters > Multistore\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToMultiStorePage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.multistoreLink,
+      );
+      await boMultistorePage.closeSfToolBar(page);
+
+      const pageTitle = await boMultistorePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistorePage.pageTitle);
+    });
+
+    it('should create the shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createShop', baseContext);
+
+      await boMultistorePage.goToNewShopPage(page);
+
+      const textResult = await boMultistoreShopCreatePage.setShop(page, createShopData);
+      expect(textResult).to.contains(boMultistorePage.successfulCreationMessage);
+
+      shopID = parseInt(await boMultistoreShopPage.getTextColumn(page, 1, 'id_shop'), 10);
+    });
+
+    it('should set the shop URL', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'setShopUrl', baseContext);
+
+      await boMultistoreShopPage.filterTable(page, 'a!name', createShopData.name);
+      await boMultistoreShopPage.goToSetURL(page, 1);
+
+      const textResult = await boMultistoreShopUrlCreatePage.setVirtualUrl(page, createShopData.name);
+      expect(textResult).to.contains(boMultistoreShopUrlCreatePage.successfulCreationMessage);
+    });
+  });
+
+  describe('Import products in the new shop context', async () => {
+    it('should go to \'Advanced Parameters > Import\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToImportPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.importLink,
+      );
+      await boImportPage.closeSfToolBar(page);
+
+      const pageTitle = await boImportPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boImportPage.pageTitle);
+    });
+
+    it('should switch the BO context to the new shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'switchToNewShop', baseContext);
+
+      await boImportPage.clickOnMultiStoreHeader(page);
+      await boImportPage.chooseShop(page, 2);
+
+      const shopName = await boImportPage.getShopName(page);
+      expect(shopName).to.eq(createShopData.name);
+    });
+
+    it('should import the products', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'importProducts', baseContext);
+
+      const uploadSuccessText = await boImportPage.uploadImportFile(page, 'Products', fileName);
+      expect(uploadSuccessText).to.contains(fileName);
+
+      await boImportPage.goToImportNextStep(page);
+      await boImportPage.startFileImport(page);
+
+      const isCompleted = await boImportPage.getImportValidationMessage(page);
+      expect(isCompleted, 'The import is not completed!').to.contains('Data imported');
+
+      await boImportPage.closeImportModal(page);
+    });
+  });
+
+  describe('Check shop-specific visibility', async () => {
+    it('should go to \'Catalog > Products\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.catalogParentLink,
+        boDashboardPage.productsLink,
+      );
+      await boProductsPage.closeSfToolBar(page);
+
+      const pageTitle = await boProductsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boProductsPage.pageTitle);
+    });
+
+    it('should find the imported products in the new shop context', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'findInNewShop', baseContext);
+
+      await boProductsPage.clickOnMultiStoreHeader(page);
+      await boProductsPage.chooseShop(page, 2);
+
+      await boProductsPage.resetFilter(page);
+      await boProductsPage.filterProducts(page, 'product_name', firstProduct, 'input');
+      expect(await boProductsPage.getNumberOfProductsFromList(page)).to.be.eq(1);
+    });
+
+    it('should not find the imported products in the default shop context', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'notInDefaultShop', baseContext);
+
+      await boProductsPage.clickOnMultiStoreHeader(page);
+      await boProductsPage.chooseShop(page, 1);
+
+      await boProductsPage.resetFilter(page);
+      await boProductsPage.filterProducts(page, 'product_name', firstProduct, 'input');
+      expect(await boProductsPage.getNumberOfProductsFromList(page)).to.be.eq(0);
+
+      await boProductsPage.resetFilter(page);
+    });
+  });
+
+  describe('Delete the second shop', async () => {
+    it('should go to \'Advanced Parameters > Multistore\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToMultiStore', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.multistoreLink,
+      );
+      await boMultistorePage.closeSfToolBar(page);
+
+      const pageTitle = await boMultistorePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistorePage.pageTitle);
+    });
+
+    it('should delete the shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteShop', baseContext);
+
+      await boMultistorePage.goToShopPage(page, shopID);
+      await boMultistoreShopPage.filterTable(page, 'a!name', createShopData.name);
+
+      const textResult = await boMultistoreShopPage.deleteShop(page, 1);
+      expect(textResult).to.contains(boMultistoreShopPage.successfulDeleteMessage);
+    });
+  });
+
+  // Post-condition: disable multistore
+  setMultiStoreStatus(false, `${baseContext}_postTest`);
+});

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/09_importMultistoreShopColumn.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/09_importMultistoreShopColumn.ts
@@ -1,0 +1,216 @@
+// Import utils
+import testContext from '@utils/testContext';
+import setMultiStoreStatus from '@commonTests/BO/advancedParameters/multistore';
+
+import {expect} from 'chai';
+import {
+  boCategoriesPage,
+  boDashboardPage,
+  boImportPage,
+  boLoginPage,
+  boMultistorePage,
+  boMultistoreShopPage,
+  boMultistoreShopCreatePage,
+  boMultistoreShopUrlCreatePage,
+  type BrowserContext,
+  FakerShop,
+  type Page,
+  utilsFile,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_advancedParameters_import_importMultistoreShopColumn';
+
+/*
+Multistore: import categories whose "shop" column explicitly targets different
+shops. Each category must end up associated only to the shop named in its row,
+proving the shop column drives the per-shop split.
+ */
+describe('BO - Advanced Parameters - Import : Multistore - import with an explicit shop column', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+  let shopID: number = 0;
+  let csvContent: string = '';
+
+  const createShopData: FakerShop = new FakerShop({name: 'columnShop', shopGroup: 'Default', categoryRoot: 'Home'});
+  const fileName: string = 'ui_import_ms_column.csv';
+  const defaultShopCategory: string = 'UI Split Category Default';
+  const secondShopCategory: string = 'UI Split Category Second';
+
+  // Pre-condition: enable multistore
+  setMultiStoreStatus(true, `${baseContext}_preTest`);
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+
+    // Columns follow the import field order; the "shop" column is the last category field.
+    csvContent = 'Category ID;Active (0/1);Name *;Parent category;Root category (0/1);'
+      + 'Description;Meta title;Meta description;URL rewritten;Image URL;ID / Name of the store\n'
+      + `;1;${defaultShopCategory};Home;0;;;;;;${global.INSTALL.SHOP_NAME}\n`
+      + `;1;${secondShopCategory};Home;0;;;;;;${createShopData.name}\n`;
+    await utilsFile.createFile('.', fileName, csvContent);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+    await utilsFile.deleteFile(fileName);
+  });
+
+  describe('Create a second shop', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
+    it('should go to \'Advanced Parameters > Multistore\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToMultiStorePage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.multistoreLink,
+      );
+      await boMultistorePage.closeSfToolBar(page);
+
+      const pageTitle = await boMultistorePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistorePage.pageTitle);
+    });
+
+    it('should create the shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createShop', baseContext);
+
+      await boMultistorePage.goToNewShopPage(page);
+
+      const textResult = await boMultistoreShopCreatePage.setShop(page, createShopData);
+      expect(textResult).to.contains(boMultistorePage.successfulCreationMessage);
+
+      shopID = parseInt(await boMultistoreShopPage.getTextColumn(page, 1, 'id_shop'), 10);
+    });
+
+    it('should set the shop URL', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'setShopUrl', baseContext);
+
+      await boMultistoreShopPage.filterTable(page, 'a!name', createShopData.name);
+      await boMultistoreShopPage.goToSetURL(page, 1);
+
+      const textResult = await boMultistoreShopUrlCreatePage.setVirtualUrl(page, createShopData.name);
+      expect(textResult).to.contains(boMultistoreShopUrlCreatePage.successfulCreationMessage);
+    });
+  });
+
+  describe('Import categories with an explicit shop column', async () => {
+    it('should go to \'Advanced Parameters > Import\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToImportPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.importLink,
+      );
+      await boImportPage.closeSfToolBar(page);
+
+      const pageTitle = await boImportPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boImportPage.pageTitle);
+    });
+
+    it('should import the categories', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'importCategories', baseContext);
+
+      const uploadSuccessText = await boImportPage.uploadImportFile(page, 'Categories', fileName);
+      expect(uploadSuccessText).to.contains(fileName);
+
+      await boImportPage.goToImportNextStep(page);
+      await boImportPage.startFileImport(page);
+
+      const isCompleted = await boImportPage.getImportValidationMessage(page);
+      expect(isCompleted, 'The import is not completed!').to.contains('Data imported');
+
+      await boImportPage.closeImportModal(page);
+    });
+  });
+
+  describe('Check the per-shop split', async () => {
+    it('should go to \'Catalog > Categories\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCategoriesPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.catalogParentLink,
+        boDashboardPage.categoriesLink,
+      );
+
+      const pageTitle = await boCategoriesPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCategoriesPage.pageTitle);
+    });
+
+    it('should see only the default-shop category in the default shop context', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDefaultShop', baseContext);
+
+      await boCategoriesPage.clickOnMultiStoreHeader(page);
+      await boCategoriesPage.chooseShop(page, 1);
+
+      await boCategoriesPage.resetFilter(page);
+      await boCategoriesPage.filterCategories(page, 'input', 'name', defaultShopCategory);
+      expect(await boCategoriesPage.getNumberOfElementInGrid(page)).to.be.eq(1);
+
+      await boCategoriesPage.resetFilter(page);
+      await boCategoriesPage.filterCategories(page, 'input', 'name', secondShopCategory);
+      expect(await boCategoriesPage.getNumberOfElementInGrid(page)).to.be.eq(0);
+    });
+
+    it('should see only the second-shop category in the second shop context', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkSecondShop', baseContext);
+
+      await boCategoriesPage.clickOnMultiStoreHeader(page);
+      await boCategoriesPage.chooseShop(page, 2);
+
+      await boCategoriesPage.resetFilter(page);
+      await boCategoriesPage.filterCategories(page, 'input', 'name', secondShopCategory);
+      expect(await boCategoriesPage.getNumberOfElementInGrid(page)).to.be.eq(1);
+
+      await boCategoriesPage.resetFilter(page);
+      await boCategoriesPage.filterCategories(page, 'input', 'name', defaultShopCategory);
+      expect(await boCategoriesPage.getNumberOfElementInGrid(page)).to.be.eq(0);
+
+      await boCategoriesPage.resetFilter(page);
+    });
+  });
+
+  describe('Delete the second shop', async () => {
+    it('should go to \'Advanced Parameters > Multistore\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToMultiStore', baseContext);
+
+      await boCategoriesPage.clickOnMultiStoreHeader(page);
+      await boCategoriesPage.chooseShop(page, 1);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.multistoreLink,
+      );
+      await boMultistorePage.closeSfToolBar(page);
+
+      const pageTitle = await boMultistorePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistorePage.pageTitle);
+    });
+
+    it('should delete the shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteShop', baseContext);
+
+      await boMultistorePage.goToShopPage(page, shopID);
+      await boMultistoreShopPage.filterTable(page, 'a!name', createShopData.name);
+
+      const textResult = await boMultistoreShopPage.deleteShop(page, 1);
+      expect(textResult).to.contains(boMultistoreShopPage.successfulDeleteMessage);
+    });
+  });
+
+  // Post-condition: disable multistore
+  setMultiStoreStatus(false, `${baseContext}_postTest`);
+});

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OSL-3.0",
       "dependencies": {
         "@faker-js/faker": "^10.5.0",
-        "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+        "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#import-page-object-extensions",
         "chai": "^6.2.2",
         "chai-string": "^2.0.0",
         "dotenv": "^17.4.1",
@@ -688,7 +688,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#47244ff6014c02c89ef286d56b460bfd89ff92d4",
+      "resolved": "git+ssh://git@github.com/mattgoud/ui-testing-library.git#4daf4f07a489a08fe73bf1abf5476ab733a8c153",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -112,7 +112,7 @@
   "homepage": "https://github.com/PrestaShop/PrestaShop/tree/develop/tests/UI#readme",
   "dependencies": {
     "@faker-js/faker": "^10.5.0",
-    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+    "@prestashop-core/ui-testing": "https://github.com/mattgoud/ui-testing-library#import-page-object-extensions",
     "chai": "^6.2.2",
     "chai-string": "^2.0.0",
     "dotenv": "^17.4.1",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Story 1 of the Import admin page migration (#41321), part 3: Playwright campaigns locking the Import page UI contract (Step-1 -> Step-2 hand-off, data-matching, progress modal, truncate). Companion to the Behat safety net in #41814 / #41815. **Draft / WIP.**
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `npm run test:functional:BO:advanced-parameters:01-06` (or trigger ga.tests.ui.pr on this PR with that command). Campaigns under `tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/`.
| UI Tests          | :green_circle: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/28165819713
| Fixed issue or discussion?     | Part of #41798
| Related PRs       | PrestaShop/ui-testing-library#1048 (import page-object methods). `tests/UI/package.json` is temporarily pinned to the fork branch; to revert to `PrestaShop/ui-testing-library#main` once that PR is merged/released.
| Sponsor company   | @PrestaShopCorp

### Campaigns (7)

- `03_importCategories` — upload -> validate+import -> assert on the Categories listing.
- `04_importProducts` — upload -> import -> assert on the Products listing.
- `05_importTruncate` — import 10 products with truncate -> grid holds exactly 10.
- `06_importMapping` — save a column-matching config on step 2, log out/in, reload it.
- `07_importAbort` — start a long import and abort it from the progress modal.
- `08_importMultistoreShopContext` — multistore: empty shop column inherits the active shop context.
- `09_importMultistoreShopColumn` — multistore: explicit shop column splits rows per shop.

### Notes

- New page-object methods (`setTruncate`, `setMatchReferences`, `saveDataMatchingConfig` / `loadDataMatchingConfig` / `deleteDataMatchingConfig` / `getDataMatchingConfigs` / `isLoadDataMatchingConfigVisible`, `abortImport`) live in the ui-testing-library; the fork branch is rebased on the latest upstream `main`.

### Known tradeoffs

- **`tests/UI/package.json` is temporarily pinned to the ui-testing-library fork branch** (PrestaShop/ui-testing-library#1048). This must be reverted to `PrestaShop/ui-testing-library#main` before merge, once #1048 is merged/released — the package-lock change is intentional and tied to that pin.
- **Campaign `09` (explicit shop column) runs the import from the default shop context, not a strict "All Shops" context**, and uses categories (whose `shop` field is reachable by position). The explicit `shop` column drives the per-shop split regardless of context, and the multistore import logic itself is already locked by Behat in #41815. (No "all shops" header helper exists in the lib.)
- **Product fixtures must list columns in the import field order** (step-2 auto-mapping is positional: column `i` -> field `i+1`, not header-based), so the CSVs use the `id;active;name;category;price` prefix.



