### PR TITLE
Build duplicate category breadcrumbs with a single query

### DIFF
--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -237,6 +237,75 @@ class CategoryRepository extends AbstractObjectModelRepository
     }
 
     /**
+     * Builds the breadcrumb parts for several categories at once. The whole category tree is loaded
+     * with a single query and each requested category's ancestors are reconstructed in memory,
+     * which avoids the two-queries-per-category cost of getBreadcrumbParts(). This matters when the
+     * display name builder needs the breadcrumbs of every duplicate-named category, which can be
+     * tens of thousands on large catalogs. The result is equivalent to calling getBreadcrumbParts()
+     * for each id.
+     *
+     * @param int[] $categoryIds
+     * @param LanguageId $languageId
+     *
+     * @return array<int, string[]> indexed by category id; each value is the ancestor names
+     *                              (level_depth >= 1, from the top of the tree) followed by the
+     *                              category own name
+     */
+    public function getBreadcrumbPartsForCategories(array $categoryIds, LanguageId $languageId): array
+    {
+        if (empty($categoryIds)) {
+            return [];
+        }
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('c.id_category, c.nleft, c.nright, c.level_depth, cl.name')
+            ->from($this->dbPrefix . 'category', 'c')
+            ->innerJoin('c', $this->dbPrefix . 'category_lang', 'cl', 'c.id_category = cl.id_category')
+            ->andWhere('cl.id_lang = :languageId')
+            ->addGroupBy('c.id_category')
+            ->addOrderBy('c.nleft', 'ASC')
+            ->setParameter('languageId', $languageId->getValue())
+        ;
+
+        $categories = $qb->executeQuery()->fetchAllAssociative();
+
+        $wantedIds = array_flip($categoryIds);
+        $breadcrumbs = [];
+        // Stack of currently open ancestors, ordered from the top of the tree to the deepest.
+        $ancestors = [];
+
+        foreach ($categories as $category) {
+            $nleft = (int) $category['nleft'];
+
+            // Drop ancestors whose subtree ends before this node starts: they no longer enclose it.
+            while (!empty($ancestors) && $ancestors[count($ancestors) - 1]['nright'] < $nleft) {
+                array_pop($ancestors);
+            }
+
+            if (isset($wantedIds[(int) $category['id_category']])) {
+                $parts = [];
+                foreach ($ancestors as $ancestor) {
+                    // level_depth >= 1 mirrors getBreadcrumbParts(): the root category is not shown.
+                    if ($ancestor['level_depth'] >= 1) {
+                        $parts[] = $ancestor['name'];
+                    }
+                }
+                $parts[] = $category['name'];
+                $breadcrumbs[(int) $category['id_category']] = $parts;
+            }
+
+            $ancestors[] = [
+                'nright' => (int) $category['nright'],
+                'level_depth' => (int) $category['level_depth'],
+                'name' => $category['name'],
+            ];
+        }
+
+        return $breadcrumbs;
+    }
+
+    /**
      * @param ProductId $productId
      * @param ShopConstraint $shopConstraint
      *

--- a/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
+++ b/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
@@ -137,15 +137,13 @@ class CategoryDisplayNameBuilder
      */
     private function fetchBreadcrumbs(array $categoryIds, LanguageId $languageId): array
     {
-        $duplicateCategoriesBreadcrumbs = [];
-        foreach ($categoryIds as $categoryId) {
-            $duplicateCategoriesBreadcrumbs[$categoryId->getValue()] = $this->categoryRepository->getBreadcrumbParts(
-                $categoryId,
-                $languageId
-            );
-        }
+        // Fetch every breadcrumb with a single query instead of two queries per category, which
+        // could mean tens of thousands of queries when many categories share the same name.
+        $ids = array_map(static function (CategoryId $categoryId): int {
+            return $categoryId->getValue();
+        }, $categoryIds);
 
-        return $duplicateCategoriesBreadcrumbs;
+        return $this->categoryRepository->getBreadcrumbPartsForCategories($ids, $languageId);
     }
 
     /**

--- a/tests/Unit/Core/Category/NameBuilder/CategoryDisplayNameBuilderTest.php
+++ b/tests/Unit/Core/Category/NameBuilder/CategoryDisplayNameBuilderTest.php
@@ -154,7 +154,7 @@ class CategoryDisplayNameBuilderTest extends TestCase
         $mock = $this->getMockBuilder(CategoryRepository::class)
             ->onlyMethods([
                 'getDuplicateNameIds',
-                'getBreadcrumbParts',
+                'getBreadcrumbPartsForCategories',
             ])
             ->disableOriginalConstructor()
             ->getMock()
@@ -166,10 +166,10 @@ class CategoryDisplayNameBuilderTest extends TestCase
             }, array_keys($breadcrumbPartsByDuplicatedIds)))
         ;
 
-        $mock->method('getBreadcrumbParts')
+        $mock->method('getBreadcrumbPartsForCategories')
             ->willReturnCallback(
-                function (CategoryId $categoryId, LanguageId $languageId) use ($breadcrumbPartsByDuplicatedIds): array {
-                    return $breadcrumbPartsByDuplicatedIds[$categoryId->getValue()];
+                function (array $categoryIds, LanguageId $languageId) use ($breadcrumbPartsByDuplicatedIds): array {
+                    return array_intersect_key($breadcrumbPartsByDuplicatedIds, array_flip($categoryIds));
                 }
             )
         ;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When opening the product edit page, `CategoryDisplayNameBuilder` disambiguates categories that share a name by building a breadcrumb for each of them (so the merchant sees "Peugeot > 108" instead of just "108"). It did this by calling `CategoryRepository::getBreadcrumbParts()` **once per duplicate-named category**, and that method runs **two queries each**. On a catalogue with many duplicate category names this explodes into tens of thousands of queries — the reporter measured 65,000+ queries and a ~600s page load with ~40,000 categories. This adds `CategoryRepository::getBreadcrumbPartsForCategories()`, which loads the whole category tree with a **single query** and reconstructs each requested category's ancestors **in memory**, using the same `nleft`/`nright` nesting and `level_depth >= 1` filter as `getBreadcrumbParts()` so the result is identical. `CategoryDisplayNameBuilder` now calls it once instead of looping. The disambiguation algorithm (`buildBreadcrumb`) is untouched.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The existing `CategoryDisplayNameBuilderTest` still passes (it now mocks the batched method; the disambiguation assertions are unchanged). For the equivalence: I seeded a catalogue with duplicate-named categories and compared, for every category (flat and nested), the parts returned by the old per-category `getBreadcrumbParts()` vs the new `getBreadcrumbPartsForCategories()` — **0 mismatches across 69 categories**. Behaviour: open a product edit page on a shop with many categories sharing names; before, the page issues `2 × (number of duplicate-named categories)` queries to build the names; after, it issues a single query.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37639
| Related PRs       |
| Sponsor company   |

Confirmed still reproducible on `9.1.x`/`develop` (the two-queries-per-category path is unchanged), so this is not only an 8.x issue.

