### PR TITLE
Bootstrap workflow: per-leg PR report and PrestaShop/docker leg

### DIFF
--- a/.github/actions/version-branch-bootstrap/action.yml
+++ b/.github/actions/version-branch-bootstrap/action.yml
@@ -84,6 +84,23 @@ runs:
         sparse-checkout: .github/release-bootstrap
         path: _scripts
 
+    # The docker transform runs the repo's own generator (prestashop_docker.py),
+    # which needs the same Python environment as docker's sync-releases.yml
+    # workflow: Python 3.9 + pinned requirements.txt (newer interpreters reject
+    # some of the pins).
+    - name: Set up Python (docker transform only)
+      if: inputs.transform_id == 'docker'
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.9'
+    - name: Install docker generator dependencies (docker transform only)
+      if: inputs.transform_id == 'docker'
+      working-directory: target
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
     - name: Apply transform & detect changes
       id: tf
       working-directory: target
@@ -202,6 +219,15 @@ runs:
           --arg transform "${TRANSFORM_ID}" \
           '{repo:$repo, action:$action, url:$url, transform:$transform}' > pr-result.json
         cat pr-result.json
+
+        # Per-leg report: surface the PR in THIS job's summary right away — the
+        # consolidated report job only runs once every leg has finished (slow
+        # when the opened PRs saturate the runners with their own CI).
+        case "${ACTION}" in
+          created|updated) echo "🔗 ${REPO}: PR ${ACTION} — ${URL_IN}" >> "$GITHUB_STEP_SUMMARY" ;;
+          dry-run)         echo "🧪 ${REPO}: [dry_run] diff computed — no PR pushed." >> "$GITHUB_STEP_SUMMARY" ;;
+          failed)          echo "❌ ${REPO}: transform or PR step failed — see job log." >> "$GITHUB_STEP_SUMMARY" ;;
+        esac
 
     - name: Upload result artifact
       if: always()

--- a/.github/release-bootstrap/transform-docker.sh
+++ b/.github/release-bootstrap/transform-docker.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# PrestaShop/docker version-branch bootstrap transform.
+# Registers the new version branch in versions.py — its PHP list is copied from
+# the always-present 'nightly' entry (nightly == develop, which NEW was just cut
+# from) and the entry is inserted right before 'nightly', matching the file's
+# indentation. The images/<NEW>/ Dockerfiles are then produced by the repo's own
+# generator (`prestashop_docker.py generate`), never written by hand — this
+# mirrors docker's sync-releases.yml workflow minus its backlog step. The
+# generator rewrites EVERY version's Dockerfile, so anything outside versions.py
+# and images/<NEW>/ is reverted afterwards: that churn belongs to the daily
+# sync-releases run, not to this PR. ADD-only and idempotent (guard on the
+# versions.py entry; regenerating already-committed files is byte-identical).
+# cwd = checked-out repo. Python 3.9 + requirements.txt are provisioned by the
+# composite action (steps gated on transform_id == 'docker').
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+f="versions.py"
+[ -f "${f}" ] || { log "skip (missing): ${f}"; exit 0; }
+
+# 1) versions.py: add the NEW entry just before 'nightly', PHP list copied
+#    verbatim from nightly's block (keeps its 8-space item indentation).
+php_list="$(awk "/'nightly': \(/{f=1;next} f && /\),/{exit} f" "${f}")"
+if [ -z "${php_list}" ]; then
+  echo "::error::could not extract the 'nightly' PHP list from ${f}" >&2
+  exit 1
+fi
+insert_block_before "${f}" "'nightly': (" "'${NEW}': (" <<EOF
+    '${NEW}': (
+${php_list}
+    ),
+EOF
+
+# 2) Let the generator create images/<NEW>/<php>-<apache|fpm>/Dockerfile from
+#    the updated versions.py.
+python3 prestashop_docker.py generate
+
+# 3) Scope the diff: revert modified files and delete generated ones outside
+#    versions.py + images/<NEW>/.
+git diff --name-only | while read -r p; do
+  case "${p}" in
+    versions.py | "images/${NEW}/"*) ;;
+    *) git checkout -q -- "${p}"; log "reverted out-of-scope change: ${p}" ;;
+  esac
+done
+git ls-files --others --exclude-standard | while read -r p; do
+  case "${p}" in
+    "images/${NEW}/"*) ;;
+    *) rm -f "${p}"; log "removed out-of-scope generated file: ${p}" ;;
+  esac
+done
+
+log "docker transform done for ${NEW}"

--- a/.github/workflows/version-branch-bootstrap.yml
+++ b/.github/workflows/version-branch-bootstrap.yml
@@ -196,6 +196,10 @@ jobs:
             base: dev
             transform_id: ps-apiresources
             reviewers: ""
+          - repo: PrestaShop/docker
+            base: master
+            transform_id: docker
+            reviewers: ""
     steps:
       - name: Checkout bootstrap action
         uses: actions/checkout@v5


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Two follow-up improvements to the **Version-branch bootstrap** workflow (#41915). **(1) Per-leg PR report:** each `bootstrap-repo` job now appends the PR it created/updated (or its dry-run / failed status) to its **own job summary**, so maintainers see the PR links as soon as each leg finishes — the consolidated report job only runs once every leg is done, which can take a while when the freshly opened PRs saturate the runners with their own CI. **(2) New `PrestaShop/docker` leg** (the repository was missing from the fan-out, see PrestaShop/docker#460 for the expected PR shape): the transform registers the new version branch in `versions.py` — the PHP list is copied from the always-present `nightly` entry (nightly == develop, which the new branch was just cut from) and the entry is inserted right before it, preserving the file's indentation — then generates `images/<branch>/<php>-<apache\|fpm>/Dockerfile` with the repo's own generator (`python prestashop_docker.py generate`), never by hand. The composite action provisions the same environment as docker's `sync-releases.yml` (Python 3.9 + pinned `requirements.txt`) only for this leg. Since the generator rewrites every version's Dockerfile, the transform reverts anything outside `versions.py` + `images/<branch>/` — that churn belongs to the daily sync-releases run, not to this PR. ADD-only and idempotent like every other leg: once the docker PR is merged, a re-run produces an empty diff and opens no PR.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | **Transform (offline):** clone `PrestaShop/docker`, then run `VERSION_BRANCH=9.2.x BASE=master bash .github/release-bootstrap/transform-docker.sh` from the clone root (needs Python 3.9 + `pip install -r requirements.txt`). First run: `versions.py` gains a `'9.2.x'` entry right before `'nightly'` (+7 lines, PHP 8.1→8.5) and exactly 10 files appear under `images/9.2.x/` with `PS_VERSION=9.2.x` — same shape as PrestaShop/docker#460 — with zero out-of-scope changes. Commit, run again: empty diff. **Workflow:** dispatch **Version-branch bootstrap** with `dry_run=true` — every leg's own job summary now shows its diff + PR status without waiting for the final report; the docker leg logs the diff it would push. After merge, a real re-run (`dry_run=false`) updates/skips the existing legs and only creates the missing docker PR.
| UI Tests          | N/A
| Fixed issue or discussion?     | Follow-up of #41915 (from #41818, does not close it)
| Related PRs       | PrestaShop/docker#460 (example of the PR this new leg automates)
| Sponsor company   | N/A
