### PR TITLE
Fix Console Command prestashop:theme:enable did not works cause new L…

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/context.yml
@@ -17,7 +17,11 @@ services:
     lazy: true
     factory: [ '@PrestaShop\PrestaShop\Core\Context\EmployeeContextBuilder', 'build' ]
 
-  PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder: ~
+  PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder:
+    calls:
+      - [setLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language.id" ]]
+      - [setDefaultLanguageId, [ "@=service('prestashop.adapter.legacy.configuration').get('PS_LANG_DEFAULT')" ]]
+
   PrestaShop\PrestaShop\Core\Context\LanguageContext:
     lazy: true
     factory: [ '@PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder', 'build' ]

--- a/src/PrestaShopBundle/Resources/config/services/core/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/context.yml
@@ -19,8 +19,8 @@ services:
 
   PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder:
     calls:
-      - [setLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language.id" ]]
-      - [setDefaultLanguageId, [ "@=service('prestashop.adapter.legacy.configuration').get('PS_LANG_DEFAULT')" ]]
+      - [ setLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language.id" ] ]
+      - [ setDefaultLanguageId, [ "@=service('prestashop.adapter.legacy.configuration').get('PS_LANG_DEFAULT')" ] ]
 
   PrestaShop\PrestaShop\Core\Context\LanguageContext:
     lazy: true

--- a/src/PrestaShopBundle/Resources/config/services/core/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/context.yml
@@ -19,8 +19,8 @@ services:
 
   PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder:
     calls:
-      - [ setLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language.id ?: 1" ] ]
-      - [ setDefaultLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language.id == null ? 1 : service('prestashop.adapter.legacy.configuration').get('PS_LANG_DEFAULT')" ] ]
+            - [ setLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language ? (service('prestashop.adapter.legacy.context').getContext().language.id ?: 1) : 1" ] ]
+      - [ setDefaultLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language and service('prestashop.adapter.legacy.context').getContext().language.id != null ? service('prestashop.adapter.legacy.configuration').get('PS_LANG_DEFAULT') : 1" ] ]
 
   PrestaShop\PrestaShop\Core\Context\LanguageContext:
     lazy: true

--- a/src/PrestaShopBundle/Resources/config/services/core/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/context.yml
@@ -19,8 +19,8 @@ services:
 
   PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder:
     calls:
-      - [ setLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language.id" ] ]
-      - [ setDefaultLanguageId, [ "@=service('prestashop.adapter.legacy.configuration').get('PS_LANG_DEFAULT')" ] ]
+      - [ setLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language.id ?: 1" ] ]
+      - [ setDefaultLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language.id == null ? 1 : service('prestashop.adapter.legacy.configuration').get('PS_LANG_DEFAULT')" ] ]
 
   PrestaShop\PrestaShop\Core\Context\LanguageContext:
     lazy: true

--- a/src/PrestaShopBundle/Resources/config/services/core/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/context.yml
@@ -19,7 +19,7 @@ services:
 
   PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder:
     calls:
-            - [ setLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language ? (service('prestashop.adapter.legacy.context').getContext().language.id ?: 1) : 1" ] ]
+      - [ setLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language ? (service('prestashop.adapter.legacy.context').getContext().language.id ?: 1) : 1" ] ]
       - [ setDefaultLanguageId, [ "@=service('prestashop.adapter.legacy.context').getContext().language and service('prestashop.adapter.legacy.context').getContext().language.id != null ? service('prestashop.adapter.legacy.configuration').get('PS_LANG_DEFAULT') : 1" ] ]
 
   PrestaShop\PrestaShop\Core\Context\LanguageContext:


### PR DESCRIPTION
…anguage Contex

LanguageContextBuilder is defined as an alias for LanguageContext. However, LanguageContextBuilder has its own initialization parameters, and the parameters of LanguageContext are not valid for initializing LanguageContextBuilder.

<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | If the theme's configuration file (theme/config/theme.yml) contains a `to_disable` directive for the module, the `prestashop:theme:enable` console command results in an error. 
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | See the https://github.com/PrestaShop/PrestaShop/issues/41289#issuecomment-4833166723
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #41289
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Metin EREN
