### PR TITLE
Prefetch listing product images in one query instead of per product

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -3,6 +3,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\FacetsRendererInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\Pagination;
@@ -90,6 +91,12 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
     {
         // Enrich data set of products
         $products = (new ProductAssembler($this->context))->assembleProducts($products);
+
+        // Prefetch every product's images in one query instead of once per product during presentation.
+        $productIds = array_map(static function (array $product): int {
+            return (int) $product['id_product'];
+        }, $products);
+        (new ImageRetriever($this->context->link))->prefetchImagesForProducts($productIds, (int) $this->context->language->id);
 
         // Prepare configuration
         $presenter = $this->getProductPresenter();

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -7,7 +7,10 @@
 namespace PrestaShop\PrestaShop\Adapter\Image;
 
 use Category;
+use Combination;
 use Configuration;
+use Context;
+use Db;
 use Image;
 use ImageManager;
 use ImageType;
@@ -19,6 +22,7 @@ use PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration;
 use PrestaShopDatabaseException;
 use PrestaShopException;
 use Product;
+use Shop;
 use Store;
 use Supplier;
 
@@ -32,9 +36,96 @@ class ImageRetriever
      */
     private $link;
 
+    /**
+     * Request-scoped prefetch of Product::getImages() rows, keyed by "id_product-id_lang-id_shop".
+     *
+     * @var array<string, array>
+     */
+    private static $prefetchedProductImages = [];
+
+    /**
+     * Request-scoped prefetch of Product::getCombinationImages() results (false = no combination images).
+     *
+     * @var array<string, array|false>
+     */
+    private static $prefetchedCombinationImages = [];
+
     public function __construct(Link $link)
     {
         $this->link = $link;
+    }
+
+    /**
+     * Prefetches the images of a whole set of products (e.g. a listing page) in one query per table,
+     * so getAllProductImages() does not run getImages()/getCombinationImages() once per product. The
+     * result is stored request-scoped and consumed by getAllProductImages().
+     *
+     * @param int[] $productIds
+     * @param int $idLang
+     */
+    public function prefetchImagesForProducts(array $productIds, int $idLang): void
+    {
+        $idShop = (int) Context::getContext()->shop->id;
+
+        $toFetch = [];
+        foreach (array_unique(array_map('intval', $productIds)) as $idProduct) {
+            if ($idProduct > 0 && !isset(self::$prefetchedProductImages[self::prefetchKey($idProduct, $idLang, $idShop)])) {
+                $toFetch[] = $idProduct;
+            }
+        }
+        if (empty($toFetch)) {
+            return;
+        }
+
+        // Mark every requested product as prefetched up front, so a product with no image keeps an
+        // empty set (and is not re-queried one by one) rather than looking "not prefetched".
+        foreach ($toFetch as $idProduct) {
+            self::$prefetchedProductImages[self::prefetchKey($idProduct, $idLang, $idShop)] = [];
+            self::$prefetchedCombinationImages[self::prefetchKey($idProduct, $idLang, $idShop)] = false;
+        }
+
+        $idList = implode(',', $toFetch);
+
+        // Same columns and shop scoping as Product::getImages(), batched by id_product.
+        $imageRows = Db::getInstance()->executeS('
+            SELECT i.`id_product`, image_shop.`cover`, i.`id_image`, il.`legend`, i.`position`
+            FROM `' . _DB_PREFIX_ . 'image` i
+            ' . Shop::addSqlAssociation('image', 'i') . '
+            LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (i.`id_image` = il.`id_image` AND il.`id_lang` = ' . $idLang . ')
+            WHERE i.`id_product` IN (' . $idList . ')
+            ORDER BY i.`id_product`, `position`') ?: [];
+        foreach ($imageRows as $row) {
+            $idProduct = (int) $row['id_product'];
+            unset($row['id_product']);
+            self::$prefetchedProductImages[self::prefetchKey($idProduct, $idLang, $idShop)][] = $row;
+        }
+
+        if (!Combination::isFeatureActive()) {
+            return;
+        }
+
+        // Same columns as Product::getCombinationImages(), batched by id_product.
+        $combinationRows = Db::getInstance()->executeS('
+            SELECT i.`id_product`, pai.`id_image`, pai.`id_product_attribute`, il.`legend`
+            FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai
+            LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (il.`id_image` = pai.`id_image`)
+            INNER JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
+            WHERE i.`id_product` IN (' . $idList . ') AND il.`id_lang` = ' . $idLang . '
+            ORDER BY i.`id_product`, i.`position`, pai.`id_product_attribute`') ?: [];
+        $combinationsByProduct = [];
+        foreach ($combinationRows as $row) {
+            $idProduct = (int) $row['id_product'];
+            unset($row['id_product']);
+            $combinationsByProduct[$idProduct][$row['id_product_attribute']][] = $row;
+        }
+        foreach ($combinationsByProduct as $idProduct => $grouped) {
+            self::$prefetchedCombinationImages[self::prefetchKey($idProduct, $idLang, $idShop)] = $grouped;
+        }
+    }
+
+    private static function prefetchKey(int $idProduct, int $idLang, int $idShop): string
+    {
+        return $idProduct . '-' . $idLang . '-' . $idShop;
     }
 
     /**
@@ -51,14 +142,17 @@ class ImageRetriever
             $language->id
         );
 
+        // Use the request-scoped prefetch when available (listing pages), otherwise load per product.
+        $prefetchKey = self::prefetchKey((int) $product['id_product'], (int) $language->id, (int) Context::getContext()->shop->id);
+
         // Get all product images that are related to this object
-        $images = $productInstance->getImages($language->id);
+        $images = self::$prefetchedProductImages[$prefetchKey] ?? $productInstance->getImages($language->id);
         if (empty($images)) {
             return [];
         }
 
         // Load all pairs of images assigned to combinations
-        $combinationImages = $productInstance->getCombinationImages($language->id);
+        $combinationImages = self::$prefetchedCombinationImages[$prefetchKey] ?? $productInstance->getCombinationImages($language->id);
         if (!$combinationImages) {
             $combinationImages = [];
         }

--- a/tests/Integration/Adapter/Image/ImageRetrieverPrefetchTest.php
+++ b/tests/Integration/Adapter/Image/ImageRetrieverPrefetchTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Image;
+
+use Configuration;
+use Context;
+use Db;
+use Language;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use ReflectionClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Listing pages prefetch every product's images in one query per table instead of running
+ * getImages()/getCombinationImages() once per product. This guards that the prefetched result of
+ * getAllProductImages() is identical to the per-product result for every product (all images,
+ * combination variants and order preserved).
+ */
+class ImageRetrieverPrefetchTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetPrefetchCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetPrefetchCache();
+        parent::tearDown();
+    }
+
+    public function testPrefetchedImagesAreIdenticalToPerProductImages(): void
+    {
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+        $language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $retriever = new ImageRetriever(Context::getContext()->link);
+
+        $productIds = array_map(
+            static fn (array $row): int => (int) $row['id_product'],
+            Db::getInstance()->executeS('SELECT id_product FROM ' . _DB_PREFIX_ . 'product ORDER BY id_product')
+        );
+        self::assertNotEmpty($productIds, 'the test database must contain products with images');
+
+        // Per-product result first, with an empty prefetch cache.
+        $perProduct = [];
+        foreach ($productIds as $idProduct) {
+            $perProduct[$idProduct] = $retriever->getAllProductImages(
+                ['id_product' => $idProduct, 'id_product_attribute' => 0],
+                $language
+            );
+        }
+
+        // Same products, now served from the batch prefetch.
+        $retriever->prefetchImagesForProducts($productIds, (int) $language->id);
+
+        foreach ($productIds as $idProduct) {
+            $prefetched = $retriever->getAllProductImages(
+                ['id_product' => $idProduct, 'id_product_attribute' => 0],
+                $language
+            );
+            self::assertSame(
+                $perProduct[$idProduct],
+                $prefetched,
+                sprintf('prefetched images differ from per-product images for product %d', $idProduct)
+            );
+        }
+    }
+
+    private function resetPrefetchCache(): void
+    {
+        $reflection = new ReflectionClass(ImageRetriever::class);
+        foreach (['prefetchedProductImages', 'prefetchedCombinationImages'] as $property) {
+            $prop = $reflection->getProperty($property);
+            $prop->setAccessible(true);
+            $prop->setValue(null, []);
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On every product-listing page (category, search, manufacturer, supplier…), the presenter builds each product's full image set per product: `ProductLazyArray::fillImages()` runs in the constructor for every product and calls `ImageRetriever::getAllProductImages()`, which runs `Product::getImages()` and `Product::getCombinationImages()` — both bare `Db::executeS()` with no cache. So a listing of N products issues ~N image queries (2N when products have combinations), and re-fetches image data the listing query already partly returned.<br><br>This prefetches the images of the whole page in one query per table. `ProductListingFrontController::prepareMultipleProductsForTemplate()` calls a new `ImageRetriever::prefetchImagesForProducts($ids, $idLang)` right after assembling the products; it runs one `... WHERE i.id_product IN (...)` for images and one for combination images, storing the rows request-scoped. `getAllProductImages()` then reads that prefetch when present and only falls back to the per-product queries when it isn't (so any other caller keeps working unchanged). The batched image query keeps the same `image_shop` shop scoping as `Product::getImages()`.<br><br>Result on a listing page: image loading drops from ~N (or ~2N) queries to 2, with the per-product output unchanged.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a category or search results page. The product thumbnails/images must be identical to before (cover, combination images, order). With SQL profiling on, the `SELECT ... FROM ps_image` / `ps_product_attribute_image` queries now run once for the whole page instead of once per product. `tests/Integration/Adapter/Image/ImageRetrieverPrefetchTest.php` asserts that, for every product in the database, `getAllProductImages()` returns byte-identical output whether served from the batch prefetch or the per-product path (all images, combination variants and order preserved).
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     |
| Related PRs       |
| Sponsor company   |

