### PR TITLE
Prevent assigning a customer to groups outside its shop in multistore

### DIFF
--- a/src/Adapter/Customer/CommandHandler/AbstractCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/AbstractCustomerHandler.php
@@ -7,9 +7,12 @@
 namespace PrestaShop\PrestaShop\Adapter\Customer\CommandHandler;
 
 use Customer;
+use Db;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerGroupShopAssociationException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\MissingCustomerRequiredFieldsException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
+use Shop;
 
 /**
  * Provides reusable methods for customer command handlers.
@@ -44,6 +47,47 @@ abstract class AbstractCustomerHandler
             $missingFields = array_keys($errors);
 
             throw new MissingCustomerRequiredFieldsException($missingFields, sprintf('One or more required fields for customer are missing. Missing fields are: %s', implode(',', $missingFields)));
+        }
+    }
+
+    /**
+     * Ensures every assigned group is associated with at least one of the shops the customer
+     * belongs to. In multistore, the group list is not scoped to the customer's shop (e.g. in
+     * "all shops" context every group is offered), so a customer could otherwise be saved with a
+     * group that does not exist in its shop.
+     *
+     * @param int[] $groupIds
+     * @param int $customerShopId
+     *
+     * @throws CustomerGroupShopAssociationException
+     */
+    protected function assertGroupsAreAssociatedToCustomerShop(array $groupIds, int $customerShopId)
+    {
+        // Single-shop installs have no per-shop group scoping to enforce.
+        if (empty($groupIds) || !Shop::isFeatureActive()) {
+            return;
+        }
+
+        // A shared customer (Shop::SHARE_CUSTOMER) belongs to every shop of its group, so any of
+        // those shops' groups are valid; otherwise only the customer's own shop counts.
+        $customerShopIds = array_map('intval', Shop::getSharedShops($customerShopId, Shop::SHARE_CUSTOMER));
+        if (empty($customerShopIds)) {
+            return;
+        }
+
+        // WHY: `group` is not a registered multistore ObjectModel, so getAssociatedShops()/the
+        // group repository cannot resolve the group_shop association — read it directly here.
+        $rows = Db::getInstance()->executeS('
+            SELECT DISTINCT `id_group`
+            FROM `' . _DB_PREFIX_ . 'group_shop`
+            WHERE `id_shop` IN (' . implode(',', $customerShopIds) . ')
+        ');
+        $allowedGroupIds = array_map('intval', array_column($rows ?: [], 'id_group'));
+
+        foreach ($groupIds as $groupId) {
+            if (!in_array((int) $groupId, $allowedGroupIds, true)) {
+                throw new CustomerGroupShopAssociationException(sprintf('Customer group with id "%d" is not associated with the customer\'s shop.', (int) $groupId));
+            }
         }
     }
 }

--- a/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
@@ -75,6 +75,10 @@ final class AddCustomerHandler extends AbstractCustomerHandler implements AddCus
         // Check if provided groups contain the correct data (the default group must be in group list)
         $this->assertCustomerCanAccessDefaultGroup($command);
 
