### PR TITLE
Associate existing payments when generating a delivery slip

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1346,25 +1346,7 @@ class OrderCore extends ObjectModel
 
             // Update order payment
             if ($use_existing_payment) {
-                $id_order_payments = Db::getInstance()->executeS('
-                    SELECT DISTINCT op.id_order_payment
-                    FROM `' . _DB_PREFIX_ . 'order_payment` op
-                    INNER JOIN `' . _DB_PREFIX_ . 'orders` o ON (o.reference = op.order_reference)
-                    LEFT JOIN `' . _DB_PREFIX_ . 'order_invoice_payment` oip ON (oip.id_order_payment = op.id_order_payment)
-                    WHERE (oip.id_order != ' . (int) $order_invoice->id_order . ' OR oip.id_order IS NULL) AND o.id_order = ' . (int) $order_invoice->id_order);
-
-                if (count($id_order_payments)) {
-                    foreach ($id_order_payments as $order_payment) {
-                        Db::getInstance()->execute('
-                            INSERT INTO `' . _DB_PREFIX_ . 'order_invoice_payment`
-                            SET
-                                `id_order_invoice` = ' . (int) $order_invoice->id . ',
-                                `id_order_payment` = ' . (int) $order_payment['id_order_payment'] . ',
-                                `id_order` = ' . (int) $order_invoice->id_order);
-                    }
-                    // Clear cache
-                    Cache::clean('order_invoice_paid_*');
-                }
+                $this->associateExistingPaymentsToInvoice($order_invoice);
             }
 
             // Update order cart rule
@@ -1446,6 +1428,35 @@ class OrderCore extends ObjectModel
     }
 
     /**
+     * Associate the order's existing payments with the given invoice, so an already-paid order is
+     * not seen as unpaid once an invoice is generated for it.
+     *
+     * @param OrderInvoice $order_invoice
+     */
+    protected function associateExistingPaymentsToInvoice($order_invoice)
+    {
+        $id_order_payments = Db::getInstance()->executeS('
+            SELECT DISTINCT op.id_order_payment
+            FROM `' . _DB_PREFIX_ . 'order_payment` op
+            INNER JOIN `' . _DB_PREFIX_ . 'orders` o ON (o.reference = op.order_reference)
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_invoice_payment` oip ON (oip.id_order_payment = op.id_order_payment)
+            WHERE (oip.id_order != ' . (int) $order_invoice->id_order . ' OR oip.id_order IS NULL) AND o.id_order = ' . (int) $order_invoice->id_order);
+
+        if (count($id_order_payments)) {
+            foreach ($id_order_payments as $order_payment) {
+                Db::getInstance()->execute('
+                    INSERT INTO `' . _DB_PREFIX_ . 'order_invoice_payment`
+                    SET
+                        `id_order_invoice` = ' . (int) $order_invoice->id . ',
+                        `id_order_payment` = ' . (int) $order_payment['id_order_payment'] . ',
+                        `id_order` = ' . (int) $order_invoice->id_order);
+            }
+            // Clear cache
+            Cache::clean('order_invoice_paid_*');
+        }
+    }
+
+    /**
      * This method allows to generate first delivery slip of the current order.
      */
     public function setDeliverySlip()
@@ -1455,6 +1466,10 @@ class OrderCore extends ObjectModel
             $order_invoice->id_order = $this->id;
             $order_invoice->number = 0;
             $this->setInvoiceDetails($order_invoice);
+            // Associate any existing payment with this invoice, the same way setInvoice() does.
+            // Otherwise a paid-status transition that generates a delivery slip (but no invoice)
+            // sees an unpaid invoice and records a duplicate payment.
+            $this->associateExistingPaymentsToInvoice($order_invoice);
             $this->delivery_date = $order_invoice->date_add;
             $this->delivery_number = $this->getDeliveryNumber($order_invoice->id);
             $this->update();

--- a/tests/Integration/Classes/OrderDeliverySlipPaymentTest.php
+++ b/tests/Integration/Classes/OrderDeliverySlipPaymentTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Cache;
+use Context;
+use Currency;
+use Order;
+use OrderInvoice;
+use OrderPayment;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+use Tools;
+
+class OrderDeliverySlipPaymentTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['orders', 'order_payment', 'order_invoice', 'order_invoice_payment'];
+
+    private const ORDER_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        // getTotalPaid() memoizes per invoice id; clear it so a restored invoice id is not read
+        // from a previous test's cache.
+        Cache::clean('order_invoice_paid_*');
+        self::bootKernel();
+
+        $order = new Order(self::ORDER_ID);
+        // setInvoiceDetails() needs the currency precision from the context.
+        Context::getContext()->currency = new Currency((int) $order->id_currency);
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        parent::tearDown();
+    }
+
+    public function testDeliverySlipAssociatesExistingPaymentSoNoDuplicateIsRecorded(): void
+    {
+        // Regression test for #41936: generating a delivery slip on an already-paid order (that has
+        // no invoice) used to leave the generated invoice unpaid, so the paid-status block recorded
+        // a duplicate payment. The existing payment must now be associated with the invoice.
+        $order = new Order(self::ORDER_ID);
+        $this->addPaymentToOrder($order, (float) $order->total_paid_tax_incl);
+
+        $order->setDeliverySlip();
+
+        $invoices = (new Order(self::ORDER_ID))->getInvoicesCollection();
+        $this->assertCount(1, $invoices);
+        /** @var OrderInvoice $invoice */
+        $invoice = $invoices->getFirst();
+        // Nothing left to pay -> the paid-status block would not create another payment.
+        $this->assertEqualsWithDelta(0, (new OrderInvoice((int) $invoice->id))->getRestPaid(), 0.001);
+    }
+
+    public function testDeliverySlipOnAnUnpaidOrderLeavesTheInvoiceUnpaid(): void
+    {
+        // The fix must not suppress a legitimate payment: with no payment yet, the generated invoice
+        // stays unpaid so the paid-status block still records the (single) real payment.
+        $order = new Order(self::ORDER_ID);
+
+        $order->setDeliverySlip();
+
+        $reloaded = new Order(self::ORDER_ID);
+        $invoices = $reloaded->getInvoicesCollection();
+        $this->assertCount(1, $invoices);
+        /** @var OrderInvoice $invoice */
+        $invoice = $invoices->getFirst();
+        $this->assertEqualsWithDelta(
+            (float) $reloaded->total_paid_tax_incl,
+            (new OrderInvoice((int) $invoice->id))->getRestPaid(),
+            0.001
+        );
+    }
+
+    private function addPaymentToOrder(Order $order, float $amount): void
+    {
+        $payment = new OrderPayment();
+        $payment->order_reference = Tools::substr($order->reference, 0, 9);
+        $payment->id_currency = (int) $order->id_currency;
+        $payment->amount = $amount;
+        $payment->payment_method = 'Test payment';
+        $payment->conversion_rate = $order->conversion_rate ?: 1;
+        $payment->save();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When a paid order has no invoice and a status transition generates a delivery slip, `Order::setDeliverySlip()` creates an `OrderInvoice` for it but, unlike `Order::setInvoice()`, did not associate the order's existing payments with that invoice. The invoice therefore looked unpaid, and the paid-status block in `OrderHistory::changeIdOrderState()` records a payment for every invoice whose remaining balance is greater than zero, producing a duplicate payment. The shared association logic is extracted into `Order::associateExistingPaymentsToInvoice()` and called from `setDeliverySlip()` as well, so the generated invoice is marked as paid by the existing payment and no duplicate is recorded. An order with no payment yet is unaffected — the invoice stays unpaid and the paid-status block still records the single real payment.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Configure an order status that marks the order as paid and generates a delivery slip but NOT an invoice, then place an order (e.g. through a payment module) that receives this status. Open the order in the Back Office: the Payment block now shows a single payment instead of a duplicated one. Automated coverage: `tests/Integration/Classes/OrderDeliverySlipPaymentTest.php` — after `setDeliverySlip()` on a paid order the generated invoice has `getRestPaid() == 0` (existing payment associated, so no duplicate), while an order with no payment leaves the invoice unpaid so the single real payment is still recorded. The first test fails on the base branch and passes with this change.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41936
| Related PRs       |
| Sponsor company   |

