### PR TITLE
Don't fatal on invokable controllers when resolving multishop context

### DIFF
--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -357,7 +357,13 @@ class ShopContextSubscriber implements EventSubscriberInterface
                 $routeInfo = $this->router->matchRequest($request);
                 $controller = $routeInfo['_controller'];
             }
-            [$className, $methodName] = explode('::', $controller);
+            $controllerParts = explode('::', $controller);
+            if (2 !== count($controllerParts)) {
+                // Invokable or service-id controllers (e.g. the API Platform docs action) have no
+                // "Class::method" form, so they cannot declare the AllShopContext attribute this way. (#39468)
+                return null;
+            }
+            [$className, $methodName] = $controllerParts;
 
             $reflectionClass = new ReflectionClass($className);
             $classAttributes = $reflectionClass->getAttributes(AllShopContext::class);

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
@@ -128,6 +128,53 @@ class ShopContextSubscriberTest extends ContextEventListenerTestCase
         $this->assertEquals($expectedShopConstraint, $event->getRequest()->attributes->get('shopConstraint'));
     }
 
+    /**
+     * The Admin API docs route (api_doc) maps to an invokable controller with no "Class::method"
+     * form. Resolving the shop context for it must not emit an "Undefined array key 1" warning,
+     * which fataled the API documentation when multistore was enabled. See #39468.
+     */
+    public function testMultiShopWithInvokableControllerRouteDoesNotFail(): void
+    {
+        $expectedShopConstraint = ShopConstraint::shop(1);
+        $event = $this->createRequestEvent(new Request());
+
+        $router = $this->createMock(RequestMatcherInterface::class);
+        $router->method('matchRequest')->willReturn(['_controller' => 'Some\\Invokable\\DocsAction']);
+
+        $shopContextBuilder = new ShopContextBuilder(
+            $this->mockShopRepository(1),
+            $this->mockContextStateManager(),
+            $this->mockMultistoreFeature(true),
+        );
+
+        $listener = new ShopContextSubscriber(
+            $shopContextBuilder,
+            $this->mockEmployeeContext(),
+            $this->mockConfiguration(['PS_SHOP_DEFAULT' => self::DEFAULT_SHOP_ID, 'PS_SSL_ENABLED' => self::PS_SSL_ENABLED]),
+            $this->mockMultistoreFeature(true),
+            $router,
+            $this->mockSecurity($expectedShopConstraint),
+            $this->mockLegacyContext(),
+            $this->createMock(TranslatorInterface::class),
+        );
+
+        $warnings = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = $errstr;
+
+            return true;
+        }, E_WARNING);
+
+        try {
+            $listener->initShopContext($event);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $warnings, 'Resolving the shop context for an invokable controller must not emit a PHP warning.');
+        $this->assertEquals($expectedShopConstraint, $event->getRequest()->attributes->get('shopConstraint'));
+    }
+
     public static function getMultiShopValues(): iterable
     {
         yield 'single shop, employee has all permissions' => [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Stops the Admin API documentation from fataling under multistore.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion? | Fixes #39468
| How to test?      | See below — covered by a unit test.
| UI Tests          | [45/45 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31744618369) on `9db54d37` (target `9.2.x`, rebased). Green on the 4th attempt, same commit throughout. The three earlier attempts lost 11 jobs each to the campaign environment, not to this diff - the two inspected were `functional:API` failing `04_postDiscounts.ts:200` with `expected '2026-08-14 01:59:32' to include '2026-08-13'`, a shop-clock-vs-runner-date rollover, and `BO:advanced-parameters:07-10` aborting with `The action has timed out.` before a single test ran.
| Sponsor company   |

## Problem

With multistore enabled, opening the Admin API documentation (Swagger/ReDoc) fataled:

```
hydra:description: "Warning: Undefined array key 1"
… ShopContextSubscriber.php
```

`ShopContextSubscriber::getShopConstraintFromRouteAttribute()` resolves the shop context from the route's controller:

```php
[$className, $methodName] = explode('::', $controller);
```

This assumes a `Class::method` controller. The API documentation route maps to an **invokable** controller (no `::`), so `explode()` returns a single element and the destructuring emits `Undefined array key 1`. In the API context that warning is escalated to an error, so the docs never render. (The path is only reached under multistore, hence the condition in the report.)

## Fix

Guard the non-`Class::method` case — invokable / service-id controllers can't declare the `AllShopContext` attribute via this lookup anyway, so return `null`:

```php
$controllerParts = explode('::', $controller);
if (2 !== count($controllerParts)) {
    return null;
}
[$className, $methodName] = $controllerParts;
```

## How to test

Unit test added to `ShopContextSubscriberTest`: drives the subscriber with a router returning an invokable `_controller` (no `::`) and asserts **no PHP warning** is emitted while the shop context still resolves.
- **Before:** `Undefined array key 1` (RED).
- **After:** clean. Existing 33 cases still pass.

