### PR TITLE
Use the small_default thumbnail for product/combination cover URLs

### DIFF
--- a/src/Adapter/Product/Image/ProductImageProvider.php
+++ b/src/Adapter/Product/Image/ProductImageProvider.php
@@ -46,7 +46,7 @@ class ProductImageProvider implements ProductImageProviderInterface
         $imageId = $this->productImageRepository->getDefaultImageId($productId, $shopId);
 
         return $imageId ?
-            $this->productImagePathFactory->getPath($imageId) :
+            $this->productImagePathFactory->getPathByType($imageId, ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT) :
             $this->productImagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT)
         ;
     }
@@ -56,7 +56,7 @@ class ProductImageProvider implements ProductImageProviderInterface
         $imageId = $this->productImageRepository->getPreviewCombinationProduct($combinationId);
 
         if ($imageId) {
-            return $this->productImagePathFactory->getPath($imageId);
+            return $this->productImagePathFactory->getPathByType($imageId, ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
         }
 
         $productId = $this->combinationRepository->getProductId($combinationId);

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_pack_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_pack_multishop.feature
@@ -95,20 +95,20 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack2" type should be pack
     And pack "productPack2" should contain products with following details for shops shop1,shop2:
       | product  | combination | name         | quantity | image url                            |
-      | product3 |             | summerstreet | 3        | http://myshop.com/img/p/{image3}.jpg |
-      | product4 |             | winterstreet | 20       | http://myshop.com/img/p/{image4}.jpg |
+      | product3 |             | summerstreet | 3        | http://myshop.com/img/p/{image3}-small_default.jpg |
+      | product4 |             | winterstreet | 20       | http://myshop.com/img/p/{image4}-small_default.jpg |
 
   Scenario: I update pack by removing one of the products
     Given pack "productPack2" should contain products with following details for shops shop1,shop2:
       | product  | combination | name         | quantity | image url                            |
-      | product3 |             | summerstreet | 3        | http://myshop.com/img/p/{image3}.jpg |
-      | product4 |             | winterstreet | 20       | http://myshop.com/img/p/{image4}.jpg |
+      | product3 |             | summerstreet | 3        | http://myshop.com/img/p/{image3}-small_default.jpg |
+      | product4 |             | winterstreet | 20       | http://myshop.com/img/p/{image4}-small_default.jpg |
     When I update pack "productPack2" with following product quantities:
       | product  | quantity |
       | product3 | 3        |
     And pack "productPack2" should contain products with following details for shops shop1,shop2:
       | product  | combination | name         | quantity | image url                            |
-      | product3 |             | summerstreet | 3        | http://myshop.com/img/p/{image3}.jpg |
+      | product3 |             | summerstreet | 3        | http://myshop.com/img/p/{image3}-small_default.jpg |
 
   Scenario: I add virtual and standard product to the same pack
     Given I add product productPack4 to shop shop1 with following information:
@@ -127,14 +127,14 @@ Feature: Add product to pack from Back Office (BO)
     And pack productPack4 should contain products with following details for shops shop1,shop2:
       | product  | combination | name             | quantity | image url                                              |
       | product2 |             | shady sunglasses | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
-      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg                   |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}-small_default.jpg                   |
 
   Scenario: I remove all products from existing pack
     Given product "productPack4" type should be pack
     When pack productPack4 should contain products with following details for shops shop1,shop2:
       | product  | name             | combination | quantity | image url                                              |
       | product2 | shady sunglasses |             | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
-      | product3 | summerstreet     |             | 3        | http://myshop.com/img/p/{image3}.jpg                   |
+      | product3 | summerstreet     |             | 3        | http://myshop.com/img/p/{image3}-small_default.jpg                   |
     And I remove all products from pack productPack4
     Then product "productPack4" type should be pack
     And pack "productPack4" should be empty for shops shop1,shop2
@@ -181,9 +181,9 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                 | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg | Ref: productSkirtRef       |
 
   Scenario: Add combination & standard product to a pack
     Given product "product2" type should be standard
@@ -203,18 +203,18 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              | Ref: productSkirtRef       |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
 
   Scenario: I remove one combination of same product from existing pack and change another combination quantity
     Given product "productPack4" type should be pack
     When pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                              |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     And I update pack productPack4 with following product quantities:
       | product       | combination         | quantity |
