### PR TITLE
Sync localization packs from LocalizationFiles

### DIFF
--- a/localization/ar.xml
+++ b/localization/ar.xml
@@ -29,6 +29,32 @@
       <taxRule iso_code_country="ar" id_tax="4"/>
     </taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Buenos Aires" iso_code="B" country="AR" zone="South America" />
+		<state name="Catamarca" iso_code="K" country="AR" zone="South America" />
+		<state name="Chaco" iso_code="H" country="AR" zone="South America" />
+		<state name="Chubut" iso_code="U" country="AR" zone="South America" />
+		<state name="Ciudad de Buenos Aires" iso_code="C" country="AR" zone="South America" />
+		<state name="Córdoba" iso_code="X" country="AR" zone="South America" />
+		<state name="Corrientes" iso_code="W" country="AR" zone="South America" />
+		<state name="Entre Ríos" iso_code="E" country="AR" zone="South America" />
+		<state name="Formosa" iso_code="P" country="AR" zone="South America" />
+		<state name="Jujuy" iso_code="Y" country="AR" zone="South America" />
+		<state name="La Pampa" iso_code="L" country="AR" zone="South America" />
+		<state name="La Rioja" iso_code="F" country="AR" zone="South America" />
+		<state name="Mendoza" iso_code="M" country="AR" zone="South America" />
+		<state name="Misiones" iso_code="N" country="AR" zone="South America" />
+		<state name="Neuquén" iso_code="Q" country="AR" zone="South America" />
+		<state name="Río Negro" iso_code="R" country="AR" zone="South America" />
+		<state name="Salta" iso_code="A" country="AR" zone="South America" />
+		<state name="San Juan" iso_code="J" country="AR" zone="South America" />
+		<state name="San Luis" iso_code="D" country="AR" zone="South America" />
+		<state name="Santa Cruz" iso_code="Z" country="AR" zone="South America" />
+		<state name="Santa Fe" iso_code="S" country="AR" zone="South America" />
+		<state name="Santiago del Estero" iso_code="G" country="AR" zone="South America" />
+		<state name="Tierra del Fuego" iso_code="V" country="AR" zone="South America" />
+		<state name="Tucumán" iso_code="T" country="AR" zone="South America" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />

--- a/localization/bg.xml
+++ b/localization/bg.xml
@@ -163,6 +163,36 @@
       <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Blagoevgrad" iso_code="01" country="BG" zone="Europe" />
+    <state name="Burgas" iso_code="02" country="BG" zone="Europe" />
+    <state name="Dobrich" iso_code="08" country="BG" zone="Europe" />
+    <state name="Gabrovo" iso_code="07" country="BG" zone="Europe" />
+    <state name="Haskovo" iso_code="26" country="BG" zone="Europe" />
+    <state name="Kardzhali" iso_code="09" country="BG" zone="Europe" />
+    <state name="Kyustendil" iso_code="10" country="BG" zone="Europe" />
+    <state name="Lovech" iso_code="11" country="BG" zone="Europe" />
+    <state name="Montana" iso_code="12" country="BG" zone="Europe" />
+    <state name="Pazardzhik" iso_code="13" country="BG" zone="Europe" />
+    <state name="Pernik" iso_code="14" country="BG" zone="Europe" />
+    <state name="Pleven" iso_code="15" country="BG" zone="Europe" />
+    <state name="Plovdiv" iso_code="16" country="BG" zone="Europe" />
+    <state name="Razgrad" iso_code="17" country="BG" zone="Europe" />
+    <state name="Ruse" iso_code="18" country="BG" zone="Europe" />
+    <state name="Shumen" iso_code="27" country="BG" zone="Europe" />
+    <state name="Silistra" iso_code="19" country="BG" zone="Europe" />
+    <state name="Sliven" iso_code="20" country="BG" zone="Europe" />
+    <state name="Smolyan" iso_code="21" country="BG" zone="Europe" />
+    <state name="Sofia (stolitsa)" iso_code="22" country="BG" zone="Europe" />
+    <state name="Sofia" iso_code="23" country="BG" zone="Europe" />
+    <state name="Stara Zagora" iso_code="24" country="BG" zone="Europe" />
+    <state name="Targovishte" iso_code="25" country="BG" zone="Europe" />
+    <state name="Varna" iso_code="03" country="BG" zone="Europe" />
+    <state name="Veliko Tarnovo" iso_code="04" country="BG" zone="Europe" />
+    <state name="Vidin" iso_code="05" country="BG" zone="Europe" />
+    <state name="Vratsa" iso_code="06" country="BG" zone="Europe" />
+    <state name="Yambol" iso_code="28" country="BG" zone="Europe" />
+  </states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/bo.xml
+++ b/localization/bo.xml
@@ -13,6 +13,17 @@
 			<taxRule iso_code_country="bo" id_tax="1" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Chuquisaca" iso_code="H" country="BO" zone="South America" />
+		<state name="Cochabamba" iso_code="C" country="BO" zone="South America" />
+		<state name="El Beni" iso_code="B" country="BO" zone="South America" />
+		<state name="La Paz" iso_code="L" country="BO" zone="South America" />
+		<state name="Oruro" iso_code="O" country="BO" zone="South America" />
+		<state name="Pando" iso_code="N" country="BO" zone="South America" />
+		<state name="Potosí" iso_code="P" country="BO" zone="South America" />
+		<state name="Santa Cruz" iso_code="S" country="BO" zone="South America" />
+		<state name="Tarija" iso_code="T" country="BO" zone="South America" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />

--- a/localization/cl.xml
+++ b/localization/cl.xml
@@ -13,6 +13,24 @@
 			<taxRule iso_code_country="cl" id_tax="1" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Antofagasta" iso_code="AN" country="CL" zone="South America" />
+		<state name="Arica y Parinacota" iso_code="AP" country="CL" zone="South America" />
+		<state name="Atacama" iso_code="AT" country="CL" zone="South America" />
+		<state name="Aysén" iso_code="AI" country="CL" zone="South America" />
+		<state name="Biobío" iso_code="BI" country="CL" zone="South America" />
+		<state name="Coquimbo" iso_code="CO" country="CL" zone="South America" />
+		<state name="La Araucanía" iso_code="AR" country="CL" zone="South America" />
+		<state name="Los Lagos" iso_code="LL" country="CL" zone="South America" />
+		<state name="Los Ríos" iso_code="LR" country="CL" zone="South America" />
+		<state name="Magallanes" iso_code="MA" country="CL" zone="South America" />
+		<state name="Maule" iso_code="ML" country="CL" zone="South America" />
+		<state name="Ñuble" iso_code="NB" country="CL" zone="South America" />
+		<state name="Metrop. de Santiago" iso_code="RM" country="CL" zone="South America" />
+		<state name="O'Higgins" iso_code="LI" country="CL" zone="South America" />
+		<state name="Tarapacá" iso_code="TA" country="CL" zone="South America" />
+		<state name="Valparaíso" iso_code="VS" country="CL" zone="South America" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />

