### PR TITLE
Set a valid default transit time for the in-store pickup carrier

### DIFF
--- a/classes/lang/KeysReference/CarrierLang.php
+++ b/classes/lang/KeysReference/CarrierLang.php
@@ -4,7 +4,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 // install-dev/langs/en/data/carrier.xml
-trans('Pick up in-store', 'Admin.Shipping.Feature');
+trans('Same day', 'Admin.Shipping.Feature');
 // install-dev/fixtures/fashion/langs/en/data/carrier.xml
 trans('Delivery next day!', 'Admin.Shipping.Feature');
 trans('Buy more to pay less!', 'Admin.Shipping.Feature');

--- a/install-dev/langs/en/data/carrier.xml
+++ b/install-dev/langs/en/data/carrier.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <entity_carrier>
   <carrier id="carrier_1" id_shop="1">
-    <delay>Pick up in-store</delay>
+    <delay>Same day</delay>
   </carrier>
 </entity_carrier>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The default "Click and collect" carrier created on a fresh install shipped with the transit time `Pick up in-store`, which describes the shipping method rather than a delivery delay (as reported in #13828). This sets the default transit time to the wording-approved value `Same day` and keeps the install-data translation key reference (`classes/lang/KeysReference/CarrierLang.php`) in sync. The carrier name part of the original report is already resolved — the default name is no longer the shop name but `Click and collect` — so only the transit time remained. This only changes the install default; existing shops keep their configured value.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a fresh shop. In BO > Shipping > Carriers (and on the FO checkout), the default "Click and collect" carrier now shows the transit time "Same day" instead of "Pick up in-store". Existing installations are unaffected.
| UI Tests          | n/a (install default-data change, no UI behaviour change)
| Fixed issue or discussion?     | Fixes #13828
| Related PRs       | #41481 covers the same two lines and also renames the carrier from `Click and collect` to `Pick up in-store`, updating `carrier_available.feature` which lists carriers by name. The two cannot both land as they are. This PR leaves the name alone because it was already changed away from the shop name in 1bedf0b1 (2022-01-24); if the rename is wanted, #41481 is the more complete one.
| Sponsor company   | Boring Investments

