### PR TITLE
Use constant-time comparison for order secure_key checks

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -251,7 +251,7 @@ abstract class PaymentModuleCore extends Module
             throw new PrestaShopException($error);
         }
 
-        if ($secure_key !== false && $secure_key != $this->context->cart->secure_key) {
+        if ($secure_key !== false && !hash_equals((string) $this->context->cart->secure_key, (string) $secure_key)) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Secure key does not match', 3, null, 'Cart', (int) $id_cart, true);
             throw new PrestaShopException('Error processing order. Secure key does not match.');
         }

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -181,7 +181,7 @@ class GetFileControllerCore extends FrontController
                     if (!Validate::isLoadedObject($order)) {
                         $this->displayCustomError('Invalid key.');
                     }
-                    if ($order->secure_key != Tools::getValue('secure_key')) {
+                    if (!hash_equals((string) $order->secure_key, (string) Tools::getValue('secure_key'))) {
                         $this->displayCustomError('Invalid key.');
                     }
                 } else {

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -85,7 +85,7 @@ class OrderConfirmationControllerCore extends FrontController
          * in database, we redirect to "page not found".
          */
         $this->secure_key = Tools::getValue('key', false);
-        if (empty($this->secure_key) || $this->secure_key != $this->order->secure_key) {
+        if (empty($this->secure_key) || !hash_equals((string) $this->order->secure_key, (string) $this->secure_key)) {
             Tools::redirect('pagenotfound');
         }
 

--- a/controllers/front/PdfInvoiceController.php
+++ b/controllers/front/PdfInvoiceController.php
@@ -48,7 +48,7 @@ class PdfInvoiceControllerCore extends FrontController
 
         // Check if the user is not trying to download an invoice of an order of different customer
         // Either the ID of the customer in context must match the customer in order OR a secure_key matching the one on the order must be provided
-        if (Tools::isSubmit('secure_key') && $order->secure_key != Tools::getValue('secure_key')) {
+        if (Tools::isSubmit('secure_key') && !hash_equals((string) $order->secure_key, (string) Tools::getValue('secure_key'))) {
             die($this->trans('The invoice was not found.', [], 'Shop.Notifications.Error'));
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The front-office guest authorization for downloadable files, invoice PDFs and the order confirmation page compares the order `secure_key` against a request parameter with the plain `!=` operator. Since that per-order secret is what lets a non-logged-in visitor reach another customer's order-scoped resources, the comparison should not be byte-by-byte; a mismatch returns as soon as the first differing character is found. On top of the timing leak, `!=` type-juggles two numeric-string md5 values numerically, so a key like `1e31` can match `10000000000000000000000000000000` without being equal. This swaps the checks to `hash_equals()` so the secret is verified in constant time and compared as a string. Same guest-auth pattern in `classes/PaymentModule.php::validateOrder()` (cart `secure_key`) is switched too.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open an order as a guest via its confirmation/invoice/download link with the correct `secure_key` (or `key`) and confirm access still works, then try a wrong value and confirm it is still rejected. `secure_key` is a 32-char md5, so `hash_equals()` is a drop-in for the previous string comparison.
| UI Tests          | N/A — only the comparison primitive changes; accept/reject outcome is preserved for every ordinary input.
| Fixed issue or discussion?     |
| Related PRs       |
| Sponsor company   |

