### PR TITLE
Scope specific-price resolution to the shop group

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -553,6 +553,7 @@ class SpecificPriceCore extends ObjectModel
 				FROM `' . _DB_PREFIX_ . 'specific_price`
 				WHERE
                 `id_shop` ' . self::formatIntInQuery(0, $id_shop) . ' AND
+                `id_shop_group` ' . self::formatIntInQuery(0, (int) Shop::getGroupFromShop($id_shop)) . ' AND
                 `id_currency` ' . self::formatIntInQuery(0, $id_currency) . ' AND
                 `id_country` ' . self::formatIntInQuery(0, $id_country) . ' AND
                 `id_group` ' . self::formatIntInQuery(0, $id_group) . ' ' . $query_extra . '
@@ -605,6 +606,7 @@ class SpecificPriceCore extends ObjectModel
 				FROM `' . _DB_PREFIX_ . 'specific_price`
 				WHERE
 					`id_shop` ' . self::formatIntInQuery(0, $id_shop) . ' AND
+					`id_shop_group` ' . self::formatIntInQuery(0, (int) Shop::getGroupFromShop($id_shop)) . ' AND
 					`id_currency` ' . self::formatIntInQuery(0, $id_currency) . ' AND
 					`id_country` ' . self::formatIntInQuery(0, $id_country) . ' AND
 					`id_group` ' . self::formatIntInQuery(0, $id_group) . ' ' . $query_extra . '
@@ -644,6 +646,7 @@ class SpecificPriceCore extends ObjectModel
 			FROM `' . _DB_PREFIX_ . 'specific_price`
 			WHERE
 					`id_shop` ' . self::formatIntInQuery(0, $id_shop) . ' AND
+					`id_shop_group` ' . self::formatIntInQuery(0, (int) Shop::getGroupFromShop($id_shop)) . ' AND
 					`id_currency` ' . self::formatIntInQuery(0, $id_currency) . ' AND
 					`id_country` ' . self::formatIntInQuery(0, $id_country) . ' AND
 					`id_group` ' . self::formatIntInQuery(0, $id_group) . ' AND
@@ -663,6 +666,7 @@ class SpecificPriceCore extends ObjectModel
 			SELECT `id_product`, `id_product_attribute`
 			FROM `' . _DB_PREFIX_ . 'specific_price`
 			WHERE	`id_shop` ' . self::formatIntInQuery(0, $id_shop) . ' AND
+					`id_shop_group` ' . self::formatIntInQuery(0, (int) Shop::getGroupFromShop($id_shop)) . ' AND
 					`id_currency` ' . self::formatIntInQuery(0, $id_currency) . ' AND
 					`id_country` ' . self::formatIntInQuery(0, $id_country) . ' AND
 					`id_group` ' . self::formatIntInQuery(0, $id_group) . ' AND

