### PR TITLE
Fall back to default precision when the context currency is null

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -9,6 +9,7 @@ use PrestaShop\PrestaShop\Adapter\ContainerFinder;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContext;
+use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\Precision;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Exception\ContainerNotFoundException;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
@@ -510,7 +511,11 @@ class ContextCore
     {
         if ($this->priceComputingPrecision === null) {
             $computingPrecision = new ComputingPrecision();
-            $this->priceComputingPrecision = $computingPrecision->getPrecision($this->currency->precision);
+            // The context currency may be unavailable (e.g. invoice/slip PDF generation on a
+            // multishop install), in which case we fall back to the default precision instead
+            // of fataling on the strictly typed ComputingPrecision::getPrecision(int).
+            $displayPrecision = isset($this->currency->precision) ? (int) $this->currency->precision : Precision::DEFAULT_PRECISION;
+            $this->priceComputingPrecision = $computingPrecision->getPrecision($displayPrecision);
         }
 
         return $this->priceComputingPrecision;

--- a/tests/Unit/Classes/ContextTest.php
+++ b/tests/Unit/Classes/ContextTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use Context;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\Precision;
+
+class ContextTest extends TestCase
+{
+    /**
+     * When no currency is set on the context (e.g. PDF generation on a multishop
+     * install), getComputingPrecision() must not fatal on the strictly typed
+     * ComputingPrecision::getPrecision(int), but fall back to a default precision.
+     */
+    public function testGetComputingPrecisionFallsBackToDefaultWhenCurrencyIsNull(): void
+    {
+        $context = new Context();
+        $context->currency = null;
+
+        $this->assertSame(Precision::DEFAULT_PRECISION, $context->getComputingPrecision());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Prevents a `TypeError` fatal when `Context::getComputingPrecision()` is called with no currency on the context.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below — covered by a unit test.
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/30435531172
| Fixed issue or discussion? | Fixes #41494
| Sponsor company   |

## Problem

On a multishop install, generating an invoice / delivery slip / credit slip PDF from the back office reaches `Context::getComputingPrecision()` with no currency set on the context. The method passed `$this->currency->precision` (which resolves to `null`) into the strictly typed `ComputingPrecision::getPrecision(int $displayPrecision)`:

```
TypeError: ComputingPrecision::getPrecision(): Argument #1 ($displayPrecision)
must be of type int, null given, called in classes/Context.php on line 480
```

This aborts the whole PDF generation (the precision is used to `ps_round()` the invoice amounts). Reported and reproduced by a maintainer in #41494.

## Fix

Guard the precision lookup and fall back to the default currency precision (`Precision::DEFAULT_PRECISION`) when the context currency — or its `precision` — is unavailable:

```php
$displayPrecision = isset($this->currency->precision)
    ? (int) $this->currency->precision
    : Precision::DEFAULT_PRECISION;
```

`isset()` is null-safe for both a null currency and a null precision, so no warning is emitted.

### Scope note

This is a defensive guard against the fatal. `getComputingPrecision()` is a generic context accessor and already derives the precision from the **context** currency (not from the order), so this change keeps the existing behaviour and only adds a safe fallback for the previously‑fataling null case. Making the back‑office PDF flow set the context currency from the order (so non‑2‑decimal currencies always round to their own precision) is a broader, separate improvement and is intentionally out of scope here.

## How to test

A unit test is included (`tests/Unit/Classes/ContextTest.php`):

1. Build a `Context` with `currency = null`.
2. Call `getComputingPrecision()`.
3. **Before:** `TypeError … null given … Context.php:480`. **After:** returns `Precision::DEFAULT_PRECISION` instead of fataling.

(The test forces the `currency = null` state at the unit level; that is the condition the multishop PDF path hits — I did not reproduce the full end‑to‑end multishop PDF flow.)
