### PR TITLE
Add bulk delete action to migrated Countries page

### DIFF
--- a/src/Adapter/Country/CommandHandler/BulkDeleteCountriesHandler.php
+++ b/src/Adapter/Country/CommandHandler/BulkDeleteCountriesHandler.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Country\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Country\Repository\CountryRepository;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\AbstractBulkCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkDeleteCountriesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler\BulkDeleteCountriesHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\BulkCountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
+use PrestaShop\PrestaShop\Core\Domain\Exception\BulkCommandExceptionInterface;
+
+#[AsCommandHandler]
+final class BulkDeleteCountriesHandler extends AbstractBulkCommandHandler implements BulkDeleteCountriesHandlerInterface
+{
+    public function __construct(
+        private readonly CountryRepository $countryRepository,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(BulkDeleteCountriesCommand $command): void
+    {
+        $this->handleBulkAction($command->getCountryIds(), CountryException::class);
+    }
+
+    /**
+     * @param CountryId $id
+     */
+    protected function handleSingleAction(mixed $id, mixed $command): void
+    {
+        $this->countryRepository->delete($id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function buildBulkException(array $caughtExceptions): BulkCommandExceptionInterface
+    {
+        return new BulkCountryException(
+            $caughtExceptions,
+            'Errors occurred during country bulk delete action',
+            BulkCountryException::FAILED_BULK_DELETE
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function supports($id): bool
+    {
+        return $id instanceof CountryId;
+    }
+}

--- a/src/Core/Domain/Country/Command/BulkDeleteCountriesCommand.php
+++ b/src/Core/Domain/Country/Command/BulkDeleteCountriesCommand.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
+
+/**
+ * Deletes countries on bulk action.
+ */
+final class BulkDeleteCountriesCommand
+{
+    /** @var array<int, CountryId> */
+    private array $countryIds = [];
+
+    /**
+     * @param array<int, int> $countryIds
+     */
+    public function __construct(array $countryIds)
+    {
+        $this->setCountryIds($countryIds);
+    }
+
+    /**
+     * @return array<int, CountryId>
+     */
+    public function getCountryIds(): array
+    {
+        return $this->countryIds;
+    }
+
+    /**
+     * @param array<int, int> $countryIds
+     */
+    private function setCountryIds(array $countryIds): void
+    {
+        foreach ($countryIds as $countryId) {
+            $this->countryIds[] = new CountryId((int) $countryId);
+        }
+    }
+}

--- a/src/Core/Domain/Country/CommandHandler/BulkDeleteCountriesHandlerInterface.php
+++ b/src/Core/Domain/Country/CommandHandler/BulkDeleteCountriesHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkDeleteCountriesCommand;
+
+interface BulkDeleteCountriesHandlerInterface
+{
+    public function handle(BulkDeleteCountriesCommand $command): void;
+}

--- a/src/Core/Domain/Country/Exception/BulkCountryException.php
+++ b/src/Core/Domain/Country/Exception/BulkCountryException.php
@@ -15,6 +15,7 @@ final class BulkCountryException extends CountryException implements BulkCommand
 {
     public const FAILED_BULK_UPDATE_STATUS = 1;
     public const FAILED_BULK_UPDATE_ZONE = 2;
+    public const FAILED_BULK_DELETE = 3;
 
     /**
      * @param Throwable[] $exceptions

--- a/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
@@ -276,6 +276,9 @@ final class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'submit_route' => 'admin_countries_bulk_update_zone',
                         'modal_id' => 'changeCountriesZoneModal',
                     ])
+            )
+            ->add(
+                $this->buildBulkDeleteAction('admin_countries_bulk_delete')
             );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
 use Exception;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkDeleteCountriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkToggleCountriesStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkUpdateCountryZoneCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\DeleteCountryCommand;
@@ -286,6 +287,33 @@ class CountryController extends PrestaShopAdminController
     }
 
     /**
+     * Deletes countries in bulk action
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    #[DemoRestricted(redirectRoute: 'admin_countries_index')]
+    #[AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute: 'admin_countries_index')]
+    public function bulkDeleteAction(Request $request): RedirectResponse
+    {
+        $countryIds = $this->getBulkCountriesFromRequest($request);
+
+        try {
+            $this->dispatchCommand(new BulkDeleteCountriesCommand($countryIds));
+
+            $this->addFlash(
+                'success',
+                $this->trans('The selection has been successfully deleted.', [], 'Admin.Notifications.Success')
+            );
+        } catch (CountryException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        }
+
+        return $this->redirectToRoute('admin_countries_index');
+    }
+
+    /**
      * @return array
      */
     protected function getCountryToolbarButtons(): array
@@ -317,6 +345,11 @@ class CountryController extends PrestaShopAdminController
                 ),
                 BulkCountryException::FAILED_BULK_UPDATE_ZONE => $this->trans(
                     'An error occurred when updating the zone for one or several countries.',
+                    [],
+                    'Admin.International.Feature'
+                ),
+                BulkCountryException::FAILED_BULK_DELETE => $this->trans(
+                    'An error occurred while deleting one or several countries.',
                     [],
                     'Admin.International.Feature'
                 ),

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
@@ -90,6 +90,15 @@ admin_countries_bulk_update_zone:
     _legacy_link: AdminCountries:submitBulkAffectZonecountry
     _legacy_feature_flag: country
 
+admin_countries_bulk_delete:
+  path: /bulk-delete
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::bulkDeleteAction'
+    _legacy_controller: AdminCountries
+    _legacy_link: AdminCountries:submitBulkdeletecountry
+    _legacy_feature_flag: country
+
 admin_countries_toggle_status:
   path: /{countryId}/toggle-status
   methods: [ POST ]

--- a/src/PrestaShopBundle/Resources/config/services/adapter/country.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/country.yml
@@ -60,6 +60,11 @@ services:
     autowire: true
     autoconfigure: true
 
+  PrestaShop\PrestaShop\Adapter\Country\CommandHandler\BulkDeleteCountriesHandler:
+    public: false
+    autowire: true
+    autoconfigure: true
+
   PrestaShop\PrestaShop\Adapter\Country\CommandHandler\BulkUpdateCountryZoneHandler:
     public: false
     autowire: true

--- a/tests/Integration/Behaviour/Features/Context/Domain/CountryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CountryFeatureContext.php
@@ -10,6 +10,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\AddCountryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkDeleteCountriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkToggleCountriesStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkUpdateCountryZoneCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\DeleteCountryCommand;
@@ -260,6 +261,32 @@ class CountryFeatureContext extends AbstractDomainFeatureContext
     {
         try {
             $this->getCommandBus()->handle(new BulkToggleCountriesStatusCommand(true, []));
+        } catch (CountryException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I bulk delete countries :countryReferences
+     */
+    public function bulkDeleteCountries(string $countryReferences): void
+    {
+        try {
+            $this->getCommandBus()->handle(new BulkDeleteCountriesCommand(
+                $this->getCountryIdsFromReferences($countryReferences)
+            ));
+        } catch (CountryException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I bulk delete an empty list of countries
+     */
+    public function bulkDeleteEmptyCountriesList(): void
+    {
+        try {
+            $this->getCommandBus()->handle(new BulkDeleteCountriesCommand([]));
         } catch (CountryException $e) {
             $this->setLastException($e);
         }

--- a/tests/Integration/Behaviour/Features/Scenario/Country/bulk_delete_countries.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Country/bulk_delete_countries.feature
@@ -1,0 +1,71 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s country --tags bulk-delete-countries
+@restore-all-tables-before-feature
+@bulk-delete-countries
+Feature: Bulk delete countries
+  PrestaShop allows BO users to delete multiple countries at once
+  As a BO user
+  I must be able to delete multiple countries at once
+
+  Scenario: Bulk delete countries
+    Given language "language1" with locale "en-US" exists
+    And I add new country "bulk_delete_country_1" with following properties:
+      | name[en-US]                | Bulk Delete Country 1                            |
+      | iso_code                   | QX                                               |
+      | call_prefix                | 21                                               |
+      | default_currency           | 1                                                |
+      | zone                       | 1                                                |
+      | need_zip_code              | true                                             |
+      | zip_code_format            | NNNNN                                            |
+      | address_format             | firstname lastname\naddress1\ncity\nCountry:name |
+      | is_enabled                 | false                                            |
+      | contains_states            | false                                            |
+      | need_identification_number | false                                            |
+      | display_tax_label          | true                                             |
+      | shop_association           | 1                                                |
+    And I add new country "bulk_delete_country_2" with following properties:
+      | name[en-US]                | Bulk Delete Country 2                            |
+      | iso_code                   | QB                                               |
+      | call_prefix                | 22                                               |
+      | default_currency           | 1                                                |
+      | zone                       | 1                                                |
+      | need_zip_code              | true                                             |
+      | zip_code_format            | NNNNN                                            |
+      | address_format             | firstname lastname\naddress1\ncity\nCountry:name |
+      | is_enabled                 | false                                            |
+      | contains_states            | false                                            |
+      | need_identification_number | false                                            |
+      | display_tax_label          | true                                             |
+      | shop_association           | 1                                                |
+    When I bulk delete countries "bulk_delete_country_1, bulk_delete_country_2"
+    Then country "bulk_delete_country_1" should be deleted
+    And country "bulk_delete_country_2" should be deleted
+
+  Scenario: Bulk delete should report invalid country id
+    Given country "invalid_country" has invalid id
+    When I bulk delete countries "invalid_country"
+    Then I should get error that country id is invalid
+
+  Scenario: Bulk delete should no-op when country list is empty
+    When I bulk delete an empty list of countries
+    Then no exception should have been thrown
+
+  Scenario: Bulk delete should continue on partial failure and aggregate errors
+    Given language "language1" with locale "en-US" exists
+    And I add new country "bulk_delete_partial_country" with following properties:
+      | name[en-US]                | Bulk Delete Partial                              |
+      | iso_code                   | QC                                               |
+      | call_prefix                | 31                                               |
+      | default_currency           | 1                                                |
+      | zone                       | 1                                                |
+      | need_zip_code              | true                                             |
+      | zip_code_format            | NNNNN                                            |
+      | address_format             | firstname lastname\naddress1\ncity\nCountry:name |
+      | is_enabled                 | false                                            |
+      | contains_states            | false                                            |
+      | need_identification_number | false                                            |
+      | display_tax_label          | true                                             |
+      | shop_association           | 1                                                |
+    And country "bulk_delete_partial_missing" does not exist
+    When I bulk delete countries "bulk_delete_partial_country, bulk_delete_partial_missing"
+    Then I should get a bulk country exception containing 1 errors
+    And country "bulk_delete_partial_country" should be deleted


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds the missing **bulk delete** action on the migrated Countries page (Improve > International > Locations). Introduces `BulkDeleteCountriesCommand` and its handler (extending `AbstractBulkCommandHandler`), registers the handler service, and wires it into `CountryController::bulkDeleteAction`. Failures are collected per country and reported together via `BulkCountryException`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the `country` feature flag. Go to *Improve > International > Locations > Countries*, select several countries, and run the **Delete selected** bulk action. The selected countries are deleted and a success message is shown. Covered by the `bulk-delete-countries` Behat feature.
| UI tests | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/28507615538
| Fixed issue or discussion?     | Fixes #41930
