### PR TITLE
Add simple HTML to text stripper, refactor getting meta

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -173,7 +173,7 @@ class CategoryCore extends ObjectModel
      */
     public static function getDescriptionClean($description)
     {
-        return strip_tags(stripslashes($description));
+        return Tools::htmlToText($description);
     }
 
     /**

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -4,6 +4,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
+use PrestaShop\PrestaShop\Core\Domain\Category\SeoSettings;
 
 /**
  * Class MetaCore.
@@ -317,17 +318,29 @@ class MetaCore extends ObjectModel
      */
     public static function getProductMetas($idProduct, $idLang, $pageName)
     {
-        $product = new Product($idProduct, false, $idLang);
-        if (Validate::isLoadedObject($product) && $product->active) {
-            $row = Meta::getPresentedObject($product);
-            if (empty($row['meta_description'])) {
-                $row['meta_description'] = strip_tags($row['description_short']);
-            }
+        // Get cache key and check if the result is already cached.
+        $cacheId = 'Meta::getProductMetas' . (int) $idProduct . '-' . (int) $idLang;
+        if (!Cache::isStored($cacheId)) {
+            // Check if the product exists and is active, if yes, process the meta, if not, load home metas as a fallback.
+            $product = new Product($idProduct, false, $idLang);
+            if (Validate::isLoadedObject($product) && $product->active) {
+                $row = Meta::getPresentedObject($product);
 
-            return Meta::completeMetaTags($row, $row['name']);
+                // Use the short description as meta description fallback.
+                if (empty($row['meta_description'])) {
+                    $row['meta_description'] = Meta::getMetaDescriptionFallback($row['description_short']);
+                }
+
+                $result = Meta::completeMetaTags($row, $row['name']);
+            } else {
+                $result = Meta::getHomeMetas($idLang, $pageName);
+            }
+            Cache::store($cacheId, $result);
+
+            return $result;
         }
 
-        return Meta::getHomeMetas($idLang, $pageName);
+        return Cache::retrieve($cacheId);
     }
 
     /**
@@ -336,21 +349,26 @@ class MetaCore extends ObjectModel
      * @param int $idCategory
      * @param int $idLang
      * @param string $pageName
+     * @param string $title
      *
      * @return array
      */
     public static function getCategoryMetas($idCategory, $idLang, $pageName, $title = '')
     {
-        $category = new Category($idCategory, $idLang);
-
-        $cacheId = 'Meta::getCategoryMetas' . (int) $idCategory . '-' . (int) $idLang;
+        // Get cache key and check if the result is already cached.
+        $cacheId = 'Meta::getCategoryMetas' . (int) $idCategory . '-' . (int) $idLang . '-' . md5((string) $title);
         if (!Cache::isStored($cacheId)) {
+            // Check if the category exists and is loaded, if yes, process the meta, if not, load home metas as a fallback.
+            $category = new Category($idCategory, $idLang);
             if (Validate::isLoadedObject($category)) {
                 $row = Meta::getPresentedObject($category);
+
+                // Use the category description as meta description fallback.
                 if (empty($row['meta_description'])) {
-                    $row['meta_description'] = strip_tags($row['description']);
+                    $row['meta_description'] = Meta::getMetaDescriptionFallback($row['description']);
                 }
 
+                // Prefer the provided title, otherwise use the category meta title or name.
                 if (is_string($title) && $title !== '') {
                     $row['meta_title'] = $title;
                 } else {
@@ -380,18 +398,29 @@ class MetaCore extends ObjectModel
      */
     public static function getManufacturerMetas($idManufacturer, $idLang, $pageName)
     {
-        $manufacturer = new Manufacturer($idManufacturer, $idLang);
-        if (Validate::isLoadedObject($manufacturer)) {
-            $row = Meta::getPresentedObject($manufacturer);
-            if (!empty($row['meta_description'])) {
-                $row['meta_description'] = strip_tags($row['meta_description']);
-            }
-            $row['meta_title'] = $row['meta_title'] ?: $row['name'];
+        // Get cache key and check if the result is already cached.
+        $cacheId = 'Meta::getManufacturerMetas' . (int) $idManufacturer . '-' . (int) $idLang;
+        if (!Cache::isStored($cacheId)) {
+            // Check if the manufacturer exists and is loaded, if yes, process the meta, if not, load home metas as a fallback.
+            $manufacturer = new Manufacturer($idManufacturer, $idLang);
+            if (Validate::isLoadedObject($manufacturer)) {
+                $row = Meta::getPresentedObject($manufacturer);
 
-            return Meta::completeMetaTags($row, $row['meta_title']);
+                // Use the manufacturer short description as meta description fallback.
+                if (empty($row['meta_description'])) {
+                    $row['meta_description'] = Meta::getMetaDescriptionFallback($row['short_description']);
+                }
+
+                $result = Meta::completeMetaTags($row, $row['name']);
+            } else {
+                $result = Meta::getHomeMetas($idLang, $pageName);
+            }
+            Cache::store($cacheId, $result);
+
+            return $result;
         }
 
-        return Meta::getHomeMetas($idLang, $pageName);
+        return Cache::retrieve($cacheId);
     }
 
     /**
@@ -405,17 +434,29 @@ class MetaCore extends ObjectModel
      */
     public static function getSupplierMetas($idSupplier, $idLang, $pageName)
     {
-        $supplier = new Supplier($idSupplier, $idLang);
-        if (Validate::isLoadedObject($supplier)) {
-            $row = Meta::getPresentedObject($supplier);
-            if (!empty($row['meta_description'])) {
-                $row['meta_description'] = strip_tags($row['meta_description']);
-            }
+        // Get cache key and check if the result is already cached.
+        $cacheId = 'Meta::getSupplierMetas' . (int) $idSupplier . '-' . (int) $idLang;
+        if (!Cache::isStored($cacheId)) {
+            // Check if the supplier exists and is loaded, if yes, process the meta, if not, load home metas as a fallback.
+            $supplier = new Supplier($idSupplier, $idLang);
+            if (Validate::isLoadedObject($supplier)) {
+                $row = Meta::getPresentedObject($supplier);
 
-            return Meta::completeMetaTags($row, $row['name']);
+                // Use the supplier description as meta description fallback.
+                if (empty($row['meta_description'])) {
+                    $row['meta_description'] = Meta::getMetaDescriptionFallback($row['description']);
+                }
+
+                $result = Meta::completeMetaTags($row, $row['name']);
+            } else {
+                $result = Meta::getHomeMetas($idLang, $pageName);
+            }
+            Cache::store($cacheId, $result);
+
+            return $result;
         }
 
-        return Meta::getHomeMetas($idLang, $pageName);
+        return Cache::retrieve($cacheId);
     }
 
     /**
@@ -429,15 +470,30 @@ class MetaCore extends ObjectModel
      */
     public static function getCmsMetas($idCms, $idLang, $pageName)
     {
-        $cms = new CMS($idCms, $idLang);
-        if (Validate::isLoadedObject($cms)) {
-            $row = Meta::getPresentedObject($cms);
-            $row['meta_title'] = !empty($row['head_seo_title']) ? $row['head_seo_title'] : $row['meta_title'];
+        // Get cache key and check if the result is already cached.
+        $cacheId = 'Meta::getCmsMetas' . (int) $idCms . '-' . (int) $idLang;
+        if (!Cache::isStored($cacheId)) {
+            // Check if the CMS page exists and is loaded, if yes, process the meta, if not, load home metas as a fallback.
+            $cms = new CMS($idCms, $idLang);
+            if (Validate::isLoadedObject($cms)) {
+                $row = Meta::getPresentedObject($cms);
+                /*
+                 * The CMS page fields are historically misnamed - somebody made a solid mess.
+                 * Against what you might think, meta_title stores the page name - the visible one.
+                 * While head_seo_title stores the actual meta title used in the page head.
+                 */
+                $row['meta_title'] = !empty($row['head_seo_title']) ? $row['head_seo_title'] : $row['meta_title'];
 
-            return Meta::completeMetaTags($row, $row['meta_title']);
+                $result = Meta::completeMetaTags($row, $row['meta_title']);
+            } else {
+                $result = Meta::getHomeMetas($idLang, $pageName);
+            }
+            Cache::store($cacheId, $result);
+
+            return $result;
         }
 
-        return Meta::getHomeMetas($idLang, $pageName);
+        return Cache::retrieve($cacheId);
     }
 
     /**
@@ -451,15 +507,23 @@ class MetaCore extends ObjectModel
      */
     public static function getCmsCategoryMetas($idCmsCategory, $idLang, $pageName)
     {
-        $cmsCategory = new CMSCategory($idCmsCategory, $idLang);
-        if (Validate::isLoadedObject($cmsCategory)) {
-            $row = Meta::getPresentedObject($cmsCategory);
-            $row['meta_title'] = empty($row['meta_title']) ? $row['name'] : $row['meta_title'];
+        // Get cache key and check if the result is already cached.
+        $cacheId = 'Meta::getCmsCategoryMetas' . (int) $idCmsCategory . '-' . (int) $idLang;
+        if (!Cache::isStored($cacheId)) {
+            // Check if the CMS category exists and is loaded, if yes, process the meta, if not, load home metas as a fallback.
+            $cmsCategory = new CMSCategory($idCmsCategory, $idLang);
+            if (Validate::isLoadedObject($cmsCategory)) {
+                $row = Meta::getPresentedObject($cmsCategory);
+                $result = Meta::completeMetaTags($row, $row['name']);
+            } else {
+                $result = Meta::getHomeMetas($idLang, $pageName);
+            }
+            Cache::store($cacheId, $result);
 
-            return Meta::completeMetaTags($row, $row['meta_title']);
+            return $result;
         }
 
-        return Meta::getHomeMetas($idLang, $pageName);
+        return Cache::retrieve($cacheId);
     }
 
     public static function completeMetaTags($metaTags, $defaultValue, ?Context $context = null)
@@ -508,5 +572,20 @@ class MetaCore extends ObjectModel
         $objectPresenter = new ObjectPresenter();
 
         return $objectPresenter->present($object);
+    }
+
+    /**
+     * Convert HTML content to a plain text meta description fallback and trim it to the SEO field limit.
+     *
+     * @param string $description
+     *
+     * @return string
+     */
+    protected static function getMetaDescriptionFallback(string $description): string
+    {
+        // Convert HTML descriptions to readable text before trimming them for the meta description field.
+        $description = Tools::htmlToText($description);
+
+        return mb_substr($description, 0, SeoSettings::MAX_DESCRIPTION_LENGTH);
     }
 }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4005,6 +4005,18 @@ exit;
 
         return false;
     }
+
+    /**
+     * Converts HTML content to readable plain text.
+     *
+     * @param string $html
+     *
+     * @return string
+     */
+    public static function htmlToText($html)
+    {
+        return self::getStringModifier()->htmlToText($html);
+    }
 }
 
 /**

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -222,6 +222,17 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
+     * Get the short description converted to readable plain text.
+     *
+     * @return string
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getDescriptionShortText(): string
+    {
+        return Tools::htmlToText($this->product['description_short'] ?? '');
+    }
+
+    /**
      * @return string
      */
     #[LazyArrayAttribute(arrayAccess: true)]

--- a/src/Core/Util/String/StringModifier.php
+++ b/src/Core/Util/String/StringModifier.php
@@ -46,6 +46,53 @@ final class StringModifier implements StringModifierInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function htmlToText(string $html): string
+    {
+        // Replace explicit line breaks with spaces so words from adjacent lines stay separated.
+        $html = preg_replace('/<br\s*\/?>/i', ' ', $html);
+
+        // Add commas after list items before stripping tags so list values stay separated.
+        $html = preg_replace('/<\/li\s*>/i', ', ', $html);
+
+        // Add a sentence boundary after lists before stripping tags.
+        $html = preg_replace('/<\/(?:ul|ol)\s*>/i', '. ', $html);
+
+        // Replace common block endings with spaces so paragraphs and headings stay separated.
+        $html = preg_replace('/<\/(?:p|div|section|article|header|footer|aside|nav|blockquote|h[1-6]|tr|td|th)\s*>/i', ' ', $html);
+
+        // Remove remaining HTML tags after separators have been inserted.
+        $text = strip_tags($html);
+
+        // Decode HTML entities so the returned text contains readable characters.
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        // Normalize all whitespace first so punctuation cleanup can use predictable spacing.
+        $text = preg_replace('/\s+/u', ' ', $text);
+
+        // Remove spaces before punctuation introduced by stripped tags.
+        $text = preg_replace('/\s+([,.!?;:])/', '$1', $text);
+
+        // Remove commas before sentence punctuation, for example after the last list item.
+        $text = preg_replace('/,\s*([.!?])/', '$1', $text);
+
+        // Remove list commas after items that already ended with sentence punctuation.
+        $text = preg_replace('/([.!?])\s*,/', '$1', $text);
+
+        // Collapse repeated commas created by empty list items.
+        $text = preg_replace('/(?:\s*,\s*){2,}/', ', ', $text);
+
+        // Collapse repeated sentence dots created by list endings next to existing punctuation.
+        $text = preg_replace('/(?:\.\s*){2,}/', '. ', $text);
+
+        // Normalize whitespace again after punctuation cleanup.
+        $text = preg_replace('/\s+/u', ' ', $text);
+
+        return trim($text);
+    }
+
+    /**
      * Return a friendly url made from the provided string
      * If the mbstring library is available, the output is the same as the js function of the same name.
      *

--- a/src/Core/Util/String/StringModifierInterface.php
+++ b/src/Core/Util/String/StringModifierInterface.php
@@ -30,4 +30,13 @@ interface StringModifierInterface
      * @return string
      */
     public function cutEnd(string $string, int $expectedLength): string;
+
+    /**
+     * Converts HTML content to readable plain text.
+     *
+     * @param string $html
+     *
+     * @return string
+     */
+    public function htmlToText(string $html): string;
 }

--- a/tests/Unit/Core/Util/String/StringModifierTest.php
+++ b/tests/Unit/Core/Util/String/StringModifierTest.php
@@ -100,6 +100,52 @@ class StringModifierTest extends TestCase
     }
 
     /**
+     * @dataProvider htmlToTextProvider
+     */
+    public function testHtmlToText(string $input, string $expected): void
+    {
+        self::assertSame($expected, $this->stringModifier->htmlToText($input));
+    }
+
+    public function htmlToTextProvider(): Generator
+    {
+        yield 'plain text' => [
+            'Plain text',
+            'Plain text',
+        ];
+
+        yield 'paragraphs' => [
+            '<p>First sentence.</p><p>Second sentence.</p>',
+            'First sentence. Second sentence.',
+        ];
+
+        yield 'unordered list' => [
+            '<ul><li>Stainless steel</li><li>Silent run</li><li>5 year warranty</li></ul>',
+            'Stainless steel, Silent run, 5 year warranty.',
+        ];
+
+        yield 'ordered list with surrounding content' => [
+            '<p>Features:</p><ol><li>Fast</li><li>Reliable</li></ol><p>Available now.</p>',
+            'Features: Fast, Reliable. Available now.',
+        ];
+
+        yield 'line break and entities' => [
+            'One&nbsp;two<br>Three &amp; four',
+            'One two Three & four',
+        ];
+
+        yield 'empty list items' => [
+            '<ul><li>First</li><li></li><li>Second</li></ul>',
+            'First, Second.',
+        ];
+
+        yield 'list items with punctuation' => [
+            '<ul><li>First sentence.</li><li>Second sentence.</li></ul>',
+            'First sentence. Second sentence.',
+        ];
+    }
+
+    /**
      * @dataProvider str2UrlProvider
      */
     public function testStr2url(string $input, string $expected, bool $allow_accented_chars): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | I made some small improvements to places that use some kind of HTML to text conversion. See below.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check the scenarios below
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/28999153487
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Changes
- Added simple HTML-to-text conversion via StringModifier::htmlToText(). Used it for slightly better, but fast HTML to text conversion that doesn't glue words together.
- Unified meta generation methods in `classes/Meta.php`:
  - All methods are now cached like in `getCategoryMetas()`.
  - Added fallback for manufacturer and supplier descriptions.
  - Used the new html-to-text converter to strip the tags.
  - Cut the descriptions to `SeoSettings::MAX_DESCRIPTION_LENGTH` in case of fallback.
- Made Tools::getStringModifier() public so legacy code can reuse the cached StringModifier instance.
- Added `ProductLazyArray::getDescriptionShortText()` so we can easily access plain text product descriptions in listings.
- Updated `Category::getDescriptionClean()` to use the new html-to-text converter to strip the tags.