### PR TITLE
Hoist order-constant loads out of the order product line loops

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -642,6 +642,9 @@ class OrderCore extends ObjectModel
         }
 
         $result_array = [];
+        // Resolve the order-constant reduction context once instead of reloading the customer per line.
+        $reductionCountryId = (int) Address::initialize($this->id_address_delivery, true)->id_country;
+        $reductionCustomerGroupId = (int) (new Customer($this->id_customer))->id_default_group;
         foreach ($products as $row) {
             // Change qty if selected
             if ($selected_qty) {
@@ -660,7 +663,7 @@ class OrderCore extends ObjectModel
 
             $this->setProductImageInformations($row);
             $this->setProductCurrentStock($row);
-            $row = $this->setProductReduction($row);
+            $row = $this->setProductReduction($row, $reductionCountryId, $reductionCustomerGroupId);
 
             // Backward compatibility 1.4 -> 1.5
             $this->setProductPrices($row);
@@ -688,16 +691,21 @@ class OrderCore extends ObjectModel
      *
      * @return array
      */
-    protected function setProductReduction(array $product): array
+    protected function setProductReduction(array $product, ?int $idCountry = null, ?int $customerGroupId = null): array
     {
-        $address = Address::initialize($this->id_address_delivery, true);
-        $id_country = (int) $address->id_country;
-        $customerGroupId = (int) (new Customer($this->id_customer))->id_default_group;
+        // Both values are constant for the whole order, so getProducts() resolves them once and
+        // passes them in; only fall back to loading them here for direct/legacy callers.
+        if (null === $idCountry) {
+            $idCountry = (int) Address::initialize($this->id_address_delivery, true)->id_country;
+        }
+        if (null === $customerGroupId) {
+            $customerGroupId = (int) (new Customer($this->id_customer))->id_default_group;
+        }
         $specific_price = SpecificPrice::getSpecificPrice(
             $product['product_id'],
             $product['id_shop'],
             $this->id_currency,
-            $id_country,
+            $idCountry,
             $customerGroupId,
             $product['product_quantity'],
             $product['product_attribute_id']

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -140,6 +140,8 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
         $productsForViewing = [];
 
         $isOrderTaxExcluded = ($taxCalculationMethod == PS_TAX_EXC);
+        // The shipments belong to the order, not to a product line, so resolve them once.
+        $shipments = $this->shipmentRepository->findByOrderId($order->id);
         foreach ($products as $product) {
             $unitPrice = $isOrderTaxExcluded ?
                 $product['unit_price_tax_excl'] :
@@ -166,7 +168,6 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 OrderProductForViewing::TYPE_PRODUCT_WITHOUT_COMBINATIONS;
 
             $orderInvoice = new OrderInvoice($product['id_order_invoice']);
-            $shipments = $this->shipmentRepository->findByOrderId($order->id);
             $shipmentIds = [];
 
             if ($shipments) {

--- a/tests/Integration/Classes/OrderGetProductsHoistTest.php
+++ b/tests/Integration/Classes/OrderGetProductsHoistTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Context;
+use Currency;
+use Db;
+use Order;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Validate;
+
+/**
+ * Order::getProducts() resolves the delivery country and the customer default group once and passes
+ * them to setProductReduction() instead of reloading the customer per product line. This guards that
+ * the per-line reduction data is unchanged by that hoist.
+ */
+class OrderGetProductsHoistTest extends KernelTestCase
+{
+    public function testGetProductsReturnsConsistentReductionDataForEveryLine(): void
+    {
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+
+        $orderId = (int) Db::getInstance()->getValue(
+            'SELECT id_order FROM ' . _DB_PREFIX_ . 'order_detail ORDER BY id_order'
+        );
+        self::assertGreaterThan(0, $orderId, 'a demo order with at least one product line is required');
+
+        $order = new Order($orderId);
+        self::assertTrue(Validate::isLoadedObject($order));
+        Context::getContext()->currency = new Currency((int) $order->id_currency);
+
+        $products = $order->getProducts();
+        self::assertNotEmpty($products);
+
+        foreach ($products as $product) {
+            self::assertArrayHasKey('reduction_type', $product);
+            self::assertArrayHasKey('reduction_applies', $product);
+            // setProductReduction() sets a default (0 / false) when no specific price matches, or the
+            // specific price values otherwise ('percentage'|'amount' + the reduction). The hoist must
+            // not change what these resolve to.
+            self::assertTrue(
+                0 === $product['reduction_type'] || in_array($product['reduction_type'], ['percentage', 'amount'], true),
+                'unexpected reduction_type: ' . var_export($product['reduction_type'], true)
+            );
+            self::assertTrue(
+                false === $product['reduction_applies'] || is_numeric($product['reduction_applies'])
+            );
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Two order-read loops recompute the same order-constant value on every product line. On an order with N lines this is N-1 redundant loads (worse the bigger the order):<br><br>1. `Order::getProducts()` — `setProductReduction()` runs `new Customer($this->id_customer)` for **every** product line only to read the order's (constant) default customer group. The delivery address is already cached, but the customer is reloaded uncached each line. Now the delivery country and the customer default group are resolved once before the loop and passed in; `setProductReduction()` keeps the same behaviour and falls back to loading them itself for any direct caller (new parameters are optional, so no signature break).<br>2. `GetOrderProductsForViewingHandler` — `$this->shipmentRepository->findByOrderId($order->id)` was called inside the product-line loop, even though the shipments belong to the order, not the line (Doctrine re-runs the query each iteration; the identity map only short-circuits `find()` by primary key). Hoisted above the loop.<br><br>Both are pure loop-invariant hoists: the value passed in is identical to what each iteration computed, so the output is unchanged.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open an order with several product lines in the back office (and via the order confirmation email / invoice which also call `Order::getProducts()`). The products, prices and reductions must be identical to before. `tests/Integration/Classes/OrderGetProductsHoistTest.php` loads a real order and asserts every line's reduction data (including a line with a specific price) is still resolved correctly. The win is fewer queries/objects per line: the customer is loaded once instead of once per line, and the shipments query runs once instead of once per line.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     |
| Related PRs       |
| Sponsor company   |

