### PR TITLE
Display the discounted unit price for percentage volume discounts

### DIFF
--- a/classes/product/SpecificPriceFormatter.php
+++ b/classes/product/SpecificPriceFormatter.php
@@ -130,11 +130,9 @@ class SpecificPriceFormatterCore
                 $this->specificPrice['real_value'] = $this->specificPrice['reduction'] * 100;
                 $discountPrice = $initialPrice - $initialPrice * $this->specificPrice['reduction'];
                 if ($this->displayDiscountPrice) {
-                    if ($this->specificPrice['reduction_tax'] == 0) {
-                        $this->specificPrice['discount'] = $priceFormatter->format($initialPrice - ($initialPrice * $this->specificPrice['reduction_with_tax']));
-                    } else {
-                        $this->specificPrice['discount'] = $priceFormatter->format($initialPrice - ($initialPrice * $this->specificPrice['reduction']));
-                    }
+                    // A percentage reduction applies the same way whether it is expressed tax included
+                    // or excluded, so the discounted unit price is always the base price minus the percentage.
+                    $this->specificPrice['discount'] = $priceFormatter->format($initialPrice - ($initialPrice * $this->specificPrice['reduction']));
                 } else {
                     $this->specificPrice['discount'] = $this->specificPrice['real_value'] . '%';
                 }

--- a/tests/Integration/Classes/product/SpecificPriceFormatterTest.php
+++ b/tests/Integration/Classes/product/SpecificPriceFormatterTest.php
@@ -105,6 +105,68 @@ class SpecificPriceFormatterTest extends KernelTestCase
         }
     }
 
+    /**
+     * A catalog price rule with a percentage reduction must display the discounted unit price
+     * (base price minus the percentage), not the base price, when the shop is configured to show
+     * the discounted unit price in the volume-discounts table.
+     */
+    public function testPercentageReductionShowsDiscountedUnitPriceWhenDisplayingDiscountPrice(): void
+    {
+        $context = Context::getContext();
+
+        $currency = new Currency();
+        $currency->active = true;
+        $currency->conversion_rate = 1.0;
+        $currency->sign = '€';
+        $currency->iso_code = 'EUR';
+        $context->currency = $currency;
+
+        $language = new Language();
+        $language->iso_code = 'EN';
+        $language->locale = 'en-US';
+        $context->language = $language;
+
+        // 5% reduction from 300 items, no fixed price, reduction expressed tax-excluded.
+        $specificPrice = [
+            'id_specific_price' => '12',
+            'id_specific_price_rule' => '1',
+            'id_cart' => '0',
+            'id_product' => '10',
+            'id_shop' => '1',
+            'id_shop_group' => '0',
+            'id_currency' => '0',
+            'id_country' => '0',
+            'id_group' => '0',
+            'id_customer' => '0',
+            'id_product_attribute' => '0',
+            'price' => '-1.000000',
+            'from_quantity' => '300',
+            'reduction' => 0.05,
+            'reduction_tax' => '0',
+            'reduction_type' => 'percentage',
+            'from' => '0000-00-00 00:00:00',
+            'to' => '0000-00-00 00:00:00',
+            'score' => '48',
+            'quantity' => '300',
+            'reduction_with_tax' => 0,
+            'nextQuantity' => -1,
+        ];
+
+        $specificPriceFormatter = new SpecificPriceFormatter(
+            $specificPrice,
+            false,
+            $context->currency,
+            true
+        );
+        $formattedSpecificPrice = $specificPriceFormatter->formatSpecificPrice(4.25, 20.0, 0);
+
+        $priceFormatter = new PriceFormatter();
+        $this->assertEquals(
+            $priceFormatter->format(4.25 - 4.25 * 0.05),
+            $formattedSpecificPrice['discount']
+        );
+    }
+
     public function dataProviderSpecificPriceFormatter(): array
     {
         $specificPrices = [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On the product page volume-discounts table, when the shop is set to display the discounted unit price (Shop Parameters > Product Settings), a **percentage** catalog price rule showed the full base price instead of the reduced one (e.g. a 5% rule on a 4.25 product displayed 4.25 instead of 4.04). In `SpecificPriceFormatter`, the percentage branch built the displayed `discount` from `$specificPrice['reduction_with_tax']`, but that key is only ever assigned in the *amount* branches, so for a percentage rule it was null/0 and the displayed price equalled the base price. A percentage reduction applies the same whether expressed tax-included or tax-excluded, so the discounted unit price is simply the base price minus the percentage.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shop Parameters > Product Settings: set the volume-discount display to the discounted unit price. Create a catalog price rule (or specific price) with a percentage reduction (e.g. 5%) from a quantity, on a product. On the product page, the discounts table must show the reduced unit price (base × (1 − %)), not the base price. Covered by `SpecificPriceFormatterTest::testPercentageReductionShowsDiscountedUnitPriceWhenDisplayingDiscountPrice` (RED before, GREEN after).
| UI Tests          | n/a (covered by an integration test on SpecificPriceFormatter)
| Fixed issue or discussion?     | Fixes #39756
| Related PRs       | 
| Sponsor company   | Boring Investments
