### PR TITLE
Add Markdown download to the legacy profiling report

### DIFF
--- a/tools/profiling/Controller.php
+++ b/tools/profiling/Controller.php
@@ -101,12 +101,19 @@ abstract class Controller extends ControllerCore
         // Process all profiling data
         $this->profiler->processData();
 
+        if (Tools::getValue('_profiling_report') === 'md') {
+            header('Content-Type: text/markdown; charset=utf-8');
+            header('Content-Disposition: attachment; filename="profiling-report.md"');
+
+            return $this->profiler->getMarkdownReport();
+        }
+
         // Add some specific style for profiling information
 
         $this->context->smarty->assign(
             $this->profiler->getSmartyVariables()
         );
-        $this->context->smarty->assign('profilingMarkdownBase64', base64_encode($this->profiler->getMarkdownReport()));
+        $this->context->smarty->assign('profilingMarkdownUrl', $this->getProfilingMarkdownUrl());
 
         if (strpos($content, '{$content}') === false) {
             return str_replace(
@@ -126,5 +133,19 @@ abstract class Controller extends ControllerCore
 
         // Return empty string since we change the outPutHtml
         return '';
+    }
+
+    /**
+     * Current page URL with the profiling report marker appended, used to
+     * re-run the page and download its Markdown profiling report.
+     *
+     * @return string
+     */
+    private function getProfilingMarkdownUrl(): string
+    {
+        $requestUri = $_SERVER['REQUEST_URI'] ?? '';
+        $separator = strpos($requestUri, '?') === false ? '?' : '&';
+
+        return $requestUri . $separator . '_profiling_report=md';
     }
 }

--- a/tools/profiling/Controller.php
+++ b/tools/profiling/Controller.php
@@ -106,6 +106,7 @@ abstract class Controller extends ControllerCore
         $this->context->smarty->assign(
             $this->profiler->getSmartyVariables()
         );
+        $this->context->smarty->assign('profilingMarkdownBase64', base64_encode($this->profiler->getMarkdownReport()));
 
         if (strpos($content, '{$content}') === false) {
             return str_replace(

--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -353,4 +353,102 @@ class Profiler
             'files' => get_included_files(),
         ];
     }
