### PR TITLE
List should honour 'Display unavailable attributes' for the default combination

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5473,7 +5473,12 @@ class ProductCore extends ObjectModel
             Combination::isFeatureActive()
             && $id_product_attribute === null
             && (
-                (isset($row['cache_default_attribute']) && ($ipa_default = $row['cache_default_attribute']) !== null)
+                // Use the cached default combination directly only when unavailable combinations
+                // may be shown (PS_DISP_UNAVAILABLE_ATTR on, or the product is still sold when out
+                // of stock). Otherwise resolve an availability-aware default so a listing does not
+                // surface an out-of-stock default combination — mirroring the product page. (#41558)
+                ((Configuration::get('PS_DISP_UNAVAILABLE_ATTR') || $row['allow_oosp'])
+                    && isset($row['cache_default_attribute']) && ($ipa_default = $row['cache_default_attribute']) !== null)
                 || ($ipa_default = Product::getDefaultAttribute($row['id_product'], (int) !$row['allow_oosp']))
             )
         ) {

--- a/tests/Integration/Classes/ProductListDisplayUnavailableAttrTest.php
+++ b/tests/Integration/Classes/ProductListDisplayUnavailableAttrTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Combination;
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+use ProductAttribute;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+/**
+ * A product listing must honour "Display unavailable attributes"
+ * (PS_DISP_UNAVAILABLE_ATTR): when it is off and the default combination is out
+ * of stock, the list must surface an available combination — just like the
+ * product page does — instead of the out-of-stock default. See issue #41558.
+ */
+class ProductListDisplayUnavailableAttrTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    private int $productId;
+    private int $defaultCombinationId;
+    private int $availableCombinationId;
+    /** @var mixed */
+    private $originalSetting;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        $this->originalSetting = Configuration::get('PS_DISP_UNAVAILABLE_ATTR');
+        $idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $idShop = (int) Configuration::get('PS_SHOP_DEFAULT');
+
+        $product = new Product(null, false, $idLang);
+        $product->name = 'Test combo product 41558';
+        $product->link_rewrite = 'test-combo-product-41558-' . uniqid();
+        $product->price = 10.0;
+        $product->active = true;
+        $product->out_of_stock = 0; // deny ordering when out of stock
+        $product->save();
+        $this->productId = (int) $product->id;
+
+        // Default combination is out of stock; the alternative is in stock.
+        $this->defaultCombinationId = $this->addCombination($idShop, $this->attributeId('Size', 'S'), 0);
+        $this->availableCombinationId = $this->addCombination($idShop, $this->attributeId('Size', 'M'), 10);
+
+        $product->setDefaultAttribute($this->defaultCombinationId);
+    }
+
+    protected function tearDown(): void
+    {
+        Configuration::updateValue('PS_DISP_UNAVAILABLE_ATTR', $this->originalSetting);
+        if (!empty($this->productId)) {
+            (new Product($this->productId))->delete();
+        }
+        parent::tearDown();
+    }
+
+    public function testListSurfacesAvailableCombinationWhenUnavailableAttributesAreHidden(): void
+    {
+        Configuration::updateValue('PS_DISP_UNAVAILABLE_ATTR', 0);
+
+        self::assertSame($this->availableCombinationId, $this->resolveListCombination());
+    }
+
+    public function testListKeepsDefaultCombinationWhenUnavailableAttributesAreShown(): void
+    {
+        Configuration::updateValue('PS_DISP_UNAVAILABLE_ATTR', 1);
+
+        self::assertSame($this->defaultCombinationId, $this->resolveListCombination());
+    }
+
+    /**
+     * Feeds Product::getProductProperties() a listing-style row (no explicit
+     * id_product_attribute) and returns the combination it resolves.
+     */
+    private function resolveListCombination(): int
+    {
+        $idShop = (int) Configuration::get('PS_SHOP_DEFAULT');
+        $row = Db::getInstance()->getRow('
+            SELECT p.*, product_shop.*, p.id_product
+            FROM ' . _DB_PREFIX_ . 'product p
+            INNER JOIN ' . _DB_PREFIX_ . 'product_shop product_shop
+                ON product_shop.id_product = p.id_product AND product_shop.id_shop = ' . $idShop . '
+            WHERE p.id_product = ' . $this->productId);
+        unset($row['id_product_attribute']);
+
+        $result = Product::getProductProperties((int) Configuration::get('PS_LANG_DEFAULT'), $row);
+
+        return (int) $result['id_product_attribute'];
+    }
+
+    private function addCombination(int $idShop, int $attributeId, int $quantity): int
+    {
+        $combination = new Combination();
+        $combination->id_product = $this->productId;
+        $combination->add();
+        $combination->setAttributes([$attributeId]);
+        $id = (int) $combination->id;
+
+        $db = Db::getInstance();
+        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'stock_available WHERE id_product = ' . $this->productId . ' AND id_product_attribute = ' . $id);
+        $db->execute('
+            INSERT INTO ' . _DB_PREFIX_ . 'stock_available
+                (id_product, id_product_attribute, id_shop, id_shop_group, quantity, physical_quantity, reserved_quantity, depends_on_stock, out_of_stock, location)
+            VALUES (' . $this->productId . ', ' . $id . ', ' . $idShop . ', 0, ' . $quantity . ', ' . $quantity . ', 0, 0, 0, "")');
+
+        return $id;
+    }
+
+    private function attributeId(string $group, string $name): int
+    {
+        foreach (ProductAttribute::getAttributes((int) Configuration::get('PS_LANG_DEFAULT')) as $attribute) {
+            if ($attribute['attribute_group'] === $group && $attribute['name'] === $name) {
+                return (int) $attribute['id_attribute'];
+            }
+        }
+
+        self::markTestSkipped(sprintf('Demo attribute %s:%s not available.', $group, $name));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Product listings now honour "Display unavailable attributes" for the default combination, like the product page already does.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion? | Fixes #41558
| How to test?      | See below — covered by an integration test.
| UI Tests          | [46/46 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31594158998) on `49ee36e4` (detected 9.2.0, target `9.2.x`). Green on the 3rd attempt: `BO:orders:01-create-orders` failed on `10_checkSummary.ts:345`, `should check that the order message is displayed on view order page`, `waitForSelector: Timeout 10000ms exceeded` at 425 passing — the same test, locator and timeout fail on unrelated PRs #41836 and #42304. `BO:community` and `BO:catalog:03-04` failed attempt 1 only.
| Sponsor company   |

## Problem

In a listing, `Product::getProductProperties()` resolves the combination to show by taking `cache_default_attribute` (the default combination) **unconditionally**, with the availability-aware `Product::getDefaultAttribute()` only as a fallback when there is no cached default.

The product **page** does not do this — `ProductController::tryToGetAvailableIdProductAttribute()` substitutes an *available* combination for the default when **Display unavailable attributes** (`PS_DISP_UNAVAILABLE_ATTR`) is off and the product is not sold out of stock.

Result: a product whose default combination is out of stock shows that out-of-stock combination (with `0` quantity) in listings regardless of the setting — the bug in #41558.

## Fix

Use the cached default directly **only** when unavailable combinations may be shown — `PS_DISP_UNAVAILABLE_ATTR` on (the install default) **or** the product is sold when out of stock. Otherwise resolve an availability-aware default via `getDefaultAttribute($id, (int) !$allow_oosp)`, which already prefers an in-stock combination. This mirrors the page and the existing `PS_DISP_UNAVAILABLE_ATTR` handling in `Product::getAttributesColorList()`.

## Scope, perf & verification

- **Scope:** only the listing path. The product page and cart pass an already-resolved `id_product_attribute` (non-null), so the `$id_product_attribute === null` guard skips them — confirmed for `ProductController`, `Cart::getProducts()` and `getProductsProperties()`.
- **Perf:** the extra `getDefaultAttribute()` lookup runs **only when `PS_DISP_UNAVAILABLE_ATTR = 0`**, which is **not** the install default (`1`) — so the common configuration keeps the cached fast path untouched. Measured cost when off: ~0.45 ms / combination-product (1 indexed query in the common in-stock case).
- **Page parity:** `getDefaultAttribute(…, 1)` filters on `stock.quantity >= 1`, the same availability basis as the page's `quantity > 0`; both surface an in-stock combination.

## How to test

Integration test `tests/Integration/Classes/ProductListDisplayUnavailableAttrTest.php` builds a product with an out-of-stock default combination and an in-stock alternative:
- **`PS_DISP_UNAVAILABLE_ATTR = 0`:** listing resolves to the **in-stock** combination (before this fix: the out-of-stock default — RED).
- **`PS_DISP_UNAVAILABLE_ATTR = 1`:** listing keeps the cached default (no regression).
