### PR TITLE
Return 404 instead of 403 for missing assets in themes/

### DIFF
--- a/themes/.htaccess
+++ b/themes/.htaccess
@@ -10,7 +10,8 @@
 # Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
-    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|woff|woff2|ttf|eot|otf|css|js|zip|avif)$">
+    # Grant on the URL path (not the resolved file) so a missing asset returns 404 instead of 403.
+    <If "%{REQUEST_URI} =~ /(?i)\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|woff|woff2|ttf|eot|otf|css|js|zip|avif)$/">
         Require all granted
-    </Files>
+    </If>
 </IfModule>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Make `themes/.htaccess` return `404` (not `403`) for missing assets, while keeping non-allowed files denied.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Request a missing asset in a non-existent sub-path, e.g. `GET /themes/classic/assets/css/9/9/9/x.css` — it must return `404`; a non-allowed file (e.g. `.php`) in `themes/` must still return `403`.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30438000523 - green (44/44 test jobs on the re-run; three attempt-1 failures passed unchanged on attempt 2)
| Fixed issue or discussion? | Same root cause as #41308 / #41834 (img/), applied to themes/
| Sponsor company   |

## Problem

`themes/.htaccess` uses the same deny‑by‑default + extension allowlist as `img/.htaccess`. When an asset's **intermediate directory no longer exists**, Apache can't resolve the request to a file, the `<Files>` block doesn't apply, and the directory‑level `Require all denied` wins → **403** instead of **404**:

```
GET /themes/classic/assets/css/99999.css        (missing, existing folder)  → 404
GET /themes/classic/assets/css/9/9/9/99999.css  (missing folder)            → 403   ← the bug
GET /themes/classic/assets/img/9/9/9/x.png      (missing folder)            → 403   ← the bug
```

This is the same SEO / `fail2ban` problem described in #41308 for `img/`; the sibling `img/` fix is #41834. Theme CSS/JS/font assets that have been removed return 403 to crawlers instead of a clean 404.

## Fix

Same approach as #41834: grant authorization based on the **request URL path** (`<If "%{REQUEST_URI} =~ …">`, Apache 2.4) instead of a resolved filename, so a request for an allowed extension passes authorization and Apache reaches normal not‑found handling (404), while everything else stays denied — the allowlist is preserved.

## Verified (live Apache 2.4)

```
                                              before  after
GET …/assets/css/9/9/9/99999.css  (missing)   403  →  404   ✅
GET …/assets/img/9/9/9/x.png      (missing)   403  →  404   ✅
GET …/assets/css/error.css        (exists)    200  →  200   ✅ no regression
GET …/themes/secret.txt           (non-allowed) 403 → 403   ✅ still denied
GET …/themes/evil.php             (non-allowed) 403 → 403   ✅ still denied
GET …/themes/evil.php?x=.css      (attack)      403 → 403   ✅ query string can't bypass
```

The Apache 2.2 block is left unchanged (`<If>` is 2.4+; 2.2 is end‑of‑life).


