### PR TITLE
Cap a product-restricted fixed-amount discount to the eligible products total

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1647,6 +1647,23 @@ class CartRuleCore extends ObjectModel
                             break;
                         }
                     }
+                } elseif ($this->reduction_product == 0 && $this->product_restriction) {
+                    // If the cart rule is restricted to specific products (category, manufacturer,
+                    // attribute, ...), the fixed amount can't exceed the total of the eligible products
+                    // in the cart, otherwise it would spill onto non-eligible products.
+                    // @see https://github.com/PrestaShop/PrestaShop/issues/41853
+                    $eligibleProductKeys = $this->checkProductRestrictionsFromCart($context->cart, true, false);
+                    if (is_array($eligibleProductKeys)) {
+                        $eligibleProductsTotal = 0;
+                        foreach ($all_products as $product) {
+                            $productKey = (int) $product['id_product'] . '-' . (int) $product['id_product_attribute'];
+                            if (in_array($productKey, $eligibleProductKeys, true)) {
+                                $productPrice = $this->reduction_tax ? $product['price_wt'] : $product['price'];
+                                $eligibleProductsTotal += (int) $product['cart_quantity'] * (float) $productPrice;
+                            }
+                        }
+                        $reduction_amount = min($reduction_amount, $eligibleProductsTotal);
+                    }
                 }
 
                 // If we need to convert the voucher value to the cart currency

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -228,6 +228,23 @@ class CartRuleCalculator
                         $concernedRows->addCartRow($cartRow);
                     }
                 }
