### PR TITLE
Add coverage for the discount form built without a selected type

### DIFF
--- a/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountFormBuilderTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountFormBuilderTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Sell\Discount;
+
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+
+class DiscountFormBuilderTest extends KernelTestCase
+{
+    private FormBuilderInterface $discountFormBuilder;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+        $shopContextBuilder->setShopId(1);
+
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+        $languageContextBuilder->setDefaultLanguageId(1);
+
+        $currencyContextBuilder = self::getContainer()->get('test_currency_context_builder');
+        $currencyContextBuilder->setCurrencyId(1);
+
+        $this->discountFormBuilder = self::getContainer()->get('prestashop.core.form.identifiable_object.builder.discount_form_builder');
+    }
+
+    /**
+     * The "Add new discount" page first GET has no type selected. The controller now passes an
+     * empty string for that state; the whole discount form (and its nested types, which all
+     * require a string discount_type) must build for it. See #40344.
+     */
+    public function testCreateFormBuildsWithNoDiscountTypeSelected(): void
+    {
+        $form = $this->discountFormBuilder->getForm([], ['discount_type' => '']);
+
+        $this->assertInstanceOf(FormInterface::class, $form);
+        $this->assertTrue($form->has('information'));
+        $this->assertTrue($form->has('usability'));
+    }
+
+    /**
+     * Documents why the controller must not pass null: the form types are typed to string, so a
+     * null discount_type (the previous first-GET behaviour) fatals the page.
+     */
+    public function testBuildingWithNullDiscountTypeIsRejected(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $this->discountFormBuilder->getForm([], ['discount_type' => null]);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Regression coverage only: the discount form must build for the "no type selected yet" state. The controller guard this PR originally carried is no longer needed - see below.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion? | Fixes #40344
| How to test?      | Enable the *new discount* experimental feature, open **Catalog > Discounts > Add**. See below.
| UI Tests          | [46/46 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31612058863) on `c44614c9` (target `develop`, rebased). Green on the 2nd attempt: attempt 1 lost `BO:catalog:03-04`, `BO:orders:01-create-orders`, `BO:orders:03-05`, `modules:20-29` and `modules:30-39` on the same commit. `BO:orders:01-create-orders` also loses attempt 1 on the unrelated #41836 and #42304, so it is a campaign flake.
| Sponsor company   |

## Problem

`DiscountController::createAction()` builds the form with the discount type from the URL:

```php
$form = $formBuilder->getForm([], ['discount_type' => $discountType]);
```

On the very first GET (clicking **Add new discount**) there is no type in the URL, so `$discountType` is `null` (`?string $discountType = null`). But `DiscountType` — and every nested type it threads `discount_type` into (`DiscountInformationType`, `DiscountConditionsType`, …) — declares `setAllowedTypes('discount_type', ['string'])`. So the first page load fatals:

```
InvalidOptionsException: The option "discount_type" with value null is expected to be of type "string", but is of type "null".
```

That's the error in #40344.

## Fix

Pass an empty string for the not-yet-selected state — exactly what the data provider already does for the edit path (`DiscountFormOptionsProvider::getOptions()` uses `$data['information']['discount_type'] ?? ''`):

```php
'discount_type' => $discountType ?? '',
```

`''` satisfies the string contract, and every `buildForm()` only adds type-specific fields for a *known* type constant, so the base form renders correctly with no type chosen.

## How to test

Integration test `DiscountFormBuilderTest`:
- builds the discount form with `discount_type = ''` (the not-yet-selected state) and asserts the full nested form builds — **before this fix the create page passed `null` here and threw**;
- documents that a `null` discount_type is rejected by the typed form (the previous first-GET behaviour).

Manual: enable the new-discount experimental feature, open **Catalog > Discounts > Add** — the page renders instead of throwing.



### Updated after rebase on current `develop`

This PR originally passed `$discountType ?? ''` into the form builder so the first GET could not fatal. Since then `1a3500cb48e` ("Fix manual order discount bufg") added an early return in `createAction()` that renders the type-selection page whenever `$discountType` is empty, so the form builder is never reached without a type. The guard is therefore dead code on current `develop` - PHPStan reports `Variable $discountType on left side of ?? always exists and is not nullable` - and it has been dropped.

What remains is the regression coverage: `DiscountFormBuilderTest` asserts the discount form builds with `discount_type => ''` and that a `null` type is rejected by the form types. That locks in the behaviour #40344 reported, which is still open. Verified locally against `develop` merged into this branch: PHPStan `[OK] No errors`, `DiscountFormBuilderTest` 2/2 (4 assertions).

