### PR TITLE
Prevent information about groups being always rendered at the bottom

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -39,7 +39,6 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterf
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CategoryGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
-use PrestaShop\PrestaShop\Core\Group\Provider\DefaultGroupsProviderInterface;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\CategoryFilters;
@@ -129,8 +128,6 @@ class CategoryController extends PrestaShopAdminController
         FormBuilderInterface $categoryFormBuilder,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.category_form_handler')]
         FormHandlerInterface $categoryFormHandler,
-        #[Autowire(service: 'prestashop.adapter.group.provider.default_groups_provider')]
-        DefaultGroupsProviderInterface $defaultGroupsProvider
     ): Response {
         $configuration = $this->getConfiguration();
         $parentId = (int) $request->query->get('id_parent', (int) $configuration->get('PS_HOME_CATEGORY'));
@@ -161,15 +158,12 @@ class CategoryController extends PrestaShopAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
-        $defaultGroups = $defaultGroupsProvider->getGroups();
-
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/create.html.twig',
             [
                 'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
                 'enableSidebar' => true,
                 'categoryForm' => $categoryForm->createView(),
-                'defaultGroups' => $defaultGroups,
                 'layoutTitle' => $this->trans('New category', [], 'Admin.Navigation.Menu'),
                 'categoryUrl' => null,
             ]
@@ -190,8 +184,6 @@ class CategoryController extends PrestaShopAdminController
         FormBuilderInterface $rootCategoryFormBuilder,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.root_category_form_handler')]
         FormHandlerInterface $rootCategoryFormHandler,
-        #[Autowire(service: 'prestashop.adapter.group.provider.default_groups_provider')]
-        DefaultGroupsProviderInterface $defaultGroupsProvider
     ): Response {
         $rootCategoryForm = $rootCategoryFormBuilder->getForm();
         $rootCategoryForm->handleRequest($request);
@@ -210,15 +202,12 @@ class CategoryController extends PrestaShopAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
-        $defaultGroups = $defaultGroupsProvider->getGroups();
-
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/create_root.html.twig',
             [
                 'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
                 'enableSidebar' => true,
                 'rootCategoryForm' => $rootCategoryForm->createView(),
-                'defaultGroups' => $defaultGroups,
                 'layoutTitle' => $this->trans('New category', [], 'Admin.Navigation.Menu'),
             ]
         );
@@ -240,8 +229,6 @@ class CategoryController extends PrestaShopAdminController
         FormBuilderInterface $categoryFormBuilder,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.category_form_handler')]
         FormHandlerInterface $categoryFormHandler,
