### PR TITLE
Build CMS links with the target shop's link_rewrite on multishop

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -505,7 +505,7 @@ class LinkCore
             if ($alias !== null && !$dispatcher->hasKeyword('cms_category_rule', $idLang, 'meta_title', $idShop)) {
                 return $url . $dispatcher->createUrl('cms_category_rule', $idLang, ['id' => (int) $cmsCategory, 'rewrite' => (string) $alias], $this->allow, '', $idShop);
             }
-            $cmsCategory = new CMSCategory($cmsCategory, $idLang);
+            $cmsCategory = new CMSCategory($cmsCategory, $idLang, $idShop);
         }
         if (is_array($cmsCategory->link_rewrite) && isset($cmsCategory->link_rewrite[(int) $idLang])) {
             $cmsCategory->link_rewrite = $cmsCategory->link_rewrite[(int) $idLang];
@@ -557,7 +557,7 @@ class LinkCore
             if ($alias !== null && !$dispatcher->hasKeyword('cms_rule', $idLang, 'meta_title', $idShop)) {
                 return $url . $dispatcher->createUrl('cms_rule', $idLang, ['id' => (int) $cms, 'rewrite' => (string) $alias], $this->allow, '', $idShop);
             }
-            $cms = new CMS($cms, $idLang);
+            $cms = new CMS($cms, $idLang, $idShop);
         }
 
         // Set available keywords
