### PR TITLE
Pin maildev image to a stable tag in behaviour tests workflow

### DIFF
--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install maildev
         run: |
-          docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev
+          docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev:2.2.1
           bash -c 'while [[ "$(curl -L -s -o /dev/null -w %{http_code} http://localhost:1080)" != "200" ]]; do echo "Wait for maildev"; sleep 5; done'
 
       - name: Run integration-behaviour-tests


### PR DESCRIPTION
| Questions         | Answers                                                        |
| ----------------- | -------------------------------------------------------------- |
| Branch?           | develop                                                       |
| Description?      | The `Behaviour tests` workflow pulls `maildev/maildev:latest`. On 2026-07-06 ~20:36 UTC that tag was republished to `3.0.0-rc.1` (a release candidate). With that image the maildev container becomes unreachable on `localhost:1080` shortly after startup, so the `I can send a password reset email to an employee` scenario fails on **every** PR built since then — unrelated to the PR contents. This pins the image to the last stable tag `2.2.1` so behaviour tests stop depending on a volatile `latest`. |
| Type?             | bug fix                                                        |
| Category?         | TE                                                            |
| BC breaks?        | no                                                             |
| Deprecations?     | no                                                             |
| Fixed ticket?     | #41981                                                        |
| How to test?      | Re-run the `Behaviour tests` jobs on any recent PR: the `Employee/employee_management.feature:120` password-reset scenario passes again because maildev stays available on `localhost:1080` throughout the run. |
| Possible impacts? | None. Only pins the maildev image tag used by the CI behaviour-tests job; no runtime/product code is touched. |
| UI Tests?         | :hourglass: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/28857929955 |

### Root cause

`docker run ... maildev/maildev` (unpinned) resolved to `latest`, which now points to `3.0.0-rc.1`. Runs before the retag passed; every run after it fails deterministically on the mail scenario. Pinning to `2.2.1` (last stable) removes the dependency on an unstable `latest`.