### PR TITLE
Fix ConfigurationCore::getFieldsLang returning boolean causing foreach crash

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -66,12 +66,12 @@ class ConfigurationCore extends ObjectModel
     /**
      * @see ObjectModel::getFieldsLang()
      *
-     * @return bool|array Multilingual fields
+     * @return array Multilingual fields
      */
     public function getFieldsLang()
     {
         if (!is_array($this->value)) {
-            return true;
+            return [];
         }
 
         return parent::getFieldsLang();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fixes a Webservice error when creating configuration entries via `POST /api/configurations`. `ConfigurationCore::getFieldsLang()` may return `true`, which is later iterated in `ObjectModel::add()`, resulting in the PHP warning `foreach() argument must be of type array\|object, true given`. This change ensures `getFieldsLang()` always returns an iterable value.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable the Webservice.<br>2. Create an API key with write access to the `configurations` resource.<br>3. Send a `POST /api/configurations` request with a simple XML payload.<br>4. Before this change, the request fails with `foreach() argument must be of type array\|object, true given`.<br>5. After this change, the configuration is created successfully.
| UI Tests          | N/A (backend change)
| Fixed issue or discussion? | Related to #41938
| Related PRs       | N/A
| Sponsor company   | N/A