### PR TITLE
Fix meta title appended to supplier URLs

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -615,7 +615,10 @@ class LinkCore
         $params = [];
         $params['id'] = $supplier->id;
         $params['rewrite'] = (!$alias) ? $supplier->link_rewrite : $alias;
-        $params['meta_title'] = Tools::str2url($supplier->meta_title);
+
+        if ($dispatcher->hasKeyword('supplier_rule', $idLang, 'meta_title', $idShop)) {
+            $params['meta_title'] = Tools::str2url($supplier->meta_title);
+        }
 
         return $url . $dispatcher->createUrl('supplier_rule', $idLang, $params, $this->allow, '', $idShop);
     }

--- a/tests/Integration/Classes/LinkTest.php
+++ b/tests/Integration/Classes/LinkTest.php
@@ -67,4 +67,17 @@ class LinkTest extends TestCase
         $this->assertEquals(1, $query['id_product']);
         $this->assertArrayNotHasKey('id_product_attribute', $query);
     }
+
+    public function testSupplierUrlOmitsMetaTitleWhenRouteHasNoMetaTitleKeyword(): void
+    {
+        $reflectionDispatcher = new ReflectionClass('Dispatcher');
+        $property = $reflectionDispatcher->getProperty('use_routes');
+        $property->setAccessible(true);
+        $property->setValue(Dispatcher::getInstance(), true);
+
+        $url = Context::getContext()->link->getSupplierLink(1);
+        parse_str(parse_url($url)['query'] ?? '', $query);
+
+        $this->assertArrayNotHasKey('meta_title', $query);
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `Link::getSupplierLink()` unconditionally added the `meta_title` query parameter even when the `supplier_rule` route does not use the `meta_title` keyword, producing URLs like `/supplier/1-fashion-supplier?meta_title=`. This guards the parameter with `Dispatcher::hasKeyword()` exactly like the other link builders already do (`getProductLink`, `getCategoryLink`, and — via #41808 — `getCMSLink`, `getCMSCategoryLink`, `getManufacturerLink`). Supplier was the last link builder still missing the guard.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With friendly URLs enabled, generate a supplier link, e.g. `Context::getContext()->link->getSupplierLink(1)`. Before: `/supplier/1-fashion-supplier?meta_title=`. After: `/supplier/1-fashion-supplier` (no `meta_title` query parameter), while the page still resolves (HTTP 200). An integration test covering this is added in `tests/Integration/Classes/LinkTest.php`.
| Fixed issue or discussion?     | Completes the regression fix from #41808 (manufacturer, CMS page, CMS category) for the remaining `getSupplierLink()` case.
| Related PRs       | #41808
| Sponsor company   |
