### PR TITLE
Index connections by (id_guest, date_add) for the last-visit query

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -540,7 +540,7 @@ CREATE TABLE `PREFIX_connections` (
   `date_add` datetime NOT NULL,
   `http_referer` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id_connections`),
-  KEY `id_guest` (`id_guest`),
+  KEY `id_guest` (`id_guest`, `date_add`),
   KEY `date_add` (`date_add`),
   KEY `id_page` (`id_page`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a `(id_guest, date_add)` index on `connections` for the customer last-visit query (the defensible part of #39960, done without redundancy).
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | New installs get the composite index on `connections`; `Customer::getStats()`'s last-visit query no longer needs a filesort on large `connections` tables.
| Related PRs       | Reworks the `connections` part of #39960
| Sponsor company   |

## What & why

`Customer::getStats()` reads a customer's last visit with:

```sql
SELECT c.date_add AS last_visit
FROM connections c
LEFT JOIN guest g USING (id_guest)
WHERE g.id_customer = X
ORDER BY c.date_add DESC
```

With only a single-column `id_guest` index, a large `connections` table has to read all of a guest's rows and **filesort** by `date_add`. Extending that index to `(id_guest, date_add)` lets the engine seek the guest and read `date_add` already in order — and the composite still serves plain `id_guest` lookups via its leftmost prefix, so it **replaces** the old index rather than adding a redundant second one.

## Why only this index (re: #39960)

I checked the three indexes proposed in #39960 against the live schema with `EXPLAIN`; this PR keeps only the one that holds up:

- **`connections (id_guest, date_add)`** — kept (above). Done by extending the existing `id_guest` key, not adding a separate one (a separate `id_guestdateadd` would leave the standalone `id_guest` redundant).
- **`product_shop (id_shop)`** — dropped: redundant. `product_shop` already has `shop_tax (id_shop, id_tax_rules_group)`, whose leftmost prefix is `id_shop`, so `WHERE id_shop = N` already uses it (`EXPLAIN` → `key: shop_tax`); the shop‑restriction *join* uses the PK `(id_product, id_shop)`.
- **`stock_available (id_product, id_shop, id_shop_group)`** — dropped: the existing `product_sqlstock (id_product, id_product_attribute, id_shop, id_shop_group)` already covers it; `EXPLAIN` for `WHERE id_product = X AND id_shop = Y` keeps choosing `product_sqlstock` even with the new index present.

Existing installs pick up the new index via the standard autoupgrade schema diff against `db_structure.sql`.