--- a/localization/co.xml
+++ b/localization/co.xml
@@ -35,19 +35,19 @@
 		<state name="Amazonas" iso_code="AMA" zone="South America" country="CO"/>
 		<state name="Antioquia" iso_code="ANT" zone="South America" country="CO"/>
 		<state name="Arauca" iso_code="ARA" zone="South America" country="CO"/>
-		<state name="Atlantico" iso_code="ATL" zone="South America" country="CO"/>
-		<state name="Bolivar" iso_code="BOL" zone="South America" country="CO"/>
-		<state name="Boyaca" iso_code="BOY" zone="South America" country="CO"/>
+		<state name="Atlántico" iso_code="ATL" zone="South America" country="CO"/>
+		<state name="Bolívar" iso_code="BOL" zone="South America" country="CO"/>
+		<state name="Boyacá" iso_code="BOY" zone="South America" country="CO"/>
 		<state name="Caldas" iso_code="CAL" zone="South America" country="CO"/>
-		<state name="Caqueta" iso_code="CAQ" zone="South America" country="CO"/>
+		<state name="Caquetá" iso_code="CAQ" zone="South America" country="CO"/>
 		<state name="Casanare" iso_code="CAS" zone="South America" country="CO"/>
 		<state name="Cauca" iso_code="CAU" zone="South America" country="CO"/>
 		<state name="Cesar" iso_code="CES" zone="South America" country="CO"/>
-		<state name="Choco" iso_code="CHO" zone="South America" country="CO"/>
-		<state name="Cordoba" iso_code="COR" zone="South America" country="CO"/>
+		<state name="Chocó" iso_code="CHO" zone="South America" country="CO"/>
+		<state name="Córdoba" iso_code="COR" zone="South America" country="CO"/>
 		<state name="Cundinamarca" iso_code="CUN" zone="South America" country="CO"/>
 		<state name="Distrito Capital" iso_code="DC" zone="South America" country="CO"/>
-		<state name="Guainia" iso_code="GUA" zone="South America" country="CO"/>
+		<state name="Guainía" iso_code="GUA" zone="South America" country="CO"/>
 		<state name="Guaviare" iso_code="GUV" zone="South America" country="CO"/>
 		<state name="Huila" iso_code="HUI" zone="South America" country="CO"/>
 		<state name="La Guajira" iso_code="LAG" zone="South America" country="CO"/>
@@ -56,14 +56,14 @@
 		<state name="Nariño" iso_code="NAR" zone="South America" country="CO"/>
 		<state name="Norte de Santander" iso_code="NSA" zone="South America" country="CO"/>
 		<state name="Putumayo" iso_code="PUT" zone="South America" country="CO"/>
-		<state name="Quindio" iso_code="QUI" zone="South America" country="CO"/>
+		<state name="Quindío" iso_code="QUI" zone="South America" country="CO"/>
 		<state name="Risaralda" iso_code="RIS" zone="South America" country="CO"/>
-		<state name="San Andres y Providencia" iso_code="SAP" zone="South America" country="CO"/>
+		<state name="San Andrés y Providencia" iso_code="SAP" zone="South America" country="CO"/>
 		<state name="Santander" iso_code="SAN" zone="South America" country="CO"/>
 		<state name="Sucre" iso_code="SUC" zone="South America" country="CO"/>
 		<state name="Tolima" iso_code="TOL" zone="South America" country="CO"/>
 		<state name="Valle del Cauca" iso_code="VAC" zone="South America" country="CO"/>
-		<state name="Vaupes" iso_code="VAU" zone="South America" country="CO"/>
+		<state name="Vaupés" iso_code="VAU" zone="South America" country="CO"/>
 		<state name="Vichada" iso_code="VID" zone="South America" country="CO"/>
 	</states>
 </localizationPack>

--- a/localization/cr.xml
+++ b/localization/cr.xml
@@ -23,6 +23,15 @@
       <taxRule iso_code_country="cr" id_tax="3" />
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Alajuela" iso_code="A" country="CR" zone="Central America/Antilla" />
+    <state name="Cartago" iso_code="C" country="CR" zone="Central America/Antilla" />
+    <state name="Guanacaste" iso_code="G" country="CR" zone="Central America/Antilla" />
+    <state name="Heredia" iso_code="H" country="CR" zone="Central America/Antilla" />
+    <state name="Limón" iso_code="L" country="CR" zone="Central America/Antilla" />
+    <state name="Puntarenas" iso_code="P" country="CR" zone="Central America/Antilla" />
+    <state name="San José" iso_code="SJ" country="CR" zone="Central America/Antilla" />
+  </states>
   <units>
     <unit type="weight" value="kg" />
     <unit type="volume" value="L" />
@@ -30,13 +39,4 @@
     <unit type="base_distance" value="m" />
     <unit type="long_distance" value="km" />
   </units>
-  <states>
-    <state name="San Jose" iso_code="CR-SJ" zone="Central America/Antilla" country="CR"/>
-    <state name="Alajuela" iso_code="CR-A" zone="Central America/Antilla" country="CR"/>
-    <state name="Cartago" iso_code="CR-C" zone="Central America/Antilla" country="CR"/>
-    <state name="Heredia" iso_code="CR-H" zone="Central America/Antilla" country="CR"/>
-    <state name="Guanacaste" iso_code="CR-G" zone="Central America/Antilla" country="CR"/>
-    <state name="Puntarenas" iso_code="CR-P" zone="Central America/Antilla" country="CR"/>
-    <state name="Limon" iso_code="CR-L" zone="Central America/Antilla" country="CR"/>
-  </states>
 </localizationPack>

--- a/localization/cy.xml
+++ b/localization/cy.xml
@@ -195,6 +195,14 @@
       <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Ammochostos (Mağusa)" iso_code="04" country="CY" zone="Europe" />
+    <state name="Keryneia (Girne)" iso_code="06" country="CY" zone="Europe" />
+    <state name="Larnaka (Larnaka)" iso_code="03" country="CY" zone="Europe" />
+    <state name="Lefkosia (Lefkoşa)" iso_code="01" country="CY" zone="Europe" />
+    <state name="Lemesos (Leymasun)" iso_code="02" country="CY" zone="Europe" />
+    <state name="Pafos (Baf)" iso_code="05" country="CY" zone="Europe" />
+  </states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/de.xml
+++ b/localization/de.xml
@@ -193,6 +193,24 @@
       <taxRule iso_code_country="sk" id_tax="30"/>
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Baden-Württemberg" iso_code="BW" country="DE" zone="Europe" />
+    <state name="Bayern" iso_code="BY" country="DE" zone="Europe" />
+    <state name="Berlin" iso_code="BE" country="DE" zone="Europe" />
+    <state name="Brandenburg" iso_code="BB" country="DE" zone="Europe" />
+    <state name="Bremen" iso_code="HB" country="DE" zone="Europe" />
+    <state name="Hamburg" iso_code="HH" country="DE" zone="Europe" />
+    <state name="Hessen" iso_code="HE" country="DE" zone="Europe" />
+    <state name="Mecklenburg-Vorpommern" iso_code="MV" country="DE" zone="Europe" />
+    <state name="Niedersachsen" iso_code="NI" country="DE" zone="Europe" />
+    <state name="Nordrhein-Westfalen" iso_code="NW" country="DE" zone="Europe" />
+    <state name="Rheinland-Pfalz" iso_code="RP" country="DE" zone="Europe" />
+    <state name="Saarland" iso_code="SL" country="DE" zone="Europe" />
+    <state name="Sachsen" iso_code="SN" country="DE" zone="Europe" />
+    <state name="Sachsen-Anhalt" iso_code="ST" country="DE" zone="Europe" />
+    <state name="Schleswig-Holstein" iso_code="SH" country="DE" zone="Europe" />
+    <state name="Thüringen" iso_code="TH" country="DE" zone="Europe" />
+  </states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/do.xml
+++ b/localization/do.xml
@@ -18,6 +18,50 @@
 			<taxRule iso_code_country="do" id_tax="2" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Azua" iso_code="02" country="DO" zone="Central America/Antilla" />
