### PR TITLE
Save password policy at global scope in multistore

### DIFF
--- a/src/Core/Security/PasswordPolicyConfiguration.php
+++ b/src/Core/Security/PasswordPolicyConfiguration.php
@@ -8,8 +8,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Security;
 
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Responsible for saving configuration options for security
@@ -38,14 +39,14 @@ class PasswordPolicyConfiguration implements DataConfigurationInterface
     public const CONFIGURATION_MINIMUM_SCORE = 'PS_SECURITY_PASSWORD_POLICY_MINIMUM_SCORE';
 
     /**
-     * @var ConfigurationInterface
+     * @var Configuration
      */
     private $configuration;
 
     /**
-     * @param ConfigurationInterface $configuration
+     * @param Configuration $configuration
      */
-    public function __construct(ConfigurationInterface $configuration)
+    public function __construct(Configuration $configuration)
     {
         $this->configuration = $configuration;
     }
@@ -55,10 +56,14 @@ class PasswordPolicyConfiguration implements DataConfigurationInterface
      */
     public function getConfiguration()
     {
+        // The password policy is a global setting (the Security page is not multistore-scoped),
+        // so it is always read at the all-shops level to stay consistent across shop contexts.
+        $shopConstraint = ShopConstraint::allShops();
+
         return [
-            'minimum_length' => $this->configuration->get(static::CONFIGURATION_MINIMUM_LENGTH),
-            'maximum_length' => $this->configuration->get(static::CONFIGURATION_MAXIMUM_LENGTH),
-            'minimum_score' => $this->configuration->get(static::CONFIGURATION_MINIMUM_SCORE),
+            'minimum_length' => $this->configuration->get(static::CONFIGURATION_MINIMUM_LENGTH, null, $shopConstraint),
+            'maximum_length' => $this->configuration->get(static::CONFIGURATION_MAXIMUM_LENGTH, null, $shopConstraint),
+            'minimum_score' => $this->configuration->get(static::CONFIGURATION_MINIMUM_SCORE, null, $shopConstraint),
         ];
     }
 
@@ -68,12 +73,16 @@ class PasswordPolicyConfiguration implements DataConfigurationInterface
     public function updateConfiguration(array $configuration)
     {
         if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set(static::CONFIGURATION_MINIMUM_SCORE, $configuration['minimum_score']);
+            // Always write at the all-shops (global) level so saving the Security page in a specific
+            // shop context does not create a phantom per-shop override that the rest of the app ignores.
+            $shopConstraint = ShopConstraint::allShops();
+
+            $this->configuration->set(static::CONFIGURATION_MINIMUM_SCORE, $configuration['minimum_score'], $shopConstraint);
             $minimumLength = min($configuration['minimum_length'], $configuration['maximum_length']);
             $maximumLength = max($configuration['minimum_length'], $configuration['maximum_length']);
 
-            $this->configuration->set(static::CONFIGURATION_MINIMUM_LENGTH, $minimumLength);
-            $this->configuration->set(static::CONFIGURATION_MAXIMUM_LENGTH, $maximumLength);
+            $this->configuration->set(static::CONFIGURATION_MINIMUM_LENGTH, $minimumLength, $shopConstraint);
+            $this->configuration->set(static::CONFIGURATION_MAXIMUM_LENGTH, $maximumLength, $shopConstraint);
         }
 
         return [];

--- a/tests/Unit/Core/Security/PasswordPolicyConfigurationTest.php
+++ b/tests/Unit/Core/Security/PasswordPolicyConfigurationTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Security;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
+
+/**
+ * The Security page is not multistore-scoped, so the password policy must always be read from and
+ * written to the global (all-shops) scope, regardless of the current shop context.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/29309
+ */
+class PasswordPolicyConfigurationTest extends TestCase
+{
+    public function testGetConfigurationReadsFromAllShopsScope(): void
+    {
+        $configuration = $this->createMock(Configuration::class);
+        $configuration
+            ->method('get')
+            ->willReturnCallback(function ($key, $default = null, $shopConstraint = null) {
+                // The fix must always read at the all-shops (global) scope.
+                $this->assertEquals(ShopConstraint::allShops(), $shopConstraint);
+
+                return [
+                    PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH => 8,
+                    PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH => 72,
+                    PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_SCORE => 3,
+                ][$key];
+            });
+
+        $result = (new PasswordPolicyConfiguration($configuration))->getConfiguration();
+
+        $this->assertSame(
+            [
+                'minimum_length' => 8,
+                'maximum_length' => 72,
+                'minimum_score' => 3,
+            ],
+            $result
+        );
+    }
+
+    public function testUpdateConfigurationWritesToAllShopsScope(): void
+    {
+        $configuration = $this->createMock(Configuration::class);
+
+        $calls = [];
+        $configuration
+            ->method('set')
+            ->willReturnCallback(function ($key, $value, $shopConstraint = null) use (&$calls, $configuration) {
+                $calls[] = [$key, $value, $shopConstraint];
+
+                return $configuration;
+            });
+
+        (new PasswordPolicyConfiguration($configuration))->updateConfiguration([
+            'minimum_length' => 10,
+            'maximum_length' => 50,
+            'minimum_score' => 4,
+        ]);
+
+        $expected = [
+            [PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_SCORE, 4, ShopConstraint::allShops()],
+            [PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH, 10, ShopConstraint::allShops()],
+            [PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH, 50, ShopConstraint::allShops()],
+        ];
+        $this->assertEquals($expected, $calls);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On the *Shop Parameters > General > Security* page, the strict password policy (`minimum_score`, `minimum_length`, `maximum_length`) was read and saved without a `ShopConstraint`. In a specific-shop context the save therefore wrote a **per-shop** configuration override via `buildShopConstraintFromContext()`, while the rest of the application reads the policy globally — so the change appeared "not taken into consideration", and simply switching the shop context changed the values shown on the page (as reported by QA). The Security page is not multistore-scoped (its sibling data provider `GeneralConfiguration` is a plain `DataConfigurationInterface` as well), so the password policy is now always read from and written to the all-shops (global) level, keeping it consistent across every shop context.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable multistore with at least two shops. Switch the back-office context to a specific shop (not "All shops"), open *Shop Parameters > General > Security*, change the password policy and save. Before the fix the value is stored only for that shop (the global value and other contexts are unchanged); after the fix the value is stored globally and is identical in every shop context and on the front office. Covered by the new unit test `tests/Unit/Core/Security/PasswordPolicyConfigurationTest.php` (asserts both read and write use `ShopConstraint::allShops()`; red on base, green with the fix).
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29309
| Related PRs       |
| Sponsor company   |

