### PR TITLE
Use canonical url in breadcrumbs, avoid using smarty value

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -98,7 +98,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     public function getCanonicalURL(): string
     {
-        $product = $this->context->smarty->getTemplateVars('product');
+        $product = $this->getTemplateVarProduct();
 
         if (!($product instanceof ProductLazyArray)) {
             return '';
@@ -1454,7 +1454,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         $breadcrumb['links'][] = [
             'title' => $this->product->name,
-            'url' => $this->context->link->getProductLink($this->product, null, null, null, null, null, (int) $this->getIdProductAttributeByRequest()),
+            'url' => $this->getCanonicalURL(),
         ];
 
         return $breadcrumb;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Breadcrumbs URL should point to the canonical URL like all other. Also removed access to smarty assigned template, I used the cached value from controller instead.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check the breadcrumb URL in structured data. Should point to the main product in case of products with variants.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/28998932097
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.