+		<state name="Baoruco" iso_code="03" country="DO" zone="Central America/Antilla" />
+		<state name="Barahona" iso_code="04" country="DO" zone="Central America/Antilla" />
+		<state name="Cibao Nordeste" iso_code="33" country="DO" zone="Central America/Antilla" />
+		<state name="Cibao Noroeste" iso_code="34" country="DO" zone="Central America/Antilla" />
+		<state name="Cibao Norte" iso_code="35" country="DO" zone="Central America/Antilla" />
+		<state name="Cibao Sur" iso_code="36" country="DO" zone="Central America/Antilla" />
+		<state name="Dajabón" iso_code="05" country="DO" zone="Central America/Antilla" />
+		<state name="Santo Domingo" iso_code="01" country="DO" zone="Central America/Antilla" />
+		<state name="Duarte" iso_code="06" country="DO" zone="Central America/Antilla" />
+		<state name="El Seibo" iso_code="08" country="DO" zone="Central America/Antilla" />
+		<state name="El Valle" iso_code="37" country="DO" zone="Central America/Antilla" />
+		<state name="Elías Piña" iso_code="07" country="DO" zone="Central America/Antilla" />
+		<state name="Enriquillo" iso_code="38" country="DO" zone="Central America/Antilla" />
+		<state name="Espaillat" iso_code="09" country="DO" zone="Central America/Antilla" />
+		<state name="Hato Mayor" iso_code="30" country="DO" zone="Central America/Antilla" />
+		<state name="Hermanas Mirabal" iso_code="19" country="DO" zone="Central America/Antilla" />
+		<state name="Higuamo" iso_code="39" country="DO" zone="Central America/Antilla" />
+		<state name="Independencia" iso_code="10" country="DO" zone="Central America/Antilla" />
+		<state name="La Altagracia" iso_code="11" country="DO" zone="Central America/Antilla" />
+		<state name="La Romana" iso_code="12" country="DO" zone="Central America/Antilla" />
+		<state name="La Vega" iso_code="13" country="DO" zone="Central America/Antilla" />
+		<state name="María Trinidad Sánchez" iso_code="14" country="DO" zone="Central America/Antilla" />
+		<state name="Monseñor Nouel" iso_code="28" country="DO" zone="Central America/Antilla" />
+		<state name="Monte Cristi" iso_code="15" country="DO" zone="Central America/Antilla" />
+		<state name="Monte Plata" iso_code="29" country="DO" zone="Central America/Antilla" />
+		<state name="Ozama" iso_code="40" country="DO" zone="Central America/Antilla" />
+		<state name="Pedernales" iso_code="16" country="DO" zone="Central America/Antilla" />
+		<state name="Peravia" iso_code="17" country="DO" zone="Central America/Antilla" />
+		<state name="Puerto Plata" iso_code="18" country="DO" zone="Central America/Antilla" />
+		<state name="Samaná" iso_code="20" country="DO" zone="Central America/Antilla" />
+		<state name="San Cristóbal" iso_code="21" country="DO" zone="Central America/Antilla" />
+		<state name="San José de Ocoa" iso_code="31" country="DO" zone="Central America/Antilla" />
+		<state name="San Juan" iso_code="22" country="DO" zone="Central America/Antilla" />
+		<state name="San Pedro de Macorís" iso_code="23" country="DO" zone="Central America/Antilla" />
+		<state name="Sánchez Ramírez" iso_code="24" country="DO" zone="Central America/Antilla" />
+		<state name="Santiago" iso_code="25" country="DO" zone="Central America/Antilla" />
+		<state name="Santiago Rodríguez" iso_code="26" country="DO" zone="Central America/Antilla" />
+		<state name="Santo Domingo" iso_code="32" country="DO" zone="Central America/Antilla" />
+		<state name="Valdesia" iso_code="41" country="DO" zone="Central America/Antilla" />
+		<state name="Valverde" iso_code="27" country="DO" zone="Central America/Antilla" />
+		<state name="Yuma" iso_code="42" country="DO" zone="Central America/Antilla" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />

--- a/localization/ec.xml
+++ b/localization/ec.xml
@@ -17,6 +17,32 @@
 			<taxRule iso_code_country="ec" id_tax="2" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Azuay" iso_code="A" country="EC" zone="South America" />
+		<state name="Bolívar" iso_code="B" country="EC" zone="South America" />
+		<state name="Cañar" iso_code="F" country="EC" zone="South America" />
+		<state name="Carchi" iso_code="C" country="EC" zone="South America" />
+		<state name="Chimborazo" iso_code="H" country="EC" zone="South America" />
+		<state name="Cotopaxi" iso_code="X" country="EC" zone="South America" />
+		<state name="El Oro" iso_code="O" country="EC" zone="South America" />
+		<state name="Esmeraldas" iso_code="E" country="EC" zone="South America" />
+		<state name="Galápagos" iso_code="W" country="EC" zone="South America" />
+		<state name="Guayas" iso_code="G" country="EC" zone="South America" />
+		<state name="Imbabura" iso_code="I" country="EC" zone="South America" />
+		<state name="Loja" iso_code="L" country="EC" zone="South America" />
+		<state name="Los Ríos" iso_code="R" country="EC" zone="South America" />
+		<state name="Manabí" iso_code="M" country="EC" zone="South America" />
+		<state name="Morona-Santiago" iso_code="S" country="EC" zone="South America" />
+		<state name="Napo" iso_code="N" country="EC" zone="South America" />
+		<state name="Orellana" iso_code="D" country="EC" zone="South America" />
+		<state name="Pastaza" iso_code="Y" country="EC" zone="South America" />
+		<state name="Pichincha" iso_code="P" country="EC" zone="South America" />
+		<state name="Santa Elena" iso_code="SE" country="EC" zone="South America" />
+		<state name="Santo Domingo de los Tsáchilas" iso_code="SD" country="EC" zone="South America" />
+		<state name="Sucumbíos" iso_code="U" country="EC" zone="South America" />
+		<state name="Tungurahua" iso_code="T" country="EC" zone="South America" />
+		<state name="Zamora Chinchipe" iso_code="Z" country="EC" zone="South America" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />

