### PR TITLE
Paginate the customers grid by id first to avoid per-row sub-selects

### DIFF
--- a/src/Core/Grid/Query/CustomerQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerQueryBuilder.php
@@ -56,18 +56,45 @@ final class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        $searchQueryBuilder = $this->getCustomerQueryBuilder($searchCriteria)
+        // Resolve the page of customer ids first, then hydrate only those rows. The `total_spent`
+        // and `connect` columns are correlated sub-selects over the (potentially huge) orders and
+        // guest/connections tables; selecting them directly evaluates them for every matched
+        // customer before the LIMIT is applied. Paginating on the ids first keeps those sub-selects
+        // limited to the page that is actually displayed.
+        $paginatedCustomerIds = $this->getCustomerQueryBuilder($searchCriteria)
+            ->select('c.id_customer');
+
+        // total_spent and connect are computed columns, so expose them on the id query only when
+        // the grid is sorted by one of them, so its ORDER BY can reference the alias.
+        if ('total_spent' === $searchCriteria->getOrderBy()) {
+            $this->appendTotalSpentQuery($paginatedCustomerIds);
+        } elseif ('connect' === $searchCriteria->getOrderBy()) {
+            $this->appendLastVisitQuery($paginatedCustomerIds);
+        }
+
+        $this->applySorting($paginatedCustomerIds, $searchCriteria);
+        $this->criteriaApplicator
+            ->applyPagination($searchCriteria, $paginatedCustomerIds)
+            ->applyDeterministicSorting($searchCriteria, $paginatedCustomerIds, 'c', 'id_customer')
+        ;
+
+        $searchQueryBuilder = $this->connection->createQueryBuilder()
+            ->from('(' . $paginatedCustomerIds->getSQL() . ')', 'paginated')
+            ->innerJoin('paginated', $this->dbPrefix . 'customer', 'c', 'c.id_customer = paginated.id_customer')
             ->select('c.id_customer, c.firstname, c.lastname, c.email, c.active, c.newsletter, c.optin')
             ->addSelect('c.date_add, gl.name as social_title, grl.name as default_group, s.name as shop_name, c.company');
+        $this->applyJoins($searchQueryBuilder);
+
+        $searchQueryBuilder->setParameters(
+            $paginatedCustomerIds->getParameters(),
+            $paginatedCustomerIds->getParameterTypes()
+        );
 
         $this->appendTotalSpentQuery($searchQueryBuilder);
         $this->appendLastVisitQuery($searchQueryBuilder);
+        // Re-apply the sorting: the join to the paginated subquery does not preserve its order.
         $this->applySorting($searchQueryBuilder, $searchCriteria);
-
-        $this->criteriaApplicator
-            ->applyPagination($searchCriteria, $searchQueryBuilder)
-            ->applyDeterministicSorting($searchCriteria, $searchQueryBuilder, 'c', 'id_customer')
-        ;
+        $this->criteriaApplicator->applyDeterministicSorting($searchCriteria, $searchQueryBuilder, 'c', 'id_customer');
 
         return $searchQueryBuilder;
     }
