### PR TITLE
Fix parent ID validation when reordering root-level items

### DIFF
--- a/src/Core/Grid/Position/PositionUpdateFactory.php
+++ b/src/Core/Grid/Position/PositionUpdateFactory.php
@@ -101,7 +101,7 @@ final class PositionUpdateFactory implements PositionUpdateFactoryInterface
             throw new PositionDataException('Missing ' . $this->positionsField . ' in your data.', 'Admin.Notifications.Failure');
         }
 
-        if (null !== $positionDefinition->getParentIdField() && empty($data[$this->parentIdField])) {
+        if (null !== $positionDefinition->getParentIdField() && !array_key_exists($this->parentIdField, $data)) {
             throw new PositionDataException('Missing ' . $this->parentIdField . ' in your data.', 'Admin.Notifications.Failure');
         }
     }

--- a/tests/Unit/Core/Grid/Position/PositionUpdateFactoryTest.php
+++ b/tests/Unit/Core/Grid/Position/PositionUpdateFactoryTest.php
@@ -65,6 +65,22 @@ class PositionUpdateFactoryTest extends TestCase
         $this->assertEquals(42, $positionUpdate->getParentId());
     }
 
+    public function testHandleDataWithRootLevelParent()
+    {
+        $definition = $this->getDefinitionWithParent();
+        $data = [
+            'positions' => [
+                ['rowId' => 1, 'oldPosition' => 1, 'newPosition' => 2],
+            ],
+            'parentId' => 0,
+        ];
+
+        $positionUpdateFactory = $this->getPositionUpdateFactory();
+        $positionUpdate = $positionUpdateFactory->buildPositionUpdate($data, $definition);
+
+        $this->assertSame(0, $positionUpdate->getParentId());
+    }
+
     public function testDataPositionsValidation()
     {
         $this->checkDataValidation([], 'Missing positions in your data.');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Fix position updates for hierarchical entities when the parent ID of root-level items is `0`.<br/>`PositionUpdateFactory` currently uses `empty()` to validate the parent ID field, causing valid values such as `0` or `'0'` to be treated as missing.<br/><br/>The validation now checks whether the field exists, allowing root-level items to be reordered correctly.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the [issueposition.zip](https://github.com/user-attachments/files/30293894/issueposition.zip) test module.<br/>2. Create three root-level categories: `Category 1`, `Category 2`, and `Category 3`.<br/>3. Under `Category 1`, create three subcategories: `Subcategory 1`, `Subcategory 2`, and `Subcategory 3`.<br/>4. Reorder the subcategories under `Category 1`.<br/>5. Check that their positions are updated correctly.<br/>6. Reorder the root-level categories: `Category 1`, `Category 2`, and `Category 3`.<br/>7. Check that their positions are updated without any error.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/31149098897
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41896
| Related PRs       | 
| Sponsor company   | Codencode snc
