### PR TITLE
Allow editing a combination whose identifiers are NULL in the database

### DIFF
--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -185,11 +185,13 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
     private function getDetails(Combination $combination): CombinationDetails
     {
         return new CombinationDetails(
-            $combination->ean13,
-            $combination->isbn,
-            $combination->mpn,
-            $combination->reference,
-            $combination->upc,
+            // These identifier columns are nullable in the database, but CombinationDetails
+            // is strictly typed to string — cast so a NULL value does not fatal. (#39988)
+            (string) $combination->ean13,
+            (string) $combination->isbn,
+            (string) $combination->mpn,
+            (string) $combination->reference,
+            (string) $combination->upc,
             $this->numberExtractor->extract($combination, 'weight')
         );
     }

--- a/tests/Integration/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandlerTest.php
+++ b/tests/Integration/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandlerTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Product\Combination\QueryHandler;
+
+use Db;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetCombinationForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class GetCombinationForEditingHandlerTest extends KernelTestCase
+{
+    /**
+     * @var object|null
+     */
+    private $queryBus;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['product_attribute']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['product_attribute']);
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->queryBus = self::getContainer()->get('prestashop.core.query_bus');
+    }
+
+    /**
+     * The product_attribute identifier columns (ean13, upc, mpn, isbn, reference) are
+     * nullable in the database, but CombinationDetails is strictly typed to string, so
+     * editing a combination whose identifiers are NULL crashed with a TypeError
+     * ("Argument #1 ($gtin) must be of type string, null given"). See issue #39988.
+     */
+    public function testGetCombinationForEditingDoesNotFatalWhenIdentifiersAreNull(): void
+    {
+        $db = Db::getInstance();
+        $combinationId = (int) $db->getValue('SELECT id_product_attribute FROM ' . _DB_PREFIX_ . 'product_attribute');
+        self::assertGreaterThan(0, $combinationId, 'Demo data must contain at least one combination.');
+
+        $db->execute('
+            UPDATE ' . _DB_PREFIX_ . 'product_attribute
+            SET ean13 = NULL, isbn = NULL, mpn = NULL, reference = NULL, upc = NULL
+            WHERE id_product_attribute = ' . $combinationId);
+
+        /** @var CombinationForEditing $result */
+        $result = $this->queryBus->handle(new GetCombinationForEditing($combinationId, ShopConstraint::allShops()));
+        $details = $result->getDetails();
+
+        // NULL identifiers degrade to empty strings instead of fataling.
+        self::assertSame('', $details->getGtin());
+        self::assertSame('', $details->getEan13());
+        self::assertSame('', $details->getIsbn());
+        self::assertSame('', $details->getMpn());
+        self::assertSame('', $details->getReference());
+        self::assertSame('', $details->getUpc());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Editing a combination whose identifier columns are NULL no longer fatals the BO.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion? | Fixes #39988
| How to test?      | See below — covered by an integration test.
| UI Tests          | [46/46 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31612048489) on `ed869bd4` (target `9.2.x`, rebased). Green on the 3rd attempt: attempt 1 lost `BO:international:03-04`, `BO:shop-parameters:05-07`, `BO:advanced-parameters:07-10` and `modules:30-39`; attempt 2 lost `BO:advanced-parameters:07-10` alone. Same commit throughout, so those are campaign flakes, not this diff.
| Sponsor company   |

## Problem

The `product_attribute` identifier columns — `ean13`, `upc`, `mpn`, `isbn`, `reference` — are `DEFAULT NULL` in the schema, but `GetCombinationForEditingHandler::getDetails()` passes them straight into the strictly-typed `CombinationDetails(string $gtin, string $isbn, string $mpn, string $reference, string $upc, …)`. A combination whose `ean13` is NULL (set by an import or a direct DB edit) therefore makes the back-office combination edit page fatal:

```
TypeError: CombinationDetails::__construct(): Argument #1 ($gtin) must be of type string,
null given, called in …/GetCombinationForEditingHandler.php
```

## Fix

Cast the nullable identifier values to string when building `CombinationDetails`, so a NULL degrades to an empty value (the same representation the BO uses for a blank identifier) instead of crashing.

## How to test

Integration test `GetCombinationForEditingHandlerTest`: sets an existing combination's `ean13/upc/mpn/isbn/reference` to NULL and dispatches `GetCombinationForEditing`.
- **Before:** `TypeError … $gtin must be of type string, null given` (RED).
- **After:** the query returns and the identifiers read back as empty strings.

