### PR TITLE
Return a boolean for the currency enabled state in GetCurrencyForEditing

### DIFF
--- a/src/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandler.php
+++ b/src/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandler.php
@@ -71,7 +71,7 @@ final class GetCurrencyForEditingHandler implements GetCurrencyForEditingHandler
             $transformations,
             $entity->conversion_rate,
             $entity->precision,
-            $entity->active,
+            (bool) $entity->active,
             $entity->unofficial,
             $entity->getAssociatedShops()
         );

--- a/tests/Integration/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandlerTest.php
+++ b/tests/Integration/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandlerTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Currency\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Query\GetCurrencyForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Currency\QueryResult\EditableCurrency;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GetCurrencyForEditingHandlerTest extends KernelTestCase
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $queryBus;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->queryBus = self::getContainer()->get('prestashop.core.query_bus');
+    }
+
+    /**
+     * The "enabled" state is read from the database where PDO returns the
+     * TINYINT(1) column as a string ("0"/"1"). EditableCurrency exposes it as a
+     * boolean (isEnabled(): @return bool) and strictly-typed API resources rely
+     * on it being a real bool, so the handler must cast it.
+     */
+    public function testEnabledStateIsExposedAsBoolean(): void
+    {
+        /** @var EditableCurrency $result */
+        $result = $this->queryBus->handle(new GetCurrencyForEditing(1));
+
+        $this->assertIsBool($result->isEnabled());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `EditableCurrency` declares its `$isEnabled` property as `bool`, but `GetCurrencyForEditingHandler` builds it from the raw `$entity->active` value, which the legacy `Currency` ObjectModel returns as a string (`"1"`/`"0"`). This casts it to `bool`, matching what `GetCountryForEditingHandler` already does for `$country->active`. Lenient consumers (Twig/forms) were unaffected, but strict consumers such as the Admin API could not deserialise the value into a boolean.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Call `GetCurrencyForEditing` and assert `EditableCurrency::isEnabled()` is a real boolean (not the string `"1"`/`"0"`). This unblocks the Currency Admin API resource.
| UI Tests          | n/a (back-office query handler, no UI change)
| Fixed issue or discussion?     | n/a
| Related PRs       | PrestaShop/ps_apiresources#294 (Currency Admin API resource, depends on this fix)
| Sponsor company   | Boring Investments
