### PR TITLE
Return 404 instead of 403 for missing assets in js/

### DIFF
--- a/js/.htaccess
+++ b/js/.htaccess
@@ -10,7 +10,8 @@
 # Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
-    <Files ~ "(?i)^.*\.(css|js|gif|png|jpg|svg|html|map|eot|ttf|woff)$">
+    # Grant on the URL path (not the resolved file) so a missing asset returns 404 instead of 403.
+    <If "%{REQUEST_URI} =~ /(?i)\.(css|js|gif|png|jpg|svg|html|map|eot|ttf|woff)$/">
         Require all granted
-    </Files>
+    </If>
 </IfModule>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Make `js/.htaccess` return `404` (not `403`) for missing assets, while keeping non-allowed files denied.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `GET /js/9/9/9/x.js` (missing) must return `404`; a non-allowed file (e.g. `.php`) in `js/` must still return `403`.
| UI Tests          | [46/46 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31594151164) on `e158c2e3` (detected 9.2.0, target `9.2.x`). Green only on the 5th attempt: `BO:orders:01-create-orders` failed attempts 1-4 on `10_checkSummary.ts:345`, `should check that the order message is displayed on view order page`, `waitForSelector: Timeout 10000ms exceeded` at 425 passing. Not this diff — the identical test, locator and timeout fail on PRs #41839 and #42304, which touch no asset-serving code. `modules:30-39` also failed attempts 1-2 and passed after.
| Fixed issue or discussion? | Same root cause as #41308 / #41834 (img/) and #41835 (themes/), applied to js/
| Sponsor company   |

## Problem

`js/.htaccess` uses the same deny‑by‑default + extension allowlist as `img/` and `themes/`. When an asset's intermediate directory no longer exists, the `<Files>` block can't match a resolved file, the directory‑level `Require all denied` wins, and Apache returns **403** instead of **404**:

```
GET /js/9/9/9/missing.js   → 403   ← the bug
GET /js/jquery/9/9/x.js     → 403   ← the bug
```

Same SEO / `fail2ban` issue as #41308. This is the third sibling of the same `.htaccess` pattern (after `img/` #41834 and `themes/` #41835).

## Fix

Grant authorization on the **request URL path** (`<If "%{REQUEST_URI} =~ …">`, Apache 2.4) so a request for an allowed extension reaches normal not‑found handling (404), while everything else stays denied (allowlist preserved).

## Verified (live Apache 2.4)

```
                                  before  after
GET /js/9/9/9/missing.js (missing) 403  →  404   ✅
GET /js/admin.js         (exists)  200  →  200   ✅ no regression
GET /js/secret.txt       (non-allowed) 403 → 403 ✅ still denied
GET /js/evil.php         (non-allowed) 403 → 403 ✅ still denied
GET /js/evil.php?x=.js   (attack)      403 → 403 ✅ query string can't bypass
```

The Apache 2.2 block is left unchanged (`<If>` is 2.4+; 2.2 is end‑of‑life).