@@ -92,6 +119,25 @@ final class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
     {
         $queryBuilder = $this->connection->createQueryBuilder()
             ->from($this->dbPrefix . 'customer', 'c')
+            ->where('c.deleted = 0')
+            ->andWhere('c.id_shop IN (:context_shop_ids)')
+            ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY)
+            ->setParameter('context_lang_id', $this->contextLangId);
+
+        $this->applyJoins($queryBuilder);
+        $this->applyFilters($searchCriteria->getFilters(), $queryBuilder);
+
+        return $queryBuilder;
+    }
+
+    /**
+     * Add the joins shared by the id and hydration queries (gender, default group and shop names).
+     *
+     * @param QueryBuilder $queryBuilder
+     */
+    private function applyJoins(QueryBuilder $queryBuilder)
+    {
+        $queryBuilder
             ->leftJoin(
                 'c',
                 $this->dbPrefix . 'gender_lang',
@@ -109,15 +155,7 @@ final class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->dbPrefix . 'shop',
                 's',
                 'c.id_shop = s.id_shop'
-            )
-            ->where('c.deleted = 0')
-            ->andWhere('c.id_shop IN (:context_shop_ids)')
-            ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY)
-            ->setParameter('context_lang_id', $this->contextLangId);
-
-        $this->applyFilters($searchCriteria->getFilters(), $queryBuilder);
-
-        return $queryBuilder;
+            );
     }
 
     /**

--- a/tests/Integration/Core/Grid/Query/CustomerQueryBuilderTest.php
+++ b/tests/Integration/Core/Grid/Query/CustomerQueryBuilderTest.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use PrestaShop\PrestaShop\Core\Grid\Query\CustomerQueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicator;
+use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Guards the id-first pagination of the customers grid: the query must keep returning the same
+ * customers, in the same order, with the same computed columns, and must not truncate the page.
+ */
+class CustomerQueryBuilderTest extends KernelTestCase
+{
+    private const PREFIX = 'ps_';
+    private const EMAIL_MARKER = 'qbtestpr_';
+
+    /** @var Connection */
+    private $connection;
+
+    /** @var CustomerQueryBuilder */
+    private $queryBuilder;
+
+    /** @var array<string, int> label => id_customer */
+    private $customerIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        $this->connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->queryBuilder = new CustomerQueryBuilder(
+            $this->connection,
+            self::PREFIX,
+            new DoctrineSearchCriteriaApplicator(),
+            1,
+            [1]
+        );
+        $this->seedCustomers();
+    }
+
+    protected function tearDown(): void
+    {
+        $ids = array_values($this->customerIds);
+        if (!empty($ids)) {
+            $this->connection->executeStatement(
+                'DELETE FROM ' . self::PREFIX . 'orders WHERE id_customer IN (' . implode(',', $ids) . ')'
+            );
+            $this->connection->executeStatement(
+                'DELETE FROM ' . self::PREFIX . 'customer WHERE id_customer IN (' . implode(',', $ids) . ')'
+            );
+        }
+        parent::tearDown();
+    }
+
+    public function testItReturnsSeededCustomersNewestFirstWithTheirTotalSpent(): void
+    {
+        $rows = $this->search(['orderBy' => 'date_add', 'sortOrder' => 'DESC']);
+
+        // Delta and Bravo have no valid orders; Alpha spent 150, Charlie spent 200.
+        $this->assertSame(
+            [
+                $this->customerIds['delta'],
+                $this->customerIds['charlie'],
+                $this->customerIds['bravo'],
+                $this->customerIds['alpha'],
+            ],
+            array_map(static fn (array $r): int => (int) $r['id_customer'], $rows)
+        );
+
+        $spentById = [];
+        foreach ($rows as $r) {
+            $spentById[(int) $r['id_customer']] = null === $r['total_spent'] ? null : (float) $r['total_spent'];
+        }
+        $this->assertSame(150.0, $spentById[$this->customerIds['alpha']]);
+        $this->assertSame(200.0, $spentById[$this->customerIds['charlie']]);
+        $this->assertNull($spentById[$this->customerIds['bravo']]);
+    }
+
+    public function testPaginationDoesNotTruncateResults(): void
+    {
+        $page1 = $this->search(['orderBy' => 'date_add', 'sortOrder' => 'DESC', 'limit' => 2, 'offset' => 0]);
+        $page2 = $this->search(['orderBy' => 'date_add', 'sortOrder' => 'DESC', 'limit' => 2, 'offset' => 2]);
+
+        $this->assertCount(2, $page1);
+        $this->assertCount(2, $page2);
+
+        $seen = array_map(static fn (array $r): int => (int) $r['id_customer'], array_merge($page1, $page2));
+        sort($seen);
+        $expected = array_values($this->customerIds);
+        sort($expected);
+        $this->assertSame($expected, $seen);
+    }
+
+    public function testItCanSortByTheComputedTotalSpentColumn(): void
+    {
+        $rows = $this->search(['orderBy' => 'total_spent', 'sortOrder' => 'DESC']);
+        $ordered = array_map(static fn (array $r): int => (int) $r['id_customer'], $rows);
+
+        // Charlie (200) before Alpha (150); both before the customers with no spend.
+        $this->assertSame($this->customerIds['charlie'], $ordered[0]);
+        $this->assertSame($this->customerIds['alpha'], $ordered[1]);
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function search(array $criteria): array
+    {
+        $criteria += ['limit' => 50, 'offset' => 0, 'filters' => ['email' => self::EMAIL_MARKER]];
+
+        return $this->queryBuilder
+            ->getSearchQueryBuilder(new CustomerFilters($criteria))
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+
+    private function seedCustomers(): void
+    {
+        $customers = [
+            'alpha' => '2020-01-01 00:00:00',
+            'bravo' => '2020-06-01 00:00:00',
+            'charlie' => '2021-01-01 00:00:00',
+            'delta' => '2021-06-01 00:00:00',
+        ];
+        foreach ($customers as $label => $dateAdd) {
+            $this->connection->insert(self::PREFIX . 'customer', [
+                'id_shop' => 1,
+                'id_shop_group' => 1,
+                'id_gender' => 1,
+                'id_default_group' => 3,
+                'id_lang' => 1,
+                'firstname' => ucfirst($label),
+                'lastname' => 'QBTESTPR',
+                'email' => self::EMAIL_MARKER . $label . '@example.com',
+                'passwd' => 'x',
+                'date_add' => $dateAdd,
+                'date_upd' => $dateAdd,
+                'newsletter' => 0,
+                'optin' => 0,
+                'active' => 1,
+                'deleted' => 0,
+                'secure_key' => md5($label),
+            ]);
+            $this->customerIds[$label] = (int) $this->connection->lastInsertId();
+        }
+
+        // Alpha: 100 + 50 = 150 (valid). Charlie: 200 (valid). One invalid order must be ignored.
+        $this->seedValidOrder($this->customerIds['alpha'], 100);
+        $this->seedValidOrder($this->customerIds['alpha'], 50);
+        $this->seedValidOrder($this->customerIds['charlie'], 200);
+        $this->seedOrder($this->customerIds['bravo'], 999, false);
+    }
+
+    private function seedValidOrder(int $customerId, float $total): void
+    {
+        $this->seedOrder($customerId, $total, true);
+    }
+
+    private function seedOrder(int $customerId, float $total, bool $valid): void
+    {
+        $this->connection->insert(self::PREFIX . 'orders', [
+            'id_customer' => $customerId,
+            'id_shop' => 1,
+            'id_shop_group' => 1,
+            'id_cart' => 0,
+            'id_currency' => 1,
+            'id_lang' => 1,
+            'id_carrier' => 1,
+            'id_address_delivery' => 0,
+            'id_address_invoice' => 0,
+            'current_state' => 2,
+            'valid' => $valid ? 1 : 0,
+            'total_paid_tax_incl' => $total,
+            'total_paid' => $total,
+            'total_paid_real' => $total,
+            'conversion_rate' => 1,
+            'payment' => 'Test',
+            'module' => 'test',
+            'secure_key' => 'k',
+            'invoice_date' => '2020-01-01 00:00:00',
+            'delivery_date' => '2020-01-01 00:00:00',
+            'date_add' => '2020-01-01 00:00:00',
+            'date_upd' => '2020-01-01 00:00:00',
+        ]);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The customers grid builds `total_spent` (a `SUM` over `orders` per customer) and `connect` (the last visit, over `guest` + `connections` per customer) as correlated sub-selects in the `SELECT` list. Because the grid is ordered and then paginated, those sub-selects are evaluated for **every matched customer before the `LIMIT`**, so on a shop with many customers and orders the grid gets slow — roughly *(matched customers) x (per-customer sub-select cost)*, over two large tables.<br><br>This applies the same id-first pagination that #41932 introduced for the orders grid: resolve the page of `id_customer` first (filters, sort and `LIMIT`, no per-row sub-selects), then hydrate the display columns and the two sub-selects for just the customers on the page. The sub-selects therefore run for the page size (e.g. 50 rows) instead of the whole matched set.<br><br>Behaviour is unchanged. `total_spent` and `connect` remain sortable: when the grid is ordered by one of them, that sub-select is added to the id query's `ORDER BY` only (so those sorts are unaffected, while every other sort — the default `date_add`, name, email, group, etc. — gets the full benefit). I verified equivalence by running the new query and the previous one against the same seeded data across the default sort, sort-by-`total_spent`, sort-by-email, pagination (page 2) and an active filter: identical rows, order and computed values in every case.<br><br>The same structural pattern exists in a couple of other grids (flagged on #41932). If a shared helper would be preferred over per-grid changes, I am happy to extract one as a follow-up.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with a large `customer` and `orders` volume, open Sell > Customers and compare the query cost before/after (e.g. via the profiler or `EXPLAIN` on the grid's SQL): the `total_spent` / `connect` sub-selects now run only for the visible page. Functionally, the grid must be unchanged — same customers, order, `total_spent` and last-visit values, working pagination and filters, including sorting by "Sales" (`total_spent`) and "Last visit" (`connect`). Covered by `tests/Integration/Core/Grid/Query/CustomerQueryBuilderTest.php` (default order + total_spent, pagination not truncated, sort by the computed total_spent column).
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     |
| Related PRs       | #41932 (same id-first pagination applied to the orders grid)
| Sponsor company   |

