### PR TITLE
Use a short-circuiting EXISTS for the order grid new-customer column

### DIFF
--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -202,15 +202,19 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
      */
     private function getNewCustomerSubSelect(): string
     {
-        return $this->connection
+        // WHY: EXISTS stops at the first earlier order, while IF(count(...)) scans every
+        // previous order of the customer. On large order tables this correlated subquery
+        // dominates the listing query, so the cheaper short-circuit form is used here.
+        $hasPreviousOrder = $this->connection
             ->createQueryBuilder()
-            ->select('IF(count(so.id_order) > 0, 0, 1)')
+            ->select('1')
             ->from($this->dbPrefix . 'orders', 'so')
             ->where('so.id_customer = o.id_customer')
             ->andWhere('so.id_order < o.id_order')
-            ->setMaxResults(1)
             ->getSQL()
         ;
+
+        return 'NOT EXISTS(' . $hasPreviousOrder . ')';
     }
 
     /**

--- a/tests/Unit/Core/Grid/Query/OrderQueryBuilderTest.php
+++ b/tests/Unit/Core/Grid/Query/OrderQueryBuilderTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicatorInterface;
+use PrestaShop\PrestaShop\Core\Grid\Query\OrderQueryBuilder;
+use PrestaShop\PrestaShop\Core\Search\Filters\OrderFilters;
+
+class OrderQueryBuilderTest extends TestCase
+{
+    private const DB_PREFIX = 'ps_';
+
+    /**
+     * The "new customer" column must be computed with a short-circuiting NOT EXISTS
+     * subquery rather than a full COUNT over every previous order of the customer.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/40672
+     */
+    public function testNewCustomerSubSelectUsesExists(): void
+    {
+        $queryBuilder = new OrderQueryBuilder(
+            $this->getMockConnection(),
+            self::DB_PREFIX,
+            $this->getMockCriteriaApplicator(),
+            1,
+            [1]
+        );
+
+        $sql = $queryBuilder
+            ->getSearchQueryBuilder(new OrderFilters(OrderFilters::getDefaults()))
+            ->getSQL();
+
+        $this->assertStringContainsStringIgnoringCase('NOT EXISTS', $sql);
+        // The old implementation counted every previous order, which is what caused the slow query.
+        $this->assertStringNotContainsStringIgnoringCase('count(so.id_order)', $sql);
+    }
+
+    private function getMockConnection(): Connection
+    {
+        $mock = $this->createMock(Connection::class);
+        $mock->method('getDatabasePlatform')->willReturn(new MySQL80Platform());
+
+        // A fresh QueryBuilder per call so the inner subquery never shares state with the outer query.
+        $mock->method('createQueryBuilder')->willReturnCallback(
+            fn (): QueryBuilder => new QueryBuilder($mock)
+        );
+
+        return $mock;
+    }
+
+    private function getMockCriteriaApplicator(): DoctrineSearchCriteriaApplicatorInterface
+    {
+        $mock = $this->createMock(DoctrineSearchCriteriaApplicatorInterface::class);
+        $mock->method('applyPagination')->willReturnSelf();
+        $mock->method('applySorting')->willReturnSelf();
+        $mock->method('applyDeterministicSorting')->willReturnSelf();
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The order listing (BO > Orders) computes the "New client" column with a correlated subquery that **counts every previous order** of the customer: `IF(count(so.id_order) > 0, 0, 1)`. Only the *existence* of an earlier order matters, so this replaces it with a short-circuiting `NOT EXISTS(...)`, which stops at the first match. The computed value is unchanged (`1` for a customer's first order, `0` otherwise) — only the cost of the subquery changes. As reported, on a shop with ~170k orders the listing query took ~2.5s, and switching to `EXISTS` more than halved it.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The result must stay identical while the plan no longer aggregates. On any dataset, for every order the two expressions return the same value:<br>`SELECT o.id_order, (SELECT IF(count(so.id_order) > 0, 0, 1) FROM ps_orders so WHERE so.id_customer = o.id_customer AND so.id_order < o.id_order LIMIT 1) AS old_val, (NOT EXISTS(SELECT 1 FROM ps_orders so WHERE so.id_customer = o.id_customer AND so.id_order < o.id_order)) AS new_val FROM ps_orders o;` → `old_val = new_val` on every row.<br>`EXPLAIN FORMAT=TREE` on the order grid query shows the `Aggregate: count(so.id_order)` node disappear; the subquery becomes a `Limit: 1` + index lookup that short-circuits on the first earlier order. A unit test (`OrderQueryBuilderTest`) asserts the generated SQL uses `NOT EXISTS` and no longer counts.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #40672
| Related PRs       |
| Sponsor company   |

#### Before / after (`EXPLAIN FORMAT=TREE`, demo data)

**Before** — counts all of the customer's earlier orders:
```
-> Select #2 (subquery in projection; dependent)
    -> Limit: 1 row(s)  (cost=0.584 rows=1)
        -> Aggregate: count(so.id_order)  (cost=0.584 rows=1)
            -> Filter: (so.id_order < o.id_order)  (cost=0.418 rows=1.67)
                -> Covering index lookup on so using id_customer  (cost=0.418 rows=5)
```

**After** — stops at the first earlier order, no aggregation:
```
-> Select #2 (subquery in projection; dependent)
    -> Limit: 1 row(s)  (cost=0.418 rows=1)
        -> Filter: (so.id_order < o.id_order)  (cost=0.418 rows=1.67)
            -> Covering index lookup on so using id_customer  (cost=0.418 rows=5)
```

The `count()` aggregation node is removed; the subquery is satisfied by the existing `id_customer` index and returns as soon as one earlier order is found. The "New client" column and its filter keep returning the same values.

