### PR TITLE
Refresh the theme config cache when re-importing an upgraded theme

### DIFF
--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -465,9 +465,47 @@ class ThemeManager implements AddonManagerInterface
         $this->filesystem->mkdir($themePath);
         $this->filesystem->mirror($sandboxPath, $themePath);
 
+        $this->refreshConfigurationCache($theme->getName());
+
         $this->importTranslationToDatabase($theme);
 
         $this->filesystem->remove($sandboxPath);
+    }
+
+    /**
+     * Refresh the cached per-shop configuration files (config/themes/<name>/shop<id>.json)
+     * from the freshly installed theme.yml.
+     *
+     * WHY: uninstalling a theme removes its directory but leaves these JSON caches behind,
+     * and re-importing is the only way to upgrade a theme (installFromZip throws when the
+     * directory already exists). Without this refresh the stale cache keeps advertising the
+     * previous version on the Theme & Logo page (#39792). The theme.yml-derived data is
+     * refreshed while the merchant's saved page layouts (theme_settings.layouts) are
+     * preserved — the cache must be updated, not deleted.
+     */
+    private function refreshConfigurationCache(string $themeName): void
+    {
+        $configDir = $this->configuration->get('_PS_CONFIG_DIR_') . 'themes/' . $themeName;
+        $themeConfigFile = $this->configuration->get('_PS_ALL_THEMES_DIR_') . $themeName . '/config/theme.yml';
+        if (!$this->filesystem->exists($configDir) || !$this->filesystem->exists($themeConfigFile)) {
+            return;
+        }
+
+        $freshData = (new Parser())->parse(file_get_contents($themeConfigFile));
+
+        foreach ((array) glob($configDir . '/*.json') as $cacheFile) {
+            $cachedData = json_decode((string) file_get_contents($cacheFile), true);
+            if (!is_array($cachedData)) {
+                continue;
+            }
+
+            $refreshedData = array_merge($cachedData, $freshData);
+            if (isset($cachedData['theme_settings']['layouts'])) {
+                $refreshedData['theme_settings']['layouts'] = $cachedData['theme_settings']['layouts'];
+            }
+
+            $this->filesystem->dumpFile($cacheFile, json_encode($refreshedData));
+        }
     }
 
     private function getSandboxPath()

