### PR TITLE
Guard order message name-uniqueness check on partial edit (backport 9.1.x)

### DIFF
--- a/src/Adapter/OrderMessage/CommandHandler/EditOrderMessageHandler.php
+++ b/src/Adapter/OrderMessage/CommandHandler/EditOrderMessageHandler.php
@@ -28,7 +28,11 @@ final class EditOrderMessageHandler extends AbstractOrderMessageHandler implemen
      */
     public function handle(EditOrderMessageCommand $command): void
     {
-        $this->assertNameIsNotAlreadyUsed($command);
+        // The name uniqueness check only makes sense when a name is being set: a partial edit may
+        // change the message only, leaving the localized name null (which would break the foreach).
+        if (null !== $command->getLocalizedName()) {
+            $this->assertNameIsNotAlreadyUsed($command);
+        }
 
         $orderMessage = $this->getOrderMessage($command->getOrderMessageId());
 

--- a/tests/Integration/Adapter/OrderMessage/CommandHandler/EditOrderMessageHandlerTest.php
+++ b/tests/Integration/Adapter/OrderMessage/CommandHandler/EditOrderMessageHandlerTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\OrderMessage\CommandHandler;
+
+use ErrorException;
+use OrderMessage;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\AddOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\EditOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\ValueObject\OrderMessageId;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class EditOrderMessageHandlerTest extends KernelTestCase
+{
+    /**
+     * @var object|CommandBusInterface|null
+     */
+    private $commandBus;
+
+    /**
+     * @var int
+     */
+    private $defaultLangId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['order_message', 'order_message_lang']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['order_message', 'order_message_lang']);
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->commandBus = self::getContainer()->get('prestashop.core.command_bus');
+        $this->defaultLangId = (int) self::getContainer()->get('prestashop.adapter.legacy.configuration')->get('PS_LANG_DEFAULT');
+    }
+
+    /**
+     * A partial edit that changes only the message (leaving the localized name null)
+     * must NOT run the name-uniqueness check: that check iterates over the localized
+     * name with foreach(), which emits a warning when the name is null. The edit must
+     * complete without warning, the name must stay untouched and the message updated.
+     */
+    public function testEditingOnlyTheMessageKeepsTheNameAndDoesNotTriggerTheNameCheck(): void
+    {
+        /** @var OrderMessageId $orderMessageId */
+        $orderMessageId = $this->commandBus->handle(new AddOrderMessageCommand(
+            [$this->defaultLangId => 'Delivery delay'],
+            [$this->defaultLangId => 'Your order is delayed.']
+        ));
+
+        // Fail loudly if the partial edit emits a PHP warning — the name-uniqueness
+        // check doing foreach() over the null localized name is exactly such a warning.
+        set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
+            if (E_WARNING === $severity) {
+                throw new ErrorException($message, 0, $severity, $file, $line);
+            }
+
+            return false;
+        });
+
+        try {
+            // Partial edit: only the message is supplied, the localized name is null.
+            $this->commandBus->handle(new EditOrderMessageCommand(
+                $orderMessageId->getValue(),
+                null,
+                [$this->defaultLangId => 'Your order is delayed by 48h.']
+            ));
+        } finally {
+            restore_error_handler();
+        }
+
+        $orderMessage = new OrderMessage($orderMessageId->getValue());
+        $this->assertSame('Delivery delay', $orderMessage->name[$this->defaultLangId]);
+        $this->assertSame('Your order is delayed by 48h.', $orderMessage->message[$this->defaultLangId]);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Backport to `9.1.x` of #41790 (merged only on `develop`). `EditOrderMessageHandler::handle()` always called `assertNameIsNotAlreadyUsed()`, which iterates over `$command->getLocalizedName()`. On a partial edit that only changes the message body, the localized name is `null`, so the `foreach` receives `null` and emits a `foreach() argument must be of type array\|object, null given` warning. Harmless in a plain PHPUnit run, but the Symfony debug error handler turns it into a 500 (that is the context #41790 was made for). The uniqueness check now only runs when a name is actually provided, mirroring the existing null guards further down in `handle()`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Edit an order message changing only its message (leaving the name untouched). Before the fix `handle()` emits a `foreach()`-on-null warning (a 500 under the debug error handler); after the fix it updates cleanly. The partial-edit path is exercised by the `ps_apiresources` integration test `OrderMessageEndpointTest::testEditOrderMessageMessagesOnly`.
| UI Tests          | :green_circle: MySQL: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/29239199725 <br> :green_circle: MariaDB: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/29239201707
| Fixed issue or discussion?     | Backport of #41790 (bug fix originally merged on `develop`; per the branching rules a bug fix belongs on `9.1.x` and merges upward).
| Related PRs       | #41790 (original fix on `develop`).
| Sponsor company   | @PrestaShopCorp
