### PR TITLE
Keep line customizations in the order email for multi-shipping orders

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -172,6 +172,37 @@ abstract class PaymentModuleCore extends Module
     }
 
     /**
+     * Flattens the customizations of one order line across the delivery-address buckets returned by
+     * Product::getAllCustomizedDatas().
+     *
+     * That method indexes a line's customizations under the cart's delivery address, so in a
+     * multi-shipping order (where a package's address differs from the cart's) indexing by the
+     * package address misses them. The customization content is the same whatever address the line
+     * ships to, so every bucket is flattened here.
+     *
+     * @param array $customizedDatas result of Product::getAllCustomizedDatas()
+     * @param int $idProduct
+     * @param int $idProductAttribute
+     *
+     * @return array<int, array>
+     */
+    protected static function flattenProductCustomizations(array $customizedDatas, $idProduct, $idProductAttribute)
+    {
+        $customizations = [];
+        if (!isset($customizedDatas[$idProduct][$idProductAttribute])) {
+            return $customizations;
+        }
+
+        foreach ($customizedDatas[$idProduct][$idProductAttribute] as $customizationsByAddress) {
+            foreach ($customizationsByAddress as $customization) {
+                $customizations[] = $customization;
+            }
+        }
+
+        return $customizations;
+    }
+
+    /**
      * Validate an order in database
      * Function called from a payment module.
      *
@@ -506,7 +537,12 @@ abstract class PaymentModuleCore extends Module
                 $customized_datas = Product::getAllCustomizedDatas((int) $order->id_cart, null, true, null, (int) $product['id_customization']);
                 if (isset($customized_datas[$product['id_product']][$product['id_product_attribute']])) {
                     $product_var_tpl['customization'] = [];
-                    foreach ($customized_datas[$product['id_product']][$product['id_product_attribute']][$order->id_address_delivery] as $customization) {
+                    // getAllCustomizedDatas() buckets a line's customizations under the cart's delivery
+                    // address, which in a multi-shipping order differs from this package's
+                    // $order->id_address_delivery — flatten every address bucket instead of indexing by
+                    // the package address, which would miss the line's customizations. WHY: fixes lost
+                    // personalization in the confirmation email for products shipped to a non-primary address.
+                    foreach (self::flattenProductCustomizations($customized_datas, (int) $product['id_product'], (int) $product['id_product_attribute']) as $customization) {
                         $customization_text = '';
                         if (isset($customization['datas'][Product::CUSTOMIZE_TEXTFIELD])) {
                             foreach ($customization['datas'][Product::CUSTOMIZE_TEXTFIELD] as $text) {

--- a/tests/Integration/Classes/PaymentModuleCustomizationEmailTest.php
+++ b/tests/Integration/Classes/PaymentModuleCustomizationEmailTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use PaymentModule;
+use Product;
+use ReflectionMethod;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The order-confirmation email lists each line's customizations. Product::getAllCustomizedDatas()
+ * buckets them under the cart's delivery address, so a multi-shipping package (whose own delivery
+ * address differs) used to lose them. PaymentModule now flattens the address buckets.
+ */
+class PaymentModuleCustomizationEmailTest extends KernelTestCase
+{
+    public function testCustomizationsAreFoundRegardlessOfTheDeliveryAddressBucket(): void
+    {
+        self::bootKernel();
+
+        // getAllCustomizedDatas() indexes the line's customizations under the cart's delivery
+        // address (here 4); a multi-shipping package ships to a different address (5).
+        $cartAddressId = 4;
+        $packageAddressId = 5;
+        $customizedDatas = [
+            7 => [ // id_product
+                0 => [ // id_product_attribute
+                    $cartAddressId => [
+                        99 => [ // id_customization
+                            'quantity' => 1,
+                            'id_customization' => 99,
+                            'datas' => [
+                                Product::CUSTOMIZE_TEXTFIELD => [
+                                    ['name' => 'Message', 'value' => 'Hello'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        // The previous code indexed by the package address, which has no bucket -> customizations lost.
+        self::assertArrayNotHasKey($packageAddressId, $customizedDatas[7][0]);
+
+        $flatten = new ReflectionMethod(PaymentModule::class, 'flattenProductCustomizations');
+        $flatten->setAccessible(true);
+        $customizations = $flatten->invoke(null, $customizedDatas, 7, 0);
+
+        self::assertCount(1, $customizations, 'the customization must be found even under the cart address bucket');
+        self::assertSame('Hello', $customizations[0]['datas'][Product::CUSTOMIZE_TEXTFIELD][0]['value']);
+    }
+
+    public function testReturnsEmptyWhenTheLineHasNoCustomization(): void
+    {
+        self::bootKernel();
+
+        $flatten = new ReflectionMethod(PaymentModule::class, 'flattenProductCustomizations');
+        $flatten->setAccessible(true);
+
+        self::assertSame([], $flatten->invoke(null, [], 7, 0));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PaymentModule::validateOrder()` builds the order-confirmation email and reads each line's customizations with `$customized_datas[id_product][id_product_attribute][$order->id_address_delivery]`. But `Product::getAllCustomizedDatas()` buckets a line's customizations under the **cart's** delivery address, not the package's. In a multi-shipping order a package's `$order->id_address_delivery` differs from the cart's, so that index does not exist: the `foreach` iterates an undefined index (PHP notice in debug) and the product's personalization is dropped from the email.<br><br>The fix flattens the address buckets (a new `PaymentModule::flattenProductCustomizations()` helper) instead of indexing by the package address — the customization content is the same whatever address the line ships to. Single-address orders are unaffected (the one bucket is the cart address).
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With multi-shipping enabled, place an order that ships a customized (text-personalized) product to a secondary address. The order-confirmation email must show that product's personalization (before: it was missing, with a PHP notice in debug). `tests/Integration/Classes/PaymentModuleCustomizationEmailTest.php` covers the flattening: a customization bucketed under the cart address is still found when the package ships elsewhere.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41958
| Related PRs       |
| Sponsor company   |