+            } elseif ($cartRule->reduction_product == 0 && $cartRule->product_restriction) {
+                // The fixed amount is restricted to specific products (a category, manufacturer, ...),
+                // so only the eligible products are concerned and the amount can't exceed their total,
+                // otherwise it would spill onto the non-eligible products of the cart.
+                // @see https://github.com/PrestaShop/PrestaShop/issues/41853
+                $selectedProducts = $cartRule->checkProductRestrictionsFromCart($cart, true, false);
+                if (is_array($selectedProducts)) {
+                    foreach ($this->cartRows as $cartRow) {
+                        $product = $cartRow->getRowData();
+                        if (in_array($product['id_product'] . '-' . $product['id_product_attribute'], $selectedProducts)
+                            || in_array($product['id_product'] . '-0', $selectedProducts)) {
+                            $concernedRows->addCartRow($cartRow);
+                        }
+                    }
+                } else {
+                    $concernedRows = $this->cartRows;
+                }
             } elseif ($cartRule->reduction_product == 0) {
                 // Discount (¤) on the whole order, that will be applied with a weight ratio on all related products
                 $concernedRows = $this->cartRows;

--- a/tests/Integration/Classes/CartRuleProductRestrictionCapTest.php
+++ b/tests/Integration/Classes/CartRuleProductRestrictionCapTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Address;
+use Cart;
+use CartRule;
+use Category;
+use Configuration;
+use Context;
+use Currency;
+use DateTime;
+use Db;
+use Product;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tax;
+use TaxRule;
+use TaxRulesGroup;
+use Tools;
+
+/**
+ * A fixed-amount cart rule restricted to specific products (here a category) must never discount
+ * more than the total of the eligible products, even when the cart also contains products outside
+ * the restriction. Otherwise part of the fixed amount spills onto non-eligible products.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/41853
+ */
+class CartRuleProductRestrictionCapTest extends KernelTestCase
+{
+    private static int $idAddress;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        // Cart-rule processing reaches the service container through the legacy Context.
+        Context::getContext()->container = self::getContainer();
+        Context::getContext()->currency = Currency::getDefaultCurrency();
+
+        Configuration::loadConfiguration();
+        Configuration::updateValue('PS_TAX_ADDRESS_TYPE', 'id_address_invoice');
+        Configuration::updateValue('PS_ORDER_OUT_OF_STOCK', true);
+        Configuration::set('PS_PRICE_DISPLAY_PRECISION', 2);
+        Configuration::set('PS_CART_RULE_FEATURE_ACTIVE', true);
+        Configuration::set('PS_GROUP_FEATURE_ACTIVE', true);
+        // Pre-existing cart rules must not interfere.
+        Db::getInstance()->execute('UPDATE ' . _DB_PREFIX_ . 'cart_rule SET active = 0');
+
+        self::$idAddress = (int) self::makeAddress()->id;
+    }
+
+    public function testFixedAmountRestrictedToCategoryIsCappedByEligibleProductsTotal(): void
+    {
+        $idTaxRulesGroup = $this->getIdTaxRulesGroup(20);
+
+        // A dedicated category holding a single eligible product priced 9.
+        $category = new Category(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $category->name = 'Restricted ' . uniqid();
+        $category->link_rewrite = Tools::str2url($category->name);
+        $category->id_parent = (int) Configuration::get('PS_HOME_CATEGORY');
+        $this->assertTrue((bool) $category->add());
+
+        $eligibleProduct = $this->makeProduct('Eligible ' . uniqid(), 9, $idTaxRulesGroup);
+        $eligibleProduct->addToCategories([(int) $category->id]);
+        $nonEligibleProduct = $this->makeProduct('NonEligible ' . uniqid(), 50, $idTaxRulesGroup);
+
+        // Fixed amount 10 cart rule (tax excluded), restricted to the category above.
+        $cartRule = new CartRule(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $cartRule->name = 'Fixed 10 restricted to category';
+        $dateFrom = (new DateTime())->modify('-2 days');
+        $dateTo = (new DateTime())->modify('+2 days');
+        $cartRule->date_from = $dateFrom->format('Y-m-d H:i:s');
+        $cartRule->date_to = $dateTo->format('Y-m-d H:i:s');
+        $cartRule->quantity = 1;
+        $cartRule->quantity_per_user = 1;
+        $cartRule->reduction_amount = 10;
+        $cartRule->reduction_tax = false;
+        $cartRule->product_restriction = true;
+        $this->assertTrue((bool) $cartRule->save());
+
+        // Restrict the rule to our category.
+        Db::getInstance()->insert('cart_rule_product_rule_group', ['id_cart_rule' => (int) $cartRule->id, 'quantity' => 1]);
+        $idProductRuleGroup = (int) Db::getInstance()->Insert_ID();
+        Db::getInstance()->insert('cart_rule_product_rule', ['id_product_rule_group' => $idProductRuleGroup, 'type' => 'categories']);
+        $idProductRule = (int) Db::getInstance()->Insert_ID();
+        Db::getInstance()->insert('cart_rule_product_rule_value', ['id_product_rule' => $idProductRule, 'id_item' => (int) $category->id]);
+
+        $cart = $this->makeCart();
+        $cart->updateQty(1, (int) $eligibleProduct->id);
+        $cart->updateQty(1, (int) $nonEligibleProduct->id);
+        $cart->addCartRule((int) $cartRule->id);
+
+        // The eligible products only total 9 (tax excl.), so the 10 fixed amount must be capped at 9
+        // and must not spill onto the 50 non-eligible product.
+        // Tax excluded (reduction_tax == use_tax => branch "reduction_tax == use_tax") and tax
+        // included (reduction_tax != use_tax => the other branch) both read getOrderTotal(ONLY_DISCOUNTS)
+        // and must respect the cap: 9 and 9 * 1.20 = 10.8.
+        $this->assertEquals(9, $cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS));
+        $this->assertEquals(10.8, $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS));
+    }
+
+    private function makeProduct(string $name, float $price, int $idTaxRulesGroup): Product
+    {
+        $product = new Product(null, false, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $product->id_tax_rules_group = $idTaxRulesGroup;
+        $product->name = $name;
+        $product->price = $price;
+        $product->link_rewrite = Tools::str2url($name);
+        $this->assertTrue((bool) $product->save());
+
+        return $product;
+    }
+
+    private function makeCart(): Cart
+    {
+        $cart = new Cart(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $cart->id_currency = (int) Currency::getDefaultCurrencyId();
+        $cart->id_address_invoice = self::$idAddress;
+        $this->assertTrue((bool) $cart->save());
+        Context::getContext()->cart = $cart;
+
+        return $cart;
+    }
+
+    private static function makeAddress(): Address
+    {
+        $address = new Address();
+        $address->id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $address->firstname = 'Unit';
+        $address->lastname = 'Tester';
+        $address->address1 = '55 rue Raspail';
+        $address->alias = microtime() . getmypid();
+        $address->city = 'Levallois';
+        $address->save();
+
+        return $address;
+    }
+
+    private function getIdTaxRulesGroup(int $rate): int
+    {
+        $tax = new Tax(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $tax->name = $rate . '% TAX ' . uniqid();
+        $tax->rate = $rate;
+        $tax->active = true;
+        $tax->save();
+
+        $taxRulesGroup = new TaxRulesGroup(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $taxRulesGroup->name = $rate . '% TRG ' . uniqid();
+        $taxRulesGroup->active = true;
+        $taxRulesGroup->save();
+
+        $taxRule = new TaxRule(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $taxRule->id_tax = (int) $tax->id;
+        $taxRule->id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $taxRule->id_tax_rules_group = (int) $taxRulesGroup->id;
+        $taxRule->save();
+
+        return (int) $taxRulesGroup->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A **fixed amount** cart rule restricted to specific products (a category, a manufacturer, an attribute, …) was capped against the **whole cart** products total instead of the total of the **eligible** products. As soon as the cart also contained a non-eligible product, the fixed amount was no longer limited to the restricted products and spilled onto the others — e.g. a `10` voucher restricted to a category whose only product costs `9` applied a `10` discount instead of `9` once a second, non-eligible product was added. The discount is computed by two paths and both are corrected to only consider the eligible products: `CartRuleCalculator` (drives the cart/order totals — the eligible rows are now the only "concerned rows", so the amount is both capped to and weighted over the restricted products) and the legacy `CartRule::getContextualValue()` (drives the displayed voucher value). Single-product (`reduction_product > 0`) and unrestricted whole-order discounts are unchanged.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create category A with one product at `9`. Create a fixed-amount `10` cart rule restricted to category A. Add the `9` product to the cart → discount is `9` (eligible total). Add a second product that is **not** in category A → the discount must stay `9` (before this change it became `10`). Covered by `tests/Integration/Classes/CartRuleProductRestrictionCapTest.php` (asserts `getOrderTotal(ONLY_DISCOUNTS)` tax excluded and tax included; red on base, green with the fix). `order_cart_rules` Behaviour suite stays green.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41853
| Related PRs       |
| Sponsor company   |

