### PR TITLE
Scope Image::getCover() to the shop

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -366,14 +366,20 @@ class ImageCore extends ObjectModel
      * Get product cover.
      *
      * @param int $idProduct Product ID
+     * @param int|null $idShop Shop ID (defaults to the current context shop)
      *
      * @return mixed result
      */
-    public static function getCover($idProduct)
+    public static function getCover($idProduct, ?int $idShop = null)
     {
+        if (null === $idShop) {
+            $idShop = Context::getContext()->shop->id;
+        }
+
         return Db::getInstance()->getRow('
 			SELECT * FROM `' . _DB_PREFIX_ . 'image_shop` image_shop
 			WHERE image_shop.`id_product` = ' . (int) $idProduct . '
+			AND image_shop.`id_shop` = ' . (int) $idShop . '
 			AND image_shop.`cover`= 1');
     }
 

--- a/tests/Integration/Classes/ImageGetCoverShopScopeTest.php
+++ b/tests/Integration/Classes/ImageGetCoverShopScopeTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration as LegacyConfiguration;
+use Db;
+use Image;
+use Shop as LegacyShop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class ImageGetCoverShopScopeTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['shop', 'shop_group', 'image_shop', 'configuration'];
+
+    private static int $secondShopId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        $configuration = self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        $db = Db::getInstance();
+        // Second shop group + shop.
+        $db->insert('shop_group', [
+            'name' => 'test_group_img', 'color' => '', 'share_customer' => 0,
+            'share_order' => 0, 'share_stock' => 0, 'active' => 1, 'deleted' => 0,
+        ]);
+        $secondGroupId = (int) $db->Insert_ID();
+        $db->insert('shop', [
+            'id_shop_group' => $secondGroupId, 'name' => 'test_shop_img', 'color' => '',
+            'id_category' => 2, 'theme_name' => 'classic', 'active' => 1, 'deleted' => 0,
+        ]);
+        self::$secondShopId = (int) $db->Insert_ID();
+        LegacyShop::resetStaticCache();
+
+        // Product 1 ships images 1 (cover in shop 1) and 2. Make image 2 the cover in the new shop.
+        $db->insert('image_shop', ['id_product' => 1, 'id_image' => 1, 'id_shop' => self::$secondShopId, 'cover' => 0]);
+        $db->insert('image_shop', ['id_product' => 1, 'id_image' => 2, 'id_shop' => self::$secondShopId, 'cover' => 1]);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    /**
+     * The product cover is stored per shop in image_shop. Image::getCover() queried it without an
+     * id_shop filter, returning an arbitrary shop's cover. Each shop must get its own cover.
+     */
+    public function testGetCoverIsShopScoped(): void
+    {
+        self::bootKernel();
+
+        $coverShop1 = Image::getCover(1, 1);
+        $coverShop2 = Image::getCover(1, self::$secondShopId);
+
+        self::assertSame(1, (int) $coverShop1['id_image'], 'shop 1 cover is image 1');
+        self::assertSame(2, (int) $coverShop2['id_image'], 'second shop cover is image 2');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `Image::getCover()` ignores the shop, returning an arbitrary shop's cover when a product has a different cover per shop.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In multishop, set a different cover image for the same product in two shops, then call `Image::getCover($idProduct, $idShop)` for each shop — each must return its own cover.
| UI Tests   | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/28683464363
| Fixed issue or discussion? | Fixes #41904
| Sponsor company   | Boring Investments

## Why

The product cover flag lives in `image_shop`, **per shop** — a product can
have a different cover image in each shop. `Image::getCover()` queried it with
no shop filter:

```sql
SELECT * FROM `ps_image_shop` image_shop
WHERE image_shop.`id_product` = :id AND image_shop.`cover` = 1
```

With several shops, this returns an arbitrary shop's cover row. The shop-scoped
sibling `Product::getCover()` already does the right thing via
`Shop::addSqlAssociation()`.

## What

Add an optional `$idShop` argument (defaulting to the current context shop) and
filter `image_shop.id_shop` on it. Backward compatible — existing callers pass
no shop and get the context shop.

## How to test

`tests/Integration/Classes/ImageGetCoverShopScopeTest.php` (added) gives
product 1 a different cover image in a second shop and asserts each shop's
`getCover()` returns its own cover. On the current code both calls return the
same arbitrary row, so the test fails; with this change each shop gets its own.
