### PR TITLE
Release healthcheck: align translation check env and accept forked build branches

### DIFF
--- a/.github/release-healthcheck/generated-files.sh
+++ b/.github/release-healthcheck/generated-files.sh
@@ -99,7 +99,9 @@ check_default_catalogue_extracted() {
   if ! git clone --quiet "$clone_url" "$tool_dir" 2>/dev/null; then
     emit "$id" "$title" "$HC_FAIL" "$HC_SEV_WARN" "could not verify (TranslationTool clone failed — needs PrestaShopCorp access)"; return
   fi
-  latest_tag="$(git -C "$tool_dir" tag -l | sort -V | tail -n1)"
+  # Same tag selection as the canonical "Create default catalog PR" workflow
+  # (most recently created tag, not highest version-sorted name) — keep in sync.
+  latest_tag="$(git -C "$tool_dir" describe --tags "$(git -C "$tool_dir" rev-list --tags --max-count=1 2>/dev/null)" 2>/dev/null)"
   [ -n "$latest_tag" ] && git -C "$tool_dir" checkout --quiet "$latest_tag" 2>/dev/null
 
   if ! ( cd "$tool_dir" && COMPOSER_PROCESS_TIMEOUT=600 composer install --no-dev --ansi --no-interaction --no-progress ) >/dev/null 2>&1; then
@@ -123,12 +125,26 @@ check_default_catalogue_extracted() {
   rm -rf "$core_dir/translations/default"
   mkdir -p "$core_dir/translations/default"
   cp -R "$dump/." "$core_dir/translations/default/"
-  if git -C "$core_dir" diff --quiet -- translations/ 2>/dev/null; then
+  # `git status --porcelain` (not `git diff`) so brand-new catalogue files — untracked
+  # after the rm+cp — count as drift too, exactly like the canonical workflow's `git add`.
+  local drift
+  drift="$(git -C "$core_dir" status --porcelain -- translations/ 2>/dev/null)"
+  if [ -z "$drift" ]; then
     emit "$id" "$title" "$HC_PASS" "$HC_SEV_FAIL" "catalogue fully extracted (no diff under translations/)"
   else
-    emit "$id" "$title" "$HC_FAIL" "$HC_SEV_FAIL" "catalogue not fully extracted: $(git -C "$core_dir" diff --name-only -- translations/ | wc -l | tr -d ' ') file(s) differ"
+    local n names
+    n="$(printf '%s\n' "$drift" | wc -l | tr -d ' ')"
+    names="$(printf '%s\n' "$drift" | awk '{print $NF}' | head -n 10 | paste -sd, - | sed 's/,/, /g')"
+    [ "$n" -gt 10 ] && names="$names, …"
+    emit "$id" "$title" "$HC_FAIL" "$HC_SEV_FAIL" "catalogue not fully extracted: $n file(s) differ — $names"
+    # Full drift goes to the job log (stderr) so the mismatch is diagnosable.
+    log "default-catalogue drift (git status --porcelain -- translations/):"
+    printf '%s\n' "$drift" >&2
+    git -C "$core_dir" diff --stat -- translations/ >&2 2>/dev/null || true
+    git -C "$core_dir" diff -- translations/ 2>/dev/null | head -n 200 >&2 || true
   fi
   git -C "$core_dir" checkout -- translations/ 2>/dev/null || true
+  git -C "$core_dir" clean -qfd translations/ 2>/dev/null || true
 }
 
 # spec ref: C7 — bundled localization packs in sync with PrestaShop/LocalizationFiles.

--- a/.github/release-healthcheck/version-integrity.sh
+++ b/.github/release-healthcheck/version-integrity.sh
@@ -63,7 +63,10 @@ check_version_consistency() {
   fi
 }
 
-# spec ref: A4 — build branch descends from the version branch OR the previous patch tag
+# spec ref: A4 — build branch forked from the version branch OR the previous patch tag.
+# The version branch keeps moving after the build branch is cut, so being behind its
+# current tip is normal: any fork point passes, with ahead/behind counts as detail
+# (a huge ahead count is the tell for a branch cut from the wrong base).
 check_build_branch_base() {
   if [ "$BRANCH_KIND" != "build" ]; then
     emit "version/build-branch-base" "Build branch base" "$HC_NA" "$HC_SEV_WARN" "ref kind '$BRANCH_KIND' — build-branch lineage check N/A"
@@ -71,9 +74,20 @@ check_build_branch_base() {
   fi
   HC_LINK="https://github.com/$REPO/compare/$VERSION_BRANCH...$REF"
   local detail=""
-  if git fetch --quiet origin "$VERSION_BRANCH" 2>/dev/null && git merge-base --is-ancestor FETCH_HEAD HEAD 2>/dev/null; then
-    emit "version/build-branch-base" "Build branch base" "$HC_PASS" "$HC_SEV_WARN" "HEAD descends from origin/$VERSION_BRANCH"
-    return
+  if git fetch --quiet origin "$VERSION_BRANCH" 2>/dev/null; then
+    if git merge-base --is-ancestor FETCH_HEAD HEAD 2>/dev/null; then
+      emit "version/build-branch-base" "Build branch base" "$HC_PASS" "$HC_SEV_WARN" "HEAD descends from origin/$VERSION_BRANCH (up to date with its tip)"
+      return
+    fi
+    local fork
+    fork="$(git merge-base HEAD FETCH_HEAD 2>/dev/null)"
+    if [ -n "$fork" ]; then
+      local behind ahead
+      behind="$(git rev-list --count "HEAD..FETCH_HEAD" 2>/dev/null)"
+      ahead="$(git rev-list --count "FETCH_HEAD..HEAD" 2>/dev/null)"
+      emit "version/build-branch-base" "Build branch base" "$HC_PASS" "$HC_SEV_WARN" "forked from origin/$VERSION_BRANCH at ${fork:0:9}; behind by ${behind:-?} commit(s), ahead by ${ahead:-?}"
+      return
+    fi
   fi
   if [ "$PATCH" -gt 0 ]; then
     local prev="$MAJOR.$MINOR.$((PATCH - 1))"
@@ -83,7 +97,7 @@ check_build_branch_base() {
     fi
     detail=" (also not a descendant of tag $prev)"
   fi
-  emit "version/build-branch-base" "Build branch base" "$HC_FAIL" "$HC_SEV_WARN" "HEAD does not descend from origin/$VERSION_BRANCH$detail"
+  emit "version/build-branch-base" "Build branch base" "$HC_FAIL" "$HC_SEV_WARN" "HEAD shares no history with origin/$VERSION_BRANCH$detail"
 }
 
 # spec ref: A5 — branch follows the build-branch naming convention for target_version

--- a/.github/workflows/release-healthcheck.yml
+++ b/.github/workflows/release-healthcheck.yml
@@ -330,13 +330,17 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
           path: target
+      # PHP version and --no-dev mirror the canonical PrestaShopCorp/TranslationTool
+      # "Create default catalog PR" workflow — the extraction must run in the same
+      # environment or the regenerated catalogue can drift from the committed one.
+      # Keep both in sync with that workflow.
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ env.PHP_VERSION }}
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
       - name: Install Composer dependencies
-        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --no-dev --ansi --prefer-dist --no-interaction --no-progress
       - name: Run translation catalogue check
         env:
           HC_RESULTS_FILE: ${{ github.workspace }}/results-translation.json


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes two false signals in the Release Healthcheck workflow, spotted on the 9.2.0-beta.1 run ([run 29079468762](https://github.com/PrestaShop/PrestaShop/actions/runs/29079468762)). See details below the table.
| Type?             | bug fix
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Dispatch `release-healthcheck.yml` from this branch with `ref=build-920-beta1` and `target_version=9.2.0-beta.1`: `generated/default-catalogue` must be ✅ (was ❌ "3 file(s) differ") and `version/build-branch-base` must be ✅ with fork-point + ahead/behind detail (was ⚠️ "HEAD does not descend from origin/9.2.x"). The remaining ❌ (`ps_onepagecheckout` pending bump) is a genuine finding, unrelated to this PR.
| UI Tests          | N/A (CI tooling only)
| Fixed issue or discussion?     | Follow-up of #41804
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA

### 1. Default catalogue check — false "catalogue not fully extracted"

The check replays the extraction of the default translation catalogue, but in a different environment than the canonical TranslationTool "Create default catalog PR" workflow: PHP 8.3 (vs 8.1) and a core `composer install` including dev dependencies (vs `--no-dev`). On `build-920-beta1` this reported 3 stale files while the canonical workflow, on the same branch tip and the same tool tag, found nothing to update.

- The translation tier now pins PHP 8.1 and installs core dependencies with `--no-dev`, mirroring the canonical workflow (comments mark both spots as to-keep-in-sync).
- The TranslationTool tag is selected the same way as the canonical workflow (most recently created tag) instead of `sort -V`.
- Drift detection uses `git status --porcelain -- translations/` so brand-new catalogue files (untracked after the replace) count as drift too, like the canonical workflow's `git add`.
- On failure the check now lists the differing files in the report (capped at 10) and dumps `git diff --stat` plus a capped unified diff to the job log, so any future mismatch is diagnosable instead of an opaque count.

### 2. Build-branch lineage check — warned on normal branch evolution

`check_build_branch_base` required HEAD to contain the *current tip* of the version branch, which inevitably fails once the version branch receives commits after the build branch is cut — a normal situation. The check now passes when a fork point with the version branch exists, reporting it with ahead/behind counts (a huge ahead count remains the tell for a branch cut from the wrong base). Only unrelated history still fails, with a clearer message ("HEAD shares no history with origin/X.Y.x").