### PR TITLE
Scope Store::atLeastOneStoreExists() to the current shop

### DIFF
--- a/classes/Store.php
+++ b/classes/Store.php
@@ -188,6 +188,6 @@ class StoreCore extends ObjectModel
      */
     public static function atLeastOneStoreExists()
     {
-        return (bool) Db::getInstance()->getValue('SELECT `id_store` FROM `' . _DB_PREFIX_ . 'store`', false);
+        return (bool) Db::getInstance()->getValue('SELECT s.`id_store` FROM `' . _DB_PREFIX_ . 'store` s ' . Shop::addSqlAssociation('store', 's') . ' WHERE s.`active` = 1', false);
     }
 }

--- a/tests/Integration/Classes/StoreAtLeastOneExistsShopScopeTest.php
+++ b/tests/Integration/Classes/StoreAtLeastOneExistsShopScopeTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration as LegacyConfiguration;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShopBundle\Entity\Shop;
+use PrestaShopBundle\Entity\ShopGroup;
+use Shop as LegacyShop;
+use Store;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class StoreAtLeastOneExistsShopScopeTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['shop', 'shop_url', 'configuration'];
+
+    private static int $secondShopId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        $container = self::$kernel->getContainer();
+        $configuration = $container->get('prestashop.adapter.legacy.configuration');
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        // Second shop in group 1 — the fixture stores are all associated to shop 1 only.
+        $shopGroup = $entityManager->find(ShopGroup::class, 1);
+        $shop = new Shop();
+        $shop->setActive(true);
+        $shop->setIdCategory(2);
+        $shop->setName('test_shop_store');
+        $shop->setShopGroup($shopGroup);
+        $shop->setColor('red');
+        $shop->setThemeName(Theme::getDefaultTheme());
+        $shop->setDeleted(false);
+        $entityManager->persist($shop);
+        $entityManager->flush();
+        self::$secondShopId = (int) $shop->getId();
+
+        LegacyShop::resetStaticCache();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    /**
+     * atLeastOneStoreExists() gates the front-office "our stores" link for the current shop, so it
+     * must be shop-scoped. It used to query the whole `store` table without the `store_shop`
+     * association, reporting that stores exist for a shop that has none.
+     */
+    public function testAtLeastOneStoreExistsIsShopScoped(): void
+    {
+        self::bootKernel();
+
+        // Shop 1 owns the fixture stores.
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, 1);
+        self::assertTrue(Store::atLeastOneStoreExists(), 'shop 1 has stores associated');
+
+        // Shop 2 has no store associated; the previous global query wrongly returned true.
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, self::$secondShopId);
+        self::assertFalse(Store::atLeastOneStoreExists(), 'shop 2 has no stores associated');
+    }
+}

--- a/tests/Integration/Classes/StoreAtLeastOneExistsShopScopeTest.php
+++ b/tests/Integration/Classes/StoreAtLeastOneExistsShopScopeTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace Tests\Integration\Classes;
 
 use Configuration as LegacyConfiguration;
+use Db;
+use Language;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShopBundle\Entity\Shop;
 use PrestaShopBundle\Entity\ShopGroup;
@@ -19,9 +21,11 @@ use Tests\Resources\DatabaseDump;
 
 class StoreAtLeastOneExistsShopScopeTest extends KernelTestCase
 {
-    private const TABLES_TO_RESTORE = ['shop', 'shop_url', 'configuration'];
+    private const TABLES_TO_RESTORE = ['shop', 'shop_url', 'configuration', 'store', 'store_lang', 'store_shop'];
 
     private static int $secondShopId;
+
+    private static int $thirdShopId;
 
     public static function setUpBeforeClass(): void
     {
@@ -51,6 +55,39 @@ class StoreAtLeastOneExistsShopScopeTest extends KernelTestCase
         $entityManager->flush();
         self::$secondShopId = (int) $shop->getId();
 
+        // Third shop whose only associated store is inactive, to cover the active = 1 condition.
+        $thirdShop = new Shop();
+        $thirdShop->setActive(true);
+        $thirdShop->setIdCategory(2);
+        $thirdShop->setName('test_shop_store_inactive');
+        $thirdShop->setShopGroup($shopGroup);
+        $thirdShop->setColor('blue');
+        $thirdShop->setThemeName(Theme::getDefaultTheme());
+        $thirdShop->setDeleted(false);
+        $entityManager->persist($thirdShop);
+        $entityManager->flush();
+        self::$thirdShopId = (int) $thirdShop->getId();
+
+        LegacyShop::resetStaticCache();
+
+        $inactiveStore = new Store();
+        $inactiveStore->id_country = (int) LegacyConfiguration::get('PS_COUNTRY_DEFAULT') ?: 1;
+        $inactiveStore->city = 'Inactive city';
+        $inactiveStore->active = false;
+        $names = [];
+        $addresses = [];
+        foreach (Language::getIDs(false) as $langId) {
+            $names[(int) $langId] = 'Inactive store';
+            $addresses[(int) $langId] = 'Inactive address';
+        }
+        $inactiveStore->name = $names;
+        $inactiveStore->address1 = $addresses;
+        $inactiveStore->add();
+        Db::getInstance()->insert('store_shop', [
+            'id_store' => (int) $inactiveStore->id,
+            'id_shop' => self::$thirdShopId,
+        ]);
+
         LegacyShop::resetStaticCache();
     }
 
@@ -78,5 +115,17 @@ class StoreAtLeastOneExistsShopScopeTest extends KernelTestCase
         // Shop 2 has no store associated; the previous global query wrongly returned true.
         LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, self::$secondShopId);
         self::assertFalse(Store::atLeastOneStoreExists(), 'shop 2 has no stores associated');
+    }
+
+    /**
+     * A shop whose only associated store is inactive must report no stores: the "our stores" link
+     * should not appear when there is nothing active to show, matching Store::getStores().
+     */
+    public function testAtLeastOneStoreExistsIgnoresInactiveStores(): void
+    {
+        self::bootKernel();
+
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, self::$thirdShopId);
+        self::assertFalse(Store::atLeastOneStoreExists(), 'shop 3 has only an inactive store associated');
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Store::atLeastOneStoreExists()` ignores the shop association, so it reports that stores exist for a shop that has none.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In multishop, with all stores associated to shop A only, switch the context to shop B (no store associated): `Store::atLeastOneStoreExists()` must return `false`. The front-office sitemap "our stores" link must not appear for shop B.
| UI Tests          | :hourglass: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/35752527867
| Fixed issue or discussion? | Fixes #41902
| Sponsor company   | Boring Investments

## Why

`atLeastOneStoreExists()` is used by `SitemapController` to decide whether to
show the front-office "our stores" link **for the current shop**. It queried
the whole `store` table without the `store_shop` association (and without the
`active` flag):

```php
SELECT `id_store` FROM `ps_store`
```

So on a shop that has no store associated, it still returned `true`, the
sitemap showed the stores link, and the link led to an empty store list
(`Store::getStores()` — which *is* shop-scoped — returns nothing).

## What

Scope the check exactly like the sibling `Store::getStores()`:

```php
SELECT s.`id_store`
FROM `ps_store` s <Shop::addSqlAssociation('store', 's')>
WHERE s.`active` = 1
```

## How to test

`tests/Integration/Classes/StoreAtLeastOneExistsShopScopeTest.php` (added)
creates a second shop with no store associated and asserts
`atLeastOneStoreExists()` is `true` for shop 1 (which owns the fixture
stores) and `false` for the second shop. It fails on the current code and
passes with this change.


