### PR TITLE
Report new module majors as a warning instead of failing the release healthcheck

### DIFF
--- a/.github/release-healthcheck/dependencies.sh
+++ b/.github/release-healthcheck/dependencies.sh
@@ -14,16 +14,29 @@ HC_GROUP="Dependencies — modules & themes"
 # "released"/"tag exists" is tautological (a release publishes the tag, so a lock pin implies
 # it shipped), and "outdated"/"no dev pin" are already covered by B1/B2.
 
-# spec ref: B1 — native modules up to date (excluding the blocked psgdpr V2)
+# spec ref: B1 — native modules up to date. Two graded signals:
+#   • semver-safe (in-constraint) updates → FAIL: a pending lock bump the release MUST pick up.
+#     `--minor-only` caps "latest" at the installed major so an available major can't mask an
+#     in-constraint minor; the status filter then keeps only the actionable bumps.
+#   • out-of-constraint MAJOR releases (latest-status "update-possible") → WARN: reported so the
+#     roadmap stays visible, but they need breaking-change review so they don't block a release.
+# This pair subsumes the old hard-coded psgdpr V2 exclusion — psgdpr V2 is a major, so it now
+# surfaces in the WARN signal instead of being silently dropped.
 check_native_modules_up_to_date() {
-  local out names
+  local safe majors
   HC_LINK="https://github.com/$REPO/blob/$REF/composer.json"
-  out=$(composer outdated -D -f json "prestashop/*" 2>/dev/null)
-  names=$(printf '%s' "$out" | jq -r '.installed[]? | select(.name != "prestashop/psgdpr") | "\(.name) \(.version)→\(.latest)"' 2>/dev/null)
-  if [ -z "$names" ]; then
-    emit "deps/native-modules-up-to-date" "Native modules up to date" "$HC_PASS" "$HC_SEV_FAIL" "no outdated prestashop/* packages (psgdpr excluded)"
+  safe=$(composer outdated -D --minor-only -f json "prestashop/*" 2>/dev/null | jq -r '.installed[]? | select(."latest-status"=="semver-safe-update") | "\(.name) \(.version)→\(.latest)"' 2>/dev/null)
+  if [ -z "$safe" ]; then
+    emit "deps/native-modules-up-to-date" "Native modules up to date" "$HC_PASS" "$HC_SEV_FAIL" "no in-constraint module updates pending"
   else
-    emit "deps/native-modules-up-to-date" "Native modules up to date" "$HC_FAIL" "$HC_SEV_FAIL" "outdated: $(printf '%s' "$names" | paste -sd'; ' -)"
+    emit "deps/native-modules-up-to-date" "Native modules up to date" "$HC_FAIL" "$HC_SEV_FAIL" "outdated: $(printf '%s' "$safe" | paste -sd'; ' -)"
+  fi
+
+  majors=$(composer outdated -D -f json "prestashop/*" 2>/dev/null | jq -r '.installed[]? | select(."latest-status"=="update-possible") | "\(.name) \(.version)→\(.latest)"' 2>/dev/null)
+  if [ -z "$majors" ]; then
+    emit "deps/native-modules-major-available" "No new module majors" "$HC_PASS" "$HC_SEV_WARN" "no out-of-constraint major releases available"
+  else
+    emit "deps/native-modules-major-available" "Module majors available" "$HC_FAIL" "$HC_SEV_WARN" "major available: $(printf '%s' "$majors" | paste -sd'; ' -)"
   fi
 }
 
@@ -39,8 +52,8 @@ check_no_dev_branch_pins() {
   fi
 }
 
-# spec ref: B7 — composer audit (security vulnerabilities). NB: the psgdpr exclusion applies
-# only to module *updates* (B1), NOT to security audit — every advisory counts here.
+# spec ref: B7 — composer audit (security vulnerabilities). NB: B1's lenient handling of
+# out-of-constraint majors (WARN, not FAIL) does NOT carry over here — every advisory counts.
 check_composer_audit() {
   local out count
   out=$(composer audit --no-interaction 2>&1)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The release-healthcheck "native modules up to date" check (`.github/release-healthcheck/dependencies.sh`, spec B1) ran `composer outdated -D` and flagged **every** newer tag, including out-of-constraint MAJOR releases. Deliberately pinned majors (`ps_emailsubscription` 3.0.0, `ps_googleanalytics` 6.0.0, `ps_specials` 2.0.0, `statsbestproducts` 3.0.0, `statssearch` 3.0.0, `psgdpr` V2) therefore produced a hard FAIL even though they are perfectly up to date *within their declared constraints*. The check is split into two graded signals: in-constraint (semver-safe) updates still **FAIL** (a stale lock the release must pick up), while out-of-constraint majors are now reported as a non-blocking **WARN** so the roadmap stays visible. `--minor-only` caps "latest" at the installed major so an available major can no longer mask a real in-constraint minor. This also removes the brittle hard-coded `psgdpr` V2 name exclusion — psgdpr V2 now surfaces in the WARN signal like every other major.
| Type?             | bug fix
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the release healthcheck dependencies checks (or `bash .github/release-healthcheck/dependencies.sh` within the workflow harness). With the current pins, `deps/native-modules-up-to-date` must **PASS** (no in-constraint updates pending) and the new `deps/native-modules-major-available` must report a **WARN** listing the available majors. Verify it does not FAIL the run. Sanity check the queries directly:<br>`composer outdated -D --minor-only -f json "prestashop/*" \| jq -r '.installed[]? \| select(."latest-status"=="semver-safe-update")'` → empty.<br>`composer outdated -D -f json "prestashop/*" \| jq -r '.installed[]? \| select(."latest-status"=="update-possible") \| .name'` → the six majors.
| UI Tests          | N/A — CI/release-tooling change, no UI impact.
| Fixed issue or discussion?     | Refs #41804 (release-healthcheck spec, section B1).
| Related PRs       | N/A
| Sponsor company   | N/A
