### PR TITLE
Fix tax rule reverting to a single country when saving all countries

### DIFF
--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -412,8 +412,14 @@ class AdminTaxRulesGroupControllerCore extends AdminController
             $this->selected_states = [0];
         }
         $tax_rules_group = new TaxRulesGroup((int) $id_tax_rules_group);
+        // WHY: $first must be reused only once across the whole selection. When editing a rule and
+        // selecting several countries (the "all countries" option), the existing rule should be
+        // updated for the first generated rule and brand-new rules created for the rest. Resetting
+        // $first inside the country loop made every country reuse $id_rule, so a single-state
+        // selection collapsed onto that one row (leaving only the last country) and a multi-country
+        // update left the edited country duplicated. @see https://github.com/PrestaShop/PrestaShop/issues/15689
+        $first = true;
         foreach ($this->selected_countries as $id_country) {
-            $first = true;
             foreach ($this->selected_states as $id_state) {
                 if ($tax_rules_group->hasUniqueTaxRuleForCountry($id_country, $id_state, $id_rule)) {
                     $this->errors[] = $this->trans('A tax rule already exists for this country/state with tax only behavior.', [], 'Admin.International.Notification');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When editing an existing tax rule and choosing the **All countries** option, `AdminTaxRulesGroupController::processCreateRule()` reset its `$first` flag **inside** the country loop, so every country reused the edited rule's id. With a single state the entire selection therefore collapsed onto that one row, leaving only the last country processed (alphabetically, Zimbabwe). The fix reuses the edited rule id only **once** (for the first generated rule) and creates new rules for the rest, by moving `$first` outside the country loop. The edited rule is updated for the first country and a fresh rule is created for every other country — no collapse and no duplicate.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | International > Taxes > Tax Rules, create a tax rule for a single country and save. Edit it again and select **All countries**, then save. Before: only one country (Zimbabwe) remains. After: a tax rule exists for every country, exactly once.
| UI Tests          |
| Fixed issue or discussion?     | Fixes #15689
| Related PRs       | Alternative approach to #36652 (which is on `develop`). Verified locally that #36652's `count() === 1` variant fixes the collapse but leaves the originally edited country **duplicated** (242 rules with the edited country appearing twice); this PR keeps it to one rule per country (241) and targets `9.1.x` so the fix reaches the patch line.
| Sponsor company   |

---

**Verification.** Drove `processCreateRule()` for an existing single-country (France) rule with the *All countries* option and inspected `ps_tax_rule`:

| | rules created | edited country (France) rows |
| --- | --- | --- |
| base `9.1.x` | **1** (Zimbabwe only) | 0 |
| this PR | **241** (one per country) | 1 |
| #36652 approach | 242 | **2** (duplicate) |

A unit test is awkward here because the handler ends in `Tools::redirectAdmin()` (which `exit`s on success), the same reason the existing `processCreateRule` path has no unit coverage; happy to add a functional/extracted-method test if preferred.
