### PR TITLE
Show an empty order status dropdown when the order has no status

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
@@ -37,14 +37,19 @@ class UpdateOrderStatusType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $hasCurrentStatus = !empty($options['data']['new_order_status_id']);
         $choiceProviderParams = [];
-        if (!empty($options['data']['new_order_status_id'])) {
+        if ($hasCurrentStatus) {
             $choiceProviderParams = ['current_state' => $options['data']['new_order_status_id']];
         }
         $builder
             ->add('new_order_status_id', ChoiceType::class, [
                 'required' => false,
-                'placeholder' => false,
+                // WHY: an order that has no current status (e.g. one left statusless by a failed
+                // creation) must show an empty dropdown, like the orders list does. Without a
+                // placeholder the ChoiceType would pre-select the first status. When the order has
+                // a status we keep placeholder=false so its current status stays selected.
+                'placeholder' => $hasCurrentStatus ? false : '',
                 'choices' => $this->statusChoiceProvider->getChoices($choiceProviderParams),
                 'choice_attr' => $this->statusChoiceAttributes,
                 'translation_domain' => false,

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusTypeTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Sell\Order;
+
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Sell\Order\UpdateOrderStatusType;
+use PrestaShopBundle\Form\Extension\AutoCompleteExtension;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class UpdateOrderStatusTypeTest extends TypeTestCase
+{
+    protected function getExtensions(): array
+    {
+        $statusChoiceProvider = $this->createMock(ConfigurableFormChoiceProviderInterface::class);
+        $statusChoiceProvider->method('getChoices')->willReturn([
+            'Awaiting payment' => 1,
+            'Payment accepted' => 2,
+        ]);
+
+        return [
+            new PreloadedExtension(
+                [new UpdateOrderStatusType($statusChoiceProvider, [])],
+                [ChoiceType::class => [new AutoCompleteExtension()]]
+            ),
+        ];
+    }
+
+    public function testItShowsAnEmptyOptionWhenTheOrderHasNoStatus(): void
+    {
+        $view = $this->factory
+            ->create(UpdateOrderStatusType::class, ['new_order_status_id' => 0])
+            ->createView();
+
+        // An empty placeholder makes the dropdown render an empty first option instead of
+        // pre-selecting the first status when the order has no current status.
+        $this->assertSame('', $view['new_order_status_id']->vars['placeholder']);
+    }
+
+    public function testItKeepsTheCurrentStatusSelectedWhenTheOrderHasOne(): void
+    {
+        $view = $this->factory
+            ->create(UpdateOrderStatusType::class, ['new_order_status_id' => 2])
+            ->createView();
+
+        // No placeholder (Symfony maps placeholder=false to null in the view), so the order's
+        // current status stays selected.
+        $this->assertNull($view['new_order_status_id']->vars['placeholder']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When an order has no status (for example an order left statusless by a failed creation), opening it in the back office pre-selects the **first** status in the "change status" dropdown, which misrepresents the order state. The orders list already shows the status empty in this case.<br><br>UpdateOrderStatusType builds the status ChoiceType with placeholder set to false, so when new_order_status_id is 0 (no current status) the select element has no empty option and the browser selects the first choice. This makes the dropdown default to an empty option when the order has no current status, so it renders empty as expected; when the order does have a status, behaviour is unchanged and that status stays selected.<br><br>This targets the reported display bug only. Whether a dedicated "payment failed" status should be created upstream when a payment module fails (as suggested in the issue) is a separate, larger change and is not addressed here.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create an order with no status (e.g. follow the reproduction in the issue: force an error during order creation from the front office so the order is saved without a history entry). Open that order in the back office. Before: the status dropdown is pre-selected with the first status in the list. After: the dropdown is empty, matching how the orders list shows it. Regression check: open an order that has a status and confirm its current status is still selected. Covered by tests/Unit/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusTypeTest.php.
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/29147848846
| Fixed issue or discussion?     | Fixes #32743
| Related PRs       |
| Sponsor company   |
