### PR TITLE
Add shipment_total to actionDeliveryPriceByPrice hook

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -388,27 +388,27 @@ class CarrierCore extends ObjectModel
     /**
      * Get delivery price for a given order by total MINUS shipping costs.
      *
-     * @param float $total total to pay
+     * @param float $order_total Shipment or order total to pay
      * @param int $id_zone Zone id (for customer delivery address)
      * @param int|null $id_currency Currency ID
      *
      * @return float Maximum delivery price
      */
-    public function getDeliveryPriceByPrice($total, $id_zone, $id_currency = null)
+    public function getDeliveryPriceByPrice($order_total, $id_zone, $id_currency = null)
     {
         $id_carrier = (int) $this->id;
-        $cache_key = $this->id . '_' . $total . '_' . $id_zone . '_' . $id_currency;
+        $cache_key = $this->id . '_' . $order_total . '_' . $id_zone . '_' . $id_currency;
         if (!isset(self::$price_by_price[$cache_key])) {
             if (!empty($id_currency)) {
-                $price = Tools::convertPrice($total, $id_currency, false);
+                $order_total = Tools::convertPrice($order_total, $id_currency, false);
             }
 
             $sql = 'SELECT d.`price`
                     FROM `' . _DB_PREFIX_ . 'delivery` d
                     LEFT JOIN `' . _DB_PREFIX_ . 'range_price` r ON d.`id_range_price` = r.`id_range_price`
                     WHERE d.`id_zone` = ' . (int) $id_zone . '
-                        AND ' . (float) $total . ' >= r.`delimiter1`
-                        AND ' . (float) $total . ' < r.`delimiter2`
+                        AND ' . (float) $order_total . ' >= r.`delimiter1`
+                        AND ' . (float) $order_total . ' < r.`delimiter2`
                         AND d.`id_carrier` = ' . $id_carrier . '
                         ' . Carrier::sqlDeliveryRangeShop('range_price') . '
                     ORDER BY r.`delimiter1` ASC';
@@ -420,9 +420,8 @@ class CarrierCore extends ObjectModel
             }
         }
 
-        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $total, 'total' => $total, 'id_zone' => $id_zone]);
+        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $order_total, 'total' => $order_total, 'id_zone' => $id_zone]);
         if (is_numeric($price_by_price)) {
-            trigger_deprecation('prestashop/prestashop', '9.3', 'The `actionDeliveryPriceByPrice` hook `order_total` parameter will be changed to `total` starting from version 10.0.');
             self::$price_by_price[$cache_key] = $price_by_price;
         }
 
@@ -433,27 +432,27 @@ class CarrierCore extends ObjectModel
      * Check if the carrier is available for a given order total, currency and zone
      *
      * @param int $id_carrier Carrier ID
-     * @param float $total Order total to pay
+     * @param float $order_total Order total to pay
      * @param int $id_zone Zone id (for customer delivery address)
      * @param int|null $id_currency Currency ID
      *
      * @return bool true if carrier is available
      */
-    public static function checkDeliveryPriceByPrice($id_carrier, $total, $id_zone, $id_currency = null)
+    public static function checkDeliveryPriceByPrice($id_carrier, $order_total, $id_zone, $id_currency = null)
     {
         $id_carrier = (int) $id_carrier;
-        $cache_key = $id_carrier . '_' . $total . '_' . $id_zone . '_' . $id_currency;
+        $cache_key = $id_carrier . '_' . $order_total . '_' . $id_zone . '_' . $id_currency;
         if (!isset(self::$price_by_price2[$cache_key])) {
             if (!empty($id_currency)) {
-                $total = Tools::convertPrice($total, $id_currency, false);
+                $order_total = Tools::convertPrice($order_total, $id_currency, false);
             }
 
             $sql = 'SELECT d.`price`
                     FROM `' . _DB_PREFIX_ . 'delivery` d
                     LEFT JOIN `' . _DB_PREFIX_ . 'range_price` r ON d.`id_range_price` = r.`id_range_price`
                     WHERE d.`id_zone` = ' . (int) $id_zone . '
-                        AND ' . (float) $total . ' >= r.`delimiter1`
-                        AND ' . (float) $total . ' < r.`delimiter2`
+                        AND ' . (float) $order_total . ' >= r.`delimiter1`
+                        AND ' . (float) $order_total . ' < r.`delimiter2`
                         AND d.`id_carrier` = ' . $id_carrier . '
                         ' . Carrier::sqlDeliveryRangeShop('range_price') . '
                     ORDER BY r.`delimiter1` ASC';
@@ -461,10 +460,9 @@ class CarrierCore extends ObjectModel
             self::$price_by_price2[$cache_key] = (isset($result['price']));
         }
 
-        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $total, 'total' => $total, 'id_zone' => $id_zone]);
+        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $order_total, 'total' => $order_total, 'id_zone' => $id_zone]);
         if (is_numeric($price_by_price)) {
-            trigger_deprecation('prestashop/prestashop', '9.3', 'The `actionDeliveryPriceByPrice` hook `order_total` parameter will be changed to `total` starting from version 10.0.');
-            self::$price_by_price[$cache_key] = $price_by_price;
+            self::$price_by_price2[$cache_key] = true;
         }
 
         return self::$price_by_price2[$cache_key];

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -388,16 +388,17 @@ class CarrierCore extends ObjectModel
     /**
      * Get delivery price for a given order by total MINUS shipping costs.
      *
-     * @param float $order_total Shipment or order total to pay
+     * @param float $order_total Order total to pay
      * @param int $id_zone Zone id (for customer delivery address)
      * @param int|null $id_currency Currency ID
+     * @param float|null $shipmentTotal Total of the current shipment, sent to the actionDeliveryPriceByPrice hook when the improved_shipment feature is enabled, null otherwise (including for legacy orders predating this feature)
      *
      * @return float Maximum delivery price
      */
