### PR TITLE
Add integration tests for ModuleHtmlAuthorizationChecker

### DIFF
--- a/tests/Integration/Adapter/Module/ModuleHtmlAuthorizationCheckerTest.php
+++ b/tests/Integration/Adapter/Module/ModuleHtmlAuthorizationCheckerTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Module;
+
+use PrestaShop\PrestaShop\Adapter\Module\Module;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleHtmlAuthorizationChecker;
+use PrestaShop\PrestaShop\Core\Module\ModuleManager;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ModuleHtmlAuthorizationCheckerTest extends KernelTestCase
+{
+    public function testCustomerInputAndUnknownModulesAreNotAuthorizedButEnabledModulesAre(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        /** @var Module $moduleAdapter */
+        $moduleAdapter = $container->get('prestashop.adapter.legacy.module');
+
+        /** @var ModuleManager $moduleManager */
+        $moduleManager = $container->get(ModuleManager::class);
+
+        /** @var ModuleDataProvider $moduleDataProvider */
+        $moduleDataProvider = $container->get('prestashop.adapter.data_provider.module');
+
+        $checker = new ModuleHtmlAuthorizationChecker(
+            $moduleAdapter,
+            $moduleManager
+        );
+
+        // Customer customization input carries no module id: never allowed (must be escaped).
+        $this->assertFalse($checker->isModuleHtmlAllowed(0));
+        $this->assertFalse($checker->isModuleHtmlAllowed(-1));
+
+        // Unknown module id: not allowed.
+        $this->assertFalse($checker->isModuleHtmlAllowed(999999));
+
+        // A real, enabled module is allowed
+        $moduleId = $moduleDataProvider->getModuleIdByName('ps_featuredproducts');
+
+        $this->assertGreaterThan(
+            0,
+            $moduleId,
+            'The ps_featuredproducts module must be installed in the test fixtures.'
+        );
+
+        $this->assertTrue($checker->isModuleHtmlAllowed($moduleId));
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR adds an integration test for `ModuleHtmlAuthorizationChecker`, introduced in #41238.<br/>The test verifies that invalid or unknown module IDs are rejected, while an installed and enabled module is authorized.<br/>
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No manual testing is required, as this PR only adds an integration test.<br/><br/>Run the new test:<br/>`composer run integration-tests -- --filter=ModuleHtmlAuthorizationCheckerTest`<br/><br/>The test should pass.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41238
| Sponsor company   | Codencode snc
