### PR TITLE
Expose the attachment id and accept scalar ids in attachment for-editing CQRS

### DIFF
--- a/src/Adapter/Attachment/QueryHandler/GetAttachmentForEditingHandler.php
+++ b/src/Adapter/Attachment/QueryHandler/GetAttachmentForEditingHandler.php
@@ -46,6 +46,7 @@ final class GetAttachmentForEditingHandler implements GetAttachmentForEditingHan
         $file = file_exists($filePath) ? new SplFileInfo($filePath) : null;
 
         $editableAttachment = new EditableAttachment(
+            $attachmentIdValue,
             $attachment->file_name,
             $attachment->name,
             $attachment->description

--- a/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
+++ b/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
@@ -49,11 +49,11 @@ class EditAttachmentCommand
     private $fileSize;
 
     /**
-     * @param AttachmentId $attachmentId
+     * @param int $attachmentId
      */
-    public function __construct(AttachmentId $attachmentId)
+    public function __construct(int $attachmentId)
     {
-        $this->attachmentId = $attachmentId;
+        $this->attachmentId = new AttachmentId($attachmentId);
     }
 
     /**

--- a/src/Core/Domain/Attachment/Query/GetAttachmentForEditing.php
+++ b/src/Core/Domain/Attachment/Query/GetAttachmentForEditing.php
@@ -20,13 +20,13 @@ class GetAttachmentForEditing
     private $attachmentId;
 
     /**
-     * @param int $attachmentIdValue
+     * @param int $attachmentId
      *
      * @throws AttachmentConstraintException
      */
-    public function __construct(int $attachmentIdValue)
+    public function __construct(int $attachmentId)
     {
-        $this->attachmentId = new AttachmentId($attachmentIdValue);
+        $this->attachmentId = new AttachmentId($attachmentId);
     }
 
     /**

--- a/src/Core/Domain/Attachment/QueryResult/EditableAttachment.php
+++ b/src/Core/Domain/Attachment/QueryResult/EditableAttachment.php
@@ -14,6 +14,11 @@ use SplFileInfo;
 class EditableAttachment
 {
     /**
+     * @var int
+     */
+    private $attachmentId;
+
+    /**
      * @var string
      */
     private $fileName;
@@ -34,18 +39,29 @@ class EditableAttachment
     private $file;
 
     /**
+     * @param int $attachmentId
      * @param string $fileName
      * @param string[] $name
      * @param string[] $description
      */
     public function __construct(
+        int $attachmentId,
         string $fileName,
         array $name,
         array $description
     ) {
+        $this->attachmentId = $attachmentId;
         $this->fileName = $fileName;
         $this->name = $name;
         $this->description = $description;
+    }
+
+    /**
+     * @return int
+     */
+    public function getAttachmentId(): int
+    {
+        return $this->attachmentId;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataHandler/AttachmentFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/AttachmentFormDataHandler.php
@@ -73,7 +73,7 @@ final class AttachmentFormDataHandler implements FormDataHandlerInterface
         /** @var UploadedFile|null $fileObject */
         $fileObject = $data['file'];
 
-        $command = new EditAttachmentCommand($attachmentId);
+        $command = new EditAttachmentCommand($attachmentId->getValue());
         $command->setLocalizedNames($data['name']);
         $command->setLocalizedDescriptions($data['file_description']);
 

--- a/tests/Unit/Core/Domain/Attachment/AttachmentForEditingTest.php
+++ b/tests/Unit/Core/Domain/Attachment/AttachmentForEditingTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Attachment;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Command\EditAttachmentCommand;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Query\GetAttachmentForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\QueryResult\EditableAttachment;
+
+class AttachmentForEditingTest extends TestCase
+{
+    public function testEditableAttachmentExposesItsId(): void
+    {
+        $editableAttachment = new EditableAttachment(42, 'doc.pdf', [1 => 'Doc'], [1 => 'Description']);
+
+        $this->assertSame(42, $editableAttachment->getAttachmentId());
+        $this->assertSame('doc.pdf', $editableAttachment->getFileName());
+    }
+
+    public function testGetAttachmentForEditingAcceptsAScalarId(): void
+    {
+        $query = new GetAttachmentForEditing(42);
+
+        $this->assertSame(42, $query->getAttachmentId()->getValue());
+    }
+
+    public function testEditAttachmentCommandAcceptsAScalarId(): void
+    {
+        $command = new EditAttachmentCommand(42);
+
+        $this->assertSame(42, $command->getAttachmentId()->getValue());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Aligns the Attachment for-editing CQRS with the conventions used by the other domains so the entity can be exposed through the Admin API (companion to a ps_apiresources Attachment resource). `EditableAttachment` now carries the attachment id (`getAttachmentId()`) like every other for-editing result (e.g. `EditableTitle::getTitleId`), so a consumer can read the id of the attachment it fetched or just created. `GetAttachmentForEditing` and `EditAttachmentCommand` now accept a scalar `int` id and build the `AttachmentId` value object internally — matching `GetTitleForEditing`, `EditTitleCommand`, `EditCatalogPriceRuleCommand`, etc. The single internal caller (`AttachmentFormDataHandler`) is updated. No behaviour change for existing callers.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `tests/Unit/Core/Domain/Attachment/AttachmentForEditingTest.php` covers the new id accessor and the scalar-id constructors. Existing attachment management (BO add/edit) is unaffected.
| UI Tests          | n/a (back-office CQRS, covered by a unit test)
| Fixed issue or discussion?     | n/a
| Related PRs       | Companion to the Attachment Admin API resource in PrestaShop/ps_apiresources
| Sponsor company   | Boring Investments
