### PR TITLE
Reassign per-shop default carrier when a carrier is re-versioned

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -1016,11 +1016,6 @@ class CarrierCore extends ObjectModel
     }
 
     /**
-     * Copy old carrier informations when update carrier.
-     *
-     * @param int $old_id Old id carrier (copy from that id)
-     */
-    /**
      * Reassigns every configuration scope whose default carrier is $oldCarrierId to $newCarrierId.
      *
      * Editing a carrier re-versions it (a new carrier id replaces the old one), so a per-shop or
@@ -1049,6 +1044,11 @@ class CarrierCore extends ObjectModel
         }
     }
 
+    /**
+     * Copy old carrier informations when update carrier.
+     *
+     * @param int $old_id Old id carrier (copy from that id)
+     */
     public function copyCarrierData($old_id)
     {
         if (!Validate::isUnsignedId($old_id)) {

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -1020,6 +1020,35 @@ class CarrierCore extends ObjectModel
      *
      * @param int $old_id Old id carrier (copy from that id)
      */
+    /**
+     * Reassigns every configuration scope whose default carrier is $oldCarrierId to $newCarrierId.
+     *
+     * Editing a carrier re-versions it (a new carrier id replaces the old one), so a per-shop or
+     * per-group PS_CARRIER_DEFAULT must follow to the new id — otherwise that scope is left
+     * pointing at a carrier id that no longer exists. Only updating the current context's default
+     * (the previous behaviour) missed those scoped overrides.
+     *
+     * @param int $oldCarrierId
+     * @param int $newCarrierId
+     */
+    public static function reassignDefaultCarrier($oldCarrierId, $newCarrierId)
+    {
+        $scopes = Db::getInstance()->executeS('
+            SELECT `id_shop_group`, `id_shop`
+            FROM `' . _DB_PREFIX_ . 'configuration`
+            WHERE `name` = "PS_CARRIER_DEFAULT" AND `value` = ' . (int) $oldCarrierId);
+
+        foreach ($scopes as $scope) {
+            Configuration::updateValue(
+                'PS_CARRIER_DEFAULT',
+                (int) $newCarrierId,
+                false,
+                isset($scope['id_shop_group']) ? (int) $scope['id_shop_group'] : null,
+                isset($scope['id_shop']) ? (int) $scope['id_shop'] : null
+            );
+        }
+    }
+
     public function copyCarrierData($old_id)
     {
         if (!Validate::isUnsignedId($old_id)) {
@@ -1084,9 +1113,7 @@ class CarrierCore extends ObjectModel
         }
 
         // Copy default carrier
-        if (Configuration::get('PS_CARRIER_DEFAULT') == $old_id) {
-            Configuration::updateValue('PS_CARRIER_DEFAULT', (int) $this->id);
-        }
+        Carrier::reassignDefaultCarrier((int) $old_id, (int) $this->id);
 
         // Copy reference
         $id_reference = Db::getInstance()->getValue('

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -793,9 +793,7 @@ class AdminCarrierWizardControllerCore extends AdminController
                     $this->changeGroups((int) $new_carrier->id);
 
                     // Copy default carrier
-                    if (Configuration::get('PS_CARRIER_DEFAULT') == $current_carrier->id) {
-                        Configuration::updateValue('PS_CARRIER_DEFAULT', (int) $new_carrier->id);
-                    }
+                    Carrier::reassignDefaultCarrier((int) $current_carrier->id, (int) $new_carrier->id);
 
                     // Call of hooks
                     Hook::exec('actionCarrierUpdate', [

--- a/tests/Integration/Classes/CarrierReversionPerShopDefaultTest.php
+++ b/tests/Integration/Classes/CarrierReversionPerShopDefaultTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Carrier;
+use Configuration as LegacyConfiguration;
+use Db;
+use Shop as LegacyShop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class CarrierReversionPerShopDefaultTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['shop', 'shop_group', 'carrier', 'carrier_shop', 'carrier_lang', 'configuration'];
+
+    private static int $secondShopId;
+    private static int $oldCarrierId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        $configuration = self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        $db = Db::getInstance();
+        $db->insert('shop_group', [
+            'name' => 'test_group_carrier', 'color' => '', 'share_customer' => 0,
+            'share_order' => 0, 'share_stock' => 0, 'active' => 1, 'deleted' => 0,
+        ]);
+        $secondGroupId = (int) $db->Insert_ID();
+        $db->insert('shop', [
+            'id_shop_group' => $secondGroupId, 'name' => 'test_shop_carrier', 'color' => '',
+            'id_category' => 2, 'theme_name' => 'classic', 'active' => 1, 'deleted' => 0,
+        ]);
+        self::$secondShopId = (int) $db->Insert_ID();
+        LegacyShop::resetStaticCache();
+
+        self::$oldCarrierId = self::insertCarrier('Old carrier');
+
+        // Global default stays carrier 1; the second shop overrides it to the carrier we will re-version.
+        LegacyConfiguration::updateValue('PS_CARRIER_DEFAULT', 1);
+        LegacyConfiguration::updateValue('PS_CARRIER_DEFAULT', self::$oldCarrierId, false, null, self::$secondShopId);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    /**
+     * Re-versioning a carrier must move every scope's PS_CARRIER_DEFAULT to the new carrier id.
+     * Only the current context's default was updated, so a per-shop override was left pointing at
+     * the old carrier id, which no longer exists after the re-version.
+     */
+    public function testReversionReassignsPerShopDefaultCarrier(): void
+    {
+        self::bootKernel();
+        LegacyConfiguration::resetStaticCache();
+
+        // Sanity: the second shop's default is the old carrier before the re-version.
+        self::assertSame(
+            self::$oldCarrierId,
+            (int) LegacyConfiguration::get('PS_CARRIER_DEFAULT', null, null, self::$secondShopId)
+        );
+
+        $newCarrierId = self::insertCarrier('New carrier');
+        $newCarrier = new Carrier($newCarrierId);
+        $newCarrier->copyCarrierData(self::$oldCarrierId);
+
+        LegacyConfiguration::resetStaticCache();
+        self::assertSame(
+            $newCarrierId,
+            (int) LegacyConfiguration::get('PS_CARRIER_DEFAULT', null, null, self::$secondShopId),
+            'the second shop default carrier must follow the re-version to the new id'
+        );
+    }
+
+    private static function insertCarrier(string $name): int
+    {
+        $db = Db::getInstance();
+        $db->insert('carrier', [
+            'id_reference' => 0, 'name' => $name, 'active' => 1, 'deleted' => 0,
+            'is_module' => 0, 'need_range' => 0, 'shipping_external' => 0, 'external_module_name' => '',
+            'shipping_handling' => 1, 'range_behavior' => 0, 'shipping_method' => 0,
+            'max_width' => 0, 'max_height' => 0, 'max_depth' => 0, 'max_weight' => 0, 'grade' => 0,
+            'url' => '', 'position' => 0,
+        ]);
+        $carrierId = (int) $db->Insert_ID();
+        $db->execute('UPDATE `' . _DB_PREFIX_ . 'carrier` SET id_reference = ' . $carrierId . ' WHERE id_carrier = ' . $carrierId);
+        $db->insert('carrier_shop', ['id_carrier' => $carrierId, 'id_shop' => 1]);
+        $db->insert('carrier_shop', ['id_carrier' => $carrierId, 'id_shop' => self::$secondShopId]);
+
+        return $carrierId;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Editing a carrier re-versions it: a new carrier id replaces the old one and the data is copied over (`Carrier::copyCarrierData()`, and the equivalent inline block in `AdminCarrierWizardController`). Both moved the default carrier to the new id with `if (Configuration::get('PS_CARRIER_DEFAULT') == $old_id) { Configuration::updateValue('PS_CARRIER_DEFAULT', $new_id); }`, which only reads and writes the **current context's** default.<br><br>In multistore, `PS_CARRIER_DEFAULT` can be overridden per shop (and per shop group). When a shop's default carrier is re-versioned, its per-shop override is left pointing at the old carrier id, which no longer exists after the re-version. This is the same class of bug as #41900 (per-shop default currency on delete).<br><br>The fix adds `Carrier::reassignDefaultCarrier($oldId, $newId)`, which updates every configuration scope (global, group or shop) whose `PS_CARRIER_DEFAULT` points at the old carrier, and both call sites use it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In a multistore install, set a second shop's default carrier (Shipping > Preferences, in that shop's context) to a carrier, then edit that carrier (which re-versions it). Before: the second shop's default carrier is now empty/invalid (it still points at the old carrier id). After: the second shop's default carrier follows the edit to the new carrier. Covered by `tests/Integration/Classes/CarrierReversionPerShopDefaultTest.php` (a per-shop default carrier is re-versioned and must move to the new id — fails on the previous code, passes with the fix).
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41955
| Related PRs       | #41900 (same fix for the per-shop default currency on delete)
| Sponsor company   |

