### PR TITLE
Fix color swatch linking to a non-default combination

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4331,7 +4331,11 @@ class ProductCore extends ObjectModel
 
         $check_stock = !Configuration::get('PS_DISP_UNAVAILABLE_ATTR');
         if (!$res = Db::getInstance()->executeS(
-            'SELECT pa.`id_product`, a.`color`, pac.`id_product_attribute`, ' . ($check_stock ? 'SUM(IF(stock.`quantity` > 0, 1, 0))' : '0') . ' qty, a.`id_attribute`, al.`name`, IF(color = "", a.id_attribute, color) group_by
+            // WHY: a color groups several combinations (one per size, etc.); without picking
+            // explicitly, GROUP BY returns an arbitrary one, so the color swatch could link to a
+            // non-default combination. Prefer the default combination of the group, then the
+            // lowest id, so the swatch points to the expected (default) combination deterministically.
+            'SELECT pa.`id_product`, a.`color`, COALESCE(MAX(IF(product_attribute_shop.`default_on` = 1, pac.`id_product_attribute`, NULL)), MIN(pac.`id_product_attribute`)) AS `id_product_attribute`, ' . ($check_stock ? 'SUM(IF(stock.`quantity` > 0, 1, 0))' : '0') . ' qty, a.`id_attribute`, al.`name`, IF(color = "", a.id_attribute, color) group_by
             FROM `' . _DB_PREFIX_ . 'product_attribute` pa
             ' . Shop::addSqlAssociation('product_attribute', 'pa') .
             ($check_stock ? Product::sqlStock('pa', 'pa') : '') . '

--- a/tests/Integration/Classes/ProductTest.php
+++ b/tests/Integration/Classes/ProductTest.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Classes;
 
+use Context;
+use Db;
 use PHPUnit\Framework\TestCase;
 use Product;
 use Tests\Integration\Utility\ContextMockerTrait;
@@ -29,5 +31,36 @@ class ProductTest extends TestCase
         $product->price = 42.42;
         $product->link_rewrite = 'a-product';
         $this->assertTrue($product->save());
+    }
+
+    /**
+     * The color swatches shown on product miniatures must point to the default combination
+     * of their color group, not an arbitrary sibling (issue #35481): product 1 ("Hummingbird
+     * printed t-shirt") has the default combination "S, White", so the white swatch must link
+     * to it and not, for example, to "M, White".
+     */
+    public function testGetAttributesColorListPointsToDefaultCombination(): void
+    {
+        $idShop = (int) Context::getContext()->shop->id;
+
+        $defaultIdProductAttribute = (int) Db::getInstance()->getValue(
+            'SELECT `id_product_attribute` FROM `' . _DB_PREFIX_ . 'product_attribute_shop`
+             WHERE `id_product` = 1 AND `id_shop` = ' . $idShop . ' AND `default_on` = 1'
+        );
+        $this->assertGreaterThan(0, $defaultIdProductAttribute);
+
+        $colorList = Product::getAttributesColorList([1]);
+        $this->assertArrayHasKey(1, $colorList);
+
+        $idProductAttributes = array_map(
+            static fn (array $color): int => (int) $color['id_product_attribute'],
+            $colorList[1]
+        );
+
+        $this->assertContains(
+            $defaultIdProductAttribute,
+            $idProductAttributes,
+            'The color swatch list must point to the default combination of its color group.'
+        );
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On product miniatures, clicking a color swatch could open a non-default combination. `Product::getAttributesColorList()` groups combinations by color but selected `pac.id_product_attribute` with no aggregation, so MySQL returned an arbitrary combination per color group. For the demo "Hummingbird printed t-shirt" the white swatch resolved to `id_product_attribute = 3` ("M, White") instead of the product's default combination `id_product_attribute = 1` ("S, White"). Fixed by selecting the group's default combination (`default_on = 1`), falling back to the lowest `id_product_attribute`, so the swatch deterministically points to the default combination.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | FO > Home > "Hummingbird printed t-shirt" miniature > click the **white** swatch. Before: the product page opens with "M, White". After: it opens with the default "S, White". Covered by a new integration test (`ProductTest::testGetAttributesColorListPointsToDefaultCombination`) that asserts the color list points to the product's default combination — it fails on the base branch and passes with this change. Verified locally: the query returned `White → 3` before and `White → 1` (the `default_on` combination) after.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #35481
| Related PRs       |
| Sponsor company   | Boring Investments

