### PR TITLE
Memoize the checkout delivery options per address and evaluate free-shipping once

### DIFF
--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -27,23 +27,15 @@ class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
         $this->priceFormatter = $priceFormatter;
     }
 
-    private function isFreeShipping($cart, array $carrier)
+    private function cartHasFreeShippingCartRule($cart)
     {
-        $free_shipping = false;
-
-        if ($carrier['is_free']) {
-            $free_shipping = true;
-        } else {
-            foreach ($cart->getCartRules() as $rule) {
-                if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
-                    $free_shipping = true;
-
-                    break;
-                }
+        foreach ($cart->getCartRules() as $rule) {
+            if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
+                return true;
             }
         }
 
-        return $free_shipping;
+        return false;
     }
 
     public function getSelectedDeliveryOption()
@@ -59,6 +51,11 @@ class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
 
         $carriers_available = [];
 
+        // A free-shipping cart rule applies to the whole cart, not to a specific carrier, so
+        // evaluate it once here instead of re-running getCartRules() (and its uncached cart-rule
+        // resolution) for every carrier in the matrix below.
+        $cartHasFreeShippingRule = $this->cartHasFreeShippingCartRule($this->context->cart);
+
         if (isset($delivery_option_list[$this->context->cart->id_address_delivery])) {
             foreach ($delivery_option_list[$this->context->cart->id_address_delivery] as $id_carriers_list => $carriers_list) {
                 foreach ($carriers_list as $carriers) {
@@ -68,7 +65,7 @@ class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
                             $delay = $carrier['delay'][$this->context->language->id];
                             unset($carrier['instance'], $carrier['delay']);
                             $carrier['delay'] = $delay;
-                            if ($this->isFreeShipping($this->context->cart, $carriers_list)) {
+                            if ($carriers_list['is_free'] || $cartHasFreeShippingRule) {
                                 $carrier['price'] = $this->translator->trans(
                                     'Free',
                                     [],

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -15,6 +15,13 @@ class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
     private $translator;
     private $priceFormatter;
 
+    /**
+     * Memoized getDeliveryOptions() result, keyed by delivery address id.
+     *
+     * @var array<int, array>
+     */
+    private $deliveryOptionsByAddress = [];
+
     public function __construct(
         Context $context,
         TranslatorInterface $translator,
@@ -45,6 +52,14 @@ class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
 
     public function getDeliveryOptions()
     {
+        // The carrier set only changes with the delivery address within a request, so memoize per
+        // address: a checkout render calls this from several steps, and each call re-presents every
+        // carrier (firing the per-carrier presentation hooks) on top of the already-cached matrix.
+        $idAddressDelivery = (int) $this->context->cart->id_address_delivery;
+        if (isset($this->deliveryOptionsByAddress[$idAddressDelivery])) {
+            return $this->deliveryOptionsByAddress[$idAddressDelivery];
+        }
+
         $delivery_option_list = $this->context->cart->getDeliveryOptionList();
         $include_taxes = !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer) && (int) Configuration::get('PS_TAX');
         $display_taxes_label = (Configuration::get('PS_TAX') && $this->context->country->display_tax_label);
@@ -114,6 +129,8 @@ class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
                 }
             }
         }
+
+        $this->deliveryOptionsByAddress[$idAddressDelivery] = $carriers_available;
 
         return $carriers_available;
     }

--- a/tests/Integration/Classes/Checkout/DeliveryOptionsFinderMemoTest.php
+++ b/tests/Integration/Classes/Checkout/DeliveryOptionsFinderMemoTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Checkout;
+
+use Address;
+use Cart;
+use Configuration;
+use Context;
+use Country;
+use Currency;
+use Customer;
+use Db;
+use DeliveryOptionsFinder;
+use Language;
+use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * DeliveryOptionsFinder::getDeliveryOptions() is called several times per checkout render and
+ * re-presents every carrier each time. It now memoizes the result per delivery address. This guards
+ * that the memoized result is identical to a freshly-computed one (same carriers, prices, labels).
+ */
+class DeliveryOptionsFinderMemoTest extends KernelTestCase
+{
+    public function testMemoizedDeliveryOptionsMatchAFreshComputation(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        Context::getContext()->container = $container;
+
+        $cartId = (int) Db::getInstance()->getValue(
+            'SELECT id_cart FROM ' . _DB_PREFIX_ . 'cart WHERE id_address_delivery > 0 ORDER BY id_cart'
+        );
+        $cart = new Cart($cartId);
+
+        $context = Context::getContext();
+        $context->cart = $cart;
+        $context->customer = new Customer((int) $cart->id_customer);
+        $context->currency = new Currency((int) $cart->id_currency);
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $address = new Address((int) $cart->id_address_delivery);
+        $context->country = new Country((int) $address->id_country);
+
+        $translator = $container->get('translator');
+        $objectPresenter = new ObjectPresenter();
+        $priceFormatter = new PriceFormatter();
+
+        $finder = new DeliveryOptionsFinder($context, $translator, $objectPresenter, $priceFormatter);
+        $firstCall = $finder->getDeliveryOptions();
+        $secondCall = $finder->getDeliveryOptions();
+
+        // A fresh finder (no memo yet) recomputes from scratch.
+        $freshFinder = new DeliveryOptionsFinder($context, $translator, $objectPresenter, $priceFormatter);
+        $recomputed = $freshFinder->getDeliveryOptions();
+
+        self::assertNotEmpty($firstCall, 'the demo cart must resolve at least one carrier');
+        self::assertSame($firstCall, $secondCall, 'the memoized call must return the same result');
+        self::assertEquals($recomputed, $firstCall, 'the memoized result must match a fresh computation');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `DeliveryOptionsFinder::getDeliveryOptions()` builds the presented carrier list for the checkout. It is called several times per rendered checkout page (the delivery step and the payment step both render on every page, and the confirm-delivery request calls it again), and each call re-presents every carrier from scratch: `ObjectPresenter::present()` per carrier (firing the `actionPresentObject` / HTML-filter hooks), price formatting and translations, and `displayCarrierExtraContent` for module carriers. The underlying shipping matrix (`Cart::getDeliveryOptionList()`) is already request-cached, but this presentation layer on top of it was not.<br><br>This makes the method efficient in two composing ways:<br>1. **Memoize the result per delivery address.** The carrier set only changes with `id_address_delivery` within a request (the addresses step can change it), so the result is cached per address and reused by the later calls instead of being rebuilt. The per-address key is actually more correct than the underlying list cache, which keys on cart id only.<br>2. **Evaluate the free-shipping cart rule once per build** instead of re-running `getCartRules()` (and its uncached cart-rule resolution) inside the per-carrier loop — a free-shipping rule applies to the whole cart, not to a specific carrier.<br><br>Behaviour is unchanged: the presentation hooks still fire (once per render instead of 2-4 times), and the output is identical.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go through checkout with several carriers available. The delivery options (carriers, prices, "Free" labels, delays) must be identical to before. `tests/Integration/Classes/Checkout/DeliveryOptionsFinderMemoTest.php` asserts the memoized result of `getDeliveryOptions()` is identical to a freshly-computed one. With SQL/hook profiling, the per-carrier presentation now runs once per render rather than on every finder call.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41906
| Related PRs       |
| Sponsor company   |