--- a/tests/Integration/Core/Addon/Theme/ThemeManagerTest.php
+++ b/tests/Integration/Core/Addon/Theme/ThemeManagerTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Addon\Theme;
+
+use FilesystemIterator;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Tests\Integration\Utility\ContextMockerTrait;
+use ZipArchive;
+
+class ThemeManagerTest extends KernelTestCase
+{
+    use ContextMockerTrait;
+
+    private const THEME_NAME = 'themeUpgradeFixture';
+
+    private ThemeManager $themeManager;
+
+    private ThemeRepository $themeRepository;
+
+    private Filesystem $filesystem;
+
+    private string $themesDir;
+
+    private string $themeConfigDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem();
+        $this->themeManager = self::getContainer()->get('prestashop.core.addon.theme.theme_manager');
+
+        $configuration = new Configuration();
+        $configuration->restrictUpdatesTo(self::getContext()->shop);
+        $this->themeRepository = new ThemeRepository($configuration, $this->filesystem, self::getContext()->shop);
+
+        $this->themesDir = (string) $configuration->get('_PS_ALL_THEMES_DIR_') . self::THEME_NAME;
+        $this->themeConfigDir = (string) $configuration->get('_PS_CONFIG_DIR_') . 'themes/' . self::THEME_NAME;
+
+        $this->cleanUpFixtures();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpFixtures();
+        parent::tearDown();
+    }
+
+    /**
+     * Reproduces #39792: re-importing an upgraded theme left the stale per-shop config cache
+     * (config/themes/<name>/shop<id>.json) in place, so the Theme & Logo page kept showing the
+     * old version. The refresh must update the version while preserving the merchant's saved
+     * page layouts (the cache is updated, not deleted).
+     */
+    public function testReimportRefreshesTheCachedVersionWhilePreservingPageLayouts(): void
+    {
+        // The merchant previously installed v1.0.0 and customised the page layouts, leaving an
+        // orphaned cache behind after uninstalling the theme.
+        $customLayouts = ['index' => 'layout-custom-marker'];
+        $this->filesystem->dumpFile(
+            $this->themeConfigDir . '/shop' . self::getContext()->shop->id . '.json',
+            json_encode([
+                'name' => self::THEME_NAME,
+                'version' => '1.0.0',
+                'theme_settings' => [
+                    'default_layout' => 'layout-full-width',
+                    'layouts' => $customLayouts,
+                ],
+            ])
+        );
+
+        // Re-import the same theme in v2.0.0.
+        // ThemeManager::importTranslationToDatabase() resolves services through the global $kernel
+        // and only checks that it is a KernelInterface, not that it is still booted; a test running
+        // earlier in the suite can leave that global pointing at a kernel it already shut down.
+        // Point it at this test's booted kernel just for the call, then put it straight back.
+        global $kernel;
+        $previousKernel = $kernel;
+        $kernel = self::$kernel;
+
+        try {
+            $this->themeManager->install($this->buildThemeZip('2.0.0'));
+        } finally {
+            $kernel = $previousKernel;
+        }
+
+        $theme = $this->themeRepository->getInstanceByName(self::THEME_NAME);
+
+        $this->assertSame('2.0.0', $theme->get('version'), 'The cached theme version must be refreshed on re-import.');
+        $this->assertSame($customLayouts, $theme->get('theme_settings.layouts'), 'The merchant page layouts must be preserved on re-import.');
+    }
+
+    /**
+     * Builds a zip of the minimal valid theme fixture renamed to self::THEME_NAME at the given version.
+     */
+    private function buildThemeZip(string $version): string
+    {
+        $sourceDir = _PS_ROOT_DIR_ . '/tests/Resources/themes/minimal-valid-theme';
+        $stagingDir = sys_get_temp_dir() . '/' . self::THEME_NAME . '-' . $version;
+        $this->filesystem->remove($stagingDir);
+        $this->filesystem->mirror($sourceDir, $stagingDir);
+
+        $yml = (string) file_get_contents($stagingDir . '/config/theme.yml');
+        $yml = preg_replace('/^name:.*/m', 'name: ' . self::THEME_NAME, $yml);
+        $yml = preg_replace('/^version:.*/m', 'version: ' . $version, $yml);
+        $this->filesystem->dumpFile($stagingDir . '/config/theme.yml', (string) $yml);
+
+        $zipPath = sys_get_temp_dir() . '/' . self::THEME_NAME . '-' . $version . '.zip';
+        $this->filesystem->remove($zipPath);
+
+        $zip = new ZipArchive();
+        $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($stagingDir, FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($files as $file) {
+            /* @var \SplFileInfo $file */
+            $zip->addFile($file->getPathname(), substr($file->getPathname(), strlen($stagingDir) + 1));
+        }
+        $zip->close();
+
+        $this->filesystem->remove($stagingDir);
+
+        return $zipPath;
+    }
+
+    private function cleanUpFixtures(): void
+    {
+        $this->filesystem->remove($this->themesDir);
+        $this->filesystem->remove($this->themeConfigDir);
+        $this->filesystem->remove(glob(sys_get_temp_dir() . '/' . self::THEME_NAME . '-*') ?: []);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | After upgrading a theme, the Design > Theme & Logo page keeps showing the old version because the per-shop theme config cache is not refreshed on re-import. This refreshes it while preserving saved page layouts.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the "How to test" section below.
| UI Tests          | n/a — covered by a new integration test (`tests/Integration/Core/Addon/Theme/ThemeManagerTest.php`).
| Fixed issue or discussion?     | Fixes #39792
| Related PRs       |
| Sponsor company   |

## Problem

After upgrading a theme, the **Design > Theme & Logo** page keeps showing the *old* version.

The per-shop theme configuration is cached in `config/themes/<name>/shop<id>.json` (a parsed snapshot of `config/theme.yml`, read by `ThemeRepository::getInstanceByName()`). Two facts combine to cause the bug:

- `ThemeManager::installFromZip()` **throws** if the theme directory already exists, so the only way to upgrade a theme is to uninstall it and re-import the new zip.
- `ThemeManager::uninstall()` removes the theme *directory* but leaves the `config/themes/<name>/shop<id>.json` cache behind.

So after `uninstall` → re-import, the new theme files are in place but the stale cache still advertises the previous version. The reporter's workaround confirms it: deleting `config/themes/<name>/shop<id>.json` by hand before re-uploading fixes the display.

## Fix

Refresh the per-shop configuration cache on import, in `installFromZip()`, right after the new theme files are mirrored. The `theme.yml`-derived data (version, settings…) is refreshed, while the merchant's saved page layouts (`theme_settings.layouts`) are **preserved** — the cache is *updated, not deleted* (as @Hlavtox noted on the issue, that file holds the layout customizations and must not be wiped).

A clean first install is unaffected (no existing cache → nothing to refresh; the cache is created from the new `theme.yml` on first read as before).

## How to test

1. Install a theme (e.g. Hummingbird), note its version on **Design > Theme & Logo**.
2. Uninstall it, then re-import the same theme at a higher version.
3. **Before:** the page still shows the old version. **After:** it shows the new version, and any saved page layouts are preserved.

Automated: `ThemeManagerTest` reproduces the upgrade flow — it seeds a stale v1 cache (with a custom `theme_settings.layouts`), re-imports the theme at v2, and asserts the read-back version is refreshed **and** the page layout survived. Verified RED→GREEN (reverting the fix fails the version assertion).

> Note: the touched code is identical on `9.1.x` and `develop`, so the fix applies to both — happy to retarget/backport to `9.1.x` if maintainers prefer.