### PR TITLE
Fix: Update cache directory handling in HTMLPurifier constructor

### DIFF
--- a/src/PrestaShopBundle/Utils/HTMLPurifier.php
+++ b/src/PrestaShopBundle/Utils/HTMLPurifier.php
@@ -14,10 +14,9 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class HTMLPurifier
 {
-    /**
-     * @var \HTMLPurifier
-     */
-    private $instance;
+    private \HTMLPurifier $instance;
+
+    private readonly string $serializerPath;
 
     public function __construct(
         private readonly Filesystem $filesystem,
@@ -25,17 +24,16 @@ class HTMLPurifier
         private readonly string $cacheDir,
     ) {
         $config = HTMLPurifier_Config::createDefault();
+
         // We must keep IDs that are by JS used to target element
         $config->set('Attr.EnableID', true);
         $config->set('Attr.AllowedFrameTargets', ['_blank']);
+        // Cache for the serializer path
+        $this->serializerPath = $this->cacheDir . 'purifier';
+        $this->filesystem->mkdir($this->serializerPath);
+        $config->set('Cache.SerializerPath', $this->serializerPath);
 
-        $serializerPath = $this->cacheDir . 'purifier';
-        $this->filesystem->mkdir($serializerPath);
-
-        $config->set('Cache.SerializerPath', $serializerPath);
-
-        $purifier = new \HTMLPurifier($config);
-        $this->instance = $purifier;
+        $this->instance = new \HTMLPurifier($config);
     }
 
     /**
@@ -47,6 +45,9 @@ class HTMLPurifier
      */
     public function purify($html)
     {
+        // In case of cache clear : the directory is removed; to avoid a race condition we recreate the cache dir for purifier
+        $this->filesystem->mkdir($this->serializerPath);
+
         return $this->instance->purify($html);
     }
 }


### PR DESCRIPTION
| Questions                  | Answers
| -------------------------- | -------
| Branch?                    | 9.1.x
| Description?               | `HTMLPurifier` tries to purify directory `purifier` in cache dir during a cache clear triggered by a debug mode toggle. This creates a race condition: the redirect after the form save starts a new request that calls `mkdir('var/cache/dev/purifier')` in `HTMLPurifier::__construct()`, but the shutdown function from the previous request runs concurrently and deletes the directory before `HTMLPurifier::purify()` reaches `_prepareDir()`. Solve issue by recreated cache dir before calling `HTMLPurifier::purify()`<br><br>Relative to #41828
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | 1. Ensure debug mode is **disabled** (`_PS_MODE_DEV_ = false` in `config/defines.inc.php`). <br> 2. Go to **BO > Advanced Parameters > Performance**. <br> 3. Enable **Debug mode** and save — the page must show a green success alert with no 500 error. <br> 4. Disable debug mode and save — same expectation. <br> 5. Run `HEADLESS=false npm run test:functional:BO:advanced-parameters:01-06` from `tests/UI` — the `enable/disable debug mode` steps must pass.
| UI Tests                   | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/28223294372
| Sponsor company            | @PrestaShopCorp