### PR TITLE
Add shared stock help message to combination availability form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -40,7 +41,8 @@ class CombinationAvailabilityType extends TranslatorAwareType
         TranslatorInterface $translator,
         array $locales,
         FormChoiceProviderInterface $outOfStockTypeChoiceProvider,
-        RouterInterface $router
+        RouterInterface $router,
+        private ShopContext $shopContext
     ) {
         parent::__construct($translator, $locales);
         $this->outOfStockTypeChoiceProvider = $outOfStockTypeChoiceProvider;
@@ -56,6 +58,10 @@ class CombinationAvailabilityType extends TranslatorAwareType
                 'expanded' => true,
                 'column_breaker' => true,
                 'modify_all_shops' => true,
+                'help' => $this->shopContext->isMultiShopEnabled()
+                        && $this->shopContext->hasGroupSharingStocks() ?
+                        $this->trans('Stock is shared between the stores in this group, so this setting is automatically applied to all of them, regardless of the "Apply changes to all stores" checkbox.', 'Admin.Catalog.Feature') :
+                        null,
                 'external_link' => [
                     'text' => $this->trans('[1]Edit default behavior[/1]', 'Admin.Catalog.Feature'),
                     'href' => $this->router->generate('admin_product_preferences') . '#configuration_fieldset_stock',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Stock;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
@@ -44,7 +45,8 @@ class AvailabilityType extends TranslatorAwareType
         TranslatorInterface $translator,
         array $locales,
         FormChoiceProviderInterface $outOfStockTypeChoiceProvider,
-        RouterInterface $router
+        RouterInterface $router,
+        private ShopContext $shopContext
     ) {
         parent::__construct($translator, $locales);
         $this->outOfStockTypeChoiceProvider = $outOfStockTypeChoiceProvider;
@@ -63,6 +65,10 @@ class AvailabilityType extends TranslatorAwareType
                 'expanded' => true,
                 'column_breaker' => true,
                 'modify_all_shops' => true,
+                'help' => $this->shopContext->isMultiShopEnabled()
+                        && $this->shopContext->hasGroupSharingStocks() ?
+                        $this->trans('Stock is shared between the stores in this group, so this setting is automatically applied to all of them, regardless of the "Apply changes to all stores" checkbox.', 'Admin.Catalog.Feature') :
+                        null,
                 'external_link' => [
                     'text' => $this->trans('[1]Edit default behavior[/1]', 'Admin.Catalog.Feature'),
                     'href' => $this->router->generate('admin_product_preferences') . '#configuration_fieldset_stock',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR follows up on this comment: https://github.com/prestaShop/PrestaShop/pull/41923#issuecomment-4850925231.<br/><br/>When stock is shared between stores in the same shop group, the **“When out of stock”** setting is shared as well. As a result, selecting or clearing the **“Apply changes to all stores”** checkbox has no effect, which may be confusing for users.<br/>This PR adds a contextual help message to the combination availability form when shared stock is enabled. The message explains that the setting is automatically applied to all stores in the group, regardless of the checkbox state.
| Type?             | improvement
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable multistore and create at least two stores in the same shop group.<br/>2. Enable stock sharing for the shop group.<br/>3. Open the Back Office in the context of one of the stores.<br/>4. Edit a product without combinations.<br/>5. Go to its availability settings and check that the contextual help message is displayed near the **“When out of stock”** setting.<br/>6. Edit a product with combinations.<br/>7. Open one of its combinations, go to the availability section, and check that the same contextual help message is displayed near the **“When out of stock”** setting.<br/>8. In both forms, check that the message explains that the setting is shared between the stores in the group and that the **“Apply changes to all stores”** checkbox has no effect.<br/>9. Disable stock sharing for the shop group.<br/>10. Reload both forms and check that the contextual help message is no longer displayed.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/prestaShop/PrestaShop/pull/41923
| Sponsor company   | Codencode snc

---
The following screenshot shows how the contextual help message is displayed when stock sharing is enabled:

<img width="723" height="384" alt="Screenshot 2026-07-02 at 21-30-21 Product • Codencode" src="https://github.com/user-attachments/assets/a2bbb2d8-3b3e-4f6f-b114-132e087160a4" />
