### PR TITLE
Fix cumulated free shipping

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -225,6 +225,16 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
             return;
         }
 
+        // Free shipping cannot be cumulated: reject the discount if the order already has a free shipping one
+        foreach ($order->getCartRules() as $orderCartRule) {
+            if (!empty($orderCartRule['free_shipping'])) {
+                throw new InvalidCartRuleDiscountValueException(
+                    'Order already has a free shipping discount',
+                    InvalidCartRuleDiscountValueException::DUPLICATE_FREE_SHIPPING
+                );
+            }
+        }
+
         if (null !== $orderInvoice) {
             $orderInvoices = [$orderInvoice];
         } elseif ($order->hasInvoice()) {

--- a/src/Core/Domain/CartRule/Exception/InvalidCartRuleDiscountValueException.php
+++ b/src/Core/Domain/CartRule/Exception/InvalidCartRuleDiscountValueException.php
@@ -37,4 +37,9 @@ class InvalidCartRuleDiscountValueException extends InvalidCartRuleValueExceptio
      * Code used when free shipping cannot be applied
      */
     public const INVALID_FREE_SHIPPING = 50;
+
+    /**
+     * Code used when a free shipping discount is added to an order that already has one
+     */
+    public const DUPLICATE_FREE_SHIPPING = 60;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -2351,6 +2351,11 @@ class OrderController extends PrestaShopAdminController
                     [],
                     'Admin.Orderscustomers.Notification'
                 ),
+                InvalidCartRuleDiscountValueException::DUPLICATE_FREE_SHIPPING => $this->trans(
+                    'This order already has a free shipping discount.',
+                    [],
+                    'Admin.Orderscustomers.Notification'
+                ),
             ],
             InvalidCancelProductException::class => [
                 InvalidCancelProductException::INVALID_QUANTITY => $this->trans(

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1396,6 +1396,17 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then I should get error that order already has a free shipping discount
+     */
+    public function assertDuplicateFreeShippingCartRule(): void
+    {
+        $this->assertLastErrorIs(
+            InvalidCartRuleDiscountValueException::class,
+            InvalidCartRuleDiscountValueException::DUPLICATE_FREE_SHIPPING
+        );
+    }
+
+    /**
      * @Then the last invoice for order :orderReference should have following prices:
      */
     public function assertLastInvoicePrices(string $orderReference, TableNode $table)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
@@ -223,6 +223,19 @@ Feature: Add discounts to order from Back Office (BO)
       | total paid tax excluded   | 18.90 |
       | total paid tax included   | 20.03 |
 
+  Scenario: Free shipping discount cannot be cumulated
+    Given order "bo_order1" does not have any invoices
+    When I add discount to order "bo_order1" with following details:
+      | name      | first free shipping |
+      | type      | free_shipping       |
+    Then I should get no order error
+    And order "bo_order1" should have 1 cart rule
+    When I add discount to order "bo_order1" with following details:
+      | name      | second free shipping |
+      | type      | free_shipping        |
+    Then I should get error that order already has a free shipping discount
+    And order "bo_order1" should have 1 cart rule
+
   Scenario: Add invalid percent value
     Given order "bo_order1" does not have any invoices
     When I add discount to order "bo_order1" with following details:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In BO => ORDER detail => it was possible to add multiple free shipping discount . This PR fixes that
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | See Issue for details step by step reproduction of the original bug
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/28376647662
| Fixed issue or discussion?     | Fixes #18576 
| Sponsor company   | PrestaShop SA