--- a/localization/ee.xml
+++ b/localization/ee.xml
@@ -193,6 +193,24 @@
       <taxRule iso_code_country="sk" id_tax="30"/>
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Harjumaa" iso_code="37" country="EE" zone="Europe" />
+    <state name="Hiiumaa" iso_code="39" country="EE" zone="Europe" />
+    <state name="Ida-Virumaa" iso_code="45" country="EE" zone="Europe" />
+    <state name="Ida-Viru" iso_code="44" country="EE" zone="Europe" />
+    <state name="Järvamaa" iso_code="52" country="EE" zone="Europe" />
+    <state name="Jõgevamaa" iso_code="50" country="EE" zone="Europe" />
+    <state name="Läänemaa" iso_code="56" country="EE" zone="Europe" />
+    <state name="Lääne-Virumaa" iso_code="60" country="EE" zone="Europe" />
+    <state name="Pärnumaa" iso_code="68" country="EE" zone="Europe" />
+    <state name="Põlvamaa" iso_code="64" country="EE" zone="Europe" />
+    <state name="Raplamaa" iso_code="71" country="EE" zone="Europe" />
+    <state name="Saaremaa" iso_code="74" country="EE" zone="Europe" />
+    <state name="Tartumaa" iso_code="79" country="EE" zone="Europe" />
+    <state name="Valgamaa" iso_code="81" country="EE" zone="Europe" />
+    <state name="Viljandimaa" iso_code="84" country="EE" zone="Europe" />
+    <state name="Võrumaa" iso_code="87" country="EE" zone="Europe" />
+  </states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/fi.xml
+++ b/localization/fi.xml
@@ -8,7 +8,7 @@
   </languages>
   <taxes>
     <tax id="1" name="ALV FI 25.5%" rate="25.5" eu-tax-group="virtual"/>
-    <tax id="2" name="ALV FI 14%" rate="14"/>
+    <tax id="2" name="ALV FI 13.5%" rate="13.5"/>
     <tax id="3" name="ALV FI 10%" rate="10"/>
     <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -69,7 +69,7 @@
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="FI Reduced Rate (14%)">
+    <taxRulesGroup name="FI Reduced Rate (13.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>
@@ -131,7 +131,7 @@
       <taxRule iso_code_country="se" id_tax="3"/>
       <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
-    <taxRulesGroup name="FI Foodstuff Rate (14%)">
+    <taxRulesGroup name="FI Foodstuff Rate (13.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>
@@ -225,6 +225,27 @@
       <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Ahvenanmaan maakunta" iso_code="01" country="FI" zone="Europe" />
+    <state name="Etelä-Karjala" iso_code="02" country="FI" zone="Europe" />
+    <state name="Etelä-Pohjanmaa" iso_code="03" country="FI" zone="Europe" />
+    <state name="Etelä-Savo" iso_code="04" country="FI" zone="Europe" />
+    <state name="Kainuu" iso_code="05" country="FI" zone="Europe" />
+    <state name="Kanta-Häme" iso_code="06" country="FI" zone="Europe" />
+    <state name="Keski-Pohjanmaa" iso_code="07" country="FI" zone="Europe" />
+    <state name="Keski-Suomi" iso_code="08" country="FI" zone="Europe" />
+    <state name="Kymenlaakso" iso_code="09" country="FI" zone="Europe" />
+    <state name="Lappi" iso_code="10" country="FI" zone="Europe" />
+    <state name="Pirkanmaa" iso_code="11" country="FI" zone="Europe" />
+    <state name="Pohjanmaa" iso_code="12" country="FI" zone="Europe" />
+    <state name="Pohjois-Karjala" iso_code="13" country="FI" zone="Europe" />
+    <state name="Pohjois-Pohjanmaa" iso_code="14" country="FI" zone="Europe" />
+    <state name="Pohjois-Savo" iso_code="15" country="FI" zone="Europe" />
+    <state name="Päijät-Häme" iso_code="16" country="FI" zone="Europe" />
+    <state name="Satakunta" iso_code="17" country="FI" zone="Europe" />
+    <state name="Uusimaa" iso_code="18" country="FI" zone="Europe" />
+    <state name="Varsinais-Suomi" iso_code="19" country="FI" zone="Europe" />
+  </states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/gt.xml
+++ b/localization/gt.xml
@@ -13,6 +13,30 @@
 			<taxRule iso_code_country="gt" id_tax="1" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Alta Verapaz" iso_code="16" country="GT" zone="Central America/Antilla" />
+		<state name="Baja Verapaz" iso_code="15" country="GT" zone="Central America/Antilla" />
+		<state name="Chimaltenango" iso_code="04" country="GT" zone="Central America/Antilla" />
+		<state name="Chiquimula" iso_code="20" country="GT" zone="Central America/Antilla" />
+		<state name="El Progreso" iso_code="02" country="GT" zone="Central America/Antilla" />
+		<state name="Escuintla" iso_code="05" country="GT" zone="Central America/Antilla" />
+		<state name="Guatemala" iso_code="01" country="GT" zone="Central America/Antilla" />
+		<state name="Huehuetenango" iso_code="13" country="GT" zone="Central America/Antilla" />
+		<state name="Izabal" iso_code="18" country="GT" zone="Central America/Antilla" />
+		<state name="Jalapa" iso_code="21" country="GT" zone="Central America/Antilla" />
+		<state name="Jutiapa" iso_code="22" country="GT" zone="Central America/Antilla" />
+		<state name="Petén" iso_code="17" country="GT" zone="Central America/Antilla" />
+		<state name="Quetzaltenango" iso_code="09" country="GT" zone="Central America/Antilla" />
+		<state name="Quiché" iso_code="14" country="GT" zone="Central America/Antilla" />
+		<state name="Retalhuleu" iso_code="11" country="GT" zone="Central America/Antilla" />
+		<state name="Sacatepéquez" iso_code="03" country="GT" zone="Central America/Antilla" />
+		<state name="San Marcos" iso_code="12" country="GT" zone="Central America/Antilla" />
+		<state name="Santa Rosa" iso_code="06" country="GT" zone="Central America/Antilla" />
+		<state name="Sololá" iso_code="07" country="GT" zone="Central America/Antilla" />
+		<state name="Suchitepéquez" iso_code="10" country="GT" zone="Central America/Antilla" />
+		<state name="Totonicapán" iso_code="08" country="GT" zone="Central America/Antilla" />
+		<state name="Zacapa" iso_code="19" country="GT" zone="Central America/Antilla" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />

--- a/localization/gy.xml
+++ b/localization/gy.xml
@@ -13,11 +13,23 @@
 			<taxRule iso_code_country="gy" id_tax="1" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Barima-Waini" iso_code="BA" country="GY" zone="South America" />
+		<state name="Cuyuni-Mazaruni" iso_code="CU" country="GY" zone="South America" />
+		<state name="Demerara-Mahaica" iso_code="DE" country="GY" zone="South America" />
+		<state name="East Berbice-Corentyne" iso_code="EB" country="GY" zone="South America" />
+		<state name="Essequibo Islands-West Demerara" iso_code="ES" country="GY" zone="South America" />
+		<state name="Mahaica-Berbice" iso_code="MA" country="GY" zone="South America" />
+		<state name="Pomeroon-Supenaam" iso_code="PM" country="GY" zone="South America" />
+		<state name="Potaro-Siparuni" iso_code="PT" country="GY" zone="South America" />
+		<state name="Upper Demerara-Berbice" iso_code="UD" country="GY" zone="South America" />
+		<state name="Upper Takutu-Upper Essequibo" iso_code="UT" country="GY" zone="South America" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />
-		<unit type="short_distance" value="in" />
-		<unit type="base_distance" value="ft" />
-		<unit type="long_distance" value="mi" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
 	</units>
 </localizationPack>

