### PR TITLE
Cover getCustomerCartRules using the passed cart for product restrictions

### DIFF
--- a/tests/Integration/Classes/CartRuleTest.php
+++ b/tests/Integration/Classes/CartRuleTest.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Classes;
 
+use Cart;
 use CartRule;
+use Context;
 use Customer;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Configuration;
@@ -62,6 +64,46 @@ class CartRuleTest extends TestCase
         );
 
         $this->assertEquals(1, count($customerCartRules));
+    }
+
+    /**
+     * When a cart is passed explicitly (as the back office customer view does),
+     * the product restriction check must use that cart and not the context cart,
+     * which is null in the back office and used to trigger a TypeError.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/35841
+     */
+    public function testGetCustomerCartRulesUsesProvidedCartForProductRestriction(): void
+    {
+        $cartRule = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id);
+        $cartRule->product_restriction = true;
+        $cartRule->save();
+
+        $cart = new Cart();
+        $cart->id_customer = (int) $this->dummyCustomer->id;
+        $cart->id_lang = $this->defaultLanguageId;
+        $cart->id_currency = (int) $this->configuration->get('PS_CURRENCY_DEFAULT', null, ShopConstraint::allShops());
+        $cart->add();
+
+        // Back office customer view has no cart in the context.
+        $context = Context::getContext();
+        $previousContextCart = $context->cart;
+        $context->cart = null;
+
+        try {
+            $customerCartRules = CartRule::getCustomerCartRules(
+                $this->defaultLanguageId,
+                (int) $this->dummyCustomer->id,
+                true,
+                true,
+                false,
+                $cart
+            );
+        } finally {
+            $context->cart = $previousContextCart;
+        }
+
+        $this->assertIsArray($customerCartRules);
     }
 
     public function testGetAllCartRulesForCustomerEvenDisabled(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Retargeted from `9.1.x`, where this also carried the source fix. `9.2.x` already applies the customer cart at `CartRule.php:511` (it arrived there via #40424), so only the missing coverage is left. The test still has teeth on `9.2.x`: putting `Context::getContext()->cart` back on that line makes `testGetCustomerCartRulesUsesProvidedCartForProductRestriction` error, and it passes as merged.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below — covered by an integration test.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30202225442 (45/45 green)
| Fixed issue or discussion? | Fixes #35841
| Related PRs       | #40424 (same fix already merged to `develop`), #35842 (proposes the same change, but targets `develop` where it is already fixed)
| Sponsor company   |

## Problem

In `CartRule::getCustomerCartRules()`, the product‑restriction branch is guarded by `if (isset($cart, $cart->id))` — i.e. it only runs when a valid customer cart has been **passed in** as the `$cart` argument. Inside that guard, however, the check was called with `Context::getContext()->cart` instead of `$cart`:

```php
if (isset($cart, $cart->id)) {
    foreach ($result as $key => $cart_rule) {
        if ($cart_rule['product_restriction']) {
            $cr = new CartRule((int) $cart_rule['id_cart_rule']);
            $r = $cr->checkProductRestrictionsFromCart(Context::getContext()->cart, false, false);
```

In the back office customer view there is no cart in the context, so `Context::getContext()->cart` is `null`, and `checkProductRestrictionsFromCart(CartCore $cart, ...)` throws:

```
CartRuleCore::checkProductRestrictionsFromCart(): Argument #1 ($cart) must be of type CartCore, null given, called in classes/CartRule.php on line 500
```

## Fix

Use the `$cart` that the method already received (and just guarded with `isset($cart, $cart->id)`), instead of the unrelated context cart. This is the cart whose restrictions we actually want to evaluate.

```php
$r = $cr->checkProductRestrictionsFromCart($cart, false, false);
```

## Note on duplication

This is the **same one‑line change already merged to `develop` in #40424**. Because fixes do not flow *down* from `develop`, `9.1.x` still carries the bug. PR #35842 proposes the identical fix but targets `develop`, where it is now redundant — credit to its author for the original diagnosis. This PR backports the fix to the maintained `9.1.x` branch.

## How to test

An integration test is included (`CartRuleTest::testGetCustomerCartRulesUsesProvidedCartForProductRestriction`):

1. Create a customer‑specific cart rule with `product_restriction = 1`.
2. Create a real cart for that customer and pass it to `getCustomerCartRules()`.
3. Set `Context::getContext()->cart = null` (back office customer view).
4. **Before:** `TypeError ... null given ... line 500`. **After:** the call returns normally.


