### PR TITLE
Fix TinyMCE 404 when the employee language has no language pack

### DIFF
--- a/admin-dev/themes/new-theme/js/components/tinymce-editor.js
+++ b/admin-dev/themes/new-theme/js/components/tinymce-editor.js
@@ -68,7 +68,10 @@ class TinyMCEEditor {
         /* eslint-disable-next-line max-len */
         'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect,hr',
       toolbar2: '',
-      language: window.iso_user,
+      // WHY: iso_user_editor is iso_user guarded server-side against the available
+      // TinyMCE language packs (falls back to 'en' when the pack is missing), avoiding
+      // a 404 on langs/<iso>.js. Keep iso_user as a fallback for safety.
+      language: window.iso_user_editor || window.iso_user,
       external_filemanager_path: `${config.baseAdminUrl}filemanager/`,
       filemanager_title: 'File manager',
       external_plugins: {

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/head_tag.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/head_tag.html.twig
@@ -15,6 +15,7 @@
 <script type="text/javascript">
   var help_class_name = '{{ this.controllerName }}';
   var iso_user = '{{ this.isoUser }}';
+  var iso_user_editor = '{{ this.isoUserForEditor }}';
   var lang_is_rtl = '{{ this.langIsRtl|intCast }}';
   var full_language_code = '{{ this.fullLanguageCode }}';
   var full_cldr_language_code = '{{ this.fullCldrLanguageCode }}';

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/head_tag.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/head_tag.html.twig
@@ -15,6 +15,7 @@
 <script type="text/javascript">
   var help_class_name = '{{ this.controllerName }}';
   var iso_user = '{{ this.isoUser }}';
+  var iso_user_editor = '{{ this.isoUserForEditor }}';
   var lang_is_rtl = '{{ this.langIsRtl|intCast }}';
   var full_language_code = '{{ this.fullLanguageCode }}';
   var full_cldr_language_code = '{{ this.fullCldrLanguageCode }}';

--- a/src/PrestaShopBundle/Twig/Component/HeadTag.php
+++ b/src/PrestaShopBundle/Twig/Component/HeadTag.php
@@ -107,6 +107,17 @@ class HeadTag
         return $this->templateVariables->getIsoUser();
     }
 
+    public function getIsoUserForEditor(): string
+    {
+        $iso = $this->templateVariables->getIsoUser();
+
+        // WHY: TinyMCE only ships a fixed set of language packs in js/tiny_mce/langs.
+        // When the employee's language has no matching file the editor requests a
+        // missing langs/<iso>.js and throws a 404 error in the console and page corner.
+        // Mirror the legacy HelperForm/HelperOptions guard and fall back to English.
+        return file_exists(_PS_ROOT_DIR_ . '/js/tiny_mce/langs/' . $iso . '.js') ? $iso : 'en';
+    }
+
     public function getCountryIsoCode(): string
     {
         return $this->countryContext->getIsoCode();

--- a/tests/Unit/PrestaShopBundle/Twig/Component/HeadTagTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Component/HeadTagTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig\Component;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Twig\Component\HeadTag;
+use PrestaShopBundle\Twig\Layout\TemplateVariables;
+use ReflectionClass;
+use ReflectionProperty;
+
+class HeadTagTest extends TestCase
+{
+    /**
+     * @dataProvider isoUserForEditorProvider
+     */
+    public function testGetIsoUserForEditorFallsBackWhenLanguagePackIsMissing(string $isoUser, string $expected): void
+    {
+        $templateVariables = $this->createMock(TemplateVariables::class);
+        $templateVariables->method('getIsoUser')->willReturn($isoUser);
+
+        $headTag = (new ReflectionClass(HeadTag::class))->newInstanceWithoutConstructor();
+        $property = new ReflectionProperty(HeadTag::class, 'templateVariables');
+        $property->setAccessible(true);
+        $property->setValue($headTag, $templateVariables);
+
+        $this->assertSame($expected, $headTag->getIsoUserForEditor());
+    }
+
+    public static function isoUserForEditorProvider(): Generator
+    {
+        // Languages that ship a TinyMCE pack in js/tiny_mce/langs are kept as-is.
+        yield 'pack exists (en)' => ['en', 'en'];
+        yield 'pack exists (fr)' => ['fr', 'fr'];
+        // Languages without a matching pack fall back to English to avoid a 404 on langs/<iso>.js.
+        yield 'no pack (mk)' => ['mk', 'en'];
+        yield 'no pack (ne)' => ['ne', 'en'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The modern back-office rich-text editor (`tinymce-editor.js`) was initialised with `language: window.iso_user`. TinyMCE only ships a fixed set of language packs in `js/tiny_mce/langs`, so when the current employee's language has no matching file (e.g. a language added via a localization pack such as the one in #34899), the editor requested a missing `langs/<iso>.js` and threw a 404 in the browser console and in the page corner. Legacy pages already guarded against this (`HelperForm`/`HelperOptions`: `file_exists(.../langs/<iso>.js) ? $iso : 'en'`). This PR mirrors that guard for modern pages: the head-tag component exposes a guarded `iso_user_editor` (falls back to `en` when the pack is missing) and the editor uses it. `HeadTag` is inherited by `LegacyHeadTag`, so both modern and legacy-wrapped pages are covered.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With an employee language whose iso has **no** TinyMCE pack (e.g. `mk`, `ne`, `lo`): open any modern page with a rich-text editor (new category/brand/CMS page). Before: the console shows a 404 for `js/tiny_mce/langs/<iso>.js` and an error in the page corner. After: no 404 — the editor falls back to English. Languages that **do** have a pack (en, fr, de, …) are unaffected. Verified on 9.1.x: `langs/en.js` → 200, `langs/mk.js` → 404; the new `iso_user_editor` resolves missing packs to `en` server-side (`mk/ne/lo → en`, `fr/de → kept`) and the editor consumes it.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34899
| Related PRs       |
| Sponsor company   | Boring Investments

