### PR TITLE
Generate links with the target shop's category link_rewrite on multishop

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1541,16 +1541,23 @@ class CategoryCore extends ObjectModel
      * Get Each parent category of this category until the root category.
      *
      * @param int $idLang Language ID
+     * @param int|null $idShop Resolve the tree and its multishop fields (e.g. link_rewrite) for this
+     *                         shop instead of the current context shop. Used when generating a link
+     *                         for another shop than the one the request bootstrapped into.
      *
      * @return array Corresponding categories
      */
-    public function getParentsCategories($idLang = null)
+    public function getParentsCategories($idLang = null, $idShop = null)
     {
         $context = Context::getContext()->cloneContext();
         $context->shop = clone $context->shop;
 
         if (null === $idLang) {
             $idLang = $context->language->id;
+        }
+
+        if (null !== $idShop) {
+            $context->shop = new Shop((int) $idShop);
         }
 
         $categories = null;
@@ -1566,7 +1573,7 @@ class CategoryCore extends ObjectModel
         $sqlAppend = 'FROM `' . _DB_PREFIX_ . 'category` c
 			LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl
 				ON (c.`id_category` = cl.`id_category`
-                    AND `id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl') . ')';
+                    AND `id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl', $idShop) . ')';
         if (Shop::isFeatureActive() && Shop::getContext() === Shop::CONTEXT_SHOP) {
             $sqlAppend .= ' LEFT JOIN `' . _DB_PREFIX_ . 'category_shop` cs ' .
                 'ON (c.`id_category` = cs.`id_category` AND cs.`id_shop` = ' . (int) $idShop . ')';

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -232,7 +232,7 @@ class LinkCore
              * We will use all categories in the path of the default category,
              * with two exceptions - the root category and the home category.
              */
-            foreach ($product->getParentCategories($idLang) as $cat) {
+            foreach ($product->getParentCategories($idLang, $idShop) as $cat) {
                 if (!in_array($cat['id_category'], Link::$category_disable_rewrite)) {
                     $cats[] = $cat['link_rewrite'];
                 }
@@ -385,18 +385,20 @@ class LinkCore
      *
      * @param Category|array|int $category
      * @param int $idLang
+     * @param int|null $idShop Load the category for this shop, so multishop-specific fields
+     *                         (e.g. link_rewrite) match the shop the link is generated for
      *
      * @return Category
      *
      * @throws PrestaShopException
      */
-    public function getCategoryObject($category, $idLang)
+    public function getCategoryObject($category, $idLang, $idShop = null)
     {
         if (!is_object($category)) {
             if (isset($category['id_category'])) {
-                $category = new Category($category['id_category'], $idLang);
+                $category = new Category($category['id_category'], $idLang, $idShop);
             } elseif ((int) $category) {
-                $category = new Category((int) $category, $idLang);
+                $category = new Category((int) $category, $idLang, $idShop);
             } else {
                 throw new PrestaShopException('Invalid category vars');
             }
@@ -452,17 +454,17 @@ class LinkCore
         $rule = 'category_rule';
 
         if (!$alias) {
-            $category = $this->getCategoryObject($category, $idLang);
+            $category = $this->getCategoryObject($category, $idLang, $idShop);
         }
         $params['rewrite'] = (!$alias) ? $category->link_rewrite : $alias;
         if ($dispatcher->hasKeyword($rule, $idLang, 'meta_title', $idShop)) {
-            $category = $this->getCategoryObject($category, $idLang);
+            $category = $this->getCategoryObject($category, $idLang, $idShop);
             $params['meta_title'] = Tools::str2url($category->getFieldByLang('meta_title'));
         }
         if ($dispatcher->hasKeyword($rule, $idLang, 'categories', $idShop)) {
-            $category = $this->getCategoryObject($category, $idLang);
+            $category = $this->getCategoryObject($category, $idLang, $idShop);
             $cats = [];
-            foreach (array_reverse($category->getParentsCategories($idLang)) as $cat) {
+            foreach (array_reverse($category->getParentsCategories($idLang, $idShop)) as $cat) {
                 if ($cat['id_category'] == $category->id) {
                     continue;
                 }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7584,10 +7584,12 @@ class ProductCore extends ObjectModel
      * Get list of parent categories.
      *
      * @param int|null $id_lang Language identifier
+     * @param int|null $id_shop Resolve category link_rewrite for this shop instead of the current
+     *                          context shop, so links generated for another shop are correct
      *
      * @return array
      */
-    public function getParentCategories($id_lang = null)
+    public function getParentCategories($id_lang = null, $id_shop = null)
     {
         if (!$id_lang) {
             $id_lang = Context::getContext()->language->id;
@@ -7600,7 +7602,7 @@ class ProductCore extends ObjectModel
 
         $sql = new DbQuery();
         $sql->from('category', 'c');
-        $sql->leftJoin('category_lang', 'cl', 'c.id_category = cl.id_category AND id_lang = ' . (int) $id_lang . Shop::addSqlRestrictionOnLang('cl'));
+        $sql->leftJoin('category_lang', 'cl', 'c.id_category = cl.id_category AND id_lang = ' . (int) $id_lang . Shop::addSqlRestrictionOnLang('cl', $id_shop));
         $sql->where('c.nleft <= ' . (int) $interval['nleft'] . ' AND c.nright >= ' . (int) $interval['nright']);
         $sql->orderBy('c.nleft');
 

--- a/tests/Integration/Classes/LinkMultishopTest.php
+++ b/tests/Integration/Classes/LinkMultishopTest.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Category;
+use Configuration;
+use Context;
+use Db;
+use Dispatcher;
+use Link;
+use PHPUnit\Framework\TestCase;
+use Product;
+use ReflectionClass;
+use Shop;
+use ShopUrl;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * Reproduces https://github.com/PrestaShop/PrestaShop/issues/36794
+ *
+ * When a category is shared between two shops with a different link_rewrite for the same
+ * language, generating a category/product link for a shop OTHER than the current context shop
+ * must use the target shop's link_rewrite, not the one of the context shop.
+ */
+class LinkMultishopTest extends TestCase
+{
+    private const TABLES = [
+        'configuration',
+        'shop',
+        'shop_group',
+        'shop_url',
+        'category',
+        'category_shop',
+        'category_lang',
+    ];
+
+    /**
+     * @var int
+     */
+    private $secondShopId;
+
+    /**
+     * @var int
+     */
+    private $categoryId = 3;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DatabaseDump::restoreTables(self::TABLES);
+
+        Configuration::updateGlobalValue('PS_MULTISHOP_FEATURE_ACTIVE', '1');
+        Configuration::updateGlobalValue('PS_REWRITING_SETTINGS', '1');
+
+        $idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        // Create a second shop in the default group, reusing the default shop's root category.
+        $shop = new Shop();
+        $shop->active = true;
+        $shop->id_shop_group = 1;
+        $shop->id_category = 2;
+        $shop->theme_name = _THEME_NAME_;
+        $shop->name = 'Second shop';
+        $shop->add();
+        $this->secondShopId = (int) $shop->id;
+
+        $shopUrl = new ShopUrl();
+        $shopUrl->id_shop = $this->secondShopId;
+        $shopUrl->active = true;
+        $shopUrl->main = true;
+        $shopUrl->domain = 'localhost';
+        $shopUrl->domain_ssl = 'localhost';
+        $shopUrl->physical_uri = '/second-shop/';
+        $shopUrl->virtual_uri = '';
+        $shopUrl->add();
+
+        Shop::resetContext();
+
+        // Make the category belong to both shops and give it a distinct slug per shop.
+        Db::getInstance()->insert('category_shop', [
+            'id_category' => $this->categoryId,
+            'id_shop' => $this->secondShopId,
+            'position' => 0,
+        ], false, true, Db::INSERT_IGNORE);
+
+        Db::getInstance()->update('category_lang', ['link_rewrite' => 'category-shop-one'], 'id_category = ' . $this->categoryId . ' AND id_shop = 1 AND id_lang = ' . $idLang);
+
+        // Ensure a category_lang row exists for the second shop, then set its slug.
+        $existing = Db::getInstance()->getValue('SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'category_lang WHERE id_category = ' . $this->categoryId . ' AND id_shop = ' . $this->secondShopId . ' AND id_lang = ' . $idLang);
+        if (!$existing) {
+            Db::getInstance()->execute(
+                'INSERT INTO ' . _DB_PREFIX_ . 'category_lang (id_category, id_shop, id_lang, name, description, additional_description, link_rewrite, meta_title, meta_description)
+                 SELECT id_category, ' . $this->secondShopId . ', id_lang, name, description, additional_description, link_rewrite, meta_title, meta_description
+                 FROM ' . _DB_PREFIX_ . 'category_lang
+                 WHERE id_category = ' . $this->categoryId . ' AND id_shop = 1 AND id_lang = ' . $idLang
+            );
+        }
+        Db::getInstance()->update('category_lang', ['link_rewrite' => 'category-shop-two'], 'id_category = ' . $this->categoryId . ' AND id_shop = ' . $this->secondShopId . ' AND id_lang = ' . $idLang);
+
+        // Bootstrap the request into the FIRST shop.
+        Shop::setContext(Shop::CONTEXT_SHOP, 1);
+        Context::getContext()->shop = new Shop(1);
+        Category::resetStaticCache();
+
+        $dispatcher = new ReflectionClass(Dispatcher::class);
+        $useRoutes = $dispatcher->getProperty('use_routes');
+        $useRoutes->setAccessible(true);
+        $useRoutes->setValue(Dispatcher::getInstance(), true);
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(self::TABLES);
+        Shop::resetContext();
+        parent::tearDown();
+    }
+
+    public function testCategoryLinkUsesTargetShopLinkRewrite(): void
+    {
+        $idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        $link = new Link();
+        $url = $link->getCategoryLink($this->categoryId, null, $idLang, null, $this->secondShopId);
+
+        $this->assertStringContainsString(
+            'category-shop-two',
+            $url,
+            'The category link generated for the second shop must use that shop\'s link_rewrite.'
+        );
+        $this->assertStringNotContainsString('category-shop-one', $url);
+    }
+
+    public function testGetParentsCategoriesResolvesLinkRewriteForTargetShop(): void
+    {
+        $idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $category = new Category($this->categoryId, $idLang);
+
+        $slugFor = static function (array $rows, int $idCategory): ?string {
+            foreach ($rows as $row) {
+                if ((int) $row['id_category'] === $idCategory) {
+                    return $row['link_rewrite'];
+                }
+            }
+
+            return null;
+        };
+
+        // Context is the first shop; without a target shop we get the context shop's slug.
+        $this->assertSame(
+            'category-shop-one',
+            $slugFor($category->getParentsCategories($idLang), $this->categoryId)
+        );
+
+        // Asking for the second shop must resolve that shop's slug.
+        $this->assertSame(
+            'category-shop-two',
+            $slugFor($category->getParentsCategories($idLang, $this->secondShopId), $this->categoryId)
+        );
+    }
+
+    /**
+     * The scenario reported in the issue: a product URL embedding its category path.
+     */
+    public function testProductGetParentCategoriesResolvesLinkRewriteForTargetShop(): void
+    {
+        $idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        $product = new Product();
+        $product->id_category_default = $this->categoryId;
+
+        $slugFor = static function (array $rows, int $idCategory): ?string {
+            foreach ($rows as $row) {
+                if ((int) $row['id_category'] === $idCategory) {
+                    return $row['link_rewrite'];
+                }
+            }
+
+            return null;
+        };
+
+        $this->assertSame(
+            'category-shop-one',
+            $slugFor($product->getParentCategories($idLang), $this->categoryId)
+        );
+
+        $this->assertSame(
+            'category-shop-two',
+            $slugFor($product->getParentCategories($idLang, $this->secondShopId), $this->categoryId)
+        );
+    }
+}

--- a/tests/Integration/Classes/LinkMultishopTest.php
+++ b/tests/Integration/Classes/LinkMultishopTest.php
@@ -17,6 +17,7 @@ use Link;
 use PHPUnit\Framework\TestCase;
 use Product;
 use ReflectionClass;
+use ReflectionProperty;
 use Shop;
 use ShopUrl;
 use Tests\Resources\DatabaseDump;
@@ -50,10 +51,19 @@ class LinkMultishopTest extends TestCase
      */
     private $categoryId = 3;
 
+    /**
+     * @var bool
+     */
+    private $originalUseRoutes;
+
     protected function setUp(): void
     {
         parent::setUp();
         DatabaseDump::restoreTables(self::TABLES);
+
+        // Capture the baseline Dispatcher routing state before this test forces it, so it can be
+        // restored in tearDown and does not leak into other test classes.
+        $this->originalUseRoutes = $this->getUseRoutesProperty()->getValue(Dispatcher::getInstance());
 
         Configuration::updateGlobalValue('PS_MULTISHOP_FEATURE_ACTIVE', '1');
         Configuration::updateGlobalValue('PS_REWRITING_SETTINGS', '1');
@@ -108,17 +118,25 @@ class LinkMultishopTest extends TestCase
         Context::getContext()->shop = new Shop(1);
         Category::resetStaticCache();
 
-        $dispatcher = new ReflectionClass(Dispatcher::class);
-        $useRoutes = $dispatcher->getProperty('use_routes');
-        $useRoutes->setAccessible(true);
-        $useRoutes->setValue(Dispatcher::getInstance(), true);
+        $this->getUseRoutesProperty()->setValue(Dispatcher::getInstance(), true);
     }
 
     protected function tearDown(): void
     {
+        // Restore the Dispatcher singleton state, otherwise the forced use_routes value leaks into
+        // other test classes and changes their generated URLs.
+        $this->getUseRoutesProperty()->setValue(Dispatcher::getInstance(), $this->originalUseRoutes);
         DatabaseDump::restoreTables(self::TABLES);
         Shop::resetContext();
         parent::tearDown();
+    }
+
+    private function getUseRoutesProperty(): ReflectionProperty
+    {
+        $property = (new ReflectionClass(Dispatcher::class))->getProperty('use_routes');
+        $property->setAccessible(true);
+
+        return $property;
     }
 
     public function testCategoryLinkUsesTargetShopLinkRewrite(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -----------------
| Branch?           | develop
| Description?      | `Link::getCategoryObject()`, `Category::getParentsCategories()` and `Product::getParentCategories()` resolved the category `link_rewrite` against the **current context shop**, ignoring the shop the link is actually generated for. On a multishop install where a category is shared between shops with a different `link_rewrite` for the same language, generating a product or category URL for a shop other than the one the request bootstrapped into (e.g. an hreflang module building alternate URLs) produced the wrong category slug. The target shop id is now threaded through so the requested shop's `link_rewrite` is used. New parameters are optional and default to the previous behaviour, so the change is backward compatible.<br><br>_Note: this also affects 9.1.x / 9.0.x. I targeted `develop`; happy to provide a 9.1.x backport if maintainers prefer the fix to land there first (the affected methods have a slightly different shape on 9.1.x, so it would be a port rather than a cherry-pick)._
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a multishop install, share a category between two shops and give it a different **friendly URL** per shop for the same language. From a page bootstrapped into shop A, generate a category/product link for shop B (e.g. `$link->getCategoryLink($idCategory, null, $idLang, null, $idShopB)`). Before this change the URL contains shop A's slug; after it, shop B's. Covered by the new `tests/Integration/Classes/LinkMultishopTest.php` (RED→GREEN), which asserts both `getCategoryLink` and the product/category-path methods (`Product::getParentCategories`, `Category::getParentsCategories`).
| UI Tests          | [45/45 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31790335734) on `e69e3882` (target `develop`, rebased). Green on the 3rd attempt, same commit throughout: attempt 1 lost `BO:catalog:03-04`, `BO:catalog:07-08`, `BO:orders:01-create-orders`, `BO:advanced-parameters:01-06` and `BO:international:03-04`; attempt 2 lost only `BO:orders:01-create-orders`, the 10s `waitForSelector` on the order message that also fails on unrelated PRs.
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/36794
| Related PRs       |
| Sponsor company   |

