### PR TITLE
Return 404 instead of 403 for missing images in img/

### DIFF
--- a/img/.htaccess
+++ b/img/.htaccess
@@ -10,7 +10,8 @@
 # Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
-    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|avif)$">
+    # Grant on the URL path (not the resolved file) so a missing image returns 404 instead of 403.
+    <If "%{REQUEST_URI} =~ /(?i)\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|avif)$/">
         Require all granted
-    </Files>
+    </If>
 </IfModule>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Make `img/.htaccess` return `404` (not `403`) for missing images, while keeping non-image files denied.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Request a missing image in a non-existent sub-path, e.g. `GET /img/p/9/9/9/99999.jpg` — it must return `404`, and a non-image file in `img/` must still return `403`.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30442265360 - green, 45/45 on the first attempt
| Fixed issue or discussion? | Fixes #41308
| Sponsor company   |

## Problem

`img/.htaccess` denies the directory by default (`Require all denied`) and only grants the allowed image extensions via `<Files>`. When an image's **intermediate directory no longer exists** (e.g. a product was deleted and its `img/p/9/9/9/` folder removed), Apache can't resolve the request to a file, so the `<Files>` block doesn't apply and the directory‑level deny wins → **403** instead of **404**.

For a missing image directly under an existing folder it's already 404, so the symptom only shows for nested paths:

```
GET /img/p/99999.jpg        → 404   (existing folder, missing file)
GET /img/p/9/9/9/99999.jpg  → 403   ← the bug (missing folder)
```

403s for missing images hurt SEO and can trip `fail2ban` into blocking crawlers (#41308).

## Fix

Grant authorization based on the **request URL path** (`<If "%{REQUEST_URI} =~ …">`, Apache 2.4) instead of a resolved filename. A request whose path ends in an allowed image extension passes authorization, so Apache reaches its normal not‑found handling (404) even when the folder is missing; everything else stays denied, so the allowlist — and its security guarantee that `img/` only serves images — is preserved.

## Verified (live Apache 2.4)

```
                                   before   after
GET /img/p/9/9/9/99999.jpg  (missing)  403  →  404   ✅ bug fixed
GET /img/p/99999.jpg        (missing)  404  →  404
GET /img/app_icon.png       (exists)   200  →  200   ✅ no regression
GET /img/secret.txt         (non-image) 403 →  403   ✅ still denied
GET /img/evil.php           (non-image) 403 →  403   ✅ still denied
GET /img/evil.php?x=.jpg    (attack)    403 →  403   ✅ query string can't bypass (REQUEST_URI is the path, not the query)
```

The Apache 2.2 block (`<IfModule !mod_authz_core.c>`) is left unchanged — `<If>` is 2.4+ only, and 2.2 is long end‑of‑life.

## Note

`themes/.htaccess` uses the same deny‑by‑default + extension allowlist pattern and would exhibit the same 403‑for‑missing‑nested‑asset behavior; happy to apply the same change there in this PR or a follow‑up if preferred. Scoped to `img/` here since that's the reported case.

