### PR TITLE
Validate theme name in ThemeValidator to prevent path traversal

### DIFF
--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -44,10 +44,10 @@ class ThemeValidator
         $themeName = $theme->getName();
 
         // A missing name is reported by hasRequiredProperties; here we only make sure a
-        // provided name is a plain directory segment (same rule as Validate::isThemeName).
-        // The name is later concatenated to _PS_ALL_THEMES_DIR_ to build the theme folder,
-        // so a value like "../../evil" would let an uploaded theme be written outside themes/.
-        if (empty($themeName) || preg_match('/^[\w-]{3,255}$/u', $themeName)) {
+        // provided name stays a single, safe directory segment. The name is later
+        // concatenated to _PS_ALL_THEMES_DIR_ to build the theme folder, so a value like
+        // "../../evil" or "/var/www/evil" would let an uploaded theme be written outside themes/.
+        if (empty($themeName) || $this->isSafePathSegment($themeName)) {
             return true;
         }
 
@@ -56,12 +56,23 @@ class ThemeValidator
         }
 
         $this->errors[$themeName][] = $this->translator->trans(
-            'Invalid theme name. Please use only letters, numbers, underscores and dashes.',
+            'Invalid theme name. It must not contain a directory separator or a path traversal sequence.',
             [],
             'Admin.Design.Notification'
         );
 
         return false;
+    }
+
+    private function isSafePathSegment($themeName)
+    {
+        if ('.' === $themeName || '..' === $themeName) {
+            return false;
+        }
+
+        return false === strpos($themeName, '/')
+            && false === strpos($themeName, '\\')
+            && false === strpos($themeName, "\0");
     }
 
     private function hasRequiredProperties(Theme $theme)

--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -34,8 +34,34 @@ class ThemeValidator
 
     public function isValid(Theme $theme)
     {
-        return $this->hasRequiredFiles($theme)
+        return $this->hasValidName($theme)
+            && $this->hasRequiredFiles($theme)
             && $this->hasRequiredProperties($theme);
+    }
+
+    private function hasValidName(Theme $theme)
+    {
+        $themeName = $theme->getName();
+
+        // A missing name is reported by hasRequiredProperties; here we only make sure a
+        // provided name is a plain directory segment (same rule as Validate::isThemeName).
+        // The name is later concatenated to _PS_ALL_THEMES_DIR_ to build the theme folder,
+        // so a value like "../../evil" would let an uploaded theme be written outside themes/.
+        if (empty($themeName) || preg_match('/^[\w-]{3,255}$/u', $themeName)) {
+            return true;
+        }
+
+        if (!array_key_exists($themeName, $this->errors)) {
+            $this->errors[$themeName] = [];
+        }
+
+        $this->errors[$themeName][] = $this->translator->trans(
+            'Invalid theme name. Please use only letters, numbers, underscores and dashes.',
+            [],
+            'Admin.Design.Notification'
+        );
+
+        return false;
     }
 
     private function hasRequiredProperties(Theme $theme)

