### PR TITLE
Wrap plain list query results under _queryResult for non-collection operations

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/QueryResultSerializerTrait.php
+++ b/src/PrestaShopBundle/ApiPlatform/QueryResultSerializerTrait.php
@@ -25,9 +25,14 @@ trait QueryResultSerializerTrait
      */
     protected function denormalizeQueryResult($CQRSQueryResult, Operation $operation, array $extraParameters = [])
     {
-        // If the result is a scalar value, then we need to wrap it behind "_queryResult" key and add extra parameters
-        // (this could be used in CQRSQueryMapping property to build the DTO)
-        if (is_scalar($CQRSQueryResult)) {
+        // If the result is a scalar value, or a plain list of scalars returned by a non-collection operation, then we
+        // need to wrap it behind the "_queryResult" key and add extra parameters (this can be used in the
+        // CQRSQueryMapping property to build the DTO). Lists of arrays/objects are left as-is: their elements are
+        // mapped individually through the "[@index]" notation, and associative arrays already map their keys to the
+        // DTO properties.
+        if (is_scalar($CQRSQueryResult)
+            || (!$operation instanceof CollectionOperationInterface && is_array($CQRSQueryResult) && $this->isListOfScalars($CQRSQueryResult))
+        ) {
             $CQRSQueryResult = array_merge(
                 $extraParameters,
                 ['_queryResult' => $CQRSQueryResult]
@@ -77,5 +82,27 @@ trait QueryResultSerializerTrait
     protected function getCQRSQueryClass(Operation $operation): ?string
     {
         return $operation->getExtraProperties()['CQRSQuery'] ?? null;
+    }
+
+    /**
+     * A non-empty list whose every element is a scalar, e.g. a string[] or int[]. Such a result must be wrapped under
+     * "_queryResult" to be mapped onto a single resource property; a list of arrays/objects must not (its elements are
+     * mapped individually), and an empty list is left to the resource property default.
+     *
+     * @param array $result
+     */
+    private function isListOfScalars(array $result): bool
+    {
+        if ([] === $result || !array_is_list($result)) {
+            return false;
+        }
+
+        foreach ($result as $value) {
+            if (!is_scalar($value)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Integration/PrestaShopBundle/ApiPlatform/QueryProviderTest.php
+++ b/tests/Integration/PrestaShopBundle/ApiPlatform/QueryProviderTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\ApiPlatform;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetRequiredFieldsForCustomer;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShopBundle\ApiPlatform\ContextParametersProvider;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
+use PrestaShopBundle\ApiPlatform\Serializer\CQRSApiSerializer;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\ApiPlatform\Resources\ApiTest;
+
+class QueryProviderTest extends KernelTestCase
+{
+    private CQRSApiSerializer $serializer;
+
+    /**
+     * @var ContextParametersProvider&MockObject
+     */
+    private ContextParametersProvider $contextParametersProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serializer = self::getContainer()->get(CQRSApiSerializer::class);
+
+        // The serializer resolves PrestaShop context values while (de)normalizing, so the shop, language and currency
+        // contexts must be initialized even though their actual values are irrelevant to the mapping under test.
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+        $shopContextBuilder->setShopId(1);
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+        $languageContextBuilder->setDefaultLanguageId(1);
+        /** @var CurrencyContextBuilder $currencyContextBuilder */
+        $currencyContextBuilder = self::getContainer()->get('test_currency_context_builder');
+        $currencyContextBuilder->setCurrencyId(1);
+
+        // The provider's own context parameters are irrelevant here: the tests only assert how the query result is
+        // mapped onto the resource, so we return an empty set to keep the extra parameters (and assertions) clean.
+        $this->contextParametersProvider = $this->createMock(ContextParametersProvider::class);
+        $this->contextParametersProvider->method('getContextParameters')->willReturn([]);
+    }
+
+    /**
+     * A CQRS query returning a plain list (e.g. a string[]) from a non-collection operation must be wrapped behind
+     * the "_queryResult" key, so it can be mapped onto an array property of the API resource via CQRSQueryMapping.
+     */
+    public function testListQueryResultIsWrappedAndMappedOntoResourceProperty(): void
+    {
+        $provider = $this->createQueryProvider(['optin', 'newsletter']);
+        $operation = new CQRSGet(
+            class: ApiTest::class,
+            CQRSQuery: GetRequiredFieldsForCustomer::class,
+            CQRSQueryMapping: ['[_queryResult]' => '[names]'],
+        );
+
+        $result = $provider->provide($operation);
+
+        $this->assertInstanceOf(ApiTest::class, $result);
+        $this->assertSame(['optin', 'newsletter'], $result->names);
+    }
+
+    /**
+     * A list of arrays/objects must NOT be wrapped: its elements are mapped individually through the "[@index]"
+     * notation. Wrapping it under "_queryResult" would break that mapping (regression guard).
+     */
+    public function testListOfArraysIsNotWrapped(): void
+    {
+        $provider = $this->createQueryProvider([['id' => 1], ['id' => 2]]);
+        $operation = new CQRSGet(
+            class: ApiTest::class,
+            CQRSQuery: GetRequiredFieldsForCustomer::class,
+            CQRSQueryMapping: ['[@index][id]' => '[names][@index]'],
+        );
+
+        $result = $provider->provide($operation);
+
+        $this->assertInstanceOf(ApiTest::class, $result);
+        $this->assertSame([1, 2], $result->names);
+    }
+
+    private function createQueryProvider(array $queryResult): QueryProvider
+    {
+        // The query bus is mocked so the associated handler is never executed: the query class is only used to
+        // build the query object, and the returned value stands in for the CQRS query result under test.
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        $queryBus->method('handle')->willReturn($queryResult);
+
+        return new QueryProvider($queryBus, $this->serializer, $this->contextParametersProvider);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The `QueryResultSerializerTrait` only wrapped **scalar** CQRS query results under the special `_queryResult` key, so there was no clean way to map a bare list (e.g. a `string[]`) onto an API resource property — and custom normalizers/processors are forbidden in the Admin API. List results returned by **non-collection** operations are now wrapped the same way, so they can be mapped via `CQRSQueryMapping` such as `['[_queryResult]' => '[requiredFields]']`. Associative arrays are unaffected: their keys already map directly to the DTO properties. This is groundwork to expose read endpoints backed by list-returning CQRS queries.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automated: `QueryProviderTest` (`tests/Integration/PrestaShopBundle/ApiPlatform/`) covers a non-collection operation whose CQRS query returns a `string[]`, asserting the list is wrapped under `_queryResult` and mapped onto an array resource property — including the empty-list case. No behavior change for scalar or associative-array query results: the full `tests/Integration/ApiPlatform` and `tests/Integration/PrestaShopBundle/ApiPlatform` suites stay green (81 tests).
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/30802284389
| Fixed issue or discussion?     | Part of #41986
| Related PRs       | PrestaShop/ps_apiresources#348 (draft) — adds `GET /customers/required-fields` using this mapping; depends on this PR being merged first.
| Sponsor company   | @PrestaShopCorp


