### PR TITLE
Add hook actionNotFound

### DIFF
--- a/controllers/front/PageNotFoundController.php
+++ b/controllers/front/PageNotFoundController.php
@@ -13,6 +13,15 @@ class PageNotFoundControllerCore extends FrontController
     public $ssl = true;
 
     /**
+     * @see FrontController::init()
+     */
+    public function init()
+    {
+        Hook::exec('actionNotFound');
+        parent::init();
+    }
+
+    /**
      * Assign template vars related to page content.
      *
      * @see FrontController::initContent()

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -131,6 +131,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         // Otherwise immediately show 404
         if (!Validate::isLoadedObject($this->product)) {
+            Hook::exec('actionNotFound');
             $this->product = null;
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -75,6 +75,7 @@ class CategoryControllerCore extends ProductListingFrontController
 
         // Otherwise immediately show 404
         if (!Validate::isLoadedObject($this->category)) {
+            Hook::exec('actionNotFound');
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
             $this->errors[] = $this->trans('This category is no longer available.', [], 'Shop.Notifications.Error');

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5678,5 +5678,10 @@
       <title/>
       <description/>
     </hook>
+    <hook id="actionNotFound">
+      <name>actionNotFound</name>
+      <title>Action when a page is not found</title>
+      <description>Allows modules to react when a page is not found - log it, redirect or perform other actions.</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Adds a hook triggered when a page is not found. It allows to log 404 events into database, perform redirection only in these cases, notify the admin etc.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try visiting some nonsense pages or product ids that don't exist and see if you get a response on this hook.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Example usage

```php
    public function hookActionNotFound($params)
    {
        // Get the current URL
        $currentUrlPath = $this->getNormalizedUrl();

        // Check if we have a redirect for this URL
        $newUrlForRedirection = Db::getInstance()->getValue('
            SELECT new_url 
            FROM ' . _DB_PREFIX_ . 'tox_redirection_redirects
            WHERE 
            (old_url = "' . pSQL($currentUrlPath) . '" || old_url = "' . pSQL($currentUrlPath . '/') . '")
        ');

        // If we have it, we redirect there with 301
        if (!empty($newUrlForRedirection)) {
            header('Cache-Control: no-cache');
            header('Location: ' . $newUrlForRedirection, true, 301);
            exit;
        }

        // If not, we log it to database for further analysis
        if (Configuration::get('TOX_REDIRECTION_LOG_ENABLED')) {
            $this->logNotFoundUrl($currentUrlPath);
        }
    }
```