### PR TITLE
Allow scalar CQRS command results to be returned by the Admin API

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/Processor/CommandProcessor.php
+++ b/src/PrestaShopBundle/ApiPlatform/Processor/CommandProcessor.php
@@ -86,6 +86,12 @@ class CommandProcessor implements ProcessorInterface
         if (!empty($commandResult)) {
             $normalizedCommandResult = $this->domainSerializer->normalize($commandResult, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSCommandMapping($operation)]);
         }
+        // If the command returned a scalar value (e.g. a generated secret string) it can't be merged
+        // with the URI variables, so wrap it behind a "_commandResult" key that resources can map to a
+        // property (same principle as "_queryResult" for scalar query results).
+        if (is_scalar($normalizedCommandResult)) {
+            $normalizedCommandResult = ['_commandResult' => $normalizedCommandResult];
+        }
         // Merge uri variables and normalized command result to have all needed data to create the CQRS query (it probably contains all the needed info to create the CQRS query)
         $normalizedCommandResult = array_merge($uriVariables, $normalizedCommandResult, $this->contextParametersProvider->getContextParameters());
 

--- a/src/PrestaShopBundle/ApiPlatform/Processor/CommandProcessor.php
+++ b/src/PrestaShopBundle/ApiPlatform/Processor/CommandProcessor.php
@@ -82,15 +82,16 @@ class CommandProcessor implements ProcessorInterface
      */
     protected function denormalizeCommandResult(mixed $commandResult, Operation $operation, array $uriVariables): mixed
     {
+        // If the command returned a scalar value (e.g. a generated secret string) it can't be merged
+        // with the URI variables, so wrap it behind a "_commandResult" key that the mapping can then
+        // target (same principle as "_queryResult" for scalar query results).
+        if (is_scalar($commandResult)) {
+            $commandResult = ['_commandResult' => $commandResult];
+        }
+
         $normalizedCommandResult = [];
         if (!empty($commandResult)) {
             $normalizedCommandResult = $this->domainSerializer->normalize($commandResult, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSCommandMapping($operation)]);
-        }
-        // If the command returned a scalar value (e.g. a generated secret string) it can't be merged
-        // with the URI variables, so wrap it behind a "_commandResult" key that resources can map to a
-        // property (same principle as "_queryResult" for scalar query results).
-        if (is_scalar($normalizedCommandResult)) {
-            $normalizedCommandResult = ['_commandResult' => $normalizedCommandResult];
         }
         // Merge uri variables and normalized command result to have all needed data to create the CQRS query (it probably contains all the needed info to create the CQRS query)
         $normalizedCommandResult = array_merge($uriVariables, $normalizedCommandResult, $this->contextParametersProvider->getContextParameters());

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Processor/CommandProcessorTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Processor/CommandProcessorTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\ApiPlatform\Processor;
+
+use ApiPlatform\Metadata\Post;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\GenerateApiClientSecretCommand;
+use PrestaShopBundle\ApiPlatform\ContextParametersProvider;
+use PrestaShopBundle\ApiPlatform\NormalizationMapper;
+use PrestaShopBundle\ApiPlatform\Processor\CommandProcessor;
+use PrestaShopBundle\ApiPlatform\Serializer\CQRSApiSerializer;
+use stdClass;
+
+class CommandProcessorTest extends TestCase
+{
+    private const API_CLIENT_ID = 42;
+
+    /**
+     * @dataProvider getScalarCommandResults
+     */
+    public function testScalarCommandResultIsForwardedToTheApiResource(mixed $commandResult): void
+    {
+        $payload = $this->processCommandReturning($commandResult, []);
+
+        $this->assertArrayHasKey('_commandResult', $payload);
+        $this->assertSame($commandResult, $payload['_commandResult']);
+        $this->assertSame(self::API_CLIENT_ID, $payload['apiClientId']);
+    }
+
+    /**
+     * The scalar result is only usable if the CQRS command mapping can reach it, the same way
+     * CQRSQueryMapping can reach "_queryResult" for scalar query results.
+     *
+     * @dataProvider getScalarCommandResults
+     */
+    public function testScalarCommandResultCanBeMappedByTheCommandMapping(mixed $commandResult): void
+    {
+        $payload = $this->processCommandReturning($commandResult, ['[_commandResult]' => '[secret]']);
+
+        $this->assertArrayHasKey('secret', $payload);
+        $this->assertSame($commandResult, $payload['secret']);
+    }
+
+    public function getScalarCommandResults(): iterable
+    {
+        yield 'non empty string' => ['generated-secret'];
+        yield 'non zero int' => [7];
+        yield 'empty string' => [''];
+        yield 'zero int' => [0];
+        yield 'false' => [false];
+    }
+
+    /**
+     * Runs the processor against a command bus returning $commandResult, and returns the normalized
+     * array that ends up being denormalized into the ApiResource DTO.
+     */
+    private function processCommandReturning(mixed $commandResult, array $commandMapping): array
+    {
+        $commandBus = $this->createMock(CommandBusInterface::class);
+        $commandBus->method('handle')->willReturn($commandResult);
+
+        $contextParametersProvider = $this->createMock(ContextParametersProvider::class);
+        $contextParametersProvider->method('getContextParameters')->willReturn([]);
+
+        // The decorated serializer returns scalars and arrays untouched, so only the normalization
+        // mapping matters here and it is performed by the real mapper.
+        $serializer = $this->createMock(CQRSApiSerializer::class);
+        $serializer->method('normalize')->willReturnCallback(
+            function (mixed $object, ?string $format = null, array $context = []): mixed {
+                (new NormalizationMapper())->mapNormalizedData($object, $context);
+
+                return $object;
+            }
+        );
+
+        $denormalizedPayload = [];
+        $serializer->method('denormalize')->willReturnCallback(
+            function (mixed $data) use (&$denormalizedPayload): stdClass {
+                $denormalizedPayload = $data;
+
+                return new stdClass();
+            }
+        );
+
+        $operation = new Post(
+            class: stdClass::class,
+            extraProperties: [
+                'CQRSCommand' => GenerateApiClientSecretCommand::class,
+                'CQRSCommandMapping' => $commandMapping,
+            ],
+        );
+
+        $processor = new CommandProcessor($commandBus, $serializer, $contextParametersProvider);
+        $processor->process(new GenerateApiClientSecretCommand(self::API_CLIENT_ID), $operation, ['apiClientId' => self::API_CLIENT_ID]);
+
+        return $denormalizedPayload;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The ApiPlatform `CommandProcessor` `array_merge`s the normalized command result with the URI variables. When a CQRS command returns a **scalar** (e.g. `GenerateApiClientSecretCommand` returns the generated secret string), `array_merge($uriVariables, $normalizedCommandResult, ...)` throws `Argument #2 must be of type array, string given`, so such commands cannot be exposed through the Admin API. This wraps a scalar command result behind a `_commandResult` key — mirroring the existing `_queryResult` wrapping for scalar query results (`QueryResultSerializerTrait`) — so resources can map it to a property via `ApiResourceMapping` (e.g. `['[_commandResult]' => '[secret]']`).
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | A companion PR in `PrestaShop/ps_apiresources` will expose `GenerateApiClientSecretCommand` (`POST /api-clients/{apiClientId}/secret`) and return the generated secret via `['[_commandResult]' => '[secret]']`; its integration test exercises this path end-to-end. Before this change the endpoint 500s with the `array_merge` TypeError; after it, the secret is returned.
| UI Tests          | N/A (Admin API / CO change, no UI impact — covered by integration tests)
| Fixed issue or discussion?     | N/A — enables exposing scalar-returning commands in the Admin API (PrestaShop/ps_apiresources)
| Related PRs       | PrestaShop/ps_apiresources#236 (the regenerate-secret endpoint relying on this mechanism will follow)
| Sponsor company   |

