### PR TITLE
Fix catalog price rule links when feature flag is enabled

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -25,6 +27,8 @@ class CatalogPriceRulesType extends TranslatorAwareType
      */
     private $legacyContext;
 
+    private const CATALOG_PRICE_RULE_ID_PLACEHOLDER = 987654321;
+
     /**
      * PricingType constructor.
      *
@@ -35,7 +39,9 @@ class CatalogPriceRulesType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        LegacyContext $legacyContext
+        LegacyContext $legacyContext,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+        private readonly UrlGeneratorInterface $urlGenerator,
     ) {
         parent::__construct($translator, $locales);
         $this->legacyContext = $legacyContext;
@@ -48,18 +54,45 @@ class CatalogPriceRulesType extends TranslatorAwareType
     {
         parent::configureOptions($resolver);
 
-        /**
-         * %catalog_price_rule_id% can't be used in this function, because getAdminLink adds unneeded stuff to % while creating url
-         * That's why catalog_price_rule_id is used and then string replaced.
-         */
-        $catalogPriceRuleEditLink = $this->legacyContext->getAdminLink(
-            'AdminSpecificPriceRule',
-            true,
-            ['updatespecific_price_rule' => '', 'id_specific_price_rule' => 'catalog_price_rule_id']
-        );
-        $catalogPriceRuleIndexLink = $this->legacyContext->getAdminLink('AdminSpecificPriceRule');
-        /** Adding % to make link more unique */
-        $catalogPriceRuleEditLink = str_replace('catalog_price_rule_id', '%catalog_price_rule_id%', $catalogPriceRuleEditLink);
+        // When the Catalog price rules feature is enabled, links must point directly
+        // to the new Symfony pages. Using getAdminLink() would resolve the legacy
+        // controller to the Symfony route and attempt to generate it with a textual
+        // placeholder that does not satisfy the route's numeric requirement.
+        if ($this->featureFlagStateChecker->isEnabled('catalog_price_rule')) {
+            $catalogPriceRuleIndexLink = $this->urlGenerator->generate(
+                'admin_catalog_price_rules_index'
+            );
+
+            // The edit route only accepts a numeric catalogPriceRuleId, so the final
+            // JavaScript placeholder cannot be passed directly to the URL generator.
+            // A temporary numeric value is used to generate a valid URL and is then
+            // replaced with the placeholder expected by the JavaScript component.
+            $catalogPriceRuleEditLink = $this->urlGenerator->generate(
+                'admin_catalog_price_rules_edit',
+                [
+                    'catalogPriceRuleId' => self::CATALOG_PRICE_RULE_ID_PLACEHOLDER,
+                ]
+            );
+
+            $catalogPriceRuleEditLink = str_replace(
+                sprintf('/%d/edit', self::CATALOG_PRICE_RULE_ID_PLACEHOLDER),
+                '/%catalog_price_rule_id%/edit',
+                $catalogPriceRuleEditLink
+            );
+        } else {
+            /**
+             * %catalog_price_rule_id% can't be used in this function, because getAdminLink adds unneeded stuff to % while creating url
+             * That's why catalog_price_rule_id is used and then string replaced.
+             */
+            $catalogPriceRuleEditLink = $this->legacyContext->getAdminLink(
+                'AdminSpecificPriceRule',
+                true,
+                ['updatespecific_price_rule' => '', 'id_specific_price_rule' => 'catalog_price_rule_id']
+            );
+            $catalogPriceRuleIndexLink = $this->legacyContext->getAdminLink('AdminSpecificPriceRule');
+            /** Adding % to make link more unique */
+            $catalogPriceRuleEditLink = str_replace('catalog_price_rule_id', '%catalog_price_rule_id%', $catalogPriceRuleEditLink);
+        }
 
         $resolver->setDefaults([
             'form_theme' => '@PrestaShop/Admin/Sell/Catalog/Product/FormTheme/catalog_price_rules.html.twig',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes the product edit page when the experimental **Catalog price rules** feature is enabled.<br/>When the feature is enabled, catalog price rule links are now generated using the new Symfony routes. When it is disabled, the existing legacy links are preserved.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **Advanced Parameters > New & Experimental Features**.<br/>2. Enable the experimental **Catalog price rules** feature.<br/>3. Go to **Catalog > Discounts > Catalog price rules**.<br/>4. Create a catalog price rule and apply it to the entire catalog.<br/>5. Go to **Catalog > Products** and open any product for editing.<br/>6. Check that the product page opens without any exception.<br/> 7. Open the **Pricing** tab.<br/>8. Check that the previously created catalog price rule is displayed.<br/>9. Click **Manage catalog price rules** and check that it opens the catalog price rules list.<br/>10. Return to the product page and click **Edit** on the catalog price rule.<br/>11. Check that the corresponding catalog price rule edit page opens correctly.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/28499759906
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41927
| Related PRs       | 
| Sponsor company   | Codencode snc