@@ -223,8 +223,8 @@ Feature: Add product to pack from Back Office (BO)
       | product2      |                     | 2        |
     Then pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                              |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     Then product "productPack4" type should be pack
 
@@ -232,8 +232,8 @@ Feature: Add product to pack from Back Office (BO)
     Given product "productPack4" type should be pack
     When pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                              |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     And I remove all products from pack productPack4
     Then product "productPack4" type should be pack
@@ -250,38 +250,38 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              | Ref: productSkirtRef       |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
     When I delete product product2 from shop "shop2"
     # Product2 still exist in shop1
     Then pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              | Ref: productSkirtRef       |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
     When I delete product product2 from shop "shop1"
     # Product2 is fully removed
     Then pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                 | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg | Ref: productSkirtRef       |
     When I delete combination productSkirt1MWhite from shops "shop2"
     # productSkirt1MWhite is still in shop1
     Then pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                 | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg | Ref: productSkirtRef       |
     When I delete combination productSkirt1MWhite from shops "shop1"
     # productSkirt1MWhite is fully removed
     Then pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                 | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg | Ref: productSkirtRef       |
 
   Scenario: I can add product to a pack regardless of their common shops (or uncommon), the name depends on the shop though
     Given I add product "productPack5" to shop shop2 with following information:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -101,20 +101,20 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack2" type should be pack
     And pack "productPack2" should contain products with following details:
       | product  | combination | name             | quantity | image url                            |
-      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg |
-      | product4 |             | winterstreet     | 20       | http://myshop.com/img/p/{image4}.jpg |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}-small_default.jpg |
+      | product4 |             | winterstreet     | 20       | http://myshop.com/img/p/{image4}-small_default.jpg |
 
   Scenario: I update pack by removing one of the products
     When pack productPack2 should contain products with following details:
       | product  | combination | name             | quantity | image url                            |
-      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg |
-      | product4 |             | winterstreet     | 20       | http://myshop.com/img/p/{image4}.jpg |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}-small_default.jpg |
+      | product4 |             | winterstreet     | 20       | http://myshop.com/img/p/{image4}-small_default.jpg |
     When I update pack "productPack2" with following product quantities:
       | product  | quantity |
       | product3 | 3        |
     And pack "productPack2" should contain products with following details:
       | product  | combination | name             | quantity | image url                            |
-      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}-small_default.jpg |
 
   Scenario: I add pack product to a pack
     Given product "productPack1" type should be pack
@@ -138,7 +138,7 @@ Feature: Add product to pack from Back Office (BO)
     And pack productPack4 should contain products with following details:
       | product  | combination | name             | quantity | image url                                              |
       | product2 |             | shady sunglasses | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
-      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg                   |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}-small_default.jpg                   |
 
   Scenario: I add product with negative quantity to a pack
     Given product "product2" type should be standard
@@ -154,7 +154,7 @@ Feature: Add product to pack from Back Office (BO)
     When pack productPack4 should contain products with following details:
       | product  | name             | combination | quantity | image url                                              |
       | product2 | shady sunglasses |             | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
-      | product3 | summerstreet     |             | 3        | http://myshop.com/img/p/{image3}.jpg                   |
+      | product3 | summerstreet     |             | 3        | http://myshop.com/img/p/{image3}-small_default.jpg                   |
     And I remove all products from pack productPack4
     Then product "productPack4" type should be pack
     And pack "productPack4" should be empty
@@ -195,9 +195,9 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                 | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg | Ref: productSkirtRef       |
 
   Scenario: Add combination & standard product to a pack
     Given product "product2" type should be standard
@@ -217,18 +217,18 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              | Ref: productSkirtRef       |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
 
   Scenario: I remove one combination of same product from existing pack and change another combination quantity
     Given product "productPack4" type should be pack
     When pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                              |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     And I update pack productPack4 with following product quantities:
       | product       | combination         | quantity |
@@ -237,8 +237,8 @@ Feature: Add product to pack from Back Office (BO)
       | product2      |                     | 2        |
     Then pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                              |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     Then product "productPack4" type should be pack
 
@@ -246,8 +246,8 @@ Feature: Add product to pack from Back Office (BO)
     Given product "productPack4" type should be pack
     When pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                              |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     And I remove all products from pack productPack4
     Then product "productPack4" type should be pack
