### PR TITLE
Display the employee who created a back-office order in the Messages block

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -13,10 +13,13 @@ use Configuration;
 use Context;
 use Currency;
 use Customer;
+use CustomerMessage;
+use CustomerThread;
 use Employee;
 use Exception;
 use Message;
 use Module;
+use Order;
 use PaymentModule;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
@@ -27,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Tools;
 use Validate;
 
 /**
@@ -68,19 +72,6 @@ final class AddOrderFromBackOfficeHandler extends AbstractOrderCommandHandler im
         // Context country, language and currency is used in PaymentModule::validateOrder (it should rely on cart address country instead)
         $this->setCartContext($this->contextStateManager, $cart);
 
-        if ($command->getEmployeeId()->getValue()) {
-            $translator = Context::getContext()->getTranslator();
-            $employee = new Employee($command->getEmployeeId()->getValue());
-            $message = sprintf(
-                '%s %s. %s',
-                $translator->trans('Manual order -- Employee:', [], 'Admin.Orderscustomers.Feature'),
-                $employee->firstname[0],
-                $employee->lastname
-            );
-        } else {
-            $message = '';
-        }
-
         try {
             $orderMessage = $command->getOrderMessage();
             if (!empty($orderMessage)) {
@@ -92,7 +83,7 @@ final class AddOrderFromBackOfficeHandler extends AbstractOrderCommandHandler im
                 $command->getOrderStateId(),
                 $cart->getOrderTotal(),
                 $paymentModule->displayName,
-                $message,
+                '',
                 [],
                 null,
                 false,
@@ -108,7 +99,66 @@ final class AddOrderFromBackOfficeHandler extends AbstractOrderCommandHandler im
             throw new OrderException('Failed to add order.');
         }
 
-        return new OrderId((int) $paymentModule->currentOrder);
+        $orderId = (int) $paymentModule->currentOrder;
+
+        // Keep track of which employee created the order from the back office, so it is
+        // displayed in the order "Messages" block (regression from 1.6, see issue #9676).
+        if ($command->getEmployeeId()->getValue()) {
+            $this->addEmployeeCreationMessage($orderId, (int) $command->getEmployeeId()->getValue());
+        }
+
+        return new OrderId($orderId);
+    }
+
+    /**
+     * Records, as a private message attached to the order's customer thread, which employee
+     * created the order from the back office, so it is displayed in the order "Messages" block.
+     *
+     * @param int $orderId
+     * @param int $employeeId
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    private function addEmployeeCreationMessage(int $orderId, int $employeeId): void
+    {
+        $employee = new Employee($employeeId);
+        if (!Validate::isLoadedObject($employee)) {
+            return;
+        }
+
+        $order = new Order($orderId);
+        $customer = new Customer((int) $order->id_customer);
+
+        $customerThreadId = (int) CustomerThread::getIdCustomerThreadByEmailAndIdOrder($customer->email, (int) $order->id);
+        if (!$customerThreadId) {
+            $customerThread = new CustomerThread();
+            $customerThread->id_contact = 0;
+            $customerThread->id_customer = (int) $order->id_customer;
+            $customerThread->id_shop = (int) $order->id_shop;
+            $customerThread->id_order = (int) $order->id;
+            $customerThread->id_lang = (int) $order->id_lang;
+            $customerThread->email = $customer->email;
+            $customerThread->status = 'open';
+            $customerThread->token = Tools::passwdGen(12);
+            $customerThread->add();
+            $customerThreadId = (int) $customerThread->id;
+        }
+
+        $translator = Context::getContext()->getTranslator();
+        $message = sprintf(
+            '%s %s. %s',
+            $translator->trans('Manual order -- Employee:', [], 'Admin.Orderscustomers.Feature'),
+            $employee->firstname[0],
+            $employee->lastname
+        );
+
+        $customerMessage = new CustomerMessage();
+        $customerMessage->id_customer_thread = $customerThreadId;
+        $customerMessage->id_employee = $employeeId;
+        $customerMessage->message = $message;
+        $customerMessage->private = true;
+        $customerMessage->add();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderMessageContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderMessageContext.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
+use Employee;
 use OrderMessage;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderForViewing;
@@ -127,6 +128,35 @@ class OrderMessageContext extends AbstractDomainFeatureContext
         if (!$messageFound) {
             throw new RuntimeException(sprintf('Message "%s" not found in Order #%s messages', $messageContent, $orderId));
         }
+    }
+
+    /**
+     * @Then order :orderReference must have a customer message created by employee :employeeEmail
+     *
+     * @param string $orderReference
+     * @param string $employeeEmail
+     *
+     * @throws RuntimeException
+     */
+    public function orderMustHaveCustomerMessageFromEmployee(string $orderReference, string $employeeEmail): void
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+
+        /** @var OrderForViewing $orderForViewing */
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+
+        $employee = (new Employee())->getByEmail($employeeEmail);
+        if (!$employee) {
+            throw new RuntimeException(sprintf('Employee with email "%s" was not found', $employeeEmail));
+        }
+
+        foreach ($orderForViewing->getMessages()->getMessages() as $orderMessageForViewing) {
+            if ((int) $orderMessageForViewing->getEmployeeId() === (int) $employee->id) {
+                return;
+            }
+        }
+
+        throw new RuntimeException(sprintf('No customer message created by employee "%s" was found in Order #%s', $employeeEmail, $orderId));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -37,7 +37,9 @@ Feature: Order from Back Office (BO)
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
 
-  Scenario: Check customer message can be null
+  # Even without a customer message, the employee who created the order from the BO must be
+  # recorded in the order messages block (regression from 1.6, see issue #9676).
+  Scenario: An order created from the BO with no customer message still records its creating employee
     When I create an empty cart "dummy_cart2" for customer "testCustomer"
     And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart2"
     And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart2"
@@ -46,7 +48,7 @@ Feature: Order from Back Office (BO)
       | message             |                             |
       | payment module name | dummy_payment               |
       | status              | Awaiting bank wire payment  |
-    Then order "bo_order2" must have no customer message
+    Then order "bo_order2" must have a customer message created by employee "test@prestashop.com"
 
   Scenario: Check customer message is saved when creating an order
     When I create an empty cart "dummy_cart2" for customer "testCustomer"
@@ -58,6 +60,7 @@ Feature: Order from Back Office (BO)
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
     Then order "bo_order2" must have customer message with content "test"
+    And order "bo_order2" must have a customer message created by employee "test@prestashop.com"
 
   Scenario: Update order status
     When I update order "bo_order1" status to "Awaiting Cash On Delivery validation"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Backport of #41595 to 9.2.x as requested by @kpodemski (https://github.com/PrestaShop/PrestaShop/pull/41595#issuecomment-4947350597). Cherry-picked cleanly. See #41595 for full context.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests | 🟢 https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/29188713822
| How to test?      | 1. BO > Sell > Orders > create a new order, selecting an employee. <br> 2. Save the order and open its detail page. <br> 3. Scroll to the **Messages** block: it now shows "Manual order -- Employee: X Y" attributed to the employee who created the order. <br> 4. Orders not created from the BO (no employee) are unaffected.
| Fixed issue or discussion?     | Fixes #9676
| Related PRs       | #41595 (develop)