--- a/tests/Integration/Classes/SpecificPriceShopGroupScopeTest.php
+++ b/tests/Integration/Classes/SpecificPriceShopGroupScopeTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration as LegacyConfiguration;
+use Db;
+use Shop as LegacyShop;
+use SpecificPrice;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class SpecificPriceShopGroupScopeTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['shop', 'shop_group', 'specific_price', 'configuration'];
+
+    private static int $secondShopId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        $configuration = self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+        $configuration->set('PS_SPECIFIC_PRICE_FEATURE_ACTIVE', 1);
+
+        $db = Db::getInstance();
+
+        // A second shop group with one shop in it (shop 1 stays in group 1).
+        $db->insert('shop_group', [
+            'name' => 'test_group_2', 'color' => '', 'share_customer' => 0,
+            'share_order' => 0, 'share_stock' => 0, 'active' => 1, 'deleted' => 0,
+        ]);
+        $secondGroupId = (int) $db->Insert_ID();
+        $db->insert('shop', [
+            'id_shop_group' => $secondGroupId, 'name' => 'test_shop_sp', 'color' => '',
+            'id_category' => 2, 'theme_name' => 'classic', 'active' => 1, 'deleted' => 0,
+        ]);
+        self::$secondShopId = (int) $db->Insert_ID();
+
+        LegacyShop::resetStaticCache();
+
+        // Start from a clean slate for this product, then add a single price scoped to shop
+        // GROUP 1 only (id_shop = 0 = all shops *in that group*). The fixtures already ship a
+        // global specific price for product 1 that legitimately applies everywhere.
+        $db->delete('specific_price', 'id_product = 1');
+        $db->insert('specific_price', [
+            'id_specific_price_rule' => 0, 'id_cart' => 0, 'id_product' => 1, 'id_shop' => 0,
+            'id_shop_group' => 1, 'id_currency' => 0, 'id_country' => 0, 'id_group' => 0,
+            'id_customer' => 0, 'id_product_attribute' => 0, 'price' => -1, 'from_quantity' => 1,
+            'reduction' => 0.5, 'reduction_tax' => 1, 'reduction_type' => 'percentage',
+            'from' => '0000-00-00 00:00:00', 'to' => '0000-00-00 00:00:00',
+        ]);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    /**
+     * A specific price scoped to one shop group (id_shop_group set, id_shop = 0) must not apply to
+     * shops in another group. getSpecificPrice() filtered every dimension except id_shop_group, so
+     * such a row leaked to all shops in all groups.
+     */
+    public function testSpecificPriceDoesNotLeakAcrossShopGroups(): void
+    {
+        self::bootKernel();
+
+        // Control: shop 1 is in group 1, so the group-1 price applies.
+        $inGroup = SpecificPrice::getSpecificPrice(1, 1, 0, 0, 0, 1, 0, 0, 0, 0);
+        self::assertNotEmpty($inGroup, 'a specific price must apply within its own shop group');
+
+        // The second shop is in another group, so the group-1 price must NOT apply.
+        $otherGroup = SpecificPrice::getSpecificPrice(1, self::$secondShopId, 0, 0, 0, 1, 0, 0, 0, 0);
+        self::assertEmpty($otherGroup, 'a shop-group-scoped specific price must not leak to another group');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Specific-price resolution never filters `id_shop_group`, so a specific price scoped to one shop group leaks to all shops in all groups.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a `specific_price` with `id_shop_group` set and `id_shop = 0`, then resolve the price for a product in a shop that belongs to a **different** group — the reduction must not apply.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #41903
| Sponsor company   | Boring Investments

## Why

`SpecificPrice::getSpecificPrice()`, `getQuantityDiscounts()`,
`getQuantityDiscount()` and `getProductIdByDate()` build their `WHERE` with

```sql
id_shop      IN (0, :id_shop)      AND
id_currency  IN (0, :id_currency)  AND
id_country   IN (0, :id_country)   AND
id_group     IN (0, :id_group)
```

but **never** constrain `id_shop_group`. `id_shop_group` is a real column on
`specific_price`, exposed and writable through the webservice
(`<id_shop_group>` xlink). A row with `id_shop_group = 1` and `id_shop = 0`
(intended for the shops of group 1) is matched by the `id_shop IN (0, …)`
wildcard and, with no group filter, applies to **every shop in every group**.

## What

Add the missing dimension, consistent with the others:

```sql
id_shop_group IN (0, <group of the shop being priced>)
```

`Shop::getGroupFromShop($id_shop)` resolves the group. A row with
`id_shop_group = 0` stays global (unchanged behaviour); a non-zero one only
matches shops in that group. The price cache key already includes `id_shop`,
which determines the group, so no cache change is needed.

## How to test

`tests/Integration/Classes/SpecificPriceShopGroupScopeTest.php` (added)
creates a second shop group with a shop in it, adds a specific price scoped
to group 1 (`id_shop_group = 1`, `id_shop = 0`), and asserts the reduction
applies for shop 1 (group 1) but **not** for the second shop (other group).
It fails on the current code (the price leaks) and passes with this change.