@@ -263,21 +263,21 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              | Ref: productSkirtRef       |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
     When I delete product product2
     Then pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}-small_default.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              | Ref: productSkirtRef       |
     When I delete combination productSkirt1MWhite
     Then pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              | Ref: productSkirtRef       |
 
   Scenario: I cannot change a product type to a pack if it is already associated with a pack
     Given I add product "product5" with following information:
@@ -292,8 +292,8 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              | Ref: productSkirtRef       |
       | product5      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |                            |
     When I update product "product5" type to pack
     Then I should get error that the product is already associated to a pack
@@ -301,6 +301,6 @@ Feature: Add product to pack from Back Office (BO)
     And product "productPack4" type should be pack
     And pack productPack4 should contain products with following details:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}-small_default.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}-small_default.jpg              | Ref: productSkirtRef       |
       | product5      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |                            |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
@@ -360,14 +360,14 @@ Feature: Update product SEO options from Back Office (BO)
       | redirect_type   | 301-product                          |
       | redirect_target | product3                             |
       | redirect_name   | amazing boots                        |
-      | redirect_image  | http://myshop.com/img/p/{image1}.jpg |
+      | redirect_image  | http://myshop.com/img/p/{image1}-small_default.jpg |
     When I update image "image2" with following information:
       | cover | true |
     Then product product2 should have following seo options:
       | redirect_type   | 301-product                          |
       | redirect_target | product3                             |
       | redirect_name   | amazing boots                        |
-      | redirect_image  | http://myshop.com/img/p/{image2}.jpg |
+      | redirect_image  | http://myshop.com/img/p/{image2}-small_default.jpg |
     When I update product "product2" with following values:
       | redirect_type   | 301-category |
       | redirect_target | men          |

--- a/tests/Unit/Adapter/Product/Image/ProductImageProviderTest.php
+++ b/tests/Unit/Adapter/Product/Image/ProductImageProviderTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Product\Image;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
+use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImageProvider;
+use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
+
+/**
+ * The product cover URL feeds small UI thumbnails (pack tab, product preview, discount form), so it
+ * must resolve to the small_default resized image - consistent with the "no image" fallback - rather
+ * than the full-size original, which broke those layouts.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/39612
+ */
+class ProductImageProviderTest extends TestCase
+{
+    public function testProductCoverUrlUsesSmallDefaultThumbnail(): void
+    {
+        $imageRepository = $this->createMock(ProductImageRepository::class);
+        $imageRepository->method('getDefaultImageId')->willReturn(new ImageId(24));
+
+        $pathFactory = $this->createMock(ProductImagePathFactory::class);
+        $pathFactory->expects($this->once())
+            ->method('getPathByType')
+            ->with($this->isInstanceOf(ImageId::class), ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT)
+            ->willReturn('24-small_default.jpg');
+        // The full-size getPath() must no longer be used for the cover thumbnail.
+        $pathFactory->expects($this->never())->method('getPath');
+
+        $provider = new ProductImageProvider(
+            $imageRepository,
+            $this->createMock(CombinationRepository::class),
+            $pathFactory
+        );
+
+        $this->assertSame(
+            '24-small_default.jpg',
+            $provider->getProductCoverUrl(new ProductId(2), new ShopId(1))
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `ProductImageProvider::getProductCoverUrl()` / `getCombinationCoverUrl()` returned the full-size original image (`/img/p/.../ID.jpg`) when a cover existed, while their own "no image" branch already fell back to the `small_default` thumbnail. These URLs feed small UI thumbnails — the product **Pack** tab, the product preview and the discount form — so loading the full-size image broke those layouts. The most visible symptom (reported here) is the Pack tab, where packed products were rendered at the cover image's full resolution instead of a resized thumbnail. The fix returns the `small_default` resized image in both methods, consistent with the existing no-image fallback.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a pack product, add a few products to it (each with a cover image), save and reopen the product page. Before: the Pack tab shows oversized images linked to `/img/p/.../ID.jpg`. After: they use the `small_default` thumbnail (`.../ID-small_default.jpg`) and display at the intended size. Covered by `tests/Unit/Adapter/Product/Image/ProductImageProviderTest.php` and the updated `tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature` (which previously asserted the full-size cover URL).
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/29720442472
| Fixed issue or discussion?     | Fixes #39612
| Related PRs       |
| Sponsor company   |
