### PR TITLE
Reassign per-shop default currency when deleting a currency

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -451,13 +451,25 @@ class CurrencyCore extends ObjectModel
      */
     public function delete()
     {
-        if ($this->id == Currency::getDefaultCurrencyId()) {
+        // Reassign the default currency for every scope (global, group or shop) whose default
+        // points at the currency being deleted, not only the current context's default — otherwise
+        // a per-shop override is left pointing at a deleted currency.
+        $defaultScopes = Db::getInstance()->executeS('SELECT `id_shop_group`, `id_shop` FROM ' . _DB_PREFIX_ . 'configuration WHERE `name` = "PS_CURRENCY_DEFAULT" AND `value` = ' . (int) $this->id);
+        if (!empty($defaultScopes)) {
             $result = Db::getInstance()->getRow('SELECT `id_currency` FROM ' . _DB_PREFIX_ . 'currency WHERE `id_currency` != ' . (int) $this->id . ' AND `deleted` = 0');
             if (empty($result['id_currency'])) {
                 return false;
             }
 
-            Configuration::updateValue('PS_CURRENCY_DEFAULT', $result['id_currency']);
+            foreach ($defaultScopes as $scope) {
+                Configuration::updateValue(
+                    'PS_CURRENCY_DEFAULT',
+                    (int) $result['id_currency'],
+                    false,
+                    isset($scope['id_shop_group']) ? (int) $scope['id_shop_group'] : null,
+                    isset($scope['id_shop']) ? (int) $scope['id_shop'] : null
+                );
+            }
         }
 
         // Remove currency restrictions

--- a/tests/Integration/Classes/CurrencyDeletePerShopDefaultTest.php
+++ b/tests/Integration/Classes/CurrencyDeletePerShopDefaultTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration as LegacyConfiguration;
+use Currency;
+use Db;
+use Shop as LegacyShop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class CurrencyDeletePerShopDefaultTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['shop', 'shop_group', 'currency', 'currency_shop', 'currency_lang', 'configuration'];
+
+    private static int $secondShopId;
+    private static int $extraCurrencyId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        $configuration = self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        $db = Db::getInstance();
+        $db->insert('shop_group', [
+            'name' => 'test_group_cur', 'color' => '', 'share_customer' => 0,
+            'share_order' => 0, 'share_stock' => 0, 'active' => 1, 'deleted' => 0,
+        ]);
+        $secondGroupId = (int) $db->Insert_ID();
+        $db->insert('shop', [
+            'id_shop_group' => $secondGroupId, 'name' => 'test_shop_cur', 'color' => '',
+            'id_category' => 2, 'theme_name' => 'classic', 'active' => 1, 'deleted' => 0,
+        ]);
+        self::$secondShopId = (int) $db->Insert_ID();
+        LegacyShop::resetStaticCache();
+
+        // A second currency, set as the second shop's default (a per-shop override).
+        $db->insert('currency', [
+            'name' => 'TestCoin', 'iso_code' => 'TST', 'numeric_iso_code' => '997',
+            'precision' => 2, 'conversion_rate' => 1.0, 'deleted' => 0, 'active' => 1,
+            'unofficial' => 0, 'modified' => 0,
+        ]);
+        self::$extraCurrencyId = (int) $db->Insert_ID();
+        $db->insert('currency_shop', [
+            'id_currency' => self::$extraCurrencyId, 'id_shop' => self::$secondShopId, 'conversion_rate' => 1.0,
+        ]);
+        foreach (Db::getInstance()->executeS('SELECT id_lang FROM `' . _DB_PREFIX_ . 'lang`') as $lang) {
+            $db->insert('currency_lang', [
+                'id_currency' => self::$extraCurrencyId, 'id_lang' => (int) $lang['id_lang'],
+                'name' => 'TestCoin', 'symbol' => 'T', 'pattern' => '',
+            ]);
+        }
+
+        // Global default stays currency 1; the second shop overrides it to the extra currency.
+        LegacyConfiguration::updateValue('PS_CURRENCY_DEFAULT', self::$extraCurrencyId, false, null, self::$secondShopId);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    /**
+     * Deleting a currency must not leave any shop's PS_CURRENCY_DEFAULT pointing at it. The delete
+     * only repaired the current context's default, so a per-shop override pointing at the deleted
+     * currency was left dangling.
+     */
+    public function testDeleteReassignsPerShopDefaultCurrency(): void
+    {
+        self::bootKernel();
+
+        // Sanity: the second shop's default is the extra currency before deletion.
+        LegacyConfiguration::resetStaticCache();
+        self::assertSame(
+            self::$extraCurrencyId,
+            (int) LegacyConfiguration::get('PS_CURRENCY_DEFAULT', null, null, self::$secondShopId)
+        );
+
+        $currency = new Currency(self::$extraCurrencyId);
+        self::assertTrue((bool) $currency->delete());
+
+        LegacyConfiguration::resetStaticCache();
+        self::assertNotSame(
+            self::$extraCurrencyId,
+            (int) LegacyConfiguration::get('PS_CURRENCY_DEFAULT', null, null, self::$secondShopId),
+            'a deleted currency must not remain a shop default'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Deleting a currency leaves a per-shop `PS_CURRENCY_DEFAULT` override pointing at the deleted (soft-deleted) currency.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In multishop, set shop B's default currency to currency X (a per-shop override) while the global default is a different currency, then delete currency X. Shop B's `PS_CURRENCY_DEFAULT` must be reassigned to a valid currency, not left pointing at X.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30202226748 (45/45 green)
| Fixed issue or discussion? | Fixes #41905
| Sponsor company   | Boring Investments

## Why

`Currency::delete()` only repaired the **current context** default:

```php
if ($this->id == Currency::getDefaultCurrencyId()) {           // unscoped read (global/context)
    ...
    Configuration::updateValue('PS_CURRENCY_DEFAULT', $fallback);  // unscoped write
}
```

`getDefaultCurrencyId()` reads `PS_CURRENCY_DEFAULT` with no shop scope, and the
update is unscoped too. So when a shop has its own `PS_CURRENCY_DEFAULT` override
and that currency is deleted from another context (e.g. all-shops), the guard
compares against the wrong (global) value, the per-shop override is never
updated, and that shop is left defaulting to a soft-deleted currency.

## What

Find every configuration scope (global, group or shop) whose
`PS_CURRENCY_DEFAULT` equals the currency being deleted and reassign each to the
fallback currency. A single-shop install has exactly one scope, so behaviour is
unchanged there; the "no other currency to fall back to → refuse deletion"
guard is preserved.

## How to test

`tests/Integration/Classes/CurrencyDeletePerShopDefaultTest.php` (added) creates
a second shop with a per-shop default pointing at an extra currency, deletes
that currency, and asserts the shop's default no longer points at it. It fails
on the current code (the override is left dangling) and passes with this change.

## Note

`Carrier::copyCarrierData()` / the carrier wizard have the same pattern for
`PS_CARRIER_DEFAULT` when re-versioning a carrier; that can be addressed in a
separate follow-up.

