### PR TITLE
Prevent orphan customer addresses when the session expires

### DIFF
--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -49,6 +49,34 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
     {
         $this->addressForm->setAction($this->getCheckoutSession()->getCheckoutURL());
 
+        // The cart is still associated with a customer, but the current customer
+        // context is no longer valid. Redirect before displaying or processing
+        // the address form.
+        if (
+            (int) $this->context->cart->id_customer > 0
+            && (
+                !Validate::isLoadedObject($this->context->customer)
+                || (int) $this->context->cart->id_customer !== (int) $this->context->customer->id
+            )
+        ) {
+            $this->context->controller->errors[] = $this->getTranslator()->trans(
+                'Your session has expired. Please sign in again to continue your order.',
+                [],
+                'Shop.Notifications.Error'
+            );
+
+            $this->context->controller->redirectWithNotifications(
+                $this->context->link->getPageLink(
+                    'authentication',
+                    true,
+                    null,
+                    [
+                        'back' => $this->getCheckoutSession()->getCheckoutURL(),
+                    ]
+                )
+            );
+        }
+
         if (array_key_exists('use_same_address', $requestParams)) {
             $this->use_same_address = (bool) $requestParams['use_same_address'];
             if (!$this->use_same_address) {
@@ -72,26 +100,6 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
         ]);
 
         if (isset($requestParams['saveAddress'])) {
-            // The customer session may have expired while the cart is still available.
-            // Redirect to authentication instead of attempting to save an orphan address.
-            if (!Validate::isLoadedObject($this->context->customer)) {
-                $this->context->controller->errors[] = $this->getTranslator()->trans(
-                    'Your session has expired. Please sign in again to continue your order.',
-                    [],
-                    'Shop.Notifications.Error'
-                );
-                $this->context->controller->redirectWithNotifications(
-                    $this->context->link->getPageLink(
-                        'authentication',
-                        true,
-                        null,
-                        [
-                            'back' => $this->getCheckoutSession()->getCheckoutURL(),
-                        ]
-                    )
-                );
-            }
-
             $saved = $this->addressForm->fillWith($requestParams)->submit();
             if (!$saved) {
                 $this->setCurrent(true);

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -75,7 +75,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             // The customer session may have expired while the cart is still available.
             // Redirect to authentication instead of attempting to save an orphan address.
             if (!Validate::isLoadedObject($this->context->customer)) {
-                $this->context->controller->error[] = $this->getTranslator()->trans(
+                $this->context->controller->errors[] = $this->getTranslator()->trans(
                     'Your session has expired. Please sign in again to continue your order.',
                     [],
                     'Shop.Notifications.Error'

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -72,6 +72,26 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
         ]);
 
         if (isset($requestParams['saveAddress'])) {
+            // The customer session may have expired while the cart is still available.
+            // Redirect to authentication instead of attempting to save an orphan address.
+            if (!Validate::isLoadedObject($this->context->customer)) {
+                $this->context->controller->error[] = $this->getTranslator()->trans(
+                    'Your session has expired. Please sign in again to continue your order.',
+                    [],
+                    'Shop.Notifications.Error'
+                );
+                $this->context->controller->redirectWithNotifications(
+                    $this->context->link->getPageLink(
+                        'authentication',
+                        true,
+                        null,
+                        [
+                            'back' => $this->getCheckoutSession()->getCheckoutURL(),
+                        ]
+                    )
+                );
+            }
+
             $saved = $this->addressForm->fillWith($requestParams)->submit();
             if (!$saved) {
                 $this->setCurrent(true);

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -102,6 +102,13 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
         if (isset($requestParams['saveAddress'])) {
             $saved = $this->addressForm->fillWith($requestParams)->submit();
             if (!$saved) {
+                if (!$this->addressForm->hasErrors()) {
+                    $this->context->controller->errors[] = $this->getTranslator()->trans(
+                        'Could not save address.',
+                        [],
+                        'Shop.Notifications.Error'
+                    );
+                }
                 $this->setCurrent(true);
                 $this->getCheckoutProcess()->setHasErrors(true);
                 if ($requestParams['saveAddress'] === 'delivery') {

--- a/classes/form/CustomerAddressPersister.php
+++ b/classes/form/CustomerAddressPersister.php
@@ -23,6 +23,12 @@ class CustomerAddressPersisterCore
 
     private function authorizeChange(Address $address, $token)
     {
+        // Prevent saving an address without a valid customer, which would create
+        // an orphan address with id_customer = 0.
+        if (!Validate::isLoadedObject($this->customer)) {
+            return false;
+        }
+
         if ($address->id_customer && (int) $address->id_customer !== (int) $this->customer->id) {
             // Can't touch anybody else's address
             return false;

--- a/classes/form/CustomerAddressPersister.php
+++ b/classes/form/CustomerAddressPersister.php
@@ -29,6 +29,15 @@ class CustomerAddressPersisterCore
             return false;
         }
 
+        // Prevent modifying customer addresses when the current cart
+        // belongs to another customer.
+        if (
+            (int) $this->cart->id_customer > 0
+            && (int) $this->cart->id_customer !== (int) $this->customer->id
+        ) {
+            return false;
+        }
+
         if ($address->id_customer && (int) $address->id_customer !== (int) $this->customer->id) {
             // Can't touch anybody else's address
             return false;

--- a/tests/Integration/Classes/Checkout/CheckoutAddressesStepTest.php
+++ b/tests/Integration/Classes/Checkout/CheckoutAddressesStepTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Classes\Checkout;
 
+use Cart;
 use CheckoutAddressesStep;
 use CheckoutProcess;
 use CheckoutSession;
@@ -38,6 +39,8 @@ class CheckoutAddressesStepTest extends TestCase
         $context = $this->createMock(Context::class);
         $context->language = $this->createMock(Language::class);
         $context->customer = $this->createMock(Customer::class);
+        $context->cart = $this->createMock(Cart::class);
+        $context->cart->id_customer = 0;
         $context->link = $this->createMock(Link::class);
         $context->link->method('getPageLink')->withAnyParameters()->willReturn('http://addresses-actions.url');
 

--- a/tests/Integration/Classes/Checkout/CheckoutAddressesStepTest.php
+++ b/tests/Integration/Classes/Checkout/CheckoutAddressesStepTest.php
@@ -12,21 +12,21 @@ use Cart;
 use CheckoutAddressesStep;
 use CheckoutProcess;
 use CheckoutSession;
-use Context;
 use Customer;
 use CustomerAddressForm;
 use Language;
 use Link;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Tests\TestCase\ContextStateTestCase;
 
-class CheckoutAddressesStepTest extends TestCase
+class CheckoutAddressesStepTest extends ContextStateTestCase
 {
     /**
      * @var CheckoutSession|MockObject
      */
     private $session;
+
     /**
      * @var CheckoutAddressesStep
      */
@@ -36,16 +36,29 @@ class CheckoutAddressesStepTest extends TestCase
     {
         parent::setUp();
 
-        $context = $this->createMock(Context::class);
-        $context->language = $this->createMock(Language::class);
-        $context->customer = $this->createMock(Customer::class);
-        $context->cart = $this->createMock(Cart::class);
-        $context->cart->id_customer = 0;
-        $context->link = $this->createMock(Link::class);
-        $context->link->method('getPageLink')->withAnyParameters()->willReturn('http://addresses-actions.url');
+        $language = $this->createContextFieldMock(Language::class, 1);
+        $customer = $this->createContextFieldMock(Customer::class, 0);
+
+        $cart = $this->createMock(Cart::class);
+        $cart->id_customer = 0;
+
+        $link = $this->createMock(Link::class);
+        $link
+            ->method('getPageLink')
+            ->withAnyParameters()
+            ->willReturn('http://addresses-actions.url');
+
+        $context = $this->createContextMock([
+            'language' => $language,
+            'customer' => $customer,
+            'cart' => $cart,
+            'link' => $link,
+        ]);
 
         $this->session = $this->createMock(CheckoutSession::class);
-        $this->session->method('getCustomer')->willReturn($context->customer);
+        $this->session
+            ->method('getCustomer')
+            ->willReturn($context->customer);
 
         $process = new CheckoutProcess($context, $this->session);
 
@@ -54,58 +67,75 @@ class CheckoutAddressesStepTest extends TestCase
             $this->createMock(TranslatorInterface::class),
             $this->createMock(CustomerAddressForm::class)
         );
+
         $this->step->setCheckoutProcess($process);
     }
 
     public function testIfCustomerHasNoAddressesThenDeliveryAddressFormIsOpen(): void
     {
-        $this->session->method('getCustomerAddressesCount')->willReturn(0);
-        $array = $this->step->handleRequest([])->getTemplateParameters();
-        $this->assertArrayHasKey(
-            'show_delivery_address_form',
-            $array
-        );
-        $this->assertEquals(true, $array['show_delivery_address_form']);
+        $this->session
+            ->method('getCustomerAddressesCount')
+            ->willReturn(0);
+
+        $array = $this->step
+            ->handleRequest([])
+            ->getTemplateParameters();
+
+        $this->assertArrayHasKey('show_delivery_address_form', $array);
+        $this->assertTrue($array['show_delivery_address_form']);
     }
 
     public function testIfCustomerHasOneAddressThenDeliveryAddressFormIsNotOpen(): void
     {
-        $this->session->method('getCustomerAddressesCount')->willReturn(1);
-        $array = $this->step->handleRequest([])->getTemplateParameters();
-        $this->assertArrayHasKey(
-            'show_delivery_address_form',
-            $array
-        );
-        $this->assertEquals(false, $array['show_delivery_address_form']);
+        $this->session
+            ->method('getCustomerAddressesCount')
+            ->willReturn(1);
+
+        $array = $this->step
+            ->handleRequest([])
+            ->getTemplateParameters();
+
+        $this->assertArrayHasKey('show_delivery_address_form', $array);
+        $this->assertFalse($array['show_delivery_address_form']);
     }
 
     public function testIfCustomerHasOneAddressAndWantsDifferentInvoiceThenInvoiceOpen(): void
     {
-        $this->session->method('getCustomerAddressesCount')->willReturn(1);
-        $array = $this->step->handleRequest(['use_same_address' => false])->getTemplateParameters();
-        $this->assertArrayHasKey(
-            'show_invoice_address_form',
-            $array
-        );
-        $this->assertEquals(false, $array['show_delivery_address_form']);
+        $this->session
+            ->method('getCustomerAddressesCount')
+            ->willReturn(1);
+
+        $array = $this->step
+            ->handleRequest([
+                'use_same_address' => false,
+            ])
+            ->getTemplateParameters();
+
+        $this->assertArrayHasKey('show_invoice_address_form', $array);
+        $this->assertFalse($array['show_delivery_address_form']);
     }
 
     public function testWhenCustomerHasOneDeliveryAddressAndEditsItThenIsOpen(): void
     {
-        $this->session->method('getCustomerAddressesCount')->willReturn(1);
+        $this->session
+            ->method('getCustomerAddressesCount')
+            ->willReturn(1);
 
         $subset = [
             'show_delivery_address_form' => true,
             'form_has_continue_button' => true,
         ];
-        $array = $this->step->handleRequest([
-            'editAddress' => 'delivery',
-            'id_address' => null,
-        ])->getTemplateParameters();
+
+        $array = $this->step
+            ->handleRequest([
+                'editAddress' => 'delivery',
+                'id_address' => null,
+            ])
+            ->getTemplateParameters();
 
         foreach ($subset as $key => $value) {
             $this->assertArrayHasKey($key, $array);
-            $this->assertEquals($value, $array[$key]);
+            $this->assertSame($value, $array[$key]);
         }
     }
 }

--- a/tests/Unit/Classes/form/CustomerAddressPersisterTest.php
+++ b/tests/Unit/Classes/form/CustomerAddressPersisterTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\form;
+
+use Address;
+use Cart;
+use Customer;
+use CustomerAddressPersister;
+use PHPUnit\Framework\TestCase;
+
+class CustomerAddressPersisterTest extends TestCase
+{
+    private const TOKEN = 'address-token';
+
+    public function testSaveIsRejectedWhenCustomerIsNotLoaded(): void
+    {
+        $customer = $this->createCustomer(null);
+        $cart = $this->createCart(0);
+        $address = $this->createAddressThatMustNotBeSaved();
+
+        $persister = new CustomerAddressPersister(
+            $customer,
+            $cart,
+            self::TOKEN
+        );
+
+        self::assertFalse(
+            $persister->save($address, self::TOKEN)
+        );
+        self::assertSame(0, $address->id_customer);
+    }
+
+    public function testSaveIsRejectedWhenCartBelongsToAnotherCustomer(): void
+    {
+        $customer = $this->createCustomer(42);
+        $cart = $this->createCart(43);
+        $address = $this->createAddressThatMustNotBeSaved();
+
+        $persister = new CustomerAddressPersister(
+            $customer,
+            $cart,
+            self::TOKEN
+        );
+
+        self::assertFalse(
+            $persister->save($address, self::TOKEN)
+        );
+        self::assertSame(0, $address->id_customer);
+    }
+
+    public function testSavePersistsAddressWhenCustomerOwnsCart(): void
+    {
+        $customer = $this->createCustomer(42);
+        $cart = $this->createCart(42);
+        $address = $this->createAddressThatMustBeSaved();
+
+        $persister = new CustomerAddressPersister(
+            $customer,
+            $cart,
+            self::TOKEN
+        );
+
+        self::assertTrue(
+            $persister->save($address, self::TOKEN)
+        );
+        self::assertSame(42, $address->id_customer);
+    }
+
+    public function testSavePersistsAddressWhenCartHasNoCustomer(): void
+    {
+        $customer = $this->createCustomer(42);
+        $cart = $this->createCart(0);
+        $address = $this->createAddressThatMustBeSaved();
+
+        $persister = new CustomerAddressPersister(
+            $customer,
+            $cart,
+            self::TOKEN
+        );
+
+        self::assertTrue(
+            $persister->save($address, self::TOKEN)
+        );
+        self::assertSame(42, $address->id_customer);
+    }
+
+    private function createCustomer(?int $id): Customer
+    {
+        $customer = $this->createMock(Customer::class);
+        $customer->id = $id;
+
+        return $customer;
+    }
+
+    private function createCart(int $idCustomer): Cart
+    {
+        $cart = $this->createMock(Cart::class);
+        $cart->id_customer = $idCustomer;
+
+        return $cart;
+    }
+
+    private function createAddressThatMustNotBeSaved(): Address
+    {
+        $address = $this->getMockBuilder(Address::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['isUsed', 'save'])
+            ->getMock();
+
+        $address->id_customer = 0;
+
+        $address
+            ->expects(self::never())
+            ->method('isUsed');
+
+        $address
+            ->expects(self::never())
+            ->method('save');
+
+        return $address;
+    }
+
+    private function createAddressThatMustBeSaved(): Address
+    {
+        $address = $this->getMockBuilder(Address::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['isUsed', 'save'])
+            ->getMock();
+
+        $address->id_customer = 0;
+
+        $address
+            ->expects(self::once())
+            ->method('isUsed')
+            ->willReturn(false);
+
+        $address
+            ->expects(self::once())
+            ->method('save')
+            ->willReturn(true);
+
+        return $address;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | This PR prevents customer addresses from being saved with `id_customer = 0` when the customer session expires during checkout.<br/>I was not able to reproduce the issue through the normal checkout flow, so I created a test module that simulates the loss of the customer session before the address form is submitted.<br/>A validation has been added to `CustomerAddressPersister` to ensure that address operations are performed only when a valid customer object is available.<br/>Additionally, when the customer session is no longer valid while submitting the address form, the checkout redirects the customer to the authentication page and displays the following error message: `Your session has expired. Please sign in again to continue your order.`<br/>This prevents orphan customer addresses from being created and avoids errors when these addresses are later managed from the Back Office.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the [issue42029.zip](https://github.com/user-attachments/files/29915892/issue42029.zip) module.<br/>2. In the Front Office, add a product to the cart.<br/>3. Start the checkout process and create a new customer account.<br/>4. Fill in and submit the new address form.<br/>5. Verify that you are redirected to the authentication page.<br/>6. Verify that the following error message is displayed: `> Your session has expired. Please sign in again to continue your order.<br/>`7. Verify in the database that no new customer address has been created with `id_customer = 0`.<br/>8. Uninstall the `MODULO NAME` module.<br/>9. Repeat the checkout process by creating a new customer account and submitting the address form.<br/>10. Verify that the address is successfully created and that the checkout can continue normally.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/31156720133
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/42029 #42027
| Related PRs       | 
| Sponsor company   | Codencode snc
