### PR TITLE
Expose attribute group position in the for-editing query result

### DIFF
--- a/src/Adapter/AttributeGroup/QueryHandler/GetAttributeGroupForEditingHandler.php
+++ b/src/Adapter/AttributeGroup/QueryHandler/GetAttributeGroupForEditingHandler.php
@@ -41,7 +41,8 @@ final class GetAttributeGroupForEditingHandler implements GetAttributeGroupForEd
             $attributeGroup->name,
             $attributeGroup->public_name,
             $attributeGroup->group_type,
-            $attributeGroup->getAssociatedShops()
+            $attributeGroup->getAssociatedShops(),
+            (int) $attributeGroup->position
         );
     }
 }

--- a/src/Core/Domain/AttributeGroup/QueryResult/EditableAttributeGroup.php
+++ b/src/Core/Domain/AttributeGroup/QueryResult/EditableAttributeGroup.php
@@ -41,24 +41,32 @@ class EditableAttributeGroup
     private $type;
 
     /**
+     * @var int
+     */
+    private $position;
+
+    /**
      * @param int $attributeGroupId
      * @param string[] $name
      * @param array $publicName
      * @param string $type
      * @param int[] $associatedShopIds
+     * @param int $position
      */
     public function __construct(
         int $attributeGroupId,
         array $name,
         array $publicName,
         string $type,
-        array $associatedShopIds
+        array $associatedShopIds,
+        int $position
     ) {
         $this->attributeGroupId = new AttributeGroupId($attributeGroupId);
         $this->name = $name;
         $this->associatedShopIds = $associatedShopIds;
         $this->publicName = $publicName;
         $this->type = $type;
+        $this->position = $position;
     }
 
     /**
@@ -99,5 +107,13 @@ class EditableAttributeGroup
     public function getType(): string
     {
         return $this->type;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPosition(): int
+    {
+        return $this->position;
     }
 }

--- a/tests/Integration/Adapter/AttributeGroup/QueryHandler/GetAttributeGroupForEditingHandlerTest.php
+++ b/tests/Integration/Adapter/AttributeGroup/QueryHandler/GetAttributeGroupForEditingHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\AttributeGroup\QueryHandler;
+
+use Db;
+use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Query\GetAttributeGroupForEditing;
+use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\QueryResult\EditableAttributeGroup;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GetAttributeGroupForEditingHandlerTest extends KernelTestCase
+{
+    /**
+     * @var object|null
+     */
+    private $queryBus;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->queryBus = self::getContainer()->get('prestashop.core.query_bus');
+    }
+
+    /**
+     * EditableAttributeGroup must expose the group position, otherwise the Admin API
+     * POST /attributes/group response is missing the "position" key. See issue #39729.
+     */
+    public function testGetAttributeGroupForEditingReturnsThePosition(): void
+    {
+        $row = Db::getInstance()->getRow('
+            SELECT id_attribute_group, position
+            FROM ' . _DB_PREFIX_ . 'attribute_group
+            ORDER BY position DESC');
+        self::assertNotEmpty($row, 'Demo data must contain at least one attribute group.');
+
+        /** @var EditableAttributeGroup $result */
+        $result = $this->queryBus->handle(new GetAttributeGroupForEditing((int) $row['id_attribute_group']));
+
+        self::assertSame((int) $row['position'], $result->getPosition());
+    }
+}

--- a/tests/UI/campaigns/functional/API/02_endpoints/attribute/08_getAttributesGroupId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/attribute/08_getAttributesGroupId.ts
@@ -139,6 +139,7 @@ describe('API : GET /attributes/groups/{attributeGroupId}', async () => {
       expect(jsonResponse).to.have.all.keys(
         'attributeGroupId',
         'names',
+        'position',
         'publicNames',
         'shopIds',
         'type',
@@ -187,6 +188,17 @@ describe('API : GET /attributes/groups/{attributeGroupId}', async () => {
       expect(jsonResponse).to.have.property('shopIds');
       expect(jsonResponse.shopIds).to.be.a('array');
       expect(jsonResponse.shopIds).to.deep.equal([1]);
+    });
+
+    it('should check the JSON Response : `position`', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkResponsePosition', baseContext);
+
+      // A new group is appended with getHighestPosition() + 1, and deleting one calls cleanPositions(),
+      // which re-sequences to 0..n-1. Positions therefore stay contiguous, so the group created above
+      // lands on the count read before it was created.
+      expect(jsonResponse).to.have.property('position');
+      expect(jsonResponse.position).to.be.a('number');
+      expect(jsonResponse.position).to.be.equal(numberOfAttributes);
     });
   });
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The Admin API `POST /attributes/group` response now includes the `position` key.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion? | Fixes #39729
| Related PRs       | PrestaShop/ps_apiresources#283 (companion — merge that one first; it does not need this PR)
| How to test?      | See below — covered by an integration test.
| UI Tests          | [45/45 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31790696244) on `fe53fc1f` (target `develop`, rebased). This covers the two assertions this PR touches: `should check the JSON Response keys` and `should check the JSON Response : \`position\`` both report `pass` in the green `functional:API` job, which ends `1604 passing` with no failing test. Green on the 5th attempt, same commit throughout: attempt 1 lost four jobs (`functional:API` aborted at setup before running a single test, plus `BO:orders:01-create-orders`, `BO:advanced-parameters:07-10`, `modules:30-39`), and attempts 2-4 lost only `BO:orders:01-create-orders`, the 10s `waitForSelector` on the order message that also fails on unrelated PRs.
| Sponsor company   |

## Problem

The Admin API `AttributeGroup` resource (in `ps_apiresources`) declares a `public int $position` and builds its responses from the `GetAttributeGroupForEditing` CQRS query. But `EditableAttributeGroup` — that query's result — never carried the position:

```php
public function __construct(int $attributeGroupId, array $name, array $publicName, string $type, array $associatedShopIds)
```

So the resource's typed `$position` property stayed uninitialised and was dropped from the serialised response — the `POST /attributes/group` response was missing the `position` key (#39729).

## Fix

Carry the position through `EditableAttributeGroup` and populate it from the attribute group in `GetAttributeGroupForEditingHandler`. The resource maps it by name (the same way `type` / `attributeGroupId` are already mapped — neither is listed in `QUERY_MAPPING`), so the key now appears in the response.

`EditableAttributeGroup` is constructed only by its handler, so the added constructor argument has no other callers.

## How to test

Integration test `GetAttributeGroupForEditingHandlerTest`: dispatches `GetAttributeGroupForEditing` for an existing group and asserts `getPosition()` returns the stored position.
- **Before:** `Call to undefined method EditableAttributeGroup::getPosition()` (the data was absent — RED).
- **After:** the position is returned.


## Why `API Module tests` is red

Exposing `position` changes the AttributeGroup endpoint responses, and the assertions on `ps_apiresources` `dev` still expect the pre-fix shape, so `AttributeGroupEndpointTest` fails on `'position' => 4` and, through the `@depends` chain, on the group count as well: the failure skips `testRemoveAttributeGroup`, whose `deleteItem()` is the only cleanup of the group created by `testAddAttributeGroup`, so the two later count assertions see 5 groups instead of 4.

Correcting an earlier version of this description: the two do **not** have to merge together. PrestaShop/ps_apiresources#283 was made version-adaptive in `9f0cccbb3` — its expectations are gated on `method_exists(EditableAttributeGroup::class, 'getPosition')`, so it passes both with and without this PR and can merge on its own, first. This job stays red until it does.

The `Sanity (8.5, firefox, mysql)` failure is the unrelated `Delete products with bulk actions` flake currently also failing on the base branches.


