### PR TITLE
Skip the base cart total computation in getCartRules for rule-less carts

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -507,27 +507,32 @@ class CartCore extends ObjectModel
             $result = Cache::retrieve($cache_key);
         }
 
-        // Define virtual context to prevent case where the cart is not the in the global context
-        $virtual_context = Context::getContext()->cloneContext();
-        /* @phpstan-ignore-next-line */
-        $virtual_context->cart = $this;
+        // The base cart total below is only consumed while enriching applied cart rules, so skip
+        // the Context clone and the getOrderTotal(ONLY_PRODUCTS) computations for carts that have
+        // no cart rules (the common case on shops that run promotions).
+        if (!empty($result)) {
+            // Define virtual context to prevent case where the cart is not the in the global context
+            $virtual_context = Context::getContext()->cloneContext();
+            /* @phpstan-ignore-next-line */
+            $virtual_context->cart = $this;
 
-        // set base cart total values, they will be updated and used for percentage cart rules (because percentage cart rules
-        // are applied to the cart total's value after previously applied cart rules)
-        $virtual_context->virtualTotalTaxExcluded = $virtual_context->cart->getOrderTotal(false, self::ONLY_PRODUCTS);
-        if (!Configuration::get('PS_TAX')) {
-            $virtual_context->virtualTotalTaxIncluded = $virtual_context->virtualTotalTaxExcluded;
-        } else {
-            $virtual_context->virtualTotalTaxIncluded = $virtual_context->cart->getOrderTotal(true, self::ONLY_PRODUCTS);
-        }
+            // set base cart total values, they will be updated and used for percentage cart rules (because percentage cart rules
+            // are applied to the cart total's value after previously applied cart rules)
+            $virtual_context->virtualTotalTaxExcluded = $virtual_context->cart->getOrderTotal(false, self::ONLY_PRODUCTS);
+            if (!Configuration::get('PS_TAX')) {
+                $virtual_context->virtualTotalTaxIncluded = $virtual_context->virtualTotalTaxExcluded;
+            } else {
+                $virtual_context->virtualTotalTaxIncluded = $virtual_context->cart->getOrderTotal(true, self::ONLY_PRODUCTS);
+            }
 
-        foreach ($result as &$row) {
-            $row['obj'] = new CartRule($row['id_cart_rule'], (int) $this->id_lang);
-            $row['value_real'] = $row['obj']->getContextualValue(true, $virtual_context, $filter);
-            $row['value_tax_exc'] = $row['obj']->getContextualValue(false, $virtual_context, $filter);
-            // Retro compatibility < 1.5.0.2
-            $row['id_discount'] = $row['id_cart_rule'];
-            $row['description'] = $row['obj']->description;
+            foreach ($result as &$row) {
+                $row['obj'] = new CartRule($row['id_cart_rule'], (int) $this->id_lang);
+                $row['value_real'] = $row['obj']->getContextualValue(true, $virtual_context, $filter);
+                $row['value_tax_exc'] = $row['obj']->getContextualValue(false, $virtual_context, $filter);
+                // Retro compatibility < 1.5.0.2
+                $row['id_discount'] = $row['id_cart_rule'];
+                $row['description'] = $row['obj']->description;
+            }
         }
 
         return $result;

--- a/tests/Integration/Classes/CartTest.php
+++ b/tests/Integration/Classes/CartTest.php
@@ -400,6 +400,34 @@ class CartTest extends KernelTestCase
         $this->assertEquals(6, $cart->getOrderTotal(true, Cart::BOTH, null, $id_carrier));
     }
 
+    public function testGetCartRulesEnrichesRulesAppliedToTheCart(): void
+    {
+        $product = self::makeProduct('Guarded Product', 10, self::getIdTaxRulesGroup(20));
+
+        self::makeCartRule(5, 'before tax');
+        $cart = self::makeCart();
+
+        $cart->updateQty(1, $product->id);
+
+        $rules = $cart->getCartRules();
+
+        // The enrichment block must still run and populate the applied rule when one exists.
+        $this->assertCount(1, $rules);
+        $this->assertArrayHasKey('obj', $rules[0]);
+        $this->assertEquals(5, $rules[0]['value_tax_exc']);
+        $this->assertEquals(6, $rules[0]['value_real']);
+    }
+
+    public function testGetCartRulesReturnsNoRowsForACartWithoutAnyRule(): void
+    {
+        $product = self::makeProduct('Ruleless Product', 10, self::getIdTaxRulesGroup(20));
+        $cart = self::makeCart();
+
+        $cart->updateQty(1, $product->id);
+
+        $this->assertSame([], $cart->getCartRules());
+    }
+
     /**
      * This test checks that if PS_ATCP_SHIPWRAP is set to true then:
      * - the shipping cost of the carrier is understood as tax included instead of tax excluded


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | In `Cart::getCartRules()` the base cart total (`virtualTotalTaxExcluded` / `virtualTotalTaxIncluded`, computed with one or two `getOrderTotal(self::ONLY_PRODUCTS)` calls) and the Context clone that carries them are built on every call, but they are only ever read inside the `foreach ($result as &$row)` loop that enriches applied cart rules. When a cart has no applied cart rule the loop body never runs, so that work is discarded. The method already returns `[]` early when `CartRule::isFeatureActive()` is false, so this only affects shops that have at least one active cart rule while the specific cart has none applied — the common voucher-less cart on a shop that runs promotions. This wraps the clone + totals + enrichment in `if (!empty($result))` so a rule-less cart skips the Context clone and the `getOrderTotal(ONLY_PRODUCTS)` computations. Behavior is unchanged: the values were unused when the result was empty, and the `ONLY_PRODUCTS` path only calls `calculateRows()`/`getRowTotal()` (never `processCalculation`/`calculateCartRules`), so no cart-rule hook is skipped. There is no query-count change (the getOrderTotal callees are request-cached); the win is the eliminated Context clone and Calculator object-churn on the rule-less path.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Two integration tests are added to `tests/Integration/Classes/CartTest.php`: `testGetCartRulesEnrichesRulesAppliedToTheCart` (a cart with an applied before-tax rule still returns one enriched row with `value_tax_exc = 5` and `value_real = 6` — the regression guard that the enrichment still runs) and `testGetCartRulesReturnsNoRowsForACartWithoutAnyRule` (a rule-less cart returns `[]`). Both pass under the integration suite; `php-cs-fixer` and PHPStan (level 5, `classes/` in scope) are clean on the change.
| UI Tests          | Not run. A campaign can be launched on request.