--- a/localization/hr.xml
+++ b/localization/hr.xml
@@ -195,6 +195,29 @@
       <taxRule iso_code_country="sk" id_tax="32"/>
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Bjelovarsko-bilogorska županija" iso_code="07" country="HR" zone="Europe" />
+    <state name="Brodsko-posavska županija" iso_code="12" country="HR" zone="Europe" />
+    <state name="Dubrovačko-neretvanska županija" iso_code="19" country="HR" zone="Europe" />
+    <state name="Grad Zagreb" iso_code="21" country="HR" zone="Europe" />
+    <state name="Istarska županija" iso_code="18" country="HR" zone="Europe" />
+    <state name="Karlovačka županija" iso_code="04" country="HR" zone="Europe" />
+    <state name="Koprivničko-križevačka županija" iso_code="06" country="HR" zone="Europe" />
+    <state name="Krapinsko-zagorska županija" iso_code="02" country="HR" zone="Europe" />
+    <state name="Ličko-senjska županija" iso_code="09" country="HR" zone="Europe" />
+    <state name="Međimurska županija" iso_code="20" country="HR" zone="Europe" />
+    <state name="Osječko-baranjska županija" iso_code="14" country="HR" zone="Europe" />
+    <state name="Požeško-slavonska županija" iso_code="11" country="HR" zone="Europe" />
+    <state name="Primorsko-goranska županija" iso_code="08" country="HR" zone="Europe" />
+    <state name="Šibensko-kninska županija" iso_code="15" country="HR" zone="Europe" />
+    <state name="Sisačko-moslavačka županija" iso_code="03" country="HR" zone="Europe" />
+    <state name="Splitsko-dalmatinska županija" iso_code="17" country="HR" zone="Europe" />
+    <state name="Varaždinska županija" iso_code="05" country="HR" zone="Europe" />
+    <state name="Virovitičko-podravska županija" iso_code="10" country="HR" zone="Europe" />
+    <state name="Vukovarsko-srijemska županija" iso_code="16" country="HR" zone="Europe" />
+    <state name="Zadarska županija" iso_code="13" country="HR" zone="Europe" />
+    <state name="Zagrebačka županija" iso_code="01" country="HR" zone="Europe" />
+  </states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/hu.xml
+++ b/localization/hu.xml
@@ -225,6 +225,51 @@
       <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Bács-Kiskun" iso_code="BK" country="HU" zone="Europe" />
+    <state name="Baranya" iso_code="BA" country="HU" zone="Europe" />
+    <state name="Békés" iso_code="BE" country="HU" zone="Europe" />
+    <state name="Békéscsaba" iso_code="BC" country="HU" zone="Europe" />
+    <state name="Borsod-Abaúj-Zemplén" iso_code="BZ" country="HU" zone="Europe" />
+    <state name="Budapest" iso_code="BU" country="HU" zone="Europe" />
+    <state name="Csongrád-Csanád" iso_code="CS" country="HU" zone="Europe" />
+    <state name="Debrecen" iso_code="DE" country="HU" zone="Europe" />
+    <state name="Dunaújváros" iso_code="DU" country="HU" zone="Europe" />
+    <state name="Eger" iso_code="EG" country="HU" zone="Europe" />
+    <state name="Érd" iso_code="ER" country="HU" zone="Europe" />
+    <state name="Fejér" iso_code="FE" country="HU" zone="Europe" />
+    <state name="Győr" iso_code="GY" country="HU" zone="Europe" />
+    <state name="Győr-Moson-Sopron" iso_code="GS" country="HU" zone="Europe" />
+    <state name="Hajdú-Bihar" iso_code="HB" country="HU" zone="Europe" />
+    <state name="Heves" iso_code="HE" country="HU" zone="Europe" />
+    <state name="Hódmezővásárhely" iso_code="HV" country="HU" zone="Europe" />
+    <state name="Jász-Nagykun-Szolnok" iso_code="JN" country="HU" zone="Europe" />
+    <state name="Kaposvár" iso_code="KV" country="HU" zone="Europe" />
+    <state name="Kecskemét" iso_code="KM" country="HU" zone="Europe" />
+    <state name="Komárom-Esztergom" iso_code="KM" country="HU" zone="Europe" />
+    <state name="Miskolc" iso_code="MI" country="HU" zone="Europe" />
+    <state name="Nagykanizsa" iso_code="NK" country="HU" zone="Europe" />
+    <state name="Nógrád" iso_code="NO" country="HU" zone="Europe" />
+    <state name="Nyíregyháza" iso_code="NY" country="HU" zone="Europe" />
+    <state name="Pécs" iso_code="PS" country="HU" zone="Europe" />
+    <state name="Pest" iso_code="PE" country="HU" zone="Europe" />
+    <state name="Salgótarján" iso_code="ST" country="HU" zone="Europe" />
+    <state name="Somogy" iso_code="SO" country="HU" zone="Europe" />
+    <state name="Sopron" iso_code="SN" country="HU" zone="Europe" />
+    <state name="Szabolcs-Szatmár-Bereg" iso_code="SZ" country="HU" zone="Europe" />
+    <state name="Szeged" iso_code="SD" country="HU" zone="Europe" />
+    <state name="Székesfehérvár" iso_code="SF" country="HU" zone="Europe" />
+    <state name="Szekszárd" iso_code="SS" country="HU" zone="Europe" />
+    <state name="Szolnok" iso_code="SK" country="HU" zone="Europe" />
+    <state name="Szombathely" iso_code="SH" country="HU" zone="Europe" />
+    <state name="Tatabánya" iso_code="TB" country="HU" zone="Europe" />
+    <state name="Tolna" iso_code="TO" country="HU" zone="Europe" />
+    <state name="Vas" iso_code="VA" country="HU" zone="Europe" />
+    <state name="Veszprém" iso_code="VM" country="HU" zone="Europe" />
+    <state name="Veszprém city" iso_code="VE" country="HU" zone="Europe" />
+    <state name="Zala" iso_code="ZA" country="HU" zone="Europe" />
+    <state name="Zalaegerszeg" iso_code="ZE" country="HU" zone="Europe" />
+  </states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/ie.xml
+++ b/localization/ie.xml
@@ -195,6 +195,12 @@
       <taxRule iso_code_country="sk" id_tax="32"/>
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Connaught" iso_code="C" country="IE" zone="Europe" />
+    <state name="Leinster" iso_code="L" country="IE" zone="Europe" />
+    <state name="Munster" iso_code="M" country="IE" zone="Europe" />
+    <state name="Ulster" iso_code="U" country="IE" zone="Europe" />
+  </states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/it.xml
+++ b/localization/it.xml
@@ -282,11 +282,10 @@
     <state name="Mantova" iso_code="MN" country="IT" zone="Europe"/>
     <state name="Massa-Carrara" iso_code="MS" country="IT" zone="Europe"/>
     <state name="Matera" iso_code="MT" country="IT" zone="Europe"/>
