### PR TITLE
Preserve existing image types when a theme applies its own

### DIFF
--- a/src/Core/Image/ImageTypeRepository.php
+++ b/src/Core/Image/ImageTypeRepository.php
@@ -25,9 +25,17 @@ class ImageTypeRepository
         $this->db_prefix = $db->getPrefix();
     }
 
+    /**
+     * Applies the image types declared by a theme. Types are upserted by name: a theme only
+     * creates or updates its own types and leaves every other row untouched. The table used to be
+     * truncated first, which silently wiped image types the merchant had created by hand as well as
+     * the types required by the theme of another shop (image_type is a global, non shop-scoped
+     * table). Truncating is therefore avoided.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/20300
+     */
     public function setTypes(array $types)
     {
-        $this->removeAllTypes();
         foreach ($types as $name => $data) {
             $this->createType(
                 $name,
@@ -56,6 +64,14 @@ class ImageTypeRepository
             }
         }
 
+        // image_type.name is unique: update the existing type instead of failing on a duplicate.
+        $existingId = $this->getIdByName($name);
+        if ($existingId) {
+            $this->db->update('image_type', $data, 'id_image_type = ' . $existingId);
+
+            return $existingId;
+        }
+
         $this->db->insert('image_type', $data);
 
         return $this->getIdByName($name);
@@ -75,12 +91,5 @@ class ImageTypeRepository
         );
 
         return (int) $id_image_type;
-    }
-
-    protected function removeAllTypes()
-    {
-        Db::getInstance()->execute(
-            "TRUNCATE TABLE {$this->db_prefix}image_type"
-        );
     }
 }

--- a/tests/Integration/Core/Image/ImageTypeRepositoryTest.php
+++ b/tests/Integration/Core/Image/ImageTypeRepositoryTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Image;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Image\ImageTypeRepository;
+
+/**
+ * Applying a theme's image types must not destroy image types that do not belong to it — neither
+ * the ones a merchant created by hand nor the ones required by another shop's theme. image_type is
+ * a global (non shop-scoped) table, and it used to be truncated whenever a theme was enabled.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/20300
+ */
+class ImageTypeRepositoryTest extends TestCase
+{
+    private const CUSTOM_TYPE = 'test_20300_custom';
+    private const THEME_TYPE = 'test_20300_theme';
+
+    private ImageTypeRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ImageTypeRepository(Db::getInstance());
+        $this->cleanUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUp();
+        parent::tearDown();
+    }
+
+    public function testApplyingThemeTypesKeepsCustomTypes(): void
+    {
+        // A type the merchant created by hand (or one required by another shop's theme).
+        $this->repository->createType(self::CUSTOM_TYPE, 120, 120, ['products']);
+        $this->assertGreaterThan(0, $this->repository->getIdByName(self::CUSTOM_TYPE), 'precondition: custom type exists');
+
+        // Enabling a theme applies its own image types through setTypes().
+        $this->repository->setTypes([
+            self::THEME_TYPE => ['width' => 200, 'height' => 200, 'scope' => ['products']],
+        ]);
+
+        // The theme type is created and the pre-existing custom type is preserved.
+        $this->assertGreaterThan(0, $this->repository->getIdByName(self::THEME_TYPE), 'the theme type must be created');
+        $this->assertGreaterThan(
+            0,
+            $this->repository->getIdByName(self::CUSTOM_TYPE),
+            'applying a theme must not delete image types that do not belong to it'
+        );
+    }
+
+    public function testReapplyingAThemeTypeUpdatesItInsteadOfDuplicating(): void
+    {
+        // image_type.name is unique; re-applying a theme (e.g. switching back) must update the row.
+        $this->repository->setTypes([
+            self::THEME_TYPE => ['width' => 200, 'height' => 200, 'scope' => ['products']],
+        ]);
+        $this->repository->setTypes([
+            self::THEME_TYPE => ['width' => 350, 'height' => 350, 'scope' => ['categories']],
+        ]);
+
+        $rows = Db::getInstance()->executeS(
+            'SELECT width, height, products, categories FROM ' . _DB_PREFIX_ . "image_type WHERE name = '" . self::THEME_TYPE . "'"
+        );
+        $this->assertCount(1, $rows, 're-applying a theme type must not create a duplicate row');
+        $this->assertSame('350', (string) $rows[0]['width']);
+        $this->assertSame('350', (string) $rows[0]['height']);
+        $this->assertSame('0', (string) $rows[0]['products']);
+        $this->assertSame('1', (string) $rows[0]['categories']);
+    }
+
+    private function cleanUp(): void
+    {
+        Db::getInstance()->execute(
+            'DELETE FROM ' . _DB_PREFIX_ . "image_type WHERE name IN ('" . self::CUSTOM_TYPE . "', '" . self::THEME_TYPE . "')"
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Enabling a theme applies the image types it declares through `ImageTypeRepository::setTypes()`, which **truncated the whole `image_type` table** before recreating only the theme's types. `image_type` is a **global, non shop-scoped** table, so this silently deleted (a) image types the merchant had created by hand and (b) the types required by **another shop's theme** — enabling/switching the theme of one shop wiped image types for the entire installation. `setTypes()` now **upserts each declared type by name** and leaves every other row untouched. `image_type.name` is unique, so an already-existing type (the theme's own, on re-apply) is updated in place instead of triggering a duplicate-key error. The obsolete `removeAllTypes()` (the `TRUNCATE`) is dropped.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Multishop with two shops, each using a theme that declares its own image types in `theme.yml`, plus an image type created manually in **Design > Image Settings**. Enable/switch a theme on one shop: before the fix the manual type and the other shop's theme types are gone from `image_type`; after the fix they are preserved and only the applied theme's own types are created/updated. Covered by `tests/Integration/Core/Image/ImageTypeRepositoryTest.php` (custom type survives a `setTypes()` call — red on base; re-applying a type updates rather than duplicates it).
| UI Tests          |
| Fixed issue or discussion?     | Fixes #20300
| Related PRs       |
| Sponsor company   |
