### PR TITLE
Use the stock delta sign to pick the combination edition movement reason

### DIFF
--- a/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
@@ -142,7 +142,7 @@ class CombinationStockUpdater
             $deltaQuantity = $stockModification->getFixedQuantity() - $previousQuantity;
         }
 
-        $movementReasonId = $this->movementReasonRepository->getEmployeeEditionReasonId($deltaQuantity > $previousQuantity);
+        $movementReasonId = $this->movementReasonRepository->getEmployeeEditionReasonId($deltaQuantity > 0);
 
         $this->stockManager->saveMovement(
             $stockAvailable->id_product,

--- a/tests/Unit/Adapter/Product/Combination/Update/CombinationStockUpdaterTest.php
+++ b/tests/Unit/Adapter/Product/Combination/Update/CombinationStockUpdaterTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Product\Combination\Update;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\MovementReasonId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockModification;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShop\PrestaShop\Core\Stock\StockManager;
+use ReflectionMethod;
+use StockAvailable;
+
+class CombinationStockUpdaterTest extends TestCase
+{
+    /**
+     * The employee-edition movement reason must reflect whether the stock actually increased,
+     * which depends on the sign of the delta - not on a comparison with the previous quantity.
+     *
+     * @dataProvider getStockModifications
+     */
+    public function testSaveMovementPicksEditionReasonFromDeltaSign(
+        StockModification $stockModification,
+        int $previousQuantity,
+        bool $expectedIncrease
+    ): void {
+        $capturedIncrease = null;
+        $movementReasonRepository = $this->createMock(MovementReasonRepository::class);
+        $movementReasonRepository
+            ->expects($this->once())
+            ->method('getEmployeeEditionReasonId')
+            ->willReturnCallback(function (bool $increased) use (&$capturedIncrease): MovementReasonId {
+                $capturedIncrease = $increased;
+
+                return new MovementReasonId(1);
+            });
+
+        $updater = new CombinationStockUpdater(
+            $this->createMock(StockAvailableRepository::class),
+            $this->createMock(CombinationRepository::class),
+            $movementReasonRepository,
+            $this->createMock(StockManager::class),
+            $this->createMock(ShopConfigurationInterface::class),
+            $this->createMock(HookDispatcherInterface::class)
+        );
+
+        $stockAvailable = $this->getMockBuilder(StockAvailable::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $stockAvailable->id_product = 1;
+        $stockAvailable->id_product_attribute = 2;
+        $stockAvailable->id_shop = 1;
+        $stockAvailable->quantity = 1;
+
+        $saveMovement = new ReflectionMethod(CombinationStockUpdater::class, 'saveMovement');
+        $saveMovement->setAccessible(true);
+        $saveMovement->invoke($updater, $stockAvailable, $stockModification, $previousQuantity, 1);
+
+        $this->assertSame($expectedIncrease, $capturedIncrease);
+    }
+
+    public static function getStockModifications(): iterable
+    {
+        // Increases from a non-zero base: the (positive) delta is smaller than the previous
+        // quantity, so a comparison against the previous quantity would wrongly report a decrease.
+        yield 'delta increase from non-zero base' => [StockModification::buildDeltaQuantity(5), 10, true];
+        yield 'fixed increase from non-zero base' => [StockModification::buildFixedQuantity(12), 10, true];
+        // Increase from empty stock (the only increase case the buggy comparison happened to get right).
+        yield 'delta increase from empty stock' => [StockModification::buildDeltaQuantity(100), 0, true];
+        // Decreases must keep reporting a decrease.
+        yield 'delta decrease' => [StockModification::buildDeltaQuantity(-3), 10, false];
+        yield 'fixed decrease' => [StockModification::buildFixedQuantity(8), 10, false];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When editing a combination's stock, `CombinationStockUpdater::saveMovement()` chose the employee-edition movement reason with `$deltaQuantity > $previousQuantity`. But `$deltaQuantity` is already the *signed* change, so from a non-zero base an increase smaller than the current stock (e.g. +5 on a stock of 10: `5 > 10` is false) was recorded as a **decrease** in the stock-movement history. The reason now uses the delta sign (`$deltaQuantity > 0`), matching what `ProductStockUpdater::saveMovement()` already does for non-combination products.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a product with combinations, set a combination's stock to a non-zero value, then increase it by a delta smaller than the current quantity (e.g. stock 10, then +5). The Stock movements history must show this as an increase, not a decrease. Covered by the new unit test `tests/Unit/Adapter/Product/Combination/Update/CombinationStockUpdaterTest.php` (RED on the old comparison, GREEN with the fix).
| UI Tests          | n/a (back-office domain logic; covered by a unit test)
| Fixed issue or discussion?     | Fixes #37597
| Related PRs       | 
| Sponsor company   | Boring Investments
