### PR TITLE
Do not turn PHP deprecation notices into webservice 500 errors

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -690,6 +690,17 @@ class WebserviceRequestCore
             return true;
         }
 
+        // WHY: a deprecation notice (e.g. PHP 8.x "Creation of dynamic property ...") must not turn a
+        // webservice call into a 500 error. Without this guard such notices fell through to the default
+        // branch below and were reported as "[PHP Unknown error #8192] ..." with a 500 status, breaking
+        // otherwise valid POST/PUT requests. Log them like the other levels but let the request proceed.
+        // @see https://github.com/PrestaShop/PrestaShop/issues/39703
+        if (in_array($errno, [E_DEPRECATED, E_USER_DEPRECATED], true)) {
+            error_log('[PHP Deprecated #' . $errno . '] ' . $errstr . ' (' . $errfile . ', line ' . $errline . ')');
+
+            return true;
+        }
+
         $errortype = [
             E_ERROR => 'Error',
             E_WARNING => 'Warning',

--- a/tests/Integration/Classes/Webservice/WebserviceRequestDeprecationTest.php
+++ b/tests/Integration/Classes/Webservice/WebserviceRequestDeprecationTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Webservice;
+
+use PHPUnit\Framework\TestCase;
+use WebserviceRequest;
+
+/**
+ * The webservice error handler must not turn a PHP deprecation notice (e.g. the PHP 8.x
+ * "Creation of dynamic property ..." notice) into a 500 error: doing so broke otherwise valid
+ * POST/PUT API calls with "[PHP Unknown error #8192] ...".
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/39703
+ */
+class WebserviceRequestDeprecationTest extends TestCase
+{
+    public function testDeprecationNoticesAreNotReportedAsWebserviceErrors(): void
+    {
+        // getInstance() instantiates WebserviceRequest::$ws_current_classname, which is only set while
+        // a real webservice request is being processed; initialise it for the test.
+        if (empty(WebserviceRequest::$ws_current_classname)) {
+            WebserviceRequest::$ws_current_classname = WebserviceRequest::class;
+        }
+
+        $request = WebserviceRequest::getInstance();
+        $request->errors = [];
+
+        // Force the handler down the escalation path it takes in production (display_errors off,
+        // deprecations part of error_reporting) instead of the early "ignore" return.
+        $previousDisplayErrors = ini_get('display_errors');
+        $previousErrorReporting = error_reporting();
+        ini_set('display_errors', 'off');
+        error_reporting(E_ALL);
+
+        try {
+            $request->webserviceErrorHandler(E_DEPRECATED, 'Creation of dynamic property Foo::$bar is deprecated', __FILE__, __LINE__);
+            $request->webserviceErrorHandler(E_USER_DEPRECATED, 'Some user deprecation', __FILE__, __LINE__);
+        } finally {
+            ini_set('display_errors', $previousDisplayErrors);
+            error_reporting($previousErrorReporting);
+        }
+
+        $errors = $request->errors;
+        $request->errors = [];
+
+        $this->assertSame([], $errors, 'Deprecation notices must not be turned into webservice errors');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The webservice error handler (`WebserviceRequest::webserviceErrorHandler`) has no case for `E_DEPRECATED` / `E_USER_DEPRECATED`, so a deprecation notice fell through to the `default` branch and was returned as `[PHP Unknown error #8192] ...` with a 500 status. On PHP 8.x any code in the request path that triggers a "Creation of dynamic property ..." notice (the reported case came from a Sentry/Raven class, but core/legacy code can trigger it too) therefore broke otherwise valid `POST`/`PUT` API calls. The fix logs deprecation notices like the other levels but lets the request continue instead of aborting with a 500.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a production-like config (`display_errors` off), issue a webservice `POST`/`PUT` (e.g. `POST /api/manufacturers`) in a code path that triggers a PHP deprecation notice. Before: HTTP 500 with `[PHP Unknown error #8192] Creation of dynamic property ...`. After: the deprecation is logged and the request completes normally. Covered by `tests/Integration/Classes/Webservice/WebserviceRequestDeprecationTest.php` (fails on the base branch because the deprecation is recorded as a webservice error, passes with the fix).
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39703
| Related PRs       |
| Sponsor company   |

