### PR TITLE
Fix ProductController::getProduct() nullable return type

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -999,9 +999,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     }
 
     /**
-     * @return Product
+     * @return Product|null
      */
-    public function getProduct(): Product
+    public function getProduct(): ?Product
     {
         return $this->product;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      |This PR fixes a fatal `TypeError` in `ProductController::getProduct()` when the requested product is invalid or does not exist.<br/><br/>In this case, `$this->product` can be `null`, but `getProduct()` still declares a non-nullable `Product` return type. If a module calls this method on a missing product page, PHP throws an error.<br/><br/>The return type is now nullable to match the actual possible value.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the [getproduct_error_test.zip](https://github.com/user-attachments/files/29807028/getproduct_error_test.zip) module.<br/>2. Go to an existing product page in the front office. No error should be displayed.<br/>3. Go to an existing but disabled product page in the front office. No error should be displayed.<br/>4. Go to a non-existing product page in the front office. No error should be displayed.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/28953553423
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41299
| Sponsor company   | Codencode snc

---
Before this fix, calling ProductController::getProduct() when the product cannot be loaded causes the following fatal error:
<img width="1920" height="486" alt="Screenshot 2026-07-08 at 17-25-14 " src="https://github.com/user-attachments/assets/253efde3-7367-4560-8408-fa3fa7644c9a" />