-    public function getDeliveryPriceByPrice($order_total, $id_zone, $id_currency = null)
+    public function getDeliveryPriceByPrice($order_total, $id_zone, $id_currency = null, $shipmentTotal = null)
     {
         $id_carrier = (int) $this->id;
-        $cache_key = $this->id . '_' . $order_total . '_' . $id_zone . '_' . $id_currency;
+        $cache_key = $this->id . '_' . $order_total . '_' . $id_zone . '_' . $id_currency . '_' . $shipmentTotal;
         if (!isset(self::$price_by_price[$cache_key])) {
             if (!empty($id_currency)) {
                 $order_total = Tools::convertPrice($order_total, $id_currency, false);
@@ -420,7 +421,12 @@ class CarrierCore extends ObjectModel
             }
         }
 
-        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $order_total, 'total' => $order_total, 'id_zone' => $id_zone]);
+        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', [
+            'id_carrier' => $id_carrier,
+            'order_total' => $order_total,
+            'shipment_total' => $shipmentTotal,
+            'id_zone' => $id_zone,
+        ]);
         if (is_numeric($price_by_price)) {
             self::$price_by_price[$cache_key] = $price_by_price;
         }
@@ -435,13 +441,14 @@ class CarrierCore extends ObjectModel
      * @param float $order_total Order total to pay
      * @param int $id_zone Zone id (for customer delivery address)
      * @param int|null $id_currency Currency ID
+     * @param float|null $shipmentTotal Total of the current shipment, sent to the actionDeliveryPriceByPrice hook when the improved_shipment feature is enabled, null otherwise (including for legacy orders predating this feature)
      *
      * @return bool true if carrier is available
      */
-    public static function checkDeliveryPriceByPrice($id_carrier, $order_total, $id_zone, $id_currency = null)
+    public static function checkDeliveryPriceByPrice($id_carrier, $order_total, $id_zone, $id_currency = null, $shipmentTotal = null)
     {
         $id_carrier = (int) $id_carrier;
-        $cache_key = $id_carrier . '_' . $order_total . '_' . $id_zone . '_' . $id_currency;
+        $cache_key = $id_carrier . '_' . $order_total . '_' . $id_zone . '_' . $id_currency . '_' . $shipmentTotal;
         if (!isset(self::$price_by_price2[$cache_key])) {
             if (!empty($id_currency)) {
                 $order_total = Tools::convertPrice($order_total, $id_currency, false);
@@ -460,7 +467,12 @@ class CarrierCore extends ObjectModel
             self::$price_by_price2[$cache_key] = (isset($result['price']));
         }
 
-        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $order_total, 'total' => $order_total, 'id_zone' => $id_zone]);
+        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', [
+            'id_carrier' => $id_carrier,
+            'order_total' => $order_total,
+            'shipment_total' => $shipmentTotal,
+            'id_zone' => $id_zone,
+        ]);
         if (is_numeric($price_by_price)) {
             self::$price_by_price2[$cache_key] = true;
         }

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -386,29 +386,29 @@ class CarrierCore extends ObjectModel
     }
 
     /**
-     * Get delivery price for a given order by total order price MINUS shipping costs.
+     * Get delivery price for a given order by total MINUS shipping costs.
      *
-     * @param float $order_total Order total to pay
+     * @param float $total total to pay
      * @param int $id_zone Zone id (for customer delivery address)
      * @param int|null $id_currency Currency ID
      *
      * @return float Maximum delivery price
      */
