### PR TITLE
Harden admin file downloads against traversal

### DIFF
--- a/src/Core/File/PathResolver.php
+++ b/src/Core/File/PathResolver.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\File;
+
+use PrestaShop\PrestaShop\Core\File\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\File\Exception\InvalidFileException;
+
+/**
+ * Resolves request-selected files under an expected filesystem directory.
+ */
+class PathResolver
+{
+    /**
+     * @throws FileNotFoundException
+     * @throws InvalidFileException
+     */
+    public function resolveFileUnderDirectory(string $directory, string $fileName): string
+    {
+        $baseDirectory = realpath($directory);
+        if (false === $baseDirectory) {
+            throw new FileNotFoundException(sprintf('Directory "%s" does not exist.', $directory));
+        }
+
+        $filePath = realpath($baseDirectory . DIRECTORY_SEPARATOR . $fileName);
+        if (false === $filePath || !is_file($filePath)) {
+            throw new FileNotFoundException(sprintf('File "%s" does not exist.', $fileName));
+        }
+
+        $baseDirectory = rtrim($baseDirectory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        if (!str_starts_with($filePath, $baseDirectory)) {
+            throw new InvalidFileException(sprintf('File "%s" is outside the allowed directory.', $fileName));
+        }
+
+        return $filePath;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -7,6 +7,8 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\File\Exception\FileException;
+use PrestaShop\PrestaShop\Core\File\PathResolver;
 use PrestaShop\PrestaShop\Core\Import\Configuration\ImportConfigFactoryInterface;
 use PrestaShop\PrestaShop\Core\Import\Configuration\ImportRuntimeConfigFactoryInterface;
 use PrestaShop\PrestaShop\Core\Import\EntityField\Provider\EntityFieldsProviderFinder;
@@ -186,9 +188,18 @@ class ImportController extends PrestaShopAdminController
     public function downloadAction(
         Request $request,
         ImportDirectory $importDirectory,
+        PathResolver $pathResolver,
     ): RedirectResponse|BinaryFileResponse {
         if ($filename = $request->query->get('filename')) {
-            $response = new BinaryFileResponse($importDirectory . $filename);
+            try {
+                $filePath = $pathResolver->resolveFileUnderDirectory($importDirectory->getDir(), $filename);
+            } catch (FileException) {
+                $this->addFlash('error', $this->trans('The file could not be found.', [], 'Admin.Notifications.Error'));
+
+                return $this->redirectToRoute('admin_import');
+            }
+
+            $response = new BinaryFileResponse($filePath);
             $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename);
 
             return $response;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -82,6 +82,8 @@ use PrestaShop\PrestaShop\Core\Domain\ValueObject\QuerySorting;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShop\PrestaShop\Core\File\Exception\FileException;
+use PrestaShop\PrestaShop\Core\File\PathResolver;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
@@ -117,7 +119,6 @@ use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use ReflectionClass;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
@@ -2040,25 +2041,19 @@ class OrderController extends PrestaShopAdminController
     public function displayCustomizationImageAction(
         int $orderId,
         string $value,
-        LegacyContext $context
+        LegacyContext $context,
+        PathResolver $pathResolver
     ) {
         $uploadDir = $context->getUploadDirectory();
-        $filePath = $uploadDir . $value;
-        $filesystem = new Filesystem();
 
         try {
-            if (!$filesystem->exists($filePath)) {
-                $this->addFlash('error', $this->trans('The product customization picture could not be found.', [], 'Admin.Notifications.Error'));
-
-                return $this->redirectToRoute('admin_orders_view', [
-                    'orderId' => $orderId,
-                ]);
-            }
-
+            $filePath = $pathResolver->resolveFileUnderDirectory($uploadDir, $value);
             $imageFile = new File($filePath);
             $fileName = sprintf('%s-customization-%s.%s', $orderId, $value, $imageFile->guessExtension() ?? 'jpg');
 
             return $this->file($filePath, $fileName);
+        } catch (FileException) {
+            $this->addFlash('error', $this->trans('The product customization picture could not be found.', [], 'Admin.Notifications.Error'));
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }

--- a/src/PrestaShopBundle/Resources/config/services/core/file.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/file.yml
@@ -2,6 +2,8 @@ services:
   _defaults:
     public: true
 
+  PrestaShop\PrestaShop\Core\File\PathResolver:
+
   prestashop.core.file.finder.invoice_model:
     class: 'PrestaShop\PrestaShop\Core\File\InvoiceModelFinder'
     arguments:

--- a/tests/Unit/Core/File/PathResolverTest.php
+++ b/tests/Unit/Core/File/PathResolverTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\File;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\File\Exception\FileException;
+use PrestaShop\PrestaShop\Core\File\PathResolver;
+
+class PathResolverTest extends TestCase
+{
+    private string $baseDirectory;
+
+    private string $outsideDirectory;
+
+    private PathResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $rootDirectory = sys_get_temp_dir() . '/ps_path_resolver_' . uniqid('', true);
+        $this->baseDirectory = $rootDirectory . '/base';
+        $this->outsideDirectory = $rootDirectory . '/outside';
+        mkdir($this->baseDirectory, 0777, true);
+        mkdir($this->outsideDirectory, 0777, true);
+
+        $this->resolver = new PathResolver();
+    }
+
+    protected function tearDown(): void
+    {
+        $rootDirectory = dirname($this->baseDirectory);
+        if (is_dir($rootDirectory)) {
+            $this->removeDirectory($rootDirectory);
+        }
+    }
+
+    public function testItResolvesFileInsideDirectory(): void
+    {
+        $filePath = $this->baseDirectory . '/import.csv';
+        file_put_contents($filePath, 'id,name');
+
+        $this->assertSame(
+            realpath($filePath),
+            $this->resolver->resolveFileUnderDirectory($this->baseDirectory, 'import.csv')
+        );
+    }
+
+    public function testItRejectsTraversalOutsideDirectory(): void
+    {
+        file_put_contents($this->outsideDirectory . '/parameters.php', 'secret');
+
+        $this->expectException(FileException::class);
+
+        $this->resolver->resolveFileUnderDirectory($this->baseDirectory, '../outside/parameters.php');
+    }
+
+    public function testItRejectsSymlinkOutsideDirectory(): void
+    {
+        if (!function_exists('symlink')) {
+            $this->markTestSkipped('symlink is not available.');
+        }
+
+        file_put_contents($this->outsideDirectory . '/parameters.php', 'secret');
+        if (!symlink($this->outsideDirectory . '/parameters.php', $this->baseDirectory . '/parameters-link.php')) {
+            $this->markTestSkipped('symlink could not be created.');
+        }
+
+        $this->expectException(FileException::class);
+
+        $this->resolver->resolveFileUnderDirectory($this->baseDirectory, 'parameters-link.php');
+    }
+
+    public function testItRejectsMissingFile(): void
+    {
+        $this->expectException(FileException::class);
+
+        $this->resolver->resolveFileUnderDirectory($this->baseDirectory, 'missing.csv');
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        $items = scandir($directory);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ('.' === $item || '..' === $item) {
+                continue;
+            }
+
+            $path = $directory . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($directory);
+    }
+}


### PR DESCRIPTION
## Description

| Questions | Answers |
| --- | --- |
| Branch? | 9.1.x |
| Description? | Harden admin file downloads against traversal and symlink escapes. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | See the detailed manual and automated validation steps below. |
| UI Tests | No UI change. The automated UI workflow for this PR passed. |
| Fixed issue or discussion? | n/a |
| Related PRs | none |
| Sponsor company | none |

## Summary

- add a shared `PathResolver` that resolves request-selected file names under an expected directory using `realpath`
- use it for import-history CSV downloads and order customization image downloads
- reject traversal and symlink escapes outside the configured import/upload directory
- add unit coverage for valid files, `..` traversal, symlink escape, and missing files

## How to test

Use a disposable development installation and an employee account with access to Imports and Orders.

1. Run the focused unit test: `php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/File/PathResolverTest.php`.
2. Verify that a normal import-history CSV download and a normal order-customization image download still work.
3. In the development installation only, use harmless controlled test files outside the configured import/upload directory and verify that request-selected `../` traversal paths are rejected for both download flows.
4. Verify that a symlink inside either allowed directory which points to a controlled file outside the directory is rejected.
5. Verify that missing files are rejected.

Expected result for invalid, missing, traversal, or symlink-escape paths: no file is returned and the Back Office redirects with its existing error message.

## Validation

- `php -l src/Core/File/PathResolver.php`
- `php -l src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php`
- `php -l src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php`
- `php -l tests/Unit/Core/File/PathResolverTest.php`
- `php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/File/PathResolverTest.php`
- `php ./vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php src/Core/File/PathResolver.php src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php tests/Unit/Core/File/PathResolverTest.php`
- `git diff origin/9.1.x..HEAD --check`

The focused PHPUnit run passed: 4 tests, 4 assertions. PHPUnit reported one deprecation unrelated to this change.

## Issue tracking

No public issue or discussion was opened before this PR. This is proactive hardening of potentially security-sensitive file-path handling, so I have not opened a public issue. Please advise if this PR should instead be handled through the project private security-reporting process.