### PR TITLE
Fix #40394: avoid 61-table join limit with many category conditions in catalog price rules

### DIFF
--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -227,8 +227,19 @@ class SpecificPriceRuleCore extends ObjectModel
                     } elseif ($condition['type'] == 'manufacturer') {
                         $query->where('p.id_manufacturer = ' . (int) $condition['value']);
                     } elseif ($condition['type'] == 'category') {
-                        $query->leftJoin('category_product', 'cp' . (int) $id_condition, 'p.`id_product` = cp' . (int) $id_condition . '.`id_product`')
-                            ->where('cp' . (int) $id_condition . '.id_category = ' . (int) $condition['value']);
+                        // Use EXISTS instead of one JOIN per category: a group with many category
+                        // conditions would otherwise exceed the SQL engine's 61-table join limit
+                        // (MySQL/MariaDB error 1116). AND semantics are preserved (one EXISTS per
+                        // condition, all ANDed) — see the supplier condition below for the same pattern.
+                        $query->where('EXISTS(
+							SELECT
+								`cp' . (int) $id_condition . '`.`id_product`
+							FROM
+								`' . _DB_PREFIX_ . 'category_product` `cp' . (int) $id_condition . '`
+							WHERE
+								`p`.`id_product` = `cp' . (int) $id_condition . '`.`id_product`
+								AND `cp' . (int) $id_condition . '`.`id_category` = ' . (int) $condition['value'] . '
+						)');
                     } elseif ($condition['type'] == 'supplier') {
                         $query->where('EXISTS(
 							SELECT

--- a/tests/Integration/Classes/SpecificPriceRuleAffectedProductsTest.php
+++ b/tests/Integration/Classes/SpecificPriceRuleAffectedProductsTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Context;
+use Db;
+use SpecificPriceRule;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class SpecificPriceRuleAffectedProductsTest extends KernelTestCase
+{
+    private const CAT_A = 900001;
+    private const CAT_B = 900002;
+    private const PRODUCT_IN_BOTH = 20;
+    private const PRODUCT_IN_A_ONLY = 21;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::restore();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::restore();
+    }
+
+    private static function restore(): void
+    {
+        DatabaseDump::restoreTables([
+            'specific_price_rule',
+            'specific_price_rule_condition',
+            'specific_price_rule_condition_group',
+            'category_product',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+    }
+
+    /**
+     * A catalog price rule whose group holds more than 61 category conditions used to
+     * generate one JOIN per category, hitting MySQL/MariaDB's 61-table join limit
+     * (error 1116) and aborting the product save. It must now run without error.
+     */
+    public function testGetAffectedProductsHandlesMoreThan61CategoryConditions(): void
+    {
+        $conditions = [];
+        for ($i = 1; $i <= 62; ++$i) {
+            $conditions[] = ['type' => 'category', 'value' => 900100 + $i];
+        }
+        $rule = $this->createRule($conditions);
+
+        $this->assertIsArray($rule->getAffectedProducts());
+    }
+
+    /**
+     * Conditions inside a group are AND-combined: a product must belong to ALL the
+     * categories of the group. This pins that semantics so the join-limit fix does not
+     * silently turn it into an OR.
+     */
+    public function testGetAffectedProductsRequiresProductToBelongToEveryCategoryOfTheGroup(): void
+    {
+        Db::getInstance()->insert('category_product', ['id_category' => self::CAT_A, 'id_product' => self::PRODUCT_IN_BOTH, 'position' => 0]);
+        Db::getInstance()->insert('category_product', ['id_category' => self::CAT_B, 'id_product' => self::PRODUCT_IN_BOTH, 'position' => 0]);
+        Db::getInstance()->insert('category_product', ['id_category' => self::CAT_A, 'id_product' => self::PRODUCT_IN_A_ONLY, 'position' => 0]);
+
+        $rule = $this->createRule([
+            ['type' => 'category', 'value' => self::CAT_A],
+            ['type' => 'category', 'value' => self::CAT_B],
+        ]);
+
+        $ids = array_map('intval', array_column($rule->getAffectedProducts(), 'id_product'));
+
+        $this->assertContains(self::PRODUCT_IN_BOTH, $ids);
+        $this->assertNotContains(self::PRODUCT_IN_A_ONLY, $ids);
+    }
+
+    /**
+     * Rows are inserted directly (rather than via ObjectModel::add) to keep the fixture
+     * independent of unrelated save-time machinery; getAffectedProducts only needs the
+     * rule id and the persisted condition groups/conditions.
+     */
+    private function createRule(array $conditions): SpecificPriceRule
+    {
+        $shopId = (int) Context::getContext()->shop->id;
+        $db = Db::getInstance();
+
+        $db->insert('specific_price_rule', [
+            'name' => 'test-rule-40394',
+            'id_shop' => $shopId,
+            'id_country' => 0,
+            'id_currency' => 0,
+            'id_group' => 0,
+            'from_quantity' => 1,
+            'price' => -1,
+            'reduction' => 0,
+            'reduction_tax' => 1,
+            'reduction_type' => 'amount',
+        ]);
+        $ruleId = (int) $db->Insert_ID();
+
+        $db->insert('specific_price_rule_condition_group', ['id_specific_price_rule' => $ruleId]);
+        $groupId = (int) $db->Insert_ID();
+
+        foreach ($conditions as $condition) {
+            $db->insert('specific_price_rule_condition', [
+                'id_specific_price_rule_condition_group' => $groupId,
+                'type' => $condition['type'],
+                'value' => (float) $condition['value'],
+            ]);
+        }
+
+        $rule = new SpecificPriceRule();
+        $rule->id = $ruleId;
+        $rule->id_shop = $shopId;
+
+        return $rule;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Use `WHERE EXISTS` instead of one JOIN per category condition in `SpecificPriceRule::getAffectedProducts()`, so a catalog price rule with many categories no longer hits the SQL 61-table join limit.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #40394
| Related PRs       | —
| Sponsor company   | —

## Problem

`SpecificPriceRule::getAffectedProducts()` added **one `LEFT JOIN category_product` per category condition** of a condition group:

```php
$query->leftJoin('category_product', 'cp' . $id_condition, 'p.id_product = cp' . $id_condition . '.id_product')
      ->where('cp' . $id_condition . '.id_category = ' . (int) $condition['value']);
```

A catalog price rule whose group holds **more than 61 category conditions** (the reporter had 122) therefore builds a query that exceeds the SQL engine's hard 61-table join limit, throwing `SQLSTATE[HY000]: 1116 Too many tables; MariaDB/MySQL can only use 61 tables in a join` and **aborting the product save** entirely.

## Fix

Each category condition now uses a `WHERE EXISTS(SELECT … FROM category_product …)` sub-select instead of a join — **the same pattern already used by the `supplier` condition in this very method**. EXISTS blocks don't add tables to the outer join, so the limit is never reached, and the **AND semantics** between conditions in a group are preserved (each EXISTS is ANDed, exactly like the previous ANDed joins).

This intentionally keeps the existing behaviour (a product must belong to *all* the categories of a group) — only the SQL shape changes. The `feature` condition has the same latent join-bloat and could get the same treatment, but it's out of scope for this fix.

## Verification

Reproduced and verified RED → GREEN on a 9.1.x build (MySQL 8.4). New test `tests/Integration/Classes/SpecificPriceRuleAffectedProductsTest.php`:

- `testGetAffectedProductsHandlesMoreThan61CategoryConditions` — a group with 62 category conditions. **Before:** `PrestaShopDatabaseException: Too many tables …`. **After:** returns without error.
- `testGetAffectedProductsRequiresProductToBelongToEveryCategoryOfTheGroup` — pins the AND semantics (a product in *both* categories matches; a product in only one does not). Passes before and after, proving the EXISTS rewrite is behaviour-preserving.

`php-cs-fixer` reports no changes on either file.

## How to test

1. Create a catalog price rule (BO ▸ Catalog ▸ Discounts ▸ Catalog price rules) with a single condition group containing more than 61 categories.
2. Edit and save any product.
3. **Before:** `1116 Too many tables` exception. **After:** the product saves normally.