-    public function getDeliveryPriceByPrice($order_total, $id_zone, $id_currency = null)
+    public function getDeliveryPriceByPrice($total, $id_zone, $id_currency = null)
     {
         $id_carrier = (int) $this->id;
-        $cache_key = $this->id . '_' . $order_total . '_' . $id_zone . '_' . $id_currency;
+        $cache_key = $this->id . '_' . $total . '_' . $id_zone . '_' . $id_currency;
         if (!isset(self::$price_by_price[$cache_key])) {
             if (!empty($id_currency)) {
-                $order_total = Tools::convertPrice($order_total, $id_currency, false);
+                $price = Tools::convertPrice($total, $id_currency, false);
             }
 
             $sql = 'SELECT d.`price`
                     FROM `' . _DB_PREFIX_ . 'delivery` d
                     LEFT JOIN `' . _DB_PREFIX_ . 'range_price` r ON d.`id_range_price` = r.`id_range_price`
                     WHERE d.`id_zone` = ' . (int) $id_zone . '
-                        AND ' . (float) $order_total . ' >= r.`delimiter1`
-                        AND ' . (float) $order_total . ' < r.`delimiter2`
+                        AND ' . (float) $total . ' >= r.`delimiter1`
+                        AND ' . (float) $total . ' < r.`delimiter2`
                         AND d.`id_carrier` = ' . $id_carrier . '
                         ' . Carrier::sqlDeliveryRangeShop('range_price') . '
                     ORDER BY r.`delimiter1` ASC';
@@ -420,8 +420,9 @@ class CarrierCore extends ObjectModel
             }
         }
 
-        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $order_total, 'id_zone' => $id_zone]);
+        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $total, 'total' => $total, 'id_zone' => $id_zone]);
         if (is_numeric($price_by_price)) {
+            trigger_deprecation('prestashop/prestashop', '9.3', 'The `actionDeliveryPriceByPrice` hook `order_total` parameter will be changed to `total` starting from version 10.0.');
             self::$price_by_price[$cache_key] = $price_by_price;
         }
 
@@ -432,27 +433,27 @@ class CarrierCore extends ObjectModel
      * Check if the carrier is available for a given order total, currency and zone
      *
      * @param int $id_carrier Carrier ID
-     * @param float $order_total Order total to pay
+     * @param float $total Order total to pay
      * @param int $id_zone Zone id (for customer delivery address)
      * @param int|null $id_currency Currency ID
      *
      * @return bool true if carrier is available
      */
-    public static function checkDeliveryPriceByPrice($id_carrier, $order_total, $id_zone, $id_currency = null)
+    public static function checkDeliveryPriceByPrice($id_carrier, $total, $id_zone, $id_currency = null)
     {
         $id_carrier = (int) $id_carrier;
-        $cache_key = $id_carrier . '_' . $order_total . '_' . $id_zone . '_' . $id_currency;
+        $cache_key = $id_carrier . '_' . $total . '_' . $id_zone . '_' . $id_currency;
         if (!isset(self::$price_by_price2[$cache_key])) {
             if (!empty($id_currency)) {
-                $order_total = Tools::convertPrice($order_total, $id_currency, false);
+                $total = Tools::convertPrice($total, $id_currency, false);
             }
 
             $sql = 'SELECT d.`price`
                     FROM `' . _DB_PREFIX_ . 'delivery` d
                     LEFT JOIN `' . _DB_PREFIX_ . 'range_price` r ON d.`id_range_price` = r.`id_range_price`
                     WHERE d.`id_zone` = ' . (int) $id_zone . '
-                        AND ' . (float) $order_total . ' >= r.`delimiter1`
-                        AND ' . (float) $order_total . ' < r.`delimiter2`
+                        AND ' . (float) $total . ' >= r.`delimiter1`
+                        AND ' . (float) $total . ' < r.`delimiter2`
                         AND d.`id_carrier` = ' . $id_carrier . '
                         ' . Carrier::sqlDeliveryRangeShop('range_price') . '
                     ORDER BY r.`delimiter1` ASC';
@@ -460,9 +461,10 @@ class CarrierCore extends ObjectModel
             self::$price_by_price2[$cache_key] = (isset($result['price']));
         }
 
-        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $order_total, 'id_zone' => $id_zone]);
+        $price_by_price = Hook::exec('actionDeliveryPriceByPrice', ['id_carrier' => $id_carrier, 'order_total' => $total, 'total' => $total, 'id_zone' => $id_zone]);
         if (is_numeric($price_by_price)) {
-            self::$price_by_price2[$cache_key] = true;
+            trigger_deprecation('prestashop/prestashop', '9.3', 'The `actionDeliveryPriceByPrice` hook `order_total` parameter will be changed to `total` starting from version 10.0.');
+            self::$price_by_price[$cache_key] = $price_by_price;
         }
 
         return self::$price_by_price2[$cache_key];

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3705,7 +3705,7 @@ class CartCore extends ObjectModel
         $order_total = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $product_list, $id_carrier, false, $keepOrderPrices);
 
         // When the improved_shipment feature is enabled and this call is scoped to a specific shipment,
