### PR TITLE
Evaluate cart discount-display fields per line, not per combination

### DIFF
--- a/src/Adapter/Presenter/Cart/CartProductLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartProductLazyArray.php
@@ -6,12 +6,53 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Presenter\Cart;
 
+use Context;
 use Language;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingLazyArray;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
+use Tools;
 
 class CartProductLazyArray extends ProductListingLazyArray
 {
+    /**
+     * Re-evaluate the discount-display fields per cart line.
+     *
+     * WHY: in the cart, `reduction`, `specific_prices` and `price_without_reduction` are filled by
+     * Product::getProductProperties() (see Cart::getProducts) and are therefore PER-COMBINATION, not
+     * per cart line. When the same combination appears on several lines (e.g. different customizations),
+     * a catalog price rule may apply to only some of them, yet the parent marks every line as discounted
+     * (`has_discount = 0 != reduction`) and renders a phantom badge ("-0", the rule's %, etc.). The line's
+     * actual paid price (`price_amount`, set line-specifically by Cart::getCartPrices) is reliable, so we
+     * derive `has_discount` from `price_amount` vs `regular_price_amount` and clear the stale labels on
+     * lines that did not actually receive a reduction. Correctly-discounted lines keep the parent's
+     * already line-specific amounts. (#41278)
+     *
+     * Note: `price_amount` and `regular_price_amount` come from two different price computations
+     * (getCartPriceFromCatalog vs Product::getProductProperties), so we compare them rounded to the
+     * currency precision — float noise between the two paths must not fabricate a discount, while any
+     * real reduction (>= the currency's smallest unit) is preserved.
+     */
+    protected function addPriceInformation(
+        ProductPresentationSettings $settings,
+        array $product
+    ): void {
+        parent::addPriceInformation($settings, $product);
+
+        $precision = (int) (Context::getContext()->currency->precision ?? 2);
+        $hasLineReduction = Tools::ps_round($this->product['regular_price_amount'], $precision)
+            > Tools::ps_round($this->product['price_amount'], $precision);
+        $this->product['has_discount'] = $hasLineReduction;
+
+        if (!$hasLineReduction) {
+            $this->product['discount_type'] = null;
+            $this->product['discount_percentage'] = null;
+            $this->product['discount_percentage_absolute'] = null;
+            $this->product['discount_amount'] = null;
+            $this->product['discount_amount_to_display'] = null;
+            $this->product['discount_to_display'] = $this->product['regular_price'];
+        }
+    }
+
     /**
      * Custom implementation of quantity information for cart products. In cart, we use the data
      * a bit differently than in product listing. We also have edge cases when some of the ordered

--- a/tests/Integration/Adapter/Presenter/Cart/CartProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Cart/CartProductLazyArrayTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\Adapter\Presenter\Cart;
+
+use Context;
+use Currency;
+use Language;
+use Link;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\HookManager;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartProductLazyArray;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
+use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Covers #41278: discount-display fields must be per cart line, not per combination.
+ */
+class CartProductLazyArrayTest extends TestCase
+{
+    /** @var Configuration|MockObject */
+    private $mockConfiguration;
+    /** @var HookManager|MockObject */
+    private $mockHookManager;
+    /** @var ImageRetriever|MockObject */
+    private $mockImageRetriever;
+    /** @var Language|MockObject */
+    private $mockLanguage;
+    /** @var Link|MockObject */
+    private $mockLink;
+    /** @var PriceFormatter|MockObject */
+    private $mockPriceFormatter;
+    /** @var ProductColorsRetriever|MockObject */
+    private $mockProductColorsRetriever;
+    /** @var ProductPresentationSettings|MockObject */
+    private $mockSettings;
+    /** @var TranslatorInterface|MockObject */
+    private $mockTranslator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockConfiguration = $this->getMockBuilder(Configuration::class)->disableOriginalConstructor()->getMock();
+        $this->mockConfiguration->method('get')->willReturn(true);
+
+        $this->mockImageRetriever = $this->getMockBuilder(ImageRetriever::class)->disableOriginalConstructor()->getMock();
+        $this->mockImageRetriever->method('getAllProductImages')->willReturn([]);
+
+        $this->mockHookManager = $this->getMockBuilder(HookManager::class)->disableOriginalConstructor()->getMock();
+
+        $this->mockLanguage = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
+        $this->mockLanguage->id = 1;
+        $this->mockLanguage->method('getId')->willReturn(1);
+
+        $this->mockLink = $this->getMockBuilder(Link::class)->disableOriginalConstructor()->getMock();
+        $this->mockPriceFormatter = $this->getMockBuilder(PriceFormatter::class)->disableOriginalConstructor()->getMock();
+        $this->mockPriceFormatter->method('format')->willReturnCallback(fn ($price) => number_format((float) $price, 2));
+        $this->mockProductColorsRetriever = $this->getMockBuilder(ProductColorsRetriever::class)->disableOriginalConstructor()->getMock();
+
+        $this->mockSettings = $this->getMockBuilder(ProductPresentationSettings::class)->disableOriginalConstructor()->getMock();
+        $this->mockSettings->include_taxes = false;
+        $this->mockSettings->stock_management_enabled = false; // short-circuits addQuantityInformation
+
+        $this->mockTranslator = $this->getMockBuilder(TranslatorInterface::class)->disableOriginalConstructor()->getMock();
+        $this->mockTranslator->method('trans')->willReturnCallback(fn ($id) => $id);
+
+        // The discount block formats the reduction percentage through the context locale.
+        $locale = $this->getMockBuilder(\PrestaShop\PrestaShop\Core\Localization\Locale::class)
+            ->disableOriginalConstructor()->getMock();
+        $locale->method('formatNumber')->willReturnCallback(fn ($n) => (string) $n);
+        Context::getContext()->currentLocale = $locale;
+        // The per-line discount check rounds to the currency precision.
+        Context::getContext()->currency = new Currency();
+        Context::getContext()->currency->precision = 2;
+    }
+
+    /**
+     * @dataProvider providerDiscountCases
+     */
+    public function testHasDiscountIsEvaluatedPerCartLine(bool $includeTaxes, float $linePrice, float $basePrice, bool $expectedHasDiscount): void
+    {
+        $this->mockSettings->include_taxes = $includeTaxes;
+
+        // A catalog price rule exists for the combination (per-combination specific_prices + reduction),
+        // exactly as Cart::getProducts fills them. The line's actual paid price decides the real discount.
+        // Both tax bases are populated so the active include_taxes branch is exercised.
+        $product = array_merge($this->baseProduct(), [
+            'price' => $linePrice,
+            'price_tax_exc' => $linePrice,
+            'price_without_reduction' => $basePrice,
+            'price_without_reduction_without_tax' => $basePrice,
+            'specific_prices' => ['reduction_type' => 'percentage', 'reduction' => '0.2'],
+            'reduction' => 2.0, // per-combination rule reduction (non-zero) — would falsely flag every line
+        ]);
+
+        $cartProduct = new CartProductLazyArray(
+            $this->mockSettings,
+            $product,
+            $this->mockLanguage,
+            $this->mockImageRetriever,
+            $this->mockLink,
+            $this->mockPriceFormatter,
+            $this->mockProductColorsRetriever,
+            $this->mockTranslator,
+            $this->mockHookManager,
+            $this->mockConfiguration
+        );
+
+        $this->assertSame($expectedHasDiscount, $cartProduct['has_discount']);
+        if (!$expectedHasDiscount) {
+            $this->assertNull($cartProduct['discount_percentage_absolute']);
+            $this->assertNull($cartProduct['discount_amount_to_display']);
+        }
+    }
+
+    public static function providerDiscountCases(): array
+    {
+        return [
+            // [include_taxes, line paid price, non-reduced base, expected has_discount]
+            // Line below the rule threshold: paid price == non-reduced base → NO discount on this line.
+            'tax-excluded, line received no reduction' => [false, 10.0, 10.0, false],
+            'tax-excluded, line received the reduction' => [false, 8.0, 10.0, true],
+            // Tax-included is the B2C default and takes a different branch in the parent.
+            'tax-included, line received no reduction' => [true, 12.0, 12.0, false],
+            'tax-included, line received the reduction' => [true, 9.6, 12.0, true],
+            // Float noise between the two price paths must not fabricate a discount
+            // (line fractionally below base by sub-cent noise → still no discount).
+            'negligible float noise is not a discount' => [false, 9.999999999, 10.0, false],
+        ];
+    }
+
+    private function baseProduct(): array
+    {
+        return [
+            'id_product' => 1,
+            'id_product_attribute' => 1,
+            'price_without_reduction' => 10.0,
+            'price_without_reduction_without_tax' => 10.0,
+            'new' => 0,
+            'pack' => 0,
+            'out_of_stock' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
+            'customizable' => 0,
+            'active' => 1,
+            'minimal_quantity' => 1,
+            'quantity' => 1,
+            'stock_quantity' => 10,
+            'is_virtual' => 0,
+            'additional_delivery_times' => DeliveryTimeNoteType::TYPE_DEFAULT,
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Cart discount labels were computed per product/combination instead of per cart line, so lines sharing a combination (e.g. different customizations) all showed the same — often wrong — discount badge. This evaluates the discount-display fields per line.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | To be added
| Fixed issue or discussion?     | Fixes #41278
| Related PRs       |
| Sponsor company   |

## Problem

When the same product combination appears on several cart lines (e.g. because of different customizations), the cart shows incorrect discount labels: a discount badge appears on lines that received no reduction, the badge sometimes renders as just `–` (a `-0.00` amount), and the percentage shown is the rule's rather than the line's.

The prices themselves are correct — only the displayed discount info is wrong.

### Root cause

In `Cart::getProducts()`, the per-line rows are enriched twice:

- `getCartPrices()` sets the line's actual paid `price` **line-specifically** (quantity-aware).
- the final enrichment loop then overwrites `reduction`, `specific_prices` and `price_without_reduction` with `Product::getProductProperties()` output, which is **per-combination**, not per line.

`ProductLazyArray::addPriceInformation()` then derives the discount display from those per-combination fields (`has_discount = 0 != $product['reduction']`), so every line of the combination is flagged as discounted even when only some lines met the catalog price rule's minimum quantity.

## Fix

Override `addPriceInformation()` in `CartProductLazyArray` (which already overrides `addQuantityInformation` for the cart context). After the parent runs, re-derive `has_discount` from the line's actual paid price (`price_amount`, set line-specifically) versus its non-reduced price (`regular_price_amount`), and clear the stale discount labels on lines that did not actually receive a reduction. Correctly-discounted lines keep the parent's amounts, which are already computed from the line-specific price.

The shared `ProductLazyArray` is untouched, so product listing / product page behaviour is unchanged.

## How to test

1. Create a product with a combination and a catalog price rule on that combination (e.g. minimum quantity 5, 20% off).
2. Add the same combination to the cart multiple times with different customizations (separate cart lines).
3. Set one line's quantity to 5 (meets the rule) and keep another below 5.
4. **Before:** every line shows a discount badge (and the non-qualifying line shows a `–`/`-0.00` badge). **After:** only the line that actually received the reduction shows a discount badge.

Automated: `tests/Integration/Adapter/Presenter/Cart/CartProductLazyArrayTest.php` builds the exact cart-row shape `Cart::getProducts` produces (per-combination `specific_prices`/`reduction` + a line-specific `price`) and asserts `has_discount` is true only when the line's paid price is actually below its non-reduced price. Verified RED→GREEN (reverting the override makes the no-reduction case fail).