### PR TITLE
Fix TypeError editing a combination with null ean13/upc/mpn/isbn

### DIFF
--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -184,12 +184,17 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
      */
     private function getDetails(Combination $combination): CombinationDetails
     {
+        // WHY: ean13, isbn, mpn, reference and upc are nullable in the product_attribute table, so a
+        // combination whose codes were left NULL (e.g. created through import, the webservice or a raw
+        // SQL insert) yields null values here. CombinationDetails expects strings, so normalise null to
+        // an empty string to avoid a TypeError that made such combinations impossible to edit.
+        // @see https://github.com/PrestaShop/PrestaShop/issues/39988
         return new CombinationDetails(
-            $combination->ean13,
-            $combination->isbn,
-            $combination->mpn,
-            $combination->reference,
-            $combination->upc,
+            (string) $combination->ean13,
+            (string) $combination->isbn,
+            (string) $combination->mpn,
+            (string) $combination->reference,
+            (string) $combination->upc,
             $this->numberExtractor->extract($combination, 'weight')
         );
     }

--- a/tests/Integration/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingNullCodesTest.php
+++ b/tests/Integration/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingNullCodesTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Product\Combination\QueryHandler;
+
+use Combination;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler\GetCombinationForEditingHandler;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationDetails;
+use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use TypeError;
+
+/**
+ * The ean13, isbn, mpn, reference and upc columns of product_attribute are nullable, so a
+ * combination created without these codes (import, webservice, raw SQL) carries null values.
+ * Building the CombinationDetails query result for such a combination must not crash on the
+ * string type hints, otherwise the combination cannot be edited in the Back Office.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/39988
+ */
+class GetCombinationForEditingNullCodesTest extends TestCase
+{
+    public function testNullCombinationCodesAreNormalisedToEmptyStrings(): void
+    {
+        $numberExtractor = new NumberExtractor(PropertyAccess::createPropertyAccessor());
+
+        $handler = (new ReflectionClass(GetCombinationForEditingHandler::class))->newInstanceWithoutConstructor();
+        $numberExtractorProperty = new ReflectionProperty($handler, 'numberExtractor');
+        $numberExtractorProperty->setAccessible(true);
+        $numberExtractorProperty->setValue($handler, $numberExtractor);
+
+        $combination = new Combination();
+        $combination->ean13 = null;
+        $combination->isbn = null;
+        $combination->mpn = null;
+        $combination->reference = null;
+        $combination->upc = null;
+        $combination->weight = 0;
+
+        $getDetails = new ReflectionMethod($handler, 'getDetails');
+        $getDetails->setAccessible(true);
+
+        try {
+            /** @var CombinationDetails $details */
+            $details = $getDetails->invoke($handler, $combination);
+        } catch (TypeError $e) {
+            $this->fail('Building CombinationDetails with null codes must not throw a TypeError: ' . $e->getMessage());
+        }
+
+        $this->assertSame('', $details->getEan13());
+        $this->assertSame('', $details->getIsbn());
+        $this->assertSame('', $details->getMpn());
+        $this->assertSame('', $details->getReference());
+        $this->assertSame('', $details->getUpc());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | The `ean13`, `isbn`, `mpn`, `reference` and `upc` columns of `product_attribute` are nullable, but `GetCombinationForEditingHandler` passed those values straight into `CombinationDetails`, whose constructor type-hints them as `string`. A combination whose codes were left `NULL` (created through import, the webservice or a raw SQL insert) therefore crashed combination editing in the Back Office with `CombinationDetails::__construct(): Argument #1 ($gtin) must be of type string, null given`, making it impossible to open or edit that combination. The fix normalises the nullable codes to empty strings when building the query result.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set `ean13` (and/or `upc`, `mpn`, `isbn`) to `NULL` for a row in `product_attribute`, then open that combination in the Back Office product page (Combinations tab). Before: a `TypeError` is thrown and the combination cannot be edited. After: the combination opens with the empty codes shown as blank fields. Covered by `tests/Integration/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingNullCodesTest.php` (fails on the base branch with the exact `TypeError`, passes with the fix).
| UI Tests          |
| Fixed issue or discussion?     | Fixes #39988
| Related PRs       |
| Sponsor company   |