+
+    /**
+     * Build a Markdown report from the collected profiling data.
+     *
+     * @return string
+     */
+    public function getMarkdownReport(): string
+    {
+        $vars = $this->getSmartyVariables();
+        $sanitizeRow = function ($value) {
+            return str_replace(['|', "\r", "\n"], [' ', ' ', ' '], (string) $value);
+        };
+
+        $md = "# PrestaShop Profiling Report\n\n";
+        $md .= '_Generated: ' . date('Y-m-d H:i:s') . "_\n\n";
+
+        $md .= "## Summary\n\n";
+        $md .= '- Load Time: ' . round((float) $vars['summary']['loadTime'], 4) . " s\n";
+        $md .= '- Querying Time: ' . $vars['summary']['queryTime'] . " ms\n";
+        $md .= '- Queries: ' . $vars['summary']['nbQueries'] . "\n";
+        $md .= '- Peak Memory Usage: ' . $vars['summary']['peakMemoryUsage'] . " bytes\n";
+        $md .= '- Included Files: ' . $vars['summary']['includedFiles'] . ' (' . $vars['summary']['totalFileSize'] . " bytes)\n";
+        $md .= '- PrestaShop Cache: ' . $vars['summary']['totalCacheSize'] . " bytes\n";
+        $md .= '- Global vars: ' . $vars['summary']['totalGlobalVarSize'] . " bytes\n";
+        foreach ($vars['summary']['globalVarSize'] as $global => $size) {
+            $md .= '  - $' . $global . ': ' . $size . " Kb\n";
+        }
+        $md .= "\n";
+
+        $md .= "## Configuration\n\n";
+        foreach ($vars['configuration'] as $key => $value) {
+            $md .= '- ' . $key . ': ' . $value . "\n";
+        }
+        $md .= "\n";
+
+        $md .= "## Hooks\n\n";
+        foreach ($vars['hooks']['perfs'] as $hookName => $perf) {
+            $md .= '### ' . $sanitizeRow($hookName) . ' — ' . round($perf['time'] * 1000, 2) . ' ms, ' . $perf['memory'] . " bytes\n\n";
+            $md .= "| Module | Time (ms) | Memory (bytes) |\n|---|---|---|\n";
+            foreach ($perf['modules'] as $moduleCall) {
+                $md .= '| ' . $sanitizeRow($moduleCall['module']) . ' | ' . round($moduleCall['time'] * 1000, 2) . ' | ' . $moduleCall['memory'] . " |\n";
+            }
+            $md .= "\n";
+        }
+
+        $md .= "## Modules\n\n";
+        foreach ($vars['modules']['perfs'] as $moduleName => $perf) {
+            $md .= '### ' . $sanitizeRow($moduleName) . ' — ' . round($perf['total_time'] * 1000, 2) . ' ms, ' . $perf['total_memory'] . " bytes\n\n";
+            $md .= "| Method | Time (ms) | Memory (bytes) |\n|---|---|---|\n";
+            foreach ($perf['details'] as $call) {
+                $md .= '| ' . $sanitizeRow($call['method']) . ' | ' . round($call['time'] * 1000, 2) . ' | ' . $call['memory'] . " |\n";
+            }
+            $md .= "\n";
+        }
+
+        $md .= "## Stopwatch queries\n\n";
+        foreach ($vars['stopwatchQueries'] as $query) {
+            $md .= '### #' . $query['id'] . ' — ' . round($query['time'] * 1000, 2) . ' ms — ' . $sanitizeRow($query['location']) . "\n\n";
+            $md .= '```sql' . "\n" . trim($query['query']) . "\n" . '```' . "\n\n";
+            $md .= '- Rows: ' . $query['rows'] . "\n";
+            $md .= '- Filesort: ' . ($query['filesort'] ? 'yes' : 'no') . "\n";
+            $md .= '- Group by: ' . ($query['group_by'] ? 'yes' : 'no') . "\n";
+            if (!empty($query['stack'])) {
+                $md .= "- Stack:\n";
+                foreach ($query['stack'] as $frame) {
+                    $md .= '  - ' . $sanitizeRow($frame) . "\n";
+                }
+            }
+            $md .= "\n";
+        }
+
+        $md .= "## Duplicate queries\n\n";
+        foreach ($vars['doublesQueries'] as $query => $count) {
+            if ($count > 1) {
+                $md .= '- (' . $count . 'x) `' . $sanitizeRow($query) . "`\n";
+            }
+        }
+        $md .= "\n";
+
+        $md .= "## Table stress\n\n| Table | Queries |\n|---|---|\n";
+        foreach ($vars['tableStress'] as $table => $count) {
+            $md .= '| ' . $sanitizeRow($table) . ' | ' . $count . " |\n";
+        }
+        $md .= "\n";
+
+        $md .= "## ObjectModel instances\n\n| Class | Instances |\n|---|---|\n";
+        foreach ($vars['objectmodel'] as $class => $instances) {
+            $md .= '| ' . $sanitizeRow($class) . ' | ' . count($instances) . " |\n";
+        }
+        $md .= "\n";
+
+        $md .= '## Included files (' . count($vars['files']) . ")\n\n";
+        foreach ($vars['files'] as $file) {
+            $md .= '- ' . str_replace('\\', '/', substr($file, strlen(_PS_ROOT_DIR_))) . "\n";
+        }
+
+        return $md;
+    }
 }

--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -368,6 +368,7 @@ class Profiler
 
         $md = "# PrestaShop Profiling Report\n\n";
         $md .= '_Generated: ' . date('Y-m-d H:i:s') . "_\n\n";
