### PR TITLE
Fix: Update cache directory handling in HTMLPurifier constructor

### DIFF
--- a/src/PrestaShopBundle/Utils/HTMLPurifier.php
+++ b/src/PrestaShopBundle/Utils/HTMLPurifier.php
@@ -20,10 +20,11 @@ class HTMLPurifier
      */
     private $instance;
 
+    private readonly string $serializerPath;
+
     public function __construct(
         private readonly Filesystem $filesystem,
-        // kernel.cache_dir (var/cache/dev/admin) is excluded by LegacyCacheClearer; using it avoids a race condition where var/cache/dev/purifier is deleted between __construct and purify().
-        #[Autowire(param: 'kernel.cache_dir')]
+        #[Autowire(param: 'prestashop.legacy_cache_dir')]
         private readonly string $cacheDir,
     ) {
         $config = HTMLPurifier_Config::createDefault();
@@ -31,10 +32,10 @@ class HTMLPurifier
         $config->set('Attr.EnableID', true);
         $config->set('Attr.AllowedFrameTargets', ['_blank']);
 
-        $serializerPath = $this->cacheDir . DIRECTORY_SEPARATOR . 'purifier';
-        $this->filesystem->mkdir($serializerPath);
+        $this->serializerPath = $this->cacheDir . 'purifier';
+        $this->filesystem->mkdir($this->serializerPath);
 
-        $config->set('Cache.SerializerPath', $serializerPath);
+        $config->set('Cache.SerializerPath', $this->serializerPath);
 
         $purifier = new \HTMLPurifier($config);
         $this->instance = $purifier;
@@ -49,6 +50,9 @@ class HTMLPurifier
      */
     public function purify($html)
     {
+        // In case of cache clear : the directory is removed; to avoid a race condition we recreate the cache dir for purifier
+        $this->filesystem->mkdir($this->serializerPath);
+
         return $this->instance->purify($html);
     }
 }

--- a/src/PrestaShopBundle/Utils/HTMLPurifier.php
+++ b/src/PrestaShopBundle/Utils/HTMLPurifier.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
@@ -21,7 +22,8 @@ class HTMLPurifier
 
     public function __construct(
         private readonly Filesystem $filesystem,
-        #[Autowire(param: 'prestashop.legacy_cache_dir')]
+        // kernel.cache_dir (var/cache/dev/admin) is excluded by LegacyCacheClearer; using it avoids a race condition where var/cache/dev/purifier is deleted between __construct and purify().
+        #[Autowire(param: 'kernel.cache_dir')]
         private readonly string $cacheDir,
     ) {
         $config = HTMLPurifier_Config::createDefault();
@@ -29,7 +31,7 @@ class HTMLPurifier
         $config->set('Attr.EnableID', true);
         $config->set('Attr.AllowedFrameTargets', ['_blank']);
 
-        $serializerPath = $this->cacheDir . 'purifier';
+        $serializerPath = $this->cacheDir . DIRECTORY_SEPARATOR . 'purifier';
         $this->filesystem->mkdir($serializerPath);
 
         $config->set('Cache.SerializerPath', $serializerPath);


### PR DESCRIPTION
| Questions                  | Answers
| -------------------------- | -------
| Branch?                    | develop
| Description?               | `HTMLPurifier` tries to purify directory `purifier` in cache dir during a cache clear triggered by a debug mode toggle. This creates a race condition: the redirect after the form save starts a new request that calls `mkdir('var/cache/dev/purifier')` in `HTMLPurifier::__construct()`, but the shutdown function from the previous request runs concurrently and deletes the directory before `HTMLPurifier::purify()` reaches `_prepareDir()`. Solve issue by recreated cache dir before calling `HTMLPurifier::purify()`
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | 1. Ensure debug mode is **disabled** (`_PS_MODE_DEV_ = false` in `config/defines.inc.php`). <br> 2. Go to **BO > Advanced Parameters > Performance**. <br> 3. Enable **Debug mode** and save — the page must show a green success alert with no 500 error. <br> 4. Disable debug mode and save — same expectation. <br> 5. Run `HEADLESS=false npm run test:functional:BO:advanced-parameters:01-06` from `tests/UI` — the `enable/disable debug mode` steps must pass.
| UI Tests                   | ✅  https://github.com/cnavarro-prestashop/ga.tests.ui.pr/actions/runs/28177406055
| Sponsor company            | PrestaShop