-    <state name="Medio Campidano" iso_code="VS" country="IT" zone="Europe"/>
     <state name="Messina" iso_code="ME" country="IT" zone="Europe"/>
     <state name="Milano" iso_code="MI" country="IT" zone="Europe"/>
     <state name="Modena" iso_code="MO" country="IT" zone="Europe"/>
-    <state name="Monza e Brianza" iso_code="MB" country="IT" zone="Europe"/>
+    <state name="Monza e della Brianza" iso_code="MB" country="IT" zone="Europe"/>
     <state name="Napoli" iso_code="NA" country="IT" zone="Europe"/>
     <state name="Novara" iso_code="NO" country="IT" zone="Europe"/>
     <state name="Nuoro" iso_code="NU" country="IT" zone="Europe"/>
@@ -318,7 +317,7 @@
     <state name="Siena" iso_code="SI" country="IT" zone="Europe"/>
     <state name="Siracusa" iso_code="SR" country="IT" zone="Europe"/>
     <state name="Sondrio" iso_code="SO" country="IT" zone="Europe"/>
-    <state name="Sulcis Iglesiente" iso_code="SU" country="IT" zone="Europe"/>
+    <state name="Sud Sardegna" iso_code="SU" country="IT" zone="Europe"/>
     <state name="Taranto" iso_code="TA" country="IT" zone="Europe"/>
     <state name="Teramo" iso_code="TE" country="IT" zone="Europe"/>
     <state name="Terni" iso_code="TR" country="IT" zone="Europe"/>

--- a/localization/pa.xml
+++ b/localization/pa.xml
@@ -24,6 +24,22 @@
       <taxRule iso_code_country="pa" behavior="0" id_tax="4"/>
     </taxRulesGroup>
   </taxes>
+	<states>
+		<state name="Bocas del Toro" iso_code="1" country="PA" zone="Central America/Antilla" />
+		<state name="Chiriquí" iso_code="4" country="PA" zone="Central America/Antilla" />
+		<state name="Coclé" iso_code="2" country="PA" zone="Central America/Antilla" />
+		<state name="Colón" iso_code="3" country="PA" zone="Central America/Antilla" />
+		<state name="Darién" iso_code="5" country="PA" zone="Central America/Antilla" />
+		<state name="Emberá" iso_code="EM" country="PA" zone="Central America/Antilla" />
+		<state name="Guna Yala" iso_code="KY" country="PA" zone="Central America/Antilla" />
+		<state name="Herrera" iso_code="6" country="PA" zone="Central America/Antilla" />
+		<state name="Los Santos" iso_code="7" country="PA" zone="Central America/Antilla" />
+		<state name="Naso Tjër Di" iso_code="NT" country="PA" zone="Central America/Antilla" />
+		<state name="Ngöbe-Buglé" iso_code="NB" country="PA" zone="Central America/Antilla" />
+		<state name="Panamá Oeste" iso_code="10" country="PA" zone="Central America/Antilla" />
+		<state name="Panamá" iso_code="8" country="PA" zone="Central America/Antilla" />
+		<state name="Veraguas" iso_code="9" country="PA" zone="Central America/Antilla" />
+	</states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/pe.xml
+++ b/localization/pe.xml
@@ -15,6 +15,33 @@
     <tax id="53" name="Impuesto General a la Ventas" rate="16.000"/>
     <tax id="54" name="Impuesto de Promocion Municipal" rate="2.000"/>
   </taxes>
+	<states>
+		<state name="Amazonas" iso_code="AMA" country="PE" zone="South America" />
+		<state name="Ancash" iso_code="ANC" country="PE" zone="South America" />
+		<state name="Apurímac" iso_code="APU" country="PE" zone="South America" />
+		<state name="Arequipa" iso_code="ARE" country="PE" zone="South America" />
+		<state name="Ayacucho" iso_code="AYA" country="PE" zone="South America" />
+		<state name="Cajamarca" iso_code="CAJ" country="PE" zone="South America" />
+		<state name="Callao" iso_code="CAL" country="PE" zone="South America" />
+		<state name="Cusco" iso_code="CUS" country="PE" zone="South America" />
+		<state name="Huancavelica" iso_code="HUV" country="PE" zone="South America" />
+		<state name="Huánuco" iso_code="HUC" country="PE" zone="South America" />
+		<state name="Ica" iso_code="ICA" country="PE" zone="South America" />
+		<state name="Junín" iso_code="JUN" country="PE" zone="South America" />
+		<state name="La Libertad" iso_code="LAL" country="PE" zone="South America" />
+		<state name="Lambayeque" iso_code="LAM" country="PE" zone="South America" />
+		<state name="Lima" iso_code="LIM" country="PE" zone="South America" />
+		<state name="Loreto" iso_code="LOR" country="PE" zone="South America" />
+		<state name="Madre de Dios" iso_code="MDD" country="PE" zone="South America" />
+		<state name="Moquegua" iso_code="MOQ" country="PE" zone="South America" />
+		<state name="Pasco" iso_code="PAS" country="PE" zone="South America" />
+		<state name="Piura" iso_code="PIU" country="PE" zone="South America" />
+		<state name="Puno" iso_code="PUN" country="PE" zone="South America" />
+		<state name="San Martín" iso_code="SAM" country="PE" zone="South America" />
+		<state name="Tacna" iso_code="TAC" country="PE" zone="South America" />
+		<state name="Tumbes" iso_code="TUM" country="PE" zone="South America" />
+		<state name="Ucayali" iso_code="UCA" country="PE" zone="South America" />
+	</states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>

--- a/localization/py.xml
+++ b/localization/py.xml
@@ -18,11 +18,31 @@
 			<taxRule iso_code_country="py" id_tax="2" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Alto Paraguay" iso_code="16" country="PY" zone="South America" />
+		<state name="Alto Paraná" iso_code="10" country="PY" zone="South America" />
+		<state name="Amambay" iso_code="13" country="PY" zone="South America" />
+		<state name="Asunción" iso_code="ASU" country="PY" zone="South America" />
+		<state name="Boquerón" iso_code="19" country="PY" zone="South America" />
+		<state name="Caaguazú" iso_code="5" country="PY" zone="South America" />
+		<state name="Caazapá" iso_code="6" country="PY" zone="South America" />
+		<state name="Canindeyú" iso_code="14" country="PY" zone="South America" />
+		<state name="Central" iso_code="11" country="PY" zone="South America" />
+		<state name="Concepción" iso_code="1" country="PY" zone="South America" />
+		<state name="Cordillera" iso_code="3" country="PY" zone="South America" />
+		<state name="Guairá" iso_code="4" country="PY" zone="South America" />
+		<state name="Itapúa" iso_code="7" country="PY" zone="South America" />
+		<state name="Misiones" iso_code="8" country="PY" zone="South America" />
+		<state name="Ñeembucú" iso_code="12" country="PY" zone="South America" />
+		<state name="Paraguarí" iso_code="9" country="PY" zone="South America" />
+		<state name="Presidente Hayes" iso_code="15" country="PY" zone="South America" />
+		<state name="San Pedro" iso_code="2" country="PY" zone="South America" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />
-		<unit type="short_distance" value="in" />
-		<unit type="base_distance" value="ft" />
-		<unit type="long_distance" value="mi" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
 	</units>
 </localizationPack>

