### PR TITLE
Bootstrap CI for 9.2.x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull
 
 | Questions         | Answers
 | ----------------- | -------------------------------------------------------
-| Branch?           | develop / 9.1.x
+| Branch?           | develop / 9.2.x / 9.1.x
 | Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
 | Type?             | bug fix / improvement / new feature / refacto
 | Category?         | FO / BO / CO / IN / WS / TE / LO / ME / PM / see explanations at https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category

--- a/.github/workflows/cron_create_merge_prs.yml
+++ b/.github/workflows/cron_create_merge_prs.yml
@@ -23,8 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         pair:
-          - source: 9.1.x
+          - source: 9.2.x
             target: develop
+          - source: 9.1.x
+            target: 9.2.x
     uses: ./.github/workflows/create-merge-pr.yml
     with:
       source_branch: ${{ matrix.pair.source }}

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -18,10 +18,13 @@ jobs:
       matrix:
         BRANCH:
           - develop
+          - 9.2.x
           - 9.1.x
           - 8.2.x
         include:
           - BRANCH: develop
+            node: 20
+          - BRANCH: 9.2.x
             node: 20
           - BRANCH: 9.1.x
             node: 20

--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -20,10 +20,13 @@ jobs:
       matrix:
         BRANCH:
           - develop
+          - 9.2.x
           - 9.1.x
           - 8.2.x
         include:
           - BRANCH: develop
+            node: 20
+          - BRANCH: 9.2.x
             node: 20
           - BRANCH: 9.1.x
             node: 20

--- a/.github/workflows/cron_nightly_tests_9.2.x_mariadb.yml
+++ b/.github/workflows/cron_nightly_tests_9.2.x_mariadb.yml
@@ -1,0 +1,21 @@
+# This workflow aim to run all UI tests on active branches
+# and upload the report on Google cloud platform storage
+name: Nightly tests and report - 9.2.x (mariadb)
+
+on:
+  workflow_run:
+    workflows: [ 'Nightly Build' ]
+    types:
+      - requested
+
+jobs:
+  test_9_2_x:
+    uses: ./.github/workflows/cron_nightly_tests_reusable.yml
+    with:
+      BRANCH: 9.2.x
+      PHP_VERSION: '8.2'
+      NODE_VERSION: '20'
+      DB_SERVER: 'mariadb'
+    secrets:
+      GC_PROJECT_ID: ${{ secrets.GC_PROJECT_ID }}
+      GC_SERVICE_KEY: ${{ secrets.GC_SERVICE_KEY }}

--- a/.github/workflows/cron_nightly_tests_9.2.x_mysql.yml
+++ b/.github/workflows/cron_nightly_tests_9.2.x_mysql.yml
@@ -1,0 +1,21 @@
+# This workflow aim to run all UI tests on active branches
+# and upload the report on Google cloud platform storage
+name: Nightly tests and report - 9.2.x (mysql)
+
+on:
+  workflow_run:
+    workflows: [ 'Nightly Build' ]
+    types:
+      - requested
+
+jobs:
+  test_9_2_x:
+    uses: ./.github/workflows/cron_nightly_tests_reusable.yml
+    with:
+      BRANCH: 9.2.x
+      PHP_VERSION: '8.2'
+      NODE_VERSION: '20'
+      DB_SERVER: 'mysql'
+    secrets:
+      GC_PROJECT_ID: ${{ secrets.GC_PROJECT_ID }}
+      GC_SERVICE_KEY: ${{ secrets.GC_SERVICE_KEY }}

--- a/.github/workflows/cron_nightly_tests_reports.yml
+++ b/.github/workflows/cron_nightly_tests_reports.yml
@@ -24,6 +24,10 @@ jobs:
             database: mysql
           - branch: 9.1.x
             database: mariadb
+          - branch: 9.2.x
+            database: mysql
+          - branch: 9.2.x
+            database: mariadb
           - branch: develop
             database: mysql
           - branch: develop

--- a/.github/workflows/cron_nightly_tests_reusable.yml
+++ b/.github/workflows/cron_nightly_tests_reusable.yml
@@ -125,6 +125,13 @@ jobs:
             CAMPAIGN: 'functional:productV2'
           - BRANCH: 9.1.x
             CAMPAIGN: 'modules'
+          ## 9.2.x
+          - BRANCH: 9.2.x
+            CAMPAIGN: 'sanity:productV2'
+          - BRANCH: 9.2.x
+            CAMPAIGN: 'functional:productV2'
+          - BRANCH: 9.2.x
+            CAMPAIGN: 'modules'
           ## develop
           - BRANCH: develop
             CAMPAIGN: 'sanity:productV2'

--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         BRANCH:
           - develop
+          - 9.2.x
           - 9.1.x
     env:
       GH_BRANCH: ${{ matrix.BRANCH }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add the new version branch `9.2.x` (opened for 9.2.0) to this repository's CI matrices / branch lists.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Review the diff: `9.2.x` is added wherever active version branches are enumerated.
| UI Tests          | N/A
| Fixed issue or discussion? | N/A
| Related PRs       | Companion PRs opened by the same "Version-branch bootstrap" run.
| Sponsor company   | N/A

> 🤖 Opened automatically by the **Version-branch bootstrap** workflow. Idempotent: re-running updates this PR; if it was closed, a new one is created.