+        $md .= "_This report comes from a separate request triggered by the download link, so its timings and query count will not match the panel on the page you downloaded it from._\n\n";
 
         $md .= "## Summary\n\n";
         $md .= '- Load Time: ' . round((float) $vars['summary']['loadTime'], 4) . " s\n";

--- a/tools/profiling/templates/links.tpl
+++ b/tools/profiling/templates/links.tpl
@@ -5,6 +5,7 @@
 
 <div id="profiling-links">
   <span>Profiling</span>
+  <a download="profiling-report.md" href="data:text/markdown;charset=utf-8;base64,{$profilingMarkdownBase64}">⬇ Download Markdown</a>
   <ol>
     <li>
       <a href="#summary">Summary</a>

--- a/tools/profiling/templates/links.tpl
+++ b/tools/profiling/templates/links.tpl
@@ -5,7 +5,7 @@
 
 <div id="profiling-links">
   <span>Profiling</span>
-  <a download="profiling-report.md" href="data:text/markdown;charset=utf-8;base64,{$profilingMarkdownBase64}">⬇ Download Markdown</a>
+  <a download="profiling-report.md" href="{$profilingMarkdownUrl}">⬇ Download Markdown</a>
   <ol>
     <li>
       <a href="#summary">Summary</a>


### PR DESCRIPTION
The legacy debug profiling report (_PS_DEBUG_PROFILING_) only exists as an HTML panel appended to the front-office page, so its data cannot be saved, diffed or shared without a screenshot.

Profiler::getMarkdownReport() reuses the data already collected by getSmartyVariables() (summary, hooks, modules, SQL queries with their call stack, object model instances, included files) and formats it as a Markdown document. Controller::displayProfiling() base64-encodes it and exposes it to Smarty, and links.tpl adds a "Download Markdown" link using a data: URI with the download attribute, so no new route or JavaScript dependency is required.

Being plain structured text instead of an HTML page, the downloaded report can also be pasted into an AI assistant to get help interpreting slow hooks/queries or spotting performance regressions, which isn't practical with the HTML panel.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds a "Download Markdown" link to the legacy front-office debug profiling report (enabled via `_PS_DEBUG_PROFILING_` in `config/defines.inc.php`). The report currently only renders as an HTML panel at the bottom of the page, so there is no way to save, diff or share its content (summary, hook/module timings, SQL queries with call stack, ObjectModel instances, included files) without a screenshot. `Profiler::getMarkdownReport()` reuses the data already collected by the existing `getSmartyVariables()` method and formats it as a single Markdown document, mirroring the sections already shown in the HTML report but with full detail (per-module breakdown under each hook, per-hook breakdown under each module, full SQL query text + call stack, global vars list). The report is base64-encoded and exposed to Smarty as `profilingMarkdownBase64`; `links.tpl` adds a plain anchor with `download="profiling-report.md"` and a `data:text/markdown;base64,...` href, so the browser handles the download natively — no new controller, route or JS dependency needed. Being plain text instead of an HTML page, the file can also be pasted into an AI assistant to help interpret slow hooks/queries or spot regressions.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. In `config/defines.inc.php`, set `_PS_DEBUG_PROFILING_` to `true` (or enable it from BO > Advanced Parameters > Performance). <br> 2. Clear the cache and load any front-office page. <br> 3. In the profiling panel appended at the bottom of the page, click "Download Markdown" in the links bar. <br> 4. Verify the downloaded `profiling-report.md` contains Summary, Configuration, Run, Hooks (with per-module timings), Modules (with per-call timings), Stopwatch queries (full SQL + call stack), Duplicate queries, Table stress, ObjectModel instances and Included files, matching what is shown in the HTML panel.
| UI Tests          | Not run — change only affects the legacy debug profiling tool (opt-in, `_PS_DEBUG_PROFILING_=false` by default), no impact on standard front/back office UI flows.
| Fixed issue or discussion?     |
| Related PRs       |
| Sponsor company   | bwlab