-        // $order_total above is actually the shipment's own total: keep it as $shipment_total and recompute
+        // $order_total above is actually the value of the shipment contents: keep it as $shipment_total and recompute
         // $order_total so it always reflects the whole order, as expected by the actionDeliveryPriceByPrice hook.
         $shipment_total = null;
         if (null !== $product_list) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3704,6 +3704,19 @@ class CartCore extends ObjectModel
         // Order total in default currency without fees
         $order_total = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $product_list, $id_carrier, false, $keepOrderPrices);
 
+        // When the improved_shipment feature is enabled and this call is scoped to a specific shipment,
+        // $order_total above is actually the shipment's own total: keep it as $shipment_total and recompute
+        // $order_total so it always reflects the whole order, as expected by the actionDeliveryPriceByPrice hook.
+        $shipment_total = null;
+        if (null !== $product_list) {
+            $containerFinder = new ContainerFinder(Context::getContext());
+            $featureFlagManager = $containerFinder->getContainer()->get(FeatureFlagStateCheckerInterface::class);
+            if ($featureFlagManager !== null && $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT)) {
+                $shipment_total = $order_total;
+                $order_total = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, null, $id_carrier, false, $keepOrderPrices);
+            }
+        }
+
         // Start with shipping cost at 0
         $shipping_cost = 0;
 
@@ -3795,7 +3808,7 @@ class CartCore extends ObjectModel
 
                     // If the carrier has price based shipping, remove the carrier if it does not have a compatible range
                     if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE
-                        && Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $order_total, (int) $id_zone, (int) $this->id_currency) === false) {
+                        && Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $order_total, (int) $id_zone, (int) $this->id_currency, $shipment_total) === false) {
                         continue;
                     }
                 }
@@ -3804,7 +3817,7 @@ class CartCore extends ObjectModel
                 if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT) {
                     $shipping = $carrier->getDeliveryPriceByWeight($this->getTotalWeight($product_list), (int) $id_zone);
                 } else {
-                    $shipping = $carrier->getDeliveryPriceByPrice($order_total, (int) $id_zone, (int) $this->id_currency);
+                    $shipping = $carrier->getDeliveryPriceByPrice($order_total, (int) $id_zone, (int) $this->id_currency, $shipment_total);
                 }
 
                 // And if it's the first carrier we check OR it's cheaper, we use the ID
@@ -3957,21 +3970,21 @@ class CartCore extends ObjectModel
         if ($carrier->range_behavior == OutOfRangeBehavior::DISABLED) {
             if (($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT && Carrier::checkDeliveryPriceByWeight($carrier->id, $this->getTotalWeight(), (int) $id_zone) === false)
                 || (
-                    $shipping_method == Carrier::SHIPPING_METHOD_PRICE && Carrier::checkDeliveryPriceByPrice($carrier->id, $order_total, $id_zone, (int) $this->id_currency) === false
+                    $shipping_method == Carrier::SHIPPING_METHOD_PRICE && Carrier::checkDeliveryPriceByPrice($carrier->id, $order_total, $id_zone, (int) $this->id_currency, $shipment_total) === false
                 )) {
                 $shipping_cost += 0;
             } else {
                 if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT) {
                     $shipping_cost += $carrier->getDeliveryPriceByWeight($this->getTotalWeight($product_list), $id_zone);
                 } else { // by price
-                    $shipping_cost += $carrier->getDeliveryPriceByPrice($order_total, $id_zone, (int) $this->id_currency);
+                    $shipping_cost += $carrier->getDeliveryPriceByPrice($order_total, $id_zone, (int) $this->id_currency, $shipment_total);
                 }
             }
         } else {
             if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT) {
                 $shipping_cost += $carrier->getDeliveryPriceByWeight($this->getTotalWeight($product_list), $id_zone);
             } else {
-                $shipping_cost += $carrier->getDeliveryPriceByPrice($order_total, $id_zone, (int) $this->id_currency);
+                $shipping_cost += $carrier->getDeliveryPriceByPrice($order_total, $id_zone, (int) $this->id_currency, $shipment_total);
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | see below
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | use 'actionDeliveryPriceByPrice' hook and see new param. The new param value is same with order_total
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/28664445883
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -

### What does this PR do?
 The `actionDeliveryPriceByPrice` hook now receives two distinct totals instead of one ambiguous value: `order_total`, which always carries the total of the whole order exactly as before (unchanged for legacy orders and when the `improved_shipment` feature is disabled), and a new `shipment_total`, which carries the total of the current shipment only. `shipment_total` is populated exclusively when the `improved_shipment` feature flag is enabled and the delivery price is being computed for a specific shipment; it stays `null` otherwise, including for legacy orders that predate the multi-shipment feature. This lets modules price a carrier based on either the whole order or the specific shipment being priced, without changing any existing behavior for stores not using the experimental feature.
 