@@ -1221,9 +1221,9 @@ class LinkCore
         } elseif ($controller == 'manufacturer' && isset($params['id_manufacturer'])) {
             return $this->getManufacturerLink((int) $params['id_manufacturer'], null, (int) $idLang);
         } elseif ($controller == 'cms' && isset($params['id_cms'])) {
-            return $this->getCMSLink(new CMS((int) $params['id_cms']), null, null, (int) $idLang);
+            return $this->getCMSLink((int) $params['id_cms'], null, null, (int) $idLang, (int) $context->shop->id);
         } elseif ($controller == 'cms' && isset($params['id_cms_category'])) {
-            return $this->getCMSCategoryLink(new CMSCategory((int) $params['id_cms_category']), null, (int) $idLang);
+            return $this->getCMSCategoryLink((int) $params['id_cms_category'], null, (int) $idLang, (int) $context->shop->id);
         } elseif (isset($params['fc']) && $params['fc'] == 'module') {
             $module = Validate::isModuleName(Tools::getValue('module')) ? Tools::getValue('module') : '';
             if (!empty($module)) {
@@ -1621,7 +1621,7 @@ class LinkCore
                 break;
             case 'cms':
                 $link = $context->link->getCMSLink(
-                    new CMS($params['id'], $params['id_lang']),
+                    (int) $params['id'],
                     $params['alias'],
                     $params['ssl'],
                     $params['id_lang'],

--- a/tests/Integration/Classes/LinkCmsShopRewriteTest.php
+++ b/tests/Integration/Classes/LinkCmsShopRewriteTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration as LegacyConfiguration;
+use Context;
+use Db;
+use Dispatcher;
+use Link;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShopBundle\Entity\Shop;
+use PrestaShopBundle\Entity\ShopGroup;
+use Shop as LegacyShop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class LinkCmsShopRewriteTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['shop', 'shop_url', 'cms_lang', 'cms_shop', 'configuration'];
+
+    private const SHOP2_REWRITE = 'cms-page-second-shop-slug';
+
+    private static int $secondShopId;
+
+    /**
+     * @var Link|null
+     */
+    private static $originalContextLink;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$originalContextLink = Context::getContext()->link;
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        $container = self::$kernel->getContainer();
+        $configuration = $container->get('prestashop.adapter.legacy.configuration');
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+        $configuration->set('PS_REWRITING_SETTINGS', 1);
+        // The dispatcher singleton snapshots PS_REWRITING_SETTINGS (use_routes) at construction,
+        // so an instance built before this class saw rewriting disabled.
+        Dispatcher::$instance = null;
+
+        // Add a second shop in the existing group 1.
+        $shopGroup = $entityManager->find(ShopGroup::class, 1);
+        $shop = new Shop();
+        $shop->setActive(true);
+        $shop->setIdCategory(2);
+        $shop->setName('test_shop_cms');
+        $shop->setShopGroup($shopGroup);
+        $shop->setColor('red');
+        $shop->setThemeName(Theme::getDefaultTheme());
+        $shop->setDeleted(false);
+        $entityManager->persist($shop);
+        $entityManager->flush();
+        self::$secondShopId = (int) $shop->getId();
+
+        LegacyShop::resetStaticCache();
+
+        // CMS page 1 exists for shop 1; give it a distinct link_rewrite in the second shop.
+        Db::getInstance()->insert('cms_shop', ['id_cms' => 1, 'id_shop' => self::$secondShopId]);
+        $langRows = Db::getInstance()->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'cms_lang` WHERE id_cms = 1 AND id_shop = 1');
+        foreach ($langRows as $row) {
+            $row['id_shop'] = self::$secondShopId;
+            $row['link_rewrite'] = self::SHOP2_REWRITE;
+            Db::getInstance()->insert('cms_lang', $row);
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+        // Rebuild the dispatcher from the restored configuration and undo the context link
+        // mutation, otherwise later test classes generate legacy URLs with use_routes still on
+        // (e.g. admin links missing index.php).
+        Dispatcher::$instance = null;
+        Context::getContext()->link = self::$originalContextLink;
+    }
+
+    /**
+     * A CMS link built for another shop must use that shop's link_rewrite. CMS link_rewrite is a
+     * per-shop (multilang_shop) value, so building the link while ignoring the target shop emits
+     * the current shop's slug under the target shop's domain (wrong/non-canonical URL).
+     */
+    public function testCmsLinkUsesTargetShopRewrite(): void
+    {
+        self::bootKernel();
+
+        $link = new Link();
+        $url = $link->getCMSLink(1, null, null, 1, self::$secondShopId);
+
+        self::assertStringContainsString(
+            self::SHOP2_REWRITE,
+            $url,
+            'getCMSLink() must use the target shop link_rewrite, not the current shop one'
+        );
+    }
+
+    /**
+     * The Smarty {url} helper built the CMS object without the target shop before passing it to
+     * getCMSLink(), so the per-shop link_rewrite was ignored. Passing the id and the target shop
+     * through lets getCMSLink() load the right shop's rewrite.
+     */
+    public function testCmsUrlSmartyUsesTargetShopRewrite(): void
+    {
+        self::bootKernel();
+
+        Context::getContext()->link = new Link();
+        $url = Link::getUrlSmarty([
+            'entity' => 'cms',
+            'id' => 1,
+            'id_lang' => 1,
+            'id_shop' => self::$secondShopId,
+        ]);
+
+        self::assertStringContainsString(
+            self::SHOP2_REWRITE,
+            $url,
+            'getUrlSmarty() must use the target shop link_rewrite for cms links'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Link::getCMSLink()` and `Link::getCMSCategoryLink()` build the link with the wrong shop's `link_rewrite`/`meta_title` in multishop, because they load the CMS / CMS-category object without the target `$idShop`.<br><br>The same class of bug also affected the callers that pre-built the object shop-unaware and passed it in: the language-switch links (`getLanguageLink()`) and the Smarty `{url}` helper (`getUrlSmarty()`) for cms links. They now pass the id and the target shop through so `getCMSLink()`/`getCMSCategoryLink()` load the right shop's rewrite.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below. In multishop, give a CMS page a different `link_rewrite` per shop, then build its link for the *other* shop from the current shop's context — the URL must contain the target shop's slug.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/35583439385
| Fixed issue or discussion? | Fixes #41901
| Sponsor company   | Boring Investments

## Why

`CMS` and `CMSCategory` are `multilang_shop` entities: their `link_rewrite`
and `meta_title` can differ per shop for the same language.

`getCMSLink()` and `getCMSCategoryLink()` already receive an `$idShop`
parameter and forward it to `getBaseLink()`, `getLangLink()`,
`Dispatcher::createUrl()` and `hasKeyword()` — but when the CMS object is
passed as an id they reload it **without** `$idShop`:

```php
$cms = new CMS($cms, $idLang);                 // getCMSLink()
$cmsCategory = new CMSCategory($cmsCategory, $idLang);  // getCMSCategoryLink()
```

`ObjectModel::__construct()` then falls back to the **current context shop**,
so the link is built with the current shop's slug under the target shop's
domain — a wrong / non-canonical URL. This shows up when generating links
for another shop: hreflang / alternate URLs, multishop sitemaps, and
`{url entity='cms' id=... id_shop=...}`.

This is the same class of bug that #41854 fixed for `getCategoryLink()`.

## What

Pass the already-available `$idShop` when loading the object:

```php
$cms = new CMS($cms, $idLang, $idShop);
$cmsCategory = new CMSCategory($cmsCategory, $idLang, $idShop);
```

When `$idShop` is null the behaviour is unchanged (still falls back to the
context shop), so this is backward compatible.

## How to test

`tests/Integration/Classes/LinkCmsShopRewriteTest.php` (added) creates a
second shop, gives CMS page 1 a distinct `link_rewrite` in that shop, and
asserts `getCMSLink(1, null, null, $idLang, $secondShopId)` contains the
**target** shop's slug. It fails on the current code (the link carries the
first shop's `delivery` slug) and passes with this change.


