### PR TITLE
Fix blank migrated permissions page for non-admin profiles

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/permission/index.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/permission/index.ts
@@ -25,19 +25,17 @@ class PermissionApp {
     }
 
     this.vm = createApp(Permission, {
-      data: () => ({
-        profileId,
-        permissionKey,
-        profilePermissions,
-        canEdit: $(target).data('can-edit'),
-        employeePermissions: employeePermissions || {},
-        messages: window.permissionsMessages,
-        permissions: $(target).data('permissions'),
-        types: $(target).data('types'),
-        title: $(target).data('title'),
-        emptyData: $(target).data('empty'),
-        updateUrl: $(target).data('update-url'),
-      }),
+      profileId,
+      permissionKey,
+      profilePermissions,
+      canEdit: $(target).data('can-edit'),
+      employeePermissions: employeePermissions || {},
+      messages: window.permissionsMessages,
+      permissions: $(target).data('permissions'),
+      types: $(target).data('types'),
+      title: $(target).data('title'),
+      emptyData: $(target).data('empty'),
+      updateUrl: $(target).data('update-url'),
     });
 
     this.vm.mount(target);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When the **Permissions** feature flag is enabled, the migrated (Symfony) permissions page (Advanced Parameters > Team > Permissions) shows an empty permissions area for every profile except SuperAdmin. The Vue permission tree is mounted with `createApp(Permission, { data: () => ({ ...props }) })`. In Vue 3 the second argument of `createApp()` is the **root component's props**, not a Vue 2 options object, so the whole props object was handed to the component as a single undeclared `data` prop — it fell through onto the component root as a stray `data="() => ({...})"` attribute while every real prop (`permissions`, `title`, `types`, `profilePermissions`, …) stayed `undefined`. With `permissions` undefined the tree renders nothing, so the card is blank. Fixed by passing the props directly as root props, matching the other Vue islands (e.g. `carrier-range-modal.ts`).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the **Permissions** feature flag (Advanced Parameters > New & Experimental Features). Go to Advanced Parameters > Team > Permissions and select a non-admin profile (e.g. Logistician). Before: the Menu/Modules permission area is blank. After: the full permission tree (Menu + Modules, with the View/Add/Edit/Delete/All and View/Configure/Uninstall checkboxes) renders and is editable. Verified in the browser on 9.1.x: the rendered content div grew from an empty card (a stray `data` attribute on the root, no rows) to the fully populated permission tree.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41117
| Related PRs       |
| Sponsor company   | Boring Investments



