### PR TITLE
Fix Admin API documentation failing to load with multistore enabled

### DIFF
--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -357,7 +357,12 @@ class ShopContextSubscriber implements EventSubscriberInterface
                 $routeInfo = $this->router->matchRequest($request);
                 $controller = $routeInfo['_controller'];
             }
-            [$className, $methodName] = explode('::', $controller);
+            // Invokable controllers (e.g. API Platform actions like the API documentation) are
+            // referenced in the route without an explicit method, so the controller string has no
+            // "::" separator. Fall back to the __invoke method instead of accessing an undefined index.
+            $controllerParts = explode('::', $controller);
+            $className = $controllerParts[0];
+            $methodName = $controllerParts[1] ?? '__invoke';
 
             $reflectionClass = new ReflectionClass($className);
             $classAttributes = $reflectionClass->getAttributes(AllShopContext::class);

--- a/tests/Integration/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberApiDocTest.php
+++ b/tests/Integration/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberApiDocTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\EventListener\Admin\Context;
+
+use Configuration;
+use Shop;
+use ShopUrl;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Tests\Integration\Utility\ContextMockerTrait;
+use Tests\Integration\Utility\LoginTrait;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * @see https://github.com/PrestaShop/PrestaShop/issues/39468
+ *
+ * When multistore is enabled, ShopContextSubscriber inspects the matched controller to look for the
+ * AllShopContext attribute. Invokable controllers (e.g. the API Platform documentation action) are
+ * referenced without a "::" method separator, which used to raise "Undefined array key 1" and broke
+ * the Admin API documentation page.
+ */
+class ShopContextSubscriberApiDocTest extends WebTestCase
+{
+    use ContextMockerTrait;
+    use LoginTrait;
+
+    private const TABLES = ['configuration', 'shop', 'shop_group', 'shop_url'];
+
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DatabaseDump::restoreTables(self::TABLES);
+        self::mockContext();
+
+        Configuration::updateGlobalValue('PS_MULTISHOP_FEATURE_ACTIVE', '1');
+
+        $shop = new Shop();
+        $shop->active = true;
+        $shop->id_shop_group = 1;
+        $shop->id_category = 2;
+        $shop->theme_name = _THEME_NAME_;
+        $shop->name = 'Second shop';
+        $shop->add();
+
+        $shopUrl = new ShopUrl();
+        $shopUrl->id_shop = (int) $shop->id;
+        $shopUrl->active = true;
+        $shopUrl->main = true;
+        $shopUrl->domain = 'localhost';
+        $shopUrl->domain_ssl = 'localhost';
+        $shopUrl->physical_uri = '/second-shop/';
+        $shopUrl->virtual_uri = '';
+        $shopUrl->add();
+
+        Shop::resetStaticCache();
+
+        $this->client = self::createClient();
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(self::TABLES);
+        Shop::resetStaticCache();
+        $this->resetContext();
+        parent::tearDown();
+    }
+
+    public function testApiDocumentationLoadsWithMultistoreEnabled(): void
+    {
+        $this->loginUser($this->client);
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        // The bug surfaces as a PHP warning raised by ShopContextSubscriber while resolving the
+        // shop context of the (invokable) API documentation controller; in the API Platform context
+        // that warning is turned into a fatal error. Capture warnings to assert it no longer happens.
+        $warnings = [];
+        set_error_handler(static function (int $severity, string $message) use (&$warnings): bool {
+            $warnings[] = $message;
+
+            return false;
+        }, E_WARNING);
+
+        try {
+            $this->client->request('GET', $router->generate('api_doc', ['_format' => 'json']));
+        } finally {
+            restore_error_handler();
+        }
+
+        $statusCode = $this->client->getResponse()->getStatusCode();
+        $this->assertSame(
+            Response::HTTP_OK,
+            $statusCode,
+            sprintf('The Admin API documentation must load when multistore is enabled, got status %d.', $statusCode)
+        );
+        $undefinedKeyWarnings = array_filter($warnings, static fn (string $m): bool => str_contains($m, 'Undefined array key'));
+        $this->assertEmpty(
+            $undefinedKeyWarnings,
+            'ShopContextSubscriber must not raise an "Undefined array key" warning for invokable controllers.'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -----------------
| Branch?           | develop
| Description?      | With multistore enabled, `ShopContextSubscriber` inspects the matched controller for the `AllShopContext` attribute by splitting the `_controller` string on `::`. Invokable controllers (e.g. the API Platform documentation action) are referenced in the route **without** an explicit method, so the string has no `::` and `[$className, $methodName] = explode('::', $controller)` raised `Undefined array key 1`. In the API Platform context that warning is turned into a fatal error, which is why the **Admin API documentation page failed to load** when multistore was on. The method name now defaults to `__invoke` when the controller string has no explicit method.<br><br>_This also affects 9.0.x / 9.1.x; targeted `develop` because the functional test needs the current test database schema. Happy to provide a 9.1.x backport (the fix itself is a one-liner that applies cleanly)._
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With multistore enabled, open the Admin API documentation (Advanced Parameters > Webservice / API – Swagger/ReDoc, route `api_doc`). It must load instead of returning an error. Covered by `ShopContextSubscriberApiDocTest`, which enables multistore and asserts the API documentation route loads without raising the `Undefined array key` warning.
| UI Tests          |
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/39468
| Related PRs       |
| Sponsor company   |
