### PR TITLE
Add autofill autocomplete tokens to the customer registration form

### DIFF
--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -91,6 +91,7 @@ class CustomerFormatterCore implements FormFormatterInterface
 
         $format['firstname'] = (new FormField())
             ->setName('firstname')
+            ->setAutocompleteAttribute('given-name')
             ->setLabel(
                 $this->translator->trans(
                     'First name',
@@ -106,6 +107,7 @@ class CustomerFormatterCore implements FormFormatterInterface
 
         $format['lastname'] = (new FormField())
             ->setName('lastname')
+            ->setAutocompleteAttribute('family-name')
             ->setLabel(
                 $this->translator->trans(
                     'Last name',
@@ -142,6 +144,7 @@ class CustomerFormatterCore implements FormFormatterInterface
         $format['email'] = (new FormField())
             ->setName('email')
             ->setType('email')
+            ->setAutocompleteAttribute('email')
             ->setLabel(
                 $this->translator->trans(
                     'Email',


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Branch?           | develop
| Description?      | `CustomerFormatter` sets an `autocomplete` attribute on the password fields (`password`, `new_password`) but not on `firstname`, `lastname` or `email`, so browsers and password managers do not autofill the customer's name and email on the registration form. This adds the standard WHATWG autofill tokens: `given-name` on first name, `family-name` on last name, `email` on the email field. The theme already renders `$field.autocomplete` when present, so no theme change is required.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open the registration form (`/registration`) and inspect the inputs: first name now carries `autocomplete="given-name"`, last name `autocomplete="family-name"`, email `autocomplete="email"` (password already had `new-password`). Browser/password-manager autofill then offers the stored name and email. Verified on a 9.2 shop with the default Hummingbird theme. No behavior other than the added attributes changes.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/28997404053
| Fixed issue or discussion?     |
| Related PRs       | None — the Hummingbird theme already outputs `autocomplete` from `$field.autocomplete`.
| Sponsor company   |
