### PR TITLE
Restrict the order detail page to the current shop context

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -500,12 +500,22 @@ class OrderController extends PrestaShopAdminController
         #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.edit_order_product_form_builder')] FormBuilderInterface $editProductFormBuilder,
         ShipmentFilters $filters,
         Tools $tools,
+        #[Autowire(expression: 'service("prestashop.adapter.shop.context").getContextListShopID(parameter("multishop.settings.share_orders"))')]
+        array $contextShopIds = [],
     ): Response {
         try {
             /** @var OrderForViewing $orderForViewing */
             $orderForViewing = $this->dispatchQuery(new GetOrderForViewing($orderId, QuerySorting::DESC));
         } catch (OrderException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+
+            return $this->redirectToRoute('admin_orders_index');
+        }
+
+        // Do not display an order that belongs to a shop outside the current shop context, the same
+        // way the orders list is restricted to the context shops (taking order sharing into account).
+        if (!in_array((int) $orderForViewing->getShopId(), array_map('intval', $contextShopIds), true)) {
+            $this->addFlash('error', $this->trans('The order cannot be found within your database.', [], 'Admin.Orderscustomers.Notification'));
 
             return $this->redirectToRoute('admin_orders_index');
         }
@@ -2348,6 +2358,11 @@ class OrderController extends PrestaShopAdminController
                 ),
                 InvalidCartRuleDiscountValueException::INVALID_FREE_SHIPPING => $this->trans(
                     'Shipping discount value cannot exceed the total price of this order.',
+                    [],
+                    'Admin.Orderscustomers.Notification'
+                ),
+                InvalidCartRuleDiscountValueException::DUPLICATE_FREE_SHIPPING => $this->trans(
+                    'This order already has a free shipping discount.',
                     [],
                     'Admin.Orderscustomers.Notification'
                 ),

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/OrderControllerMultishopTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/OrderControllerMultishopTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Controller\Admin\Sell\Order;
+
+use Configuration;
+use Context;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Shop;
+use ShopUrl;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Tests\Integration\Utility\ContextMockerTrait;
+use Tests\Integration\Utility\LoginTrait;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * @see https://github.com/PrestaShop/PrestaShop/issues/31822
+ *
+ * The order detail page must not be displayed when the current shop context does not include the
+ * order's shop, just like the orders list which is restricted to the context shops.
+ */
+class OrderControllerMultishopTest extends WebTestCase
+{
+    use ContextMockerTrait;
+    use LoginTrait;
+
+    private const TABLES = ['configuration', 'shop', 'shop_group', 'shop_url'];
+
+    /**
+     * The default fixtures place every order in the default shop (1).
+     */
+    private const ORDER_IN_SHOP_1 = 1;
+
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    /**
+     * @var int
+     */
+    private $secondShopId;
+
+    /**
+     * @var mixed
+     */
+    private $previousKernel;
+
+    /**
+     * @var mixed
+     */
+    private $previousContainer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DatabaseDump::restoreTables(self::TABLES);
+        self::mockContext();
+
+        Configuration::updateGlobalValue('PS_MULTISHOP_FEATURE_ACTIVE', '1');
+
+        $shop = new Shop();
+        $shop->active = true;
+        $shop->id_shop_group = 1;
+        $shop->id_category = 2;
+        $shop->theme_name = _THEME_NAME_;
+        $shop->name = 'Second shop';
+        $shop->add();
+        $this->secondShopId = (int) $shop->id;
+
+        $shopUrl = new ShopUrl();
+        $shopUrl->id_shop = $this->secondShopId;
+        $shopUrl->active = true;
+        $shopUrl->main = true;
+        $shopUrl->domain = 'localhost';
+        $shopUrl->domain_ssl = 'localhost';
+        $shopUrl->physical_uri = '/second-shop/';
+        $shopUrl->virtual_uri = '';
+        $shopUrl->add();
+
+        Shop::resetStaticCache();
+
+        $this->client = self::createClient();
+
+        // mockContext() resets SymfonyContainer's cached instance, and it can only repopulate from
+        // the global $kernel. A KernelTestCase running earlier in the suite (e.g.
+        // AdminSearchControllerCoreTest) leaves that global pointing at a shut-down kernel, so the
+        // legacy layer reached from the order form (Cart -> ContainerFinder) would throw
+        // "Kernel Container is not available" and the page would answer 500. Point both at the
+        // client's live kernel.
+        global $kernel;
+        $this->previousKernel = $kernel;
+        $this->previousContainer = Context::getContext()->container ?? null;
+        $kernel = self::$kernel;
+        Context::getContext()->container = self::getContainer();
+    }
+
+    protected function tearDown(): void
+    {
+        // Put the globals back exactly as they were, so this test does not hand a live-but-about-to-die
+        // kernel to the rest of the suite.
+        global $kernel;
+        $kernel = $this->previousKernel;
+        Context::getContext()->container = $this->previousContainer;
+        // Drop the cached reference to this test's kernel container as well, so the next test
+        // resolves it from the restored global instead of a container we are about to shut down.
+        SymfonyContainer::resetStaticCache();
+
+        DatabaseDump::restoreTables(self::TABLES);
+        Shop::resetStaticCache();
+        $this->resetContext();
+        parent::tearDown();
+    }
+
+    public function testViewingAnOrderFromAnotherShopRedirectsToTheList(): void
+    {
+        // Bootstrap the back office into the second shop, which does not own order #1.
+        $this->loginUser($this->client, ShopConstraint::shop($this->secondShopId));
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $this->client->request('GET', $router->generate('admin_orders_view', ['orderId' => self::ORDER_IN_SHOP_1]));
+
+        $response = $this->client->getResponse();
+        $this->assertTrue(
+            $response->isRedirect($router->generate('admin_orders_index')),
+            sprintf('Expected a redirect to the orders list, got status %d.', $response->getStatusCode())
+        );
+    }
+
+    public function testViewingAnOrderFromTheCurrentShopIsAllowed(): void
+    {
+        // Bootstrap into shop 1, which owns order #1: the page must not redirect to the list.
+        $this->loginUser($this->client, ShopConstraint::shop(1));
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $this->client->request('GET', $router->generate('admin_orders_view', ['orderId' => self::ORDER_IN_SHOP_1]));
+
+        $response = $this->client->getResponse();
+        $this->assertFalse(
+            $response->isRedirect($router->generate('admin_orders_index')),
+            'The order of the current shop must not be redirected away from.'
+        );
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -----------------
| Branch?           | develop
| Description?      | The Back Office order detail page (`OrderController::viewAction`) loaded and displayed any order by its ID without checking that the order belongs to the current shop context. The orders **list** is already restricted to the context shops (`OrderQueryBuilder`: `o.id_shop IN getContextListShopID(SHARE_ORDER)`), but the **detail view** was not — so an order placed in one shop could be opened while browsing another shop's context. The fix mirrors the list behaviour: it redirects to the orders list when the order's shop is not part of the current shop context, honouring order sharing between shops of a group exactly like the list query does.<br><br>_This also affects 9.0.x / 9.1.x; targeted `develop` because the new functional test needs the current test database schema. Happy to provide a 9.1.x backport if preferred._
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a multishop install, open an order placed in shop A, then switch the BO context to shop B (which does not own that order): the order detail must no longer be displayed — you are redirected to the orders list. A functional test is included (`OrderControllerMultishopTest`): it logs into shop 2's context and asserts that viewing shop 1's order redirects to the list, while an order of the current shop still renders.
| UI Tests          | [45/45 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/32118628000) on `d09c29d3` (target `develop`, rebased). Green on the 6th attempt, same commit throughout. `BO:orders:01-create-orders` drove attempts 2 to 5 on its own - the 10s `waitForSelector` on the order message that also fails on unrelated PRs - and attempt 1 additionally lost `functional:API`, `BO:catalog:03-04`, `BO:shop-parameters:05-07`, `BO:international:03-04`, `modules:30-39` and `FO:hummingbird:08-12`, none of which recurred once retried.
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/31822
| Related PRs       |
| Sponsor company   |

