### PR TITLE
Fix CI matrix generator crashing on backticks in PR description

### DIFF
--- a/.github/workflows/workflow-matrix-generator.yml
+++ b/.github/workflows/workflow-matrix-generator.yml
@@ -28,7 +28,12 @@ jobs:
         run: |
           # Put label list in one line JSON style to avoid parse error
           labelList=$( echo '${{ env.PR_LABEL_LIST }}' | jq -c )
-          if [[ ${{ env.DESCRIPTION }} =~ \|?[[:space:]]*Category\?[[:space:]]*\|[[:space:]]*ME([[:space:]]|(\\[rn]))+ ]]; then
+          description=$(
+          cat <<"EOF"
+          ${{ toJSON(github.event.pull_request.body) }}
+          EOF
+          )
+          if [[ $description =~ \|?[[:space:]]*Category\?[[:space:]]*\|[[:space:]]*ME([[:space:]]|(\\[rn]))+ ]]; then
             echo Using all versions for a merge request
             echo "use_all_versions=1" >> $GITHUB_OUTPUT
           elif [[ "$labelList" == *"Run all versions"* ]]; then


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | The workflow_matrix_generator job evaluates the pull request description inside a bash conditional (.github/workflows/workflow-matrix-generator.yml, the "Detect complete or default values" step). The description is substituted into the script verbatim, so any Markdown backtick code-span in a PR description is interpreted by the shell as command substitution. The step then fails with a command-not-found / "syntax error near unexpected token newline" error and the rest of the test matrix is cancelled.<br><br>develop already fixes this by reading the description through a quoted heredoc so its content is treated as literal text. This change backports that exact fix to 9.1.x. Behaviour is unchanged for descriptions without backticks. The failure was observed on the CI of #41950.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open or update a pull request against 9.1.x whose description contains a Markdown backtick code-span. Before: the "workflow_matrix_generator / Build workflow matrix" check fails and cancels the dependent jobs. After: the check passes and the description content no longer reaches the shell as code.
| UI Tests          | Not applicable. This only changes a CI workflow and has no runtime or UI surface.
| Fixed issue or discussion?     |
| Related PRs       | Backports the fix already present on develop (quoted heredoc in the same workflow). Failure observed on #41950.
| Sponsor company   |