+        if (null !== $command->getGroupIds()) {
+            $this->assertGroupsAreAssociatedToCustomerShop($command->getGroupIds(), (int) $command->getShopId());
+        }
+
         $customer->add();
         if (null !== $command->getGroupIds()) {
             $customer->updateGroup($command->getGroupIds());

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -64,6 +64,10 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
 
         $this->assertCustomerCanAccessDefaultGroup($customer, $command);
 
+        if (null !== $command->getGroupIds()) {
+            $this->assertGroupsAreAssociatedToCustomerShop($command->getGroupIds(), (int) $customer->id_shop);
+        }
+
         $this->updateCustomerWithCommandData($customer, $command);
 
         // validateFieldsRequiredDatabase() below is using $_POST

--- a/src/Core/Domain/Customer/Exception/CustomerGroupShopAssociationException.php
+++ b/src/Core/Domain/Customer/Exception/CustomerGroupShopAssociationException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Customer\Exception;
+
+/**
+ * Exception is thrown when a customer is assigned a group that is not associated
+ * with any of the shops the customer belongs to (multistore).
+ */
+class CustomerGroupShopAssociationException extends CustomerException
+{
+}

--- a/tests/Integration/Adapter/Customer/CommandHandler/EditCustomerGroupShopAssociationTest.php
+++ b/tests/Integration/Adapter/Customer/CommandHandler/EditCustomerGroupShopAssociationTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Customer\CommandHandler;
+
+use Configuration as LegacyConfiguration;
+use Customer;
+use Db;
+use Group;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerGroupShopAssociationException;
+use PrestaShopBundle\Entity\Shop;
+use PrestaShopBundle\Entity\ShopGroup;
+use Shop as LegacyShop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * @see https://github.com/PrestaShop/PrestaShop/issues/23192
+ */
+class EditCustomerGroupShopAssociationTest extends KernelTestCase
+{
+    private const ID_DEFAULT_GROUP = 3; // Customer group, present on shop 1 by default
+
+    private static int $idShop2;
+    private static int $shopTwoOnlyGroupId;
+    private static int $customerInShopOneId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::initMultistore();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreAllTables();
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    public function testAssigningGroupFromAnotherShopThrows(): void
+    {
+        $commandBus = self::getContainer()->get('prestashop.core.command_bus');
+
+        $command = new EditCustomerCommand(self::$customerInShopOneId);
+        // The default group (shop 1) stays valid; the extra group exists only on shop 2.
+        $command->setGroupIds([self::ID_DEFAULT_GROUP, self::$shopTwoOnlyGroupId]);
+        $command->setDefaultGroupId(self::ID_DEFAULT_GROUP);
+
+        $this->expectException(CustomerGroupShopAssociationException::class);
+
+        $commandBus->handle($command);
+    }
+
+    public function testAssigningGroupFromTheCustomerShopSucceeds(): void
+    {
+        $commandBus = self::getContainer()->get('prestashop.core.command_bus');
+
+        $command = new EditCustomerCommand(self::$customerInShopOneId);
+        $command->setGroupIds([self::ID_DEFAULT_GROUP]);
+        $command->setDefaultGroupId(self::ID_DEFAULT_GROUP);
+
+        $commandBus->handle($command);
+
+        $customer = new Customer(self::$customerInShopOneId);
+        $this->assertSame([self::ID_DEFAULT_GROUP], array_map('intval', $customer->getGroups()));
+    }
+
+    private static function initMultistore(): void
+    {
+        DatabaseDump::restoreAllTables();
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+        $container = self::$kernel->getContainer();
+        $configuration = $container->get('prestashop.adapter.legacy.configuration');
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        // activate multistore
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        // add a shop in existing group (shop group 1 does not share customers by default)
+        $shopGroup = $entityManager->find(ShopGroup::class, 1);
+        $shop = new Shop();
+        $shop->setActive(true);
+        $shop->setIdCategory(2);
+        $shop->setName('test_shop_2');
+        $shop->setShopGroup($shopGroup);
+        $shop->setColor('red');
+        $shop->setThemeName(Theme::getDefaultTheme());
+        $shop->setDeleted(false);
+        $entityManager->persist($shop);
+        $entityManager->flush();
+        self::$idShop2 = (int) $shop->getId();
+
+        LegacyShop::resetStaticCache();
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, 1);
+
+        // a group associated ONLY with shop 2
+        $group = new Group();
+        $group->name = [1 => 'Shop 2 only', 2 => 'Shop 2 only'];
+        $group->price_display_method = 0;
+        $group->show_prices = true;
+        $group->add();
+        self::$shopTwoOnlyGroupId = (int) $group->id;
+        // Group::add() auto-associates the group with the current context shop (1); replace that
+        // association so the group exists ONLY on shop 2.
+        Db::getInstance()->delete('group_shop', 'id_group = ' . self::$shopTwoOnlyGroupId);
+        Db::getInstance()->insert('group_shop', [
+            'id_group' => self::$shopTwoOnlyGroupId,
+            'id_shop' => self::$idShop2,
+        ]);
+
+        // a customer that belongs to shop 1
+        $customer = new Customer();
+        $customer->firstname = 'John';
+        $customer->lastname = 'Doe';
+        $customer->email = 'issue23192@example.com';
+        $customer->passwd = md5('issue23192');
+        $customer->id_shop = 1;
+        $customer->id_default_group = self::ID_DEFAULT_GROUP;
+        $customer->add();
+        $customer->updateGroup([self::ID_DEFAULT_GROUP]);
+        self::$customerInShopOneId = (int) $customer->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | In a multistore setup, when editing (or adding) a customer the *Group access* and *Default customer group* lists are not scoped to the customer's shop — in *All shops* context every group of every shop is offered. A customer that belongs to shop A could therefore be assigned a group that only exists in shop B, and it was saved without any validation. This adds a guard in the Add/Edit customer command handlers (`AbstractCustomerHandler::assertGroupsAreAssociatedToCustomerShop`) that rejects any assigned group not associated with one of the shops the customer belongs to, respecting `Shop::SHARE_CUSTOMER` (a shared customer may use groups from any shop of its group). The check is a no-op on single-shop installs (`Shop::isFeatureActive()` guard), so existing behaviour is preserved there.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable multistore with two shops in a shop group that does **not** share customers. Create a customer group associated only with shop B. Create a customer in shop A. In *All shops* context, edit the customer and try to assign the shop-B-only group: before the fix it saves silently; after the fix an error is returned (`CustomerGroupShopAssociationException`). Covered by the new integration test `tests/Integration/Adapter/Customer/CommandHandler/EditCustomerGroupShopAssociationTest.php` (red on base, green with the fix). Existing `customer_management.feature` (10 scenarios) still passes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23192
| Related PRs       |
| Sponsor company   |

