### PR TITLE
Fix: Problem with manual special price setting with comma becoming dot (product page)

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/price-reduction-manager.ts
+++ b/admin-dev/themes/new-theme/js/components/form/price-reduction-manager.ts
@@ -16,6 +16,8 @@ export default class PriceReductionManager {
 
   private readonly $taxInclusionInputs: JQuery;
 
+  private readonly $reductionValueInputs: JQuery;
+
   private readonly currencySelect: string;
 
   private readonly reductionValueSymbolSelector: string;
@@ -29,14 +31,17 @@ export default class PriceReductionManager {
     taxInclusionInputs: string,
     currencySelect: string,
     reductionValueSymbolSelector: string,
+    reductionValueSelector: string,
     toggleCurrencySelector: string | null = null,
   ) {
     this.reductionTypeSelector = reductionTypeSelector;
     this.$reductionTypeSelect = $(reductionTypeSelector);
     this.$taxInclusionInputs = $(taxInclusionInputs);
+    this.$reductionValueInputs = $(reductionValueSelector);
     this.currencySelect = currencySelect;
     this.reductionValueSymbolSelector = reductionValueSymbolSelector;
     this.toggleCurrencySelector = toggleCurrencySelector;
+
     this.currencySymbolUpdater = new CurrencySymbolUpdater(
       this.currencySelect,
       ((symbol: string): void => {
@@ -53,16 +58,25 @@ export default class PriceReductionManager {
   }
 
   /**
-   * When source value is 'percentage', target field is shown, else hidden
+   * Update reduction fields according to the selected reduction type.
    */
   private handle(): void {
-    if (this.$reductionTypeSelect.val() === 'percentage') {
+    const isPercentage = this.$reductionTypeSelect.val() === 'percentage';
+
+    this.$reductionValueInputs.toggleClass(
+      'js-comma-transformer',
+      !isPercentage,
+    );
+
+    if (isPercentage) {
       this.$taxInclusionInputs.fadeOut();
+
       if (this.toggleCurrencySelector) {
         $(this.toggleCurrencySelector).fadeOut();
       }
     } else {
       this.$taxInclusionInputs.fadeIn();
+
       if (this.toggleCurrencySelector) {
         $(this.toggleCurrencySelector).fadeIn();
       }
@@ -72,7 +86,9 @@ export default class PriceReductionManager {
   }
 
   private updateSymbol(symbol: string): void {
-    const reductionTypeSelect = <HTMLSelectElement> document.querySelector(this.reductionTypeSelector);
+    const reductionTypeSelect = <HTMLSelectElement> document.querySelector(
+      this.reductionTypeSelector,
+    );
 
     if (reductionTypeSelect) {
       for (let i = 0; i < reductionTypeSelect.options.length; i += 1) {
@@ -84,10 +100,12 @@ export default class PriceReductionManager {
         }
       }
 
-      const selectedReduction = <string> reductionTypeSelect.options[reductionTypeSelect.selectedIndex].value;
-      const reductionValueSymbols = <NodeListOf<HTMLSelectElement>> document.querySelectorAll(
-        this.reductionValueSymbolSelector,
-      );
+      const selectedReduction = <string> reductionTypeSelect.options[
+        reductionTypeSelect.selectedIndex
+      ].value;
+
+      const reductionValueSymbols = <NodeListOf<HTMLSelectElement>>
+        document.querySelectorAll(this.reductionValueSymbolSelector);
 
       if (reductionValueSymbols.length === 0) {
         return;

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/cart-rule-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/cart-rule-map.ts
@@ -21,4 +21,6 @@ export default {
   reductionValueSymbol: `${discountContainer} .price-reduction-value .input-group .input-group-append .input-group-text, .price-reduction-value .input-group .input-group-prepend .input-group-text`,
   specificProductSearchComponent: '#cart_rule_actions_discount_specific_product',
   specificProductSearchContainer: '.specific-product-search-container',
+  // TODO <cnc-notice> NOTE: I don't know which page this script belongs to.
+  reductionValueInput: '#specific_price_impact_reduction_value',
 };

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/cart-rule-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/cart-rule-map.ts
@@ -21,6 +21,8 @@ export default {
   reductionValueSymbol: `${discountContainer} .price-reduction-value .input-group .input-group-append .input-group-text, .price-reduction-value .input-group .input-group-prepend .input-group-text`,
   specificProductSearchComponent: '#cart_rule_actions_discount_specific_product',
   specificProductSearchContainer: '.specific-product-search-container',
-  // TODO <cnc-notice> NOTE: I don't know which page this script belongs to.
+  // TODO: Remove this placeholder and the remaining obsolete cart rule migration scripts.
+  // cart-rule-map.ts and form/discount-manager.ts are leftovers from PR https://github.com/PrestaShop/PrestaShop/pull/40603,
+  // and no corresponding reduction value input exists.
   reductionValueInput: '#specific_price_impact_reduction_value',
 };

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/form/discount-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/form/discount-manager.ts
@@ -19,6 +19,8 @@ export default class DiscountManager {
       CartRuleMap.includeTaxInput,
       CartRuleMap.currencySelect,
       CartRuleMap.reductionValueSymbol,
+      // TODO <cnc-notice> NOTE: I don't know which page this script belongs to.
+      CartRuleMap.reductionValueInput,
     );
     this.toggleCurrency();
     document.querySelector(CartRuleMap.reductionTypeSelect)?.addEventListener('change', this.toggleCurrency);

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/form/discount-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/form/discount-manager.ts
@@ -19,7 +19,6 @@ export default class DiscountManager {
       CartRuleMap.includeTaxInput,
       CartRuleMap.currencySelect,
       CartRuleMap.reductionValueSymbol,
-      // TODO <cnc-notice> NOTE: I don't know which page this script belongs to.
       CartRuleMap.reductionValueInput,
     );
     this.toggleCurrency();

--- a/admin-dev/themes/new-theme/js/pages/catalog-price-rule/form/catalog-price-rule-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog-price-rule/form/catalog-price-rule-form-map.ts
@@ -18,4 +18,5 @@ export default {
   // mapping for include-tax-field-visibility-handler
   reductionType: '.js-reduction-type-source',
   includeTax: '.js-include-tax-row',
+  reductionValueInput: '#catalog_price_rule_reduction_value',
 };

--- a/admin-dev/themes/new-theme/js/pages/catalog-price-rule/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog-price-rule/form/index.ts
@@ -20,5 +20,6 @@ $(() => {
     CatalogPriceRuleFormMap.includeTax,
     CatalogPriceRuleFormMap.currencyId,
     CatalogPriceRuleFormMap.reductionTypeAmountSymbol,
+    CatalogPriceRuleFormMap.reductionValueInput,
   );
 });

--- a/admin-dev/themes/new-theme/js/pages/discount/discount-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/discount-map.ts
@@ -28,4 +28,5 @@ export default {
   productSegmentFeatures: '#discount_conditions_product_product_segment_features',
   quantityPerCustomerInput: '#discount_usability_quantity_per_customer',
   customerEligibilityInput: '#discount_customer_eligibility_eligibility',
+  reductionValueInput: '#discount_value_reduction_value',
 };

--- a/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
@@ -45,6 +45,7 @@ $(() => {
       DiscountMap.includeTaxInput,
       DiscountMap.currencySelect,
       DiscountMap.reductionValueSymbol,
+      DiscountMap.reductionValueInput,
       DiscountMap.currencySelectContainer,
     );
     toggleCurrency();

--- a/admin-dev/themes/new-theme/js/pages/product/specific-price/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/specific-price/form/index.ts
@@ -42,6 +42,7 @@ $(() => {
     SpecificPriceMap.includeTaxInputContainer,
     SpecificPriceMap.currencyId,
     SpecificPriceMap.reductionTypeAmountSymbol,
+    SpecificPriceMap.reductionValueInput,
   );
 
   new CustomerSelector();

--- a/admin-dev/themes/new-theme/js/pages/product/specific-price/specific-price-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/specific-price/specific-price-map.ts
@@ -21,4 +21,5 @@ export default {
   switchFixedName: 'specific_price[impact][disabling_switch_fixed_price_tax_excluded]',
   shopIdSelect: '#specific_price_groups_shop_id',
   combinationIdSelect: '#specific_price_combination_id',
+  reductionValueInput: '#specific_price_impact_reduction_value',
 };


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x
| Description?      | This PR fixes the handling of locale-specific decimal separators in percentage reduction fields.<br/>When a reduction field is initially rendered as a monetary amount, it receives the `js-comma-transformer` class. If the reduction type is then changed to `percentage`, the field keeps this class. As a result, when the field loses focus, the global number transformer normalizes the entered value and may replace the locale-specific decimal separator.<br/><br/>For example:<br/>- with the Italian locale, `5,5` is converted to `5.5`;<br/>- with the English locale, `5.5` is the expected format, while `5,5` is invalid.<br/><br/>The submitted value is subsequently processed by Symfony's localized `PercentType`. If the decimal separator does not match the current locale, the form displays the `Please enter a percentage value.` validation error.<br/><br/>This PR updates `PriceReductionManager` so that the `js-comma-transformer` class is:<br/><br/>- removed when the selected reduction type is `percentage`;<br/>- restored when the selected reduction type is `amount`.<br/><br/>This keeps the percentage value in the format expected by the current locale while preserving the existing normalization behavior for monetary reductions.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/prestaShop/PrestaShop/issues/41913
| Related PRs       | 
| Sponsor company   | Codencode snc

---
## Before PR

[without-fix.webm](https://github.com/user-attachments/assets/f23f22cf-b078-434b-b513-2f04e62a7cb2)

## Aftrer PR

[with-fix.webm](https://github.com/user-attachments/assets/7213b4a5-e794-47af-aca6-5015af50961d)


---
## How to test

### Product specific price

This is the scenario originally reported in the issue.

1. Set the Back Office language to Italian or French.
2. Go to **Catalog > Products** and edit a product.
3. Open the **Pricing** tab.
4. Add a new specific price.
5. Select a percentage reduction.
6. Enter `5,5` in the reduction value field.
7. Move the focus away from the field.
8. Check that the value remains `5,5` and is not converted to `5.5`.
9. Save the specific price.
10. Check that it is saved without the `Please enter a percentage value.` error.
11. Change the Back Office language to English and repeat the test using `5.5`.
12. Check that the percentage is saved correctly.
13. In both languages, switch the reduction type back to an amount and check that monetary values are still normalized correctly.

### Migrated catalog price rules page

1. Enable the following feature flag:

   ```text
   discount - Enable / Enable / Disable the new discount system
   ```

2. Open the migrated catalog price rules page.
3. Create a new catalog price rule.
4. Select a percentage reduction.
5. With the Italian Back Office locale, enter `5,5`.
6. Move the focus away from the field.
7. Check that the value remains `5,5`.
8. Save the rule and check that no percentage validation error is displayed.
9. Repeat the test with the English locale using `5.5`.
10. Switch the reduction type to an amount and check that the monetary value behavior is unchanged.

### Migrated cart rules page

1. Enable the following feature flag:

   ```text
   cart_rule - Enable / Disable the migrated cart rules page
   ```

2. Open the migrated cart rules page.
3. Create a new cart rule with a reduction.
4. Select a percentage reduction.
5. With the Italian Back Office locale, enter `5,5`.
6. Move the focus away from the field.
7. Check that the value remains `5,5`.
8. Save the rule and check that no percentage validation error is displayed.
9. Repeat the test with the English locale using `5.5`.
10. Switch the reduction type to an amount and check that the monetary value behavior is unchanged.

---
## Additional note

The following files appear to be leftovers from the abandoned cart rule page migration:

admin-dev/themes/new-theme/js/pages/cart-rule/cart-rule-map.ts
admin-dev/themes/new-theme/js/pages/cart-rule/form/discount-manager.ts

They seem to have been unintentionally left behind during the cleanup introduced in PR #40603, and I could not find any Back Office page currently using them.

Since PriceReductionManager now requires the reduction value selector, I added a non-matching placeholder selector to keep the TypeScript code compilable. I also added a TODO explaining that this placeholder, together with the obsolete cart rule scripts, should probably be removed in a dedicated cleanup.