### PR TITLE
Fix #41753: map legacy lang param to locale for email body translation route

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/email_body_translation.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/email_body_translation.yml
@@ -5,6 +5,8 @@ admin_email_body_translation_index:
     _controller: PrestaShopBundle\Controller\Admin\Improve\International\EmailBodyTranslationController::indexAction
     _legacy_controller: AdminTranslations
     _legacy_feature_flag: email_body_translation
+    _legacy_parameters:
+      lang: locale
 
 admin_email_body_translation_search:
   path: /{locale}/search


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Map the legacy `lang` parameter to `locale` for the `admin_email_body_translation_index` route so a legacy AdminTranslations link can be converted to it without throwing.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the "How to test" section below.
| UI Tests          | No UI campaign attached: this is a backend routing-config fix (it stops an HTTP 500 thrown during URL generation, before any page renders) with no FO/BO behaviour change. Glad to trigger a campaign if a maintainer prefers.
| Fixed issue or discussion?     | Fixes #41753
| Related PRs       | —
| Sponsor company   | —

## Problem

With the `email_body_translation` feature flag enabled, a legacy `AdminTranslations` link that carries a `lang` parameter is converted to the modern `admin_email_body_translation_index` route (path `/{locale}`). That route declared **no `_legacy_parameters`**, and `LegacyUrlConverter::convertLegacyParameters()` can only *rename* parameters — so `lang` was never mapped to `locale`. URL generation then throws `MissingMandatoryParametersException ("locale")`, surfacing as an HTTP 500 — e.g. on the **ps_accounts configuration page**, which renders a "Translate" button that builds such a link (the reported reproduction).

Thanks to @L3RAZ for the precise diagnosis in #41753.

## Why a plain rename is correct (no value transform needed)

The legacy `AdminTranslations` `lang` parameter is an **iso code** — it is read straight into `$iso_code` in `AdminTranslationsController` (`$iso_code = Tools::getValue('lang') ? Tools::getValue('lang') : Tools::getValue('iso_code')`). The modern route's `{locale}` is the **same iso code**: `TranslationRouteFinder::findRouteParameters()` sets `['locale' => $language]` where `$language` is the `iso_code` from `LocaleChoiceType`, and the email-body grid defaults `locale` to `'en'`. So `lang` (iso) → `locale` (iso) is a correct 1:1 rename; no `langToLocale()` transform is required.

## Verification

Reproduced on a clean develop (9.2.0) environment with the feature flag on:

```
$router->generate('admin_email_body_translation_index', ['lang' => 'en']);
// before: MissingMandatoryParametersException: Some mandatory parameters are missing ("locale") …

$router->generate('admin_email_body_translation_index', ['locale' => 'en']);
// → /improve/international/translations/email-body/en   (valid)
```

With the `_legacy_parameters: { lang: locale }` mapping added, the converter renames the incoming `lang` to `locale` before generation, so the URL builds correctly.

The existing converter unit suite (`tests/Unit/PrestaShopBundle/Routing/Converter`) stays green (60/60).

## How to test

1. PS 9.2.0 (develop), debug on, `email_body_translation` feature flag enabled.
2. Install + Configure the latest ps_accounts module (it renders a Translate button targeting `AdminTranslations` with `lang`).
3. Before: HTTP 500 (`MissingMandatoryParametersException`). After: the configuration page renders.

## Note on automated tests

A converter-level regression test for this exact route needs the `email_body_translation` feature flag enabled in the integration fixture; the current test database ships it disabled, so the route isn't registered in the converter map there. Happy to add an integration test if maintainers can point me at the preferred way to toggle that feature flag in the converter test fixtures.