--- a/localization/sk.xml
+++ b/localization/sk.xml
@@ -101,35 +101,35 @@
       <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SK Reduced Rate 2 (5%)">
-      <taxRule iso_code_country="be" id_tax="31"/>
-      <taxRule iso_code_country="bg" id_tax="31"/>
-      <taxRule iso_code_country="cz" id_tax="31"/>
-      <taxRule iso_code_country="dk" id_tax="31"/>
-      <taxRule iso_code_country="de" id_tax="31"/>
-      <taxRule iso_code_country="ee" id_tax="31"/>
-      <taxRule iso_code_country="gr" id_tax="31"/>
-      <taxRule iso_code_country="hr" id_tax="31"/>
-      <taxRule iso_code_country="es" id_tax="31"/>
-      <taxRule iso_code_country="fr" id_tax="31"/>
-      <taxRule iso_code_country="mc" id_tax="31"/>
-      <taxRule iso_code_country="ie" id_tax="31"/>
-      <taxRule iso_code_country="it" id_tax="31"/>
-      <taxRule iso_code_country="cy" id_tax="31"/>
-      <taxRule iso_code_country="lv" id_tax="31"/>
-      <taxRule iso_code_country="lt" id_tax="31"/>
-      <taxRule iso_code_country="lu" id_tax="31"/>
-      <taxRule iso_code_country="hu" id_tax="31"/>
-      <taxRule iso_code_country="mt" id_tax="31"/>
-      <taxRule iso_code_country="nl" id_tax="31"/>
-      <taxRule iso_code_country="at" id_tax="31"/>
-      <taxRule iso_code_country="pl" id_tax="31"/>
-      <taxRule iso_code_country="pt" id_tax="31"/>
-      <taxRule iso_code_country="ro" id_tax="31"/>
-      <taxRule iso_code_country="si" id_tax="31"/>
-      <taxRule iso_code_country="sk" id_tax="31"/>
-      <taxRule iso_code_country="fi" id_tax="31"/>
-      <taxRule iso_code_country="se" id_tax="31"/>
-      <taxRule iso_code_country="gb" id_tax="31"/>
+      <taxRule iso_code_country="be" id_tax="3"/>
+      <taxRule iso_code_country="bg" id_tax="3"/>
+      <taxRule iso_code_country="cz" id_tax="3"/>
+      <taxRule iso_code_country="dk" id_tax="3"/>
+      <taxRule iso_code_country="de" id_tax="3"/>
+      <taxRule iso_code_country="ee" id_tax="3"/>
+      <taxRule iso_code_country="gr" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
+      <taxRule iso_code_country="es" id_tax="3"/>
+      <taxRule iso_code_country="fr" id_tax="3"/>
+      <taxRule iso_code_country="mc" id_tax="3"/>
+      <taxRule iso_code_country="ie" id_tax="3"/>
+      <taxRule iso_code_country="it" id_tax="3"/>
+      <taxRule iso_code_country="cy" id_tax="3"/>
+      <taxRule iso_code_country="lv" id_tax="3"/>
+      <taxRule iso_code_country="lt" id_tax="3"/>
+      <taxRule iso_code_country="lu" id_tax="3"/>
+      <taxRule iso_code_country="hu" id_tax="3"/>
+      <taxRule iso_code_country="mt" id_tax="3"/>
+      <taxRule iso_code_country="nl" id_tax="3"/>
+      <taxRule iso_code_country="at" id_tax="3"/>
+      <taxRule iso_code_country="pl" id_tax="3"/>
+      <taxRule iso_code_country="pt" id_tax="3"/>
+      <taxRule iso_code_country="ro" id_tax="3"/>
+      <taxRule iso_code_country="si" id_tax="3"/>
+      <taxRule iso_code_country="sk" id_tax="3"/>
+      <taxRule iso_code_country="fi" id_tax="3"/>
+      <taxRule iso_code_country="se" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="sk" id_tax="1"/>

--- a/localization/sv.xml
+++ b/localization/sv.xml
@@ -13,6 +13,22 @@
 			<taxRule iso_code_country="sv" id_tax="1" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Ahuachapán" iso_code="AH" country="SV" zone="Central America/Antilla" />
+		<state name="Cabañas" iso_code="CA" country="SV" zone="Central America/Antilla" />
+		<state name="Chalatenango" iso_code="CH" country="SV" zone="Central America/Antilla" />
+		<state name="Cuscatlán" iso_code="CU" country="SV" zone="Central America/Antilla" />
+		<state name="La Libertad" iso_code="LI" country="SV" zone="Central America/Antilla" />
+		<state name="La Paz" iso_code="PA" country="SV" zone="Central America/Antilla" />
+		<state name="La Unión" iso_code="UN" country="SV" zone="Central America/Antilla" />
+		<state name="Morazán" iso_code="MO" country="SV" zone="Central America/Antilla" />
+		<state name="San Miguel" iso_code="SM" country="SV" zone="Central America/Antilla" />
+		<state name="San Salvador" iso_code="SS" country="SV" zone="Central America/Antilla" />
+		<state name="San Vicente" iso_code="SV" country="SV" zone="Central America/Antilla" />
+		<state name="Santa Ana" iso_code="SA" country="SV" zone="Central America/Antilla" />
+		<state name="Sonsonate" iso_code="SO" country="SV" zone="Central America/Antilla" />
+		<state name="Usulután" iso_code="US" country="SV" zone="Central America/Antilla" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />

--- a/localization/us.xml
+++ b/localization/us.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <localizationPack name="United States" version="1.0">
-
 	<languages>
 		<language iso_code="en" />
 	</languages>
@@ -229,6 +228,7 @@
 		<state name="Colorado" iso_code="CO" country="US" zone="North America" />
 		<state name="Connecticut" iso_code="CT" country="US" zone="North America" />
 		<state name="Delaware" iso_code="DE" country="US" zone="North America" />
+		<state name="District of Columbia" iso_code="DC" country="US" zone="North America" />
 		<state name="Florida" iso_code="FL" country="US" zone="North America" />
 		<state name="Georgia" iso_code="GA" country="US" zone="North America" />
 		<state name="Hawaii" iso_code="HI" country="US" zone="North America" />
@@ -252,6 +252,7 @@
 		<state name="New Hampshire" iso_code="NH" country="US" zone="North America" />
 		<state name="New Jersey" iso_code="NJ" country="US" zone="North America" />
 		<state name="New Mexico" iso_code="NM" country="US" zone="North America" />
+		<state name="New York" iso_code="NY" country="US" zone="North America" />
 		<state name="North Carolina" iso_code="NC" country="US" zone="North America" />
 		<state name="North Dakota" iso_code="ND" country="US" zone="North America" />
 		<state name="Ohio" iso_code="OH" country="US" zone="North America" />