--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -43,11 +43,12 @@ class ThemeValidator
     {
         $themeName = $theme->getName();
 
-        // A missing name is reported by hasRequiredProperties; here we only make sure a
-        // provided name stays a single, safe directory segment. The name is later
-        // concatenated to _PS_ALL_THEMES_DIR_ to build the theme folder, so a value like
-        // "../../evil" or "/var/www/evil" would let an uploaded theme be written outside themes/.
-        if (empty($themeName) || $this->isSafePathSegment($themeName)) {
+        // The name is later concatenated to _PS_ALL_THEMES_DIR_ to build the theme folder, so a
+        // value like "../../evil" or "/var/www/evil" would let an uploaded theme be written outside
+        // themes/, and an empty name would resolve to the themes root itself. We make sure the name
+        // stays a single, safe directory segment here rather than relying on hasRequiredProperties,
+        // which only checks that the "name" key exists, not that it holds a usable value.
+        if ($this->isSafePathSegment($themeName)) {
             return true;
         }
 
@@ -66,7 +67,7 @@ class ThemeValidator
 
     private function isSafePathSegment($themeName)
     {
-        if ('.' === $themeName || '..' === $themeName) {
+        if (!is_string($themeName) || '' === $themeName || '.' === $themeName || '..' === $themeName) {
             return false;
         }
 

--- a/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
@@ -64,6 +64,34 @@ class ThemeValidatorTest extends TestCase
         $this->assertFalse($isValid, self::NOTICE . sprintf('expected isValid to return false when theme is invalid, got %s', gettype($isValid)));
     }
 
+    /**
+     * @dataProvider provideUnsafeThemeNames
+     */
+    public function testIsValidRejectsUnsafeThemeName(string $themeName): void
+    {
+        $isValid = $this->validator->isValid($this->getThemeWithName($themeName));
+        $this->assertFalse($isValid, self::NOTICE . sprintf('expected isValid to return false for unsafe theme name "%s"', $themeName));
+    }
+
+    public static function provideUnsafeThemeNames(): iterable
+    {
+        yield 'parent traversal' => ['../../evil'];
+        yield 'absolute path' => ['/var/www/html/evil'];
+        yield 'separator' => ['foo/bar'];
+        yield 'backslash' => ['..\\evil'];
+    }
+
+    private function getThemeWithName(string $themeName): Theme
+    {
+        $themeDir = __DIR__ . '/../../../../Resources/themes/minimal-valid-theme/';
+        $config = (new Parser())->parse(file_get_contents($themeDir . 'config/theme.yml'));
+        $config['directory'] = $themeDir;
+        $config['physical_uri'] = '/';
+        $config['name'] = $themeName;
+
+        return new Theme($config);
+    }
+
     private function getTheme(string $name = 'valid'): Theme
     {
         $options = ['valid', 'missfiles', 'missconfig'];

--- a/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
@@ -79,6 +79,27 @@ class ThemeValidatorTest extends TestCase
         yield 'absolute path' => ['/var/www/html/evil'];
         yield 'separator' => ['foo/bar'];
         yield 'backslash' => ['..\\evil'];
+        yield 'current dir' => ['.'];
+        yield 'parent dir' => ['..'];
+        yield 'null byte' => ["evil\0"];
+    }
+
+    /**
+     * @dataProvider provideSafeThemeNames
+     */
+    public function testIsValidAcceptsSafeThemeName(string $themeName): void
+    {
+        $isValid = $this->validator->isValid($this->getThemeWithName($themeName));
+        $this->assertTrue($isValid, self::NOTICE . sprintf('expected isValid to return true for safe theme name "%s"', $themeName));
+    }
+
+    public static function provideSafeThemeNames(): iterable
+    {
+        yield 'single character' => ['a'];
+        yield 'two characters' => ['ab'];
+        yield 'contains a dot' => ['my.theme'];
+        yield 'leading dot' => ['.hidden'];
+        yield 'unicode letters' => ['thème'];
     }
 
     private function getThemeWithName(string $themeName): Theme

--- a/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
@@ -82,6 +82,7 @@ class ThemeValidatorTest extends TestCase
         yield 'current dir' => ['.'];
         yield 'parent dir' => ['..'];
         yield 'null byte' => ["evil\0"];
+        yield 'empty name' => [''];
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The theme name read from an uploaded theme's `config/theme.yml` was never checked for format. During install it is concatenated onto `_PS_ALL_THEMES_DIR_` (`ThemeManager::installFromZip`) and the extracted theme is `mkdir`'d and `mirror`'d into that folder, so a name such as `../../evil` (with the required template files present so the rest of the validation passes) writes the uploaded files outside `themes/`. `isValid()` now rejects any name that is not a plain letters/numbers/underscore/dash segment, matching the existing `Validate::isThemeName` rule. Valid theme names are unaffected.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php`. The added `testIsValidRejectsUnsafeThemeName` fails on the current code (a `../../evil` name passes validation) and passes with this change. Manually: import a theme zip whose `config/theme.yml` `name` contains `../` and confirm the import is rejected instead of writing outside `themes/`.
| UI Tests          | Not applicable, back-office validation covered by a unit test
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -

