### PR TITLE
Softfail extra properties registry table not available on autoupgrade…

### DIFF
--- a/src/Core/ExtraProperty/Definition/ExtraPropertyDefinitionRepository.php
+++ b/src/Core/ExtraProperty/Definition/ExtraPropertyDefinitionRepository.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\ExtraProperty\Definition;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ExtraPropertyDefinitionNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ProtectedModuleExtraPropertyDefinitionException;
@@ -44,7 +45,17 @@ class ExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionReposi
             ->from($table, 'eef')
             ->orderBy('eef.id_extra_property_definition', 'ASC');
 
-        $rows = $this->enrichRowsWithColumnMetadata($qb->executeQuery()->fetchAllAssociative() ?: []);
+        try {
+            $rows = $qb->executeQuery()->fetchAllAssociative() ?: [];
+        } catch (Throwable $exception) {
+            if ($this->isMissingDefinitionTableException($exception)) {
+                return ExtraPropertyDefinitionCollection::empty();
+            }
+
+            throw $exception;
+        }
+
+        $rows = $this->enrichRowsWithColumnMetadata($rows);
 
         return new ExtraPropertyDefinitionCollection(array_values(array_map(
             static fn (array $row): ExtraPropertyDefinition => ExtraPropertyDefinition::fromRow($row),
@@ -326,5 +337,18 @@ class ExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionReposi
         }
 
         return $metadata;
+    }
+
+    private function isMissingDefinitionTableException(Throwable $exception): bool
+    {
+        do {
+            if ($exception instanceof TableNotFoundException) {
+                return true;
+            }
+
+            $exception = $exception->getPrevious();
+        } while (null !== $exception);
+
+        return false;
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Prevent extra property definition lookup from crashing when the registry table does not exist yet. This can happen during autoupgrade to 9.2.x from older versions: the target code is already loaded while upgrade SQL scripts are still being executed, so `ObjectModel` may try to validate extra properties before `ps_extra_property_definition` has been created.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `php vendor/bin/phpunit tests/Unit/Core/ExtraProperty/ExtraPropertyDefinitionRepositoryTest.php`. Also verify an upgrade from 8.2.7 to 9.2.x no longer fails during `install_ps_apiresources()` when `ps_extra_property_definition` is not created yet.
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/28520266208
| Fixed issue or discussion?     | N/A
| Related PRs       | Related to PrestaShop/autoupgrade#1850
| Sponsor company   | KIWIK

## Additional information

During an upgrade from versions below 9.0.0 to 9.2.x, the new core code can be loaded before all target-version SQL scripts have run. In that transient state, `ObjectModel::validateExtraProperties()` may ask the extra property definition repository for definitions before the `ps_extra_property_definition` registry table exists.

This PR makes the repository gracefully return an empty definition collection when DBAL reports that the registry table is missing. Other database errors are still thrown normally.