@@ -270,9 +271,13 @@
 		<state name="West Virginia" iso_code="WV" country="US" zone="North America" />
 		<state name="Wisconsin" iso_code="WI" country="US" zone="North America" />
 		<state name="Wyoming" iso_code="WY" country="US" zone="North America" />
+		<!-- Outlying areas or islands -->
+		<state name="American Samoa" iso_code="AS" country="US" zone="North America" />
+		<state name="Guam" iso_code="GU" country="US" zone="North America" />
+		<state name="Northern Mariana Islands" iso_code="MP" country="US" zone="North America" />
 		<state name="Puerto Rico" iso_code="PR" country="US" zone="North America" />
+		<state name="US Minor Outlying Islands" iso_code="UM" country="US" zone="North America" />
 		<state name="US Virgin Islands" iso_code="VI" country="US" zone="North America" />
-		<state name="District of Columbia" iso_code="DC" country="US" zone="North America" />
 	</states>
 	<units>
 		<unit type="weight" value="lb" />
@@ -281,9 +286,11 @@
 		<unit type="base_distance" value="ft" />
 		<unit type="long_distance" value="mi" />
 	</units>
+	<modules>
+		<module name="carriercompare" install="1" />
+	</modules>
 	<configurations>
 		<configuration name="PS_TAX_DISPLAY" value="1" />
 	</configurations>
 	<group_default price_display_method="1" />
 </localizationPack>
-

--- a/localization/uy.xml
+++ b/localization/uy.xml
@@ -18,11 +18,32 @@
 			<taxRule iso_code_country="uy" id_tax="2" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Artigas" iso_code="AR" country="UY" zone="South America" />
+		<state name="Canelones" iso_code="CA" country="UY" zone="South America" />
+		<state name="Cerro Largo" iso_code="CL" country="UY" zone="South America" />
+		<state name="Colonia" iso_code="CO" country="UY" zone="South America" />
+		<state name="Durazno" iso_code="DU" country="UY" zone="South America" />
+		<state name="Flores" iso_code="FS" country="UY" zone="South America" />
+		<state name="Florida" iso_code="FD" country="UY" zone="South America" />
+		<state name="Lavalleja" iso_code="LA" country="UY" zone="South America" />
+		<state name="Maldonado" iso_code="MA" country="UY" zone="South America" />
+		<state name="Montevideo" iso_code="MO" country="UY" zone="South America" />
+		<state name="Paysandú" iso_code="PA" country="UY" zone="South America" />
+		<state name="Río Negro" iso_code="RN" country="UY" zone="South America" />
+		<state name="Rivera" iso_code="RV" country="UY" zone="South America" />
+		<state name="Rocha" iso_code="RO" country="UY" zone="South America" />
+		<state name="Salto" iso_code="SA" country="UY" zone="South America" />
+		<state name="San José" iso_code="SJ" country="UY" zone="South America" />
+		<state name="Soriano" iso_code="SO" country="UY" zone="South America" />
+		<state name="Tacuarembó" iso_code="TA" country="UY" zone="South America" />
+		<state name="Treinta y Tres" iso_code="TT" country="UY" zone="South America" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />
-		<unit type="short_distance" value="in" />
-		<unit type="base_distance" value="ft" />
-		<unit type="long_distance" value="mi" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
 	</units>
 </localizationPack>

--- a/localization/ve.xml
+++ b/localization/ve.xml
@@ -29,11 +29,38 @@
 			<taxRule iso_code_country="ve" id_tax="4" />
 		</taxRulesGroup>
   </taxes>
+	<states>
+		<state name="Amazonas" iso_code="Z" country="VE" zone="South America" />
+		<state name="Anzoátegui" iso_code="B" country="VE" zone="South America" />
+		<state name="Apure" iso_code="C" country="VE" zone="South America" />
+		<state name="Aragua" iso_code="D" country="VE" zone="South America" />
+		<state name="Barinas" iso_code="E" country="VE" zone="South America" />
+		<state name="Bolívar" iso_code="F" country="VE" zone="South America" />
+		<state name="Carabobo" iso_code="G" country="VE" zone="South America" />
+		<state name="Cojedes" iso_code="H" country="VE" zone="South America" />
+		<state name="Delta Amacuro" iso_code="Y" country="VE" zone="South America" />
+		<state name="Dependencias Federales" iso_code="W" country="VE" zone="South America" />
+		<state name="Distrito Capital" iso_code="A" country="VE" zone="South America" />
+		<state name="Falcón" iso_code="I" country="VE" zone="South America" />
+		<state name="Guárico" iso_code="J" country="VE" zone="South America" />
+		<state name="La Guaira" iso_code="X" country="VE" zone="South America" />
+		<state name="Lara" iso_code="K" country="VE" zone="South America" />
+		<state name="Mérida" iso_code="L" country="VE" zone="South America" />
+		<state name="Miranda" iso_code="M" country="VE" zone="South America" />
+		<state name="Monagas" iso_code="N" country="VE" zone="South America" />
+		<state name="Nueva Esparta" iso_code="O" country="VE" zone="South America" />
+		<state name="Portuguesa" iso_code="P" country="VE" zone="South America" />
+		<state name="Sucre" iso_code="R" country="VE" zone="South America" />
+		<state name="Táchira" iso_code="S" country="VE" zone="South America" />
+		<state name="Trujillo" iso_code="T" country="VE" zone="South America" />
+		<state name="Yaracuy" iso_code="U" country="VE" zone="South America" />
+		<state name="Zulia" iso_code="V" country="VE" zone="South America" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />
-		<unit type="short_distance" value="in" />
-		<unit type="base_distance" value="ft" />
-		<unit type="long_distance" value="mi" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
 	</units>
 </localizationPack>


### PR DESCRIPTION
| Questions                      | Answers |
| ------------------------------ | ------------------------------------------------------- |
| Branch?                        | develop |
| Description?                   | Automated sync of the bundled localization packs with the canonical PrestaShop/LocalizationFiles repository (source of truth for downloadable packs). Changed files listed below. |
| Type?                          | improvement |
| Category?                      | LO |
| BC breaks?                     | no |
| Deprecations?                  | no |
| Fixed ticket?                  | N/A |
| How to test?                   | Install a shop selecting one of the changed countries and check its taxes, states, currencies and languages match the updated pack. |
| UI Tests?                      | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/28943867925
| Fixed issue or discussion?     | N/A |
| Related PRs                    | N/A |
## Changed localization packs
- `ar.xml`
- `bg.xml`
- `bo.xml`
- `cl.xml`
- `co.xml`
- `cr.xml`
- `cy.xml`
- `de.xml`
- `do.xml`
- `ec.xml`
- `ee.xml`
- `fi.xml`
- `gt.xml`
- `gy.xml`
- `hr.xml`
- `hu.xml`
- `ie.xml`
- `it.xml`
- `pa.xml`
- `pe.xml`
- `py.xml`
- `sk.xml`
- `sv.xml`
- `us.xml`
- `uy.xml`
- `ve.xml`