### PR TITLE
Keep word separation when stripping HTML for the search index

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -110,6 +110,9 @@ class SearchCore
     public const PS_SEARCH_ABSCISSA_MAX = 2;
     public const PS_DISTANCE_MAX = 5;
 
+    /* Block-level tags whose boundaries act as a word separator when stripping HTML for the index */
+    private const HTML_BLOCK_TAGS_REGEX = '#</?(?:address|article|aside|blockquote|br|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|li|main|nav|ol|p|pre|section|table|tbody|td|tfoot|th|thead|tr|ul)\b[^>]*>#i';
+
     /**
      * Method that takes a raw string (sentence) and extract all keywords it can find.
      *
@@ -173,6 +176,14 @@ class SearchCore
 
         // The string gets into this method in a raw form of, like "Prestashop Tést A-1000".
         // This get rid of all tags, special characters and convert everything to lowercase.
+        // Separate block-level tag boundaries with a space so words on adjacent lines or list
+        // items do not merge (e.g. "in</li><li>File" -> "in File", not "infile"), while inline
+        // tags are stripped without a separator so a styled word stays whole
+        // (e.g. "<b>bio</b><span>logic</span>" -> "biologic"). The regex is skipped for tag-free
+        // input, which is the common case for a front-office search query.
+        if (strpos($string, '<') !== false) {
+            $string = preg_replace(self::HTML_BLOCK_TAGS_REGEX, ' ', $string) ?? $string;
+        }
         $string = Tools::strtolower(strip_tags($string));
         $string = html_entity_decode($string, ENT_NOQUOTES, 'utf-8');
         $string = preg_replace('/([' . PREG_CLASS_NUMBERS . ']+)[' . PREG_CLASS_PUNCTUATION . ']+(?=[' . PREG_CLASS_NUMBERS . '])/u', '\1', $string);

--- a/tests/Integration/Classes/SearchTest.php
+++ b/tests/Integration/Classes/SearchTest.php
@@ -102,6 +102,23 @@ class SearchTest extends TestCase
                 'langId' => 1,
                 'expected' => ['test1', '-', 'test2'],
             ],
+            // Block-level tags separate words so list items do not merge (#40244 search index pollution).
+            'with html list items' => [
+                'input' => '<ul><li>red</li><li>shirt</li></ul>',
+                'langId' => 1,
+                'expected' => ['red', 'shirt'],
+            ],
+            'with adjacent block paragraphs' => [
+                'input' => '<p>hello</p><p>world</p>',
+                'langId' => 1,
+                'expected' => ['hello', 'world'],
+            ],
+            // Inline tags are stripped without a separator so a word styled mid-way stays whole.
+            'with mixed inline styling inside a word' => [
+                'input' => '<b>bio</b><span>logic</span>',
+                'langId' => 1,
+                'expected' => ['biologic'],
+            ],
         ];
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Separate block-level tags when stripping HTML for the search index, so adjacent list items no longer merge while a word styled mid-way stays whole.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
 | UI Tests          |  🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/29645469615
| Fixed issue or discussion? | Fixes #40244
| How to test?      | See below — covered by unit cases.
| Sponsor company   |



## Problem

`Search::sanitize()` cleans the indexed text with `strip_tags()` directly. `strip_tags()` removes tags **without** inserting a separator, so adjacent text segments are concatenated:

```
<ul><li>Position: in</li><li>File format: mp3</li></ul>
```

is sanitized to `… infile format …` — the bogus word **`infile`** is stored in `ps_search_word` instead of `in` and `file` (verified with `Search::sanitize()` on 9.1.x). As the reporter notes, with some content the merged token also breaks the full index rebuild.

## Fix

Insert a space only at **block-level** tag boundaries (list items, paragraphs, table cells, `<br>`, headings, ...), then strip the remaining tags. **Inline** tags (`<b>`, `<span>`, `<a>`, ...) are still removed without a separator, so a word that is styled mid-way is not split:

- `<li>in</li><li>File</li>` → `in File` → indexed as `in` / `file` (fixes the reported bug)
- `<b>bio</b><span>logic</span>` → `biologic` (a styled single word stays one token)

This is the block-vs-inline distinction raised by @matrixino and @Codencode in the discussion on #39967. The block-tag regex is skipped entirely when the input contains no `<`, so a front-office search query (the common tag-free case) keeps its previous cost — benchmarked at parity for tag-free input, and about 7 µs per call on a ~2 KB HTML description on the indexation path.

## How to test


1. Use an existing active product that is visible in search.
2. Update the description of an existing product directly in the database

```sql
UPDATE ps_product_lang
SET description = '<ul><li>red</li><li>shirt</li></ul><p>hello</p><p>world</p><b>bio</b><span>logic</span>'
WHERE id_product = 1
  

UPDATE ps_product
SET indexed = 0
WHERE id_product = 1;

UPDATE ps_product_shop
SET indexed = 0
WHERE id_product = 1;
```

3. Go to **Shop Parameters > Search** and click **Add missing products to the index**.

4. Run the following query to inspect the words associated with the tested product:

```sql
SELECT * FROM ps_search_word WHERE `word` IN  ( 'red', 'shirt', 'hello', 'world', 'biologic', 'bio', 'logic' );
```

The result must contain:

```text
biologic
hello
red
shirt
world
```


5. In the front office, search individually for:

```text
red
hello
biologic
```
