### PR TITLE
use CSPRNG for password reset token generation

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1520,8 +1520,7 @@ class CustomerCore extends ObjectModel
      */
     public function stampResetPasswordToken()
     {
-        $salt = $this->id . '-' . $this->secure_key;
-        $this->reset_password_token = sha1(time() . $salt);
+        $this->reset_password_token = bin2hex(random_bytes(20));
         $validity = (int) Configuration::get('PS_PASSWD_RESET_VALIDITY') ?: 1440;
         $this->reset_password_validity = date('Y-m-d H:i:s', strtotime('+' . $validity . ' minutes'));
     }

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -645,8 +645,7 @@ class EmployeeCore extends ObjectModel
      */
     public function stampResetPasswordToken()
     {
-        $salt = $this->id . '+' . uniqid((string) mt_rand(0, mt_getrandmax()), true);
-        $this->reset_password_token = sha1(time() . $salt);
+        $this->reset_password_token = bin2hex(random_bytes(20));
         $validity = (int) Configuration::get('PS_PASSWD_RESET_VALIDITY') ?: 1440;
         $this->reset_password_validity = date('Y-m-d H:i:s', strtotime('+' . $validity . ' minutes'));
     }

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -118,7 +118,7 @@ class PasswordControllerCore extends FrontController
                 $this->errors[] = $this->trans('Customer account not found', [], 'Shop.Notifications.Error');
             } elseif (!$customer->active) {
                 $this->errors[] = $this->trans('You cannot regenerate the password for this account.', [], 'Shop.Notifications.Error');
-            } elseif ($customer->getValidResetPasswordToken() !== $reset_token) {
+            } elseif (!hash_equals((string) $customer->getValidResetPasswordToken(), (string) $reset_token)) {
                 $this->errors[] = $this->trans('The password change request expired. You should ask for a new one.', [], 'Shop.Notifications.Error');
             }
 

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -118,7 +118,7 @@ class PasswordControllerCore extends FrontController
                 $this->errors[] = $this->trans('Customer account not found', [], 'Shop.Notifications.Error');
             } elseif (!$customer->active) {
                 $this->errors[] = $this->trans('You cannot regenerate the password for this account.', [], 'Shop.Notifications.Error');
-            } elseif (!hash_equals((string) $customer->getValidResetPasswordToken(), (string) $reset_token)) {
+            } elseif (!($validResetToken = $customer->getValidResetPasswordToken()) || !hash_equals($validResetToken, (string) $reset_token)) {
                 $this->errors[] = $this->trans('The password change request expired. You should ask for a new one.', [], 'Shop.Notifications.Error');
             }
 

--- a/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
+++ b/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
@@ -147,9 +147,8 @@ class EmployeePasswordResetter
     private function updateEmployeeResetData(Employee $employee): void
     {
         $validityDuration = (int) ($this->configuration->get('PS_PASSWD_RESET_VALIDITY') ?: 1440);
-        $salt = $employee->getId() . '+' . uniqid((string) mt_rand(0, mt_getrandmax()), true);
         $employee
-            ->setResetPasswordToken(sha1(time() . $salt))
+            ->setResetPasswordToken(bin2hex(random_bytes(20)))
             ->setResetPasswordValidity((new DateTime())->add(DateInterval::createFromDateString($validityDuration . 'min')))
         ;
         $this->entityManager->flush();

--- a/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
+++ b/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
@@ -69,7 +69,7 @@ class EmployeePasswordResetter
 
         if (!empty($employee)
             && $employee->hasValidResetPasswordToken()
-            && $employee->getResetPasswordToken() === $resetPasswordToken) {
+            && hash_equals((string) $employee->getResetPasswordToken(), (string) $resetPasswordToken)) {
             return $employee;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | see below
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Trigger a password reset from the FO forgot-password form and from the BO login reset flow, confirm the emailed link still resolves and logs the reset through, and check that `reset_password_token` is stored as a 40-char hex string.
| Fixed issue or discussion? | n/a
| Related PRs       | n/a
| Sponsor company   | n/a

The customer and employee forgot-password tokens are built from `time()` plus known or PRNG-derived values (the customer's `secure_key`, and `uniqid()`/`mt_rand()` for employees) rather than a CSPRNG. For a customer the `id` and `secure_key` both appear in front-office order URLs, so the only unknown left is the request second and the token can be reconstructed by brute-forcing the validity window. Generate all three tokens with `bin2hex(random_bytes(20))`, which stays a 40-char hex value and keeps passing the `isSha1` field validation.

Also compare the stored token in constant time with `hash_equals()` in `PasswordController` and `EmployeePasswordResetter`, so the secret token check doesn't short-circuit on the first mismatching byte.

