### PR TITLE
Keep remote assets untouched when a media server is configured

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1103,7 +1103,9 @@ class FrontControllerCore extends Controller
         ];
         $params = array_merge($default_params, $params);
 
-        if (Tools::hasMediaServer() && !Configuration::get('PS_CSS_THEME_CACHE')) {
+        // Only local assets are served from the media server; a remote asset (e.g. a module's
+        // external CDN script) must keep its absolute URL and never be rewritten to the media server.
+        if ($params['server'] === 'local' && Tools::hasMediaServer() && !Configuration::get('PS_CSS_THEME_CACHE')) {
             $fullPath = $this->stylesheetManager->getFullPath($relativePath);
 
             if (!$fullPath) {
@@ -1138,7 +1140,9 @@ class FrontControllerCore extends Controller
         ];
         $params = array_merge($default_params, $params);
 
-        if (Tools::hasMediaServer() && !Configuration::get('PS_JS_THEME_CACHE')) {
+        // Only local assets are served from the media server; a remote asset (e.g. a module's
+        // external CDN script) must keep its absolute URL and never be rewritten to the media server.
+        if ($params['server'] === 'local' && Tools::hasMediaServer() && !Configuration::get('PS_JS_THEME_CACHE')) {
             $fullPath = $this->javascriptManager->getFullPath($relativePath);
 
             if (!$fullPath) {

--- a/tests/Integration/Classes/Controller/FrontControllerMediaServerTest.php
+++ b/tests/Integration/Classes/Controller/FrontControllerMediaServerTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use Configuration;
+use FrontController;
+use JavascriptManager;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use StylesheetManager;
+use Tools;
+
+/**
+ * When a media server (CDN) is configured, remote assets registered by modules must keep their
+ * absolute URL instead of being rewritten to the media server.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/36939
+ * @see https://github.com/PrestaShop/PrestaShop/issues/36644
+ */
+class FrontControllerMediaServerTest extends TestCase
+{
+    private const REMOTE_URL = 'https://assets.example.com/sdk/ps_checkout-fo-sdk.js';
+
+    /** @var array<string, mixed> */
+    private array $originalConfig = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        foreach (['PS_JS_THEME_CACHE', 'PS_CSS_THEME_CACHE'] as $key) {
+            $this->originalConfig[$key] = Configuration::get($key);
+        }
+        Configuration::updateValue('PS_JS_THEME_CACHE', 0);
+        Configuration::updateValue('PS_CSS_THEME_CACHE', 0);
+        // Tools::hasMediaServer() reads the _MEDIA_SERVER_*_ constants via a static cache; force the
+        // cache to "1 media server configured" so the media-server branch is active in this test.
+        $this->setMediaServerCount(1);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalConfig as $key => $value) {
+            Configuration::updateValue($key, $value);
+        }
+        $this->setMediaServerCount(null);
+        parent::tearDown();
+    }
+
+    private function setMediaServerCount(?int $count): void
+    {
+        $property = (new ReflectionClass(Tools::class))->getProperty('_cache_nb_media_servers');
+        $property->setAccessible(true);
+        $property->setValue(null, $count);
+    }
+
+    public function testRemoteJavascriptKeepsItsUrlWhenMediaServerIsSet(): void
+    {
+        $manager = $this->createMock(JavascriptManager::class);
+        // The remote URL must reach the asset manager untouched, with the 'remote' server flag.
+        $manager->expects($this->once())
+            ->method('register')
+            ->with(
+                'ps-checkout-sdk',
+                self::REMOTE_URL,
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                'remote'
+            );
+
+        $controller = $this->createFrontController('javascriptManager', $manager);
+        $controller->registerJavascript('ps-checkout-sdk', self::REMOTE_URL, ['server' => 'remote']);
+    }
+
+    public function testRemoteStylesheetKeepsItsUrlWhenMediaServerIsSet(): void
+    {
+        $manager = $this->createMock(StylesheetManager::class);
+        $manager->expects($this->once())
+            ->method('register')
+            ->with(
+                'ps-checkout-css',
+                self::REMOTE_URL,
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                'remote'
+            );
+
+        $controller = $this->createFrontController('stylesheetManager', $manager);
+        $controller->registerStylesheet('ps-checkout-css', self::REMOTE_URL, ['server' => 'remote']);
+    }
+
+    /**
+     * Builds a usable FrontController without running its heavy constructor, with the given asset
+     * manager injected into the matching protected property.
+     */
+    private function createFrontController(string $property, object $manager): FrontController
+    {
+        $controller = $this->getMockBuilder(FrontController::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMockForAbstractClass();
+
+        $reflection = new ReflectionClass(FrontController::class);
+        $prop = $reflection->getProperty($property);
+        $prop->setAccessible(true);
+        $prop->setValue($controller, $manager);
+
+        return $controller;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When a media server (CDN) is configured, `FrontController::registerStylesheet()` and `registerJavascript()` rewrote **every** asset URL to the media server — including remote assets that a module registers with `'server' => 'remote'` (for example an external payment SDK such as `ps_checkout`'s). For an absolute remote URL, `getFullPath()` returns `false`, so the method hit its early `return` and the asset was **silently dropped**, leaving the module unusable; the rest of the time the absolute URL was rewritten to `https://<media-server>…`, which also breaks it. The media-server rewrite now only applies to assets served locally (`'server' === 'local'`), so remote assets keep their absolute URL. Default callers are unaffected (`server` defaults to `'local'`). This supersedes the stale/conflicting #36645 (thanks @gregzawadzki for the original analysis) and targets the lowest applicable branch with a regression test.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Configure a media server (Shop Parameters > General, or set `_MEDIA_SERVER_1_`). From a module, register a remote asset, e.g. `$this->context->controller->registerJavascript('sdk', 'https://cdn.example.com/sdk.js', ['server' => 'remote']);`. Before the fix the script is missing from the rendered page (dropped) / rewritten to the media-server host; after the fix it is rendered with its original absolute URL. Covered by `tests/Integration/Classes/Controller/FrontControllerMediaServerTest.php` (red on base, green with the fix) for both JS and CSS.
| UI Tests          |
| Fixed issue or discussion?     | Fixes #36644, Fixes #36939
| Related PRs       | Supersedes #36645
| Sponsor company   |
