### PR TITLE
Do not add the admin CSRF token to API Platform IRIs

### DIFF
--- a/src/PrestaShopBundle/Service/Routing/Router.php
+++ b/src/PrestaShopBundle/Service/Routing/Router.php
@@ -28,7 +28,11 @@ class Router extends BaseRouter
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string
     {
         $url = parent::generate($name, $parameters, $referenceType);
-        if (TokenInUrls::isDisabled() || $this->anonymousRouteProvider->isRouteAnonymous($name)) {
+        if (TokenInUrls::isDisabled()
+            || $this->anonymousRouteProvider->isRouteAnonymous($name)
+            // API Platform routes are stateless and OAuth-authenticated; they must not carry the
+            // admin CSRF token in generated IRIs (e.g. the Location header). (#39496)
+            || str_starts_with($name, '_api_')) {
             return $url;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Stop adding the admin CSRF `_token` to API Platform IRIs (Location header etc.).
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion? | Fixes #39496
| How to test?      | See below — verified end-to-end against the ps_apiresources API tests.
| Sponsor company   |

## Problem

The admin `Router` override (`PrestaShopBundle\Service\Routing\Router::generate()`) appends a `_token` query parameter to generated admin URLs for CSRF protection. API Platform IRIs are generated through the same router, so Admin API responses leaked the token, e.g. on create:

```
Location: /attributes/groups/5?_token=76d5ef…
```

API Platform routes are stateless and OAuth-authenticated — the CSRF token is useless and shouldn't appear there (#39496, reported by @jolelievre; applies to the IRIs returned by POST/PUT/PATCH/GET).

## Fix (proposal)

Skip the token in `generate()` when the route name is an API Platform route (prefixed `_api_`), alongside the existing `TokenInUrls::isDisabled()` / anonymous-route guards:

```php
if (TokenInUrls::isDisabled()
    || $this->anonymousRouteProvider->isRouteAnonymous($name)
    || str_starts_with($name, '_api_')) {
    return $url;
}
```

@jolelievre — the **detection mechanism** is the open design choice here; I used the route-name prefix because it needs no new dependency and only affects API-route URL generation (vs. injecting the request context to detect an API request more broadly). Happy to switch to whichever signal you prefer.

## Verification (end-to-end)

Ran the `ps_apiresources` `AttributeGroupEndpointTest` against an install carrying this change:
- **Before:** `Location: /attributes/groups/5?_token=76d5ef…` (reproduced).
- **After:** `Location: /attributes/groups/5` — no `_token`; full suite still green (no regression).

A companion test asserting the clean Location header is proposed on the module side: **PrestaShop/ps_apiresources** (linked once opened).