-        #[Autowire(service: 'prestashop.adapter.group.provider.default_groups_provider')]
-        DefaultGroupsProviderInterface $defaultGroupsProvider,
     ): Response {
         try {
             /** @var EditableCategory $editableCategory */
@@ -284,8 +271,6 @@ class CategoryController extends PrestaShopAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
-        $defaultGroups = $defaultGroupsProvider->getGroups();
-
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/edit.html.twig',
             [
@@ -295,7 +280,6 @@ class CategoryController extends PrestaShopAdminController
                 'contextLangId' => $this->getLanguageContext()->getId(),
                 'editCategoryForm' => $categoryForm->createView(),
                 'editableCategory' => $editableCategory,
-                'defaultGroups' => $defaultGroups,
                 'layoutTitle' => $this->trans(
                     'Editing category %category_name%',
                     [
@@ -323,8 +307,6 @@ class CategoryController extends PrestaShopAdminController
         FormBuilderInterface $rootCategoryFormBuilder,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.root_category_form_handler')]
         FormHandlerInterface $rootCategoryFormHandler,
-        #[Autowire(service: 'prestashop.adapter.group.provider.default_groups_provider')]
-        DefaultGroupsProviderInterface $defaultGroupsProvider
     ): Response {
         try {
             /** @var EditableCategory $editableCategory */
@@ -362,8 +344,6 @@ class CategoryController extends PrestaShopAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
-        $defaultGroups = $defaultGroupsProvider->getGroups();
-
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/edit_root.html.twig',
             [
@@ -373,7 +353,6 @@ class CategoryController extends PrestaShopAdminController
                 'contextLangId' => $this->getLanguageContext()->getId(),
                 'editRootCategoryForm' => $rootCategoryForm->createView(),
                 'editableCategory' => $editableCategory,
-                'defaultGroups' => $defaultGroups,
                 'layoutTitle' => $this->trans(
                     'Editing category %category_name%',
                     [

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
@@ -14,6 +14,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShop\PrestaShop\Core\Domain\Category\CategorySettings;
 use PrestaShop\PrestaShop\Core\Domain\Category\SeoSettings;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+use PrestaShop\PrestaShop\Core\Group\Provider\DefaultGroups;
 use PrestaShopBundle\Form\Admin\Sell\Category\SEO\RedirectOptionType;
 use PrestaShopBundle\Form\Admin\Type\CategorySeoPreviewType;
 use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
@@ -26,6 +27,8 @@ use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -51,24 +54,32 @@ abstract class AbstractCategoryType extends TranslatorAwareType
     protected $configuration;
 
     /**
+     * @var DefaultGroups|null
+     */
+    private $defaultGroups;
+
+    /**
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param array $customerGroupChoices
      * @param FeatureInterface $multiStoreFeature
      * @param ConfigurationInterface $configuration
+     * @param DefaultGroups|null $defaultGroups
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
         array $customerGroupChoices,
         FeatureInterface $multiStoreFeature,
-        ConfigurationInterface $configuration
+        ConfigurationInterface $configuration,
+        ?DefaultGroups $defaultGroups = null
     ) {
         parent::__construct($translator, $locales);
 
         $this->customerGroupChoices = $customerGroupChoices;
         $this->multiStoreFeature = $multiStoreFeature;
         $this->configuration = $configuration;
+        $this->defaultGroups = $defaultGroups;
     }
 
     /**
@@ -273,6 +284,20 @@ abstract class AbstractCategoryType extends TranslatorAwareType
             $builder->add('shop_association', ShopChoiceTreeType::class, [
                 'label' => $this->trans('Store association', 'Admin.Global'),
             ]);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Expose the default customer groups on the group access field so the
+     * informative alert stays bound to that field wherever it is rendered,
+     * instead of being hardcoded at the end of the form template.
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        if (null !== $this->defaultGroups && isset($view['group_association'])) {
+            $view['group_association']->vars['default_groups'] = $this->defaultGroups;
         }
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -33,6 +33,7 @@ services:
       $contextCountryId: '@=service("prestashop.adapter.legacy.context").getContext().country.id'
       $employeeIsoCode: '@=service("prestashop.adapter.legacy.context").getEmployeeLanguageIso()'
       $customerGroupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
+      $defaultGroups: '@=service("prestashop.adapter.group.provider.default_groups_provider").getGroups()'
       $isSingleShopContext: '@=service("prestashop.adapter.shop.context").isShopContext()'
       $categoryDataProvider: '@prestashop.adapter.data_provider.category'
       $ecoTaxGroupId: "@=service('prestashop.adapter.legacy.configuration').getInt('PS_ECOTAX_TAX_RULES_GROUP_ID')"

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -14,20 +14,6 @@
   <div class="card-body">
     <div class="form-wrapper">
       {{ form_widget(categoryForm) }}
-      <div class="form-group row">
-        <label class="form-control-label"></label>
-        <div class="col-sm">
-          <div class="alert alert-info">
-            <p class="mb-1">
-              <strong>{{ 'You now have three default customer groups.'|trans({}, 'Admin.Catalog.Help') }}</strong>
-            </p>
-
-            <p>{{ '%group_name% - All people without a valid customer account.'|trans({'%group_name%': '<strong>' ~ defaultGroups.visitorsGroup.name ~ '</strong>'}, 'Admin.Catalog.Feature')|raw_purified }}</p>
-            <p>{{ '%group_name% - Customer who placed an order with the guest checkout.'|trans({'%group_name%': '<strong>' ~ defaultGroups.guestsGroup.name ~ '</strong>'}, 'Admin.Catalog.Feature')|raw_purified }}</p>
-            <p>{{ '%group_name% - All people who have created an account on this site.'|trans({'%group_name%': '<strong>' ~ defaultGroups.customersGroup.name ~ '</strong>'}, 'Admin.Catalog.Feature')|raw_purified }}</p>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/FormTheme/category.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/FormTheme/category.html.twig
@@ -10,3 +10,23 @@
       {{ 'Here is a preview of how your page will appear in search engine results.'|trans({}, 'Admin.Global') }}
     </small>
 {% endblock category_seo_preview_widget %}
+
+{% block material_choice_table_row %}
+    {{ block('form_row') }}
+    {% if default_groups is defined %}
+      <div class="form-group row">
+        <label class="form-control-label"></label>
+        <div class="col-sm">
+          <div class="alert alert-info">
+            <p class="mb-1">
+              <strong>{{ 'You now have three default customer groups.'|trans({}, 'Admin.Catalog.Help') }}</strong>
+            </p>
+
+            <p>{{ '%group_name% - All people without a valid customer account.'|trans({'%group_name%': '<strong>' ~ default_groups.visitorsGroup.name ~ '</strong>'}, 'Admin.Catalog.Feature')|raw_purified }}</p>
+            <p>{{ '%group_name% - Customer who placed an order with the guest checkout.'|trans({'%group_name%': '<strong>' ~ default_groups.guestsGroup.name ~ '</strong>'}, 'Admin.Catalog.Feature')|raw_purified }}</p>
+            <p>{{ '%group_name% - All people who have created an account on this site.'|trans({'%group_name%': '<strong>' ~ default_groups.customersGroup.name ~ '</strong>'}, 'Admin.Catalog.Feature')|raw_purified }}</p>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+{% endblock material_choice_table_row %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When extending Category form type, fields added at the end are always before the information about the group confusing the user
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use the demo module, try before and after this PR
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/28785347941
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | impSolutions

Demo module: 
[demoextendcategoryformextension.zip](https://github.com/user-attachments/files/29699227/demoextendcategoryformextension.zip)
