### PR TITLE
Remove orphan stock_available rows when share-stock changes

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -522,15 +522,22 @@ class StockAvailableCore extends ObjectModel
      */
     public static function resetProductFromStockAvailableByShopGroup(ShopGroup $shop_group)
     {
-        $shop_list = $shop_group->share_stock ? Shop::getShops(false, $shop_group->id, true) : [];
+        if ($shop_group->share_stock) {
+            // Stock is now shared at the shop-group level (rows use id_shop = 0, id_shop_group = group).
+            // The per-shop rows of the group's shops became obsolete: remove them instead of leaving
+            // orphan lines that bloat the table and feed inconsistent data (e.g. to the webservice).
+            $shop_list = Shop::getShops(false, $shop_group->id, true);
+            if (count($shop_list) > 0) {
+                $id_shops_list = implode(', ', array_map('intval', $shop_list));
+                Db::getInstance()->delete('stock_available', 'id_shop IN (' . $id_shops_list . ') AND id_shop_group = 0');
+            }
 
-        if (count($shop_list) > 0) {
-            $id_shops_list = implode(', ', $shop_list);
-
-            return Db::getInstance()->update('stock_available', ['quantity' => 0], 'id_shop IN (' . $id_shops_list . ')');
+            return Db::getInstance()->update('stock_available', ['quantity' => 0], 'id_shop_group = ' . (int) $shop_group->id);
         }
 
-        return Db::getInstance()->update('stock_available', ['quantity' => 0], 'id_shop_group = ' . $shop_group->id);
+        // Stock is no longer shared (rows use id_shop = X, id_shop_group = 0). The previous shared
+        // row (id_shop = 0, id_shop_group = group) is now obsolete and must be removed.
+        return Db::getInstance()->delete('stock_available', 'id_shop_group = ' . (int) $shop_group->id);
     }
 
     /**

--- a/tests/Integration/Classes/StockAvailableShopGroupTest.php
+++ b/tests/Integration/Classes/StockAvailableShopGroupTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration as LegacyConfiguration;
+use Db;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShopBundle\Entity\Shop;
+use PrestaShopBundle\Entity\ShopGroup as ShopGroupEntity;
+use Shop as LegacyShop;
+use ShopGroup;
+use StockAvailable;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * Changing the share-stock parameter of a shop group must clean up the stock_available rows that
+ * belong to the previous sharing model, instead of leaving orphan lines behind.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/28779
+ */
+class StockAvailableShopGroupTest extends KernelTestCase
+{
+    private const ID_PRODUCT = 999999;
+    private const ID_GROUP = 1;
+
+    private static int $idShop2;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$idShop2 = self::initMultistore();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreAllTables();
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    protected function tearDown(): void
+    {
+        Db::getInstance()->delete('stock_available', 'id_product = ' . self::ID_PRODUCT);
+        parent::tearDown();
+    }
+
+    public function testDisablingStockSharingRemovesTheObsoleteSharedRow(): void
+    {
+        // State right after stock sharing was disabled: the new per-shop rows plus the now-obsolete
+        // shared row (id_shop = 0 / id_shop_group = group).
+        $this->insertStock(0, self::ID_GROUP, 50);
+        $this->insertStock(1, 0, 10);
+        $this->insertStock(self::$idShop2, 0, 20);
+
+        $group = new ShopGroup(self::ID_GROUP);
+        $group->share_stock = false;
+        StockAvailable::resetProductFromStockAvailableByShopGroup($group);
+
+        // The obsolete shared row is gone; the per-shop rows are kept.
+        $this->assertSame(0, $this->countStock('id_shop = 0 AND id_shop_group = ' . self::ID_GROUP));
+        $this->assertSame(1, $this->countStock('id_shop = 1 AND id_shop_group = 0'));
+        $this->assertSame(1, $this->countStock('id_shop = ' . self::$idShop2 . ' AND id_shop_group = 0'));
+    }
+
+    public function testEnablingStockSharingRemovesTheObsoletePerShopRows(): void
+    {
+        // State right after stock sharing was enabled: the new shared row plus the now-obsolete
+        // per-shop rows.
+        $this->insertStock(0, self::ID_GROUP, 50);
+        $this->insertStock(1, 0, 10);
+        $this->insertStock(self::$idShop2, 0, 20);
+
+        $group = new ShopGroup(self::ID_GROUP);
+        $group->share_stock = true;
+        StockAvailable::resetProductFromStockAvailableByShopGroup($group);
+
+        // The obsolete per-shop rows are gone; the shared row is kept (quantity reset to 0).
+        $this->assertSame(0, $this->countStock('id_shop = 1 AND id_shop_group = 0'));
+        $this->assertSame(0, $this->countStock('id_shop = ' . self::$idShop2 . ' AND id_shop_group = 0'));
+        $this->assertSame(1, $this->countStock('id_shop = 0 AND id_shop_group = ' . self::ID_GROUP));
+        $this->assertSame(
+            '0',
+            (string) Db::getInstance()->getValue(
+                'SELECT quantity FROM ' . _DB_PREFIX_ . 'stock_available
+                 WHERE id_product = ' . self::ID_PRODUCT . ' AND id_shop = 0 AND id_shop_group = ' . self::ID_GROUP
+            )
+        );
+    }
+
+    private function insertStock(int $idShop, int $idShopGroup, int $quantity): void
+    {
+        Db::getInstance()->insert('stock_available', [
+            'id_product' => self::ID_PRODUCT,
+            'id_product_attribute' => 0,
+            'id_shop' => $idShop,
+            'id_shop_group' => $idShopGroup,
+            'quantity' => $quantity,
+            'out_of_stock' => 0,
+        ]);
+    }
+
+    private function countStock(string $where): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'stock_available
+             WHERE id_product = ' . self::ID_PRODUCT . ' AND ' . $where
+        );
+    }
+
+    private static function initMultistore(): int
+    {
+        DatabaseDump::restoreAllTables();
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+        $container = self::$kernel->getContainer();
+        $configuration = $container->get('prestashop.adapter.legacy.configuration');
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        $shopGroup = $entityManager->find(ShopGroupEntity::class, self::ID_GROUP);
+        $shop = new Shop();
+        $shop->setActive(true);
+        $shop->setIdCategory(2);
+        $shop->setName('test_shop_2');
+        $shop->setShopGroup($shopGroup);
+        $shop->setColor('red');
+        $shop->setThemeName(Theme::getDefaultTheme());
+        $shop->setDeleted(false);
+        $entityManager->persist($shop);
+        $entityManager->flush();
+
+        LegacyShop::resetStaticCache();
+
+        return (int) $shop->getId();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When the *share stock* parameter of a shop group is toggled, `StockAvailable::resetProductFromStockAvailableByShopGroup()` only reset the quantities to `0`; it never removed the `stock_available` rows that belonged to the previous sharing model. After **disabling** sharing the obsolete shared row (`id_shop = 0`, `id_shop_group = group`) stays in the table alongside the new per-shop rows; after **enabling** sharing the per-shop rows (`id_shop = X`, `id_shop_group = 0`) stay alongside the new shared row. These orphan lines bloat the table and feed inconsistent data (notably to the webservice). The method now deletes the obsolete rows of the previous model instead of merely zeroing them. Stock is already reset to `0` on a sharing change, so no live quantity is lost.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable multistore, put two shops in the same group with *share stock* enabled, set a quantity on a product (creates one `ps_stock_available` row with `id_shop = 0`). Disable *share stock* and save: before the fix the `id_shop = 0` row remains as an orphan next to the new per-shop rows; after the fix it is removed. The reverse (enabling sharing) removes the obsolete per-shop rows. Covered by `tests/Integration/Classes/StockAvailableShopGroupTest.php` (both directions; red on base, green with the fix).
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28779
| Related PRs       |
| Sponsor company   |

