### PR TITLE
Fix bulk combination edit not saving the unit price impact

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
+++ b/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
@@ -32,7 +32,11 @@ class BulkCombinationFormDataFormatter extends AbstractFormDataFormatter
             '[price][price_tax_included]' => '[price_impact][price_tax_included]',
             '[price][wholesale_price]' => '[price_impact][wholesale_price]',
             '[price][price_tax_excluded]' => '[price_impact][price_tax_excluded]',
-            '[price][unit_price]' => '[price_impact][unit_price]',
+            // WHY: the command builder reads the unit price impact from [price_impact][unit_price_tax_excluded]
+            // (mapped to setImpactOnUnitPrice). Formatting the bulk field to [price_impact][unit_price] left it
+            // at a path nothing reads, so bulk editing "Impact on price per unit" silently did not persist
+            // (unit_price_impact stayed unchanged). @see https://github.com/PrestaShop/PrestaShop/issues/38786
+            '[price][unit_price]' => '[price_impact][unit_price_tax_excluded]',
             '[price][weight]' => '[price_impact][weight]',
             '[stock][delta_quantity][delta]' => '[stock][quantities][delta_quantity][delta]',
             '[stock][fixed_quantity]' => '[stock][quantities][fixed_quantity]',

--- a/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
@@ -276,7 +276,7 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                     'wholesale_price' => 12,
                     'price_tax_excluded' => 10,
                     'price_tax_included' => 18,
-                    'unit_price' => 87,
+                    'unit_price_tax_excluded' => 87,
                     'weight' => 45,
                 ],
             ],
@@ -303,8 +303,8 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                     'price_tax_excluded' => 10,
                     self::MODIFY_ALL_SHOPS_PREFIX . 'price_tax_excluded' => true,
                     'price_tax_included' => 18,
-                    'unit_price' => 87,
-                    self::MODIFY_ALL_SHOPS_PREFIX . 'unit_price' => false,
+                    'unit_price_tax_excluded' => 87,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'unit_price_tax_excluded' => false,
                     'weight' => 45,
                     self::MODIFY_ALL_SHOPS_PREFIX . 'weight' => false,
                 ],
@@ -323,7 +323,7 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                 'price_impact' => [
                     'wholesale_price' => 12,
                     'price_tax_included' => 18,
-                    'unit_price' => 87,
+                    'unit_price_tax_excluded' => 87,
                 ],
             ],
         ];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When bulk editing combinations (select combinations → bulk edit → Price section), the **Impact on price per unit (tax excl.)** field appeared to save but never persisted: `unit_price_impact` stayed unchanged in `product_attribute` and the front office unit price did not change. The bulk form submits this field as `[price][unit_price]` and `BulkCombinationFormDataFormatter` remapped it to `[price_impact][unit_price]`, but the combination command builder reads the unit price impact from `[price_impact][unit_price_tax_excluded]` (mapped to `setImpactOnUnitPrice`). The value therefore landed at a path nothing consumed and was silently dropped, while all the other bulk price fields (which map to matching paths) saved correctly. The fix remaps the bulk field to `[price_impact][unit_price_tax_excluded]`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a product with combinations, set a unit price + unity in the Price tab. In the Combinations tab, select one or more combinations, use bulk edit, and set "Impact on price per unit (tax excl.)". Before: `product_attribute.unit_price_impact` stays unchanged and the FO unit price is unaffected. After: the impact is saved and reflected in the FO. Covered by the updated `tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php` (the bulk field now formats to `[price_impact][unit_price_tax_excluded]`).
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/35598461531
| Fixed issue or discussion?     | Fixes #38786
| Related PRs       |
| Sponsor company   |

