### PR TITLE
Add import feature flag (beta)

### DIFF
--- a/install-dev/data/xml/feature_flag.xml
+++ b/install-dev/data/xml/feature_flag.xml
@@ -32,5 +32,6 @@
     <feature_flag id="email_body_translation" name="email_body_translation" type="env,dotenv,db" label_wording="Email body translations" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the migrated email body translations page." description_domain="Admin.Advparameters.Help" state="1" stability="stable" />
     <feature_flag id="hook_module_v2" name="hook_module_v2" type="env,dotenv,db" label_wording="Hook a module" label_domain="Admin.Design.Feature" description_wording="Enable / Disable the migrated Hook a module form page." description_domain="Admin.Design.Help" state="1" stability="stable" />
     <feature_flag id="quick_access" name="quick_access" type="env,dotenv,db" label_wording="Quick access" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the migrated quick access page." description_domain="Admin.Advparameters.Help" state="1" stability="stable" />
+    <feature_flag id="import" name="import" type="env,dotenv,db" label_wording="Import" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the migrated import page." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
   </entities>
 </entity_feature_flag>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Step 1 of the Import page Symfony migration (#41907): register the `import` feature flag that will gate the legacy `AdminImportController` versus the upcoming Symfony import page. `stability=beta`, `state=0` (opt-in, hidden from merchants until GA). No route carries `_legacy_feature_flag: import` yet — those land with the Symfony pages in a later step — so this entry is inert until then and the legacy page is unaffected.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Fresh install (or upgrade): the flag appears under **Advanced Parameters > New & Experimental Features** as "Import", disabled. Toggling it has no visible effect yet (no migrated page). The legacy Import page keeps working with the flag on or off.
| UI Tests          | :green_circle: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/28382583268
| Fixed issue or discussion?     | Part of #41907
| Related PRs       | First step of the migration tracked in #41907 (supersedes the closed #41798 / #41799).
| Sponsor company   | @PrestaShopCorp

### Notes

Single-line `feature_flag.xml` entry mirroring the existing flags (e.g. `quick_access`, `carrier`). Like every other flag, new installs get the row from this fixture; no upgrade SQL is needed (none of the existing flags ship one).

