### PR TITLE
Optimize Category::getProducts() random product selection for large catalogs

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1030,16 +1030,40 @@ class CategoryCore extends ObjectModel
             $nbDaysNewProduct = 20;
         }
 
+        $filters = ($active ? ' AND product_shop.`active` = 1' : '')
+            . ($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '')
+            . ($idSupplier ? ' AND p.id_supplier = ' . (int) $idSupplier : '');
+
+        // When picking random products, first narrow down to a handful of ids using a lightweight
+        // query (no product_lang/image/manufacturer/sales joins) so ORDER BY RAND() only ever has to
+        // sort a thin id-only result set instead of the full, heavily joined product catalog. This
+        // keeps the query fast even on catalogs with hundreds of thousands of products.
+        $categoryProductFrom = '`' . _DB_PREFIX_ . 'category_product` cp
+				LEFT JOIN `' . _DB_PREFIX_ . 'product` p
+					ON p.`id_product` = cp.`id_product`
+				' . Shop::addSqlAssociation('product', 'p');
+
+        if ($random === true) {
+            $sqlRandomIds = 'SELECT cp.`id_product`
+				FROM ' . $categoryProductFrom . '
+				WHERE product_shop.`id_shop` = ' . (int) $context->shop->id . '
+					AND cp.`id_category` = ' . (int) $this->id
+                . $filters . '
+				ORDER BY RAND() LIMIT ' . (int) $randomNumberProducts;
+
+            $categoryProductFrom = '(' . $sqlRandomIds . ') random_product
+				INNER JOIN `' . _DB_PREFIX_ . 'product` p
+					ON p.`id_product` = random_product.`id_product`
+				' . Shop::addSqlAssociation('product', 'p');
+        }
+
         $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) AS quantity' . (Combination::isFeatureActive() ? ', IFNULL(product_attribute_shop.id_product_attribute, 0) AS id_product_attribute,
 					product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity' : '') . ', pl.`description`, pl.`description_short`, pl.`available_now`,
 					pl.`available_later`, pl.`link_rewrite`, pl.`meta_description`, pl.`meta_title`, pl.`name`, image_shop.`id_image` id_image,
 					il.`legend` as legend, m.`name` AS manufacturer_name, cl.`name` AS category_default,
 					DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",
 					INTERVAL ' . (int) $nbDaysNewProduct . ' DAY)) > 0 AS new, product_shop.price AS orderprice, psales.`quantity` as sales
-				FROM `' . _DB_PREFIX_ . 'category_product` cp
-				LEFT JOIN `' . _DB_PREFIX_ . 'product` p
-					ON p.`id_product` = cp.`id_product`
-				' . Shop::addSqlAssociation('product', 'p') .
+				FROM ' . $categoryProductFrom .
                 (Combination::isFeatureActive() ? ' LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
 				ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')' : '') . '
 				' . Product::sqlStock('p', 0) . '
@@ -1058,15 +1082,15 @@ class CategoryCore extends ObjectModel
 					ON m.`id_manufacturer` = p.`id_manufacturer`
                 LEFT JOIN `' . _DB_PREFIX_ . 'product_sale` psales
 					ON psales.`id_product` = p.`id_product`
-				WHERE product_shop.`id_shop` = ' . (int) $context->shop->id . '
-					AND cp.`id_category` = ' . (int) $this->id
-                    . ($active ? ' AND product_shop.`active` = 1' : '')
-                    . ($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '')
-                    . ($idSupplier ? ' AND p.id_supplier = ' . (int) $idSupplier : '');
+				WHERE product_shop.`id_shop` = ' . (int) $context->shop->id .
+                (
+                    $random === true
+                    ? ''
+                    : ' AND cp.`id_category` = ' . (int) $this->id . $filters
+                );
 
-        if ($random === true) {
-            $sql .= ' ORDER BY RAND() LIMIT ' . (int) $randomNumberProducts;
-        } elseif ($orderBy !== 'orderprice') {
+        // When random, ordering is already random from the id subquery above; no further ORDER BY/LIMIT needed here.
+        if ($random !== true && $orderBy !== 'orderprice') {
             $sql .= ' ORDER BY ' . (!empty($orderByPrefix) ? $orderByPrefix . '.' : '') . '`' . bqSQL($orderBy) . '` ' . pSQL($orderWay) . '
 			LIMIT ' . (((int) $pageNumber - 1) * (int) $productPerPage) . ',' . (int) $productPerPage;
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `Category::getProducts()` used `ORDER BY RAND() LIMIT N` on the full, heavily joined product query (product_lang, image_shop/image_lang, manufacturer, product_sale, stock, product_attribute_shop...) whenever `$random = true`. MySQL has to compute `RAND()` and filesort **every** matching row across all those joins before applying the limit, which becomes extremely expensive on catalogs with hundreds of thousands of products (500k+). This PR splits the random selection into two steps: a lightweight query first picks the `id_product`(s) via `ORDER BY RAND() LIMIT N` restricted to `category_product`/`product`/`product_shop` only (no wide joins), then the existing full-detail query joins only those N ids. Output/behavior is unchanged, only the execution plan is optimized.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a category with a large number of products, call `Category::getProducts($idLang, 1, 10, null, null, false, true, true, 4)` (random branch) and compare the query plan / execution time before and after the fix (e.g. via `EXPLAIN` or MySQL slow query log). Functionally, the returned products should still be random and respect the category's active/visibility/supplier filters, same as before.
| UI Tests          | N/A (backend query optimization, no UI behavior change)
| Fixed issue or discussion?     | Fixes #42036
| Related PRs       |
| Sponsor company   |
