### PR TITLE
Fix injecting Translator to the CheckoutProcessProviderResolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "0.6.2",
+        "prestashop/ps_onepagecheckout": "0.6.4",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5e99877b976b48992fc2de115178abf",
+    "content-hash": "34f1b13063758d6bbdc21a0d4ff911aa",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6429,16 +6429,16 @@
         },
         {
             "name": "prestashop/ps_onepagecheckout",
-            "version": "v0.6.2",
+            "version": "v0.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
-                "reference": "521db0a4d459069b367b7be5292e5520632d2a09"
+                "reference": "49f564de4136e12fdfbfe1611493c8b9cfe938f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/521db0a4d459069b367b7be5292e5520632d2a09",
-                "reference": "521db0a4d459069b367b7be5292e5520632d2a09",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/49f564de4136e12fdfbfe1611493c8b9cfe938f6",
+                "reference": "49f564de4136e12fdfbfe1611493c8b9cfe938f6",
                 "shasum": ""
             },
             "require": {
@@ -6472,9 +6472,9 @@
             "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
-                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.2"
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.4"
             },
-            "time": "2026-07-02T14:45:01+00:00"
+            "time": "2026-07-15T14:02:21+00:00"
         },
         {
             "name": "prestashop/ps_searchbar",

--- a/src/Adapter/Order/Checkout/CheckoutProcessProviderInterface.php
+++ b/src/Adapter/Order/Checkout/CheckoutProcessProviderInterface.php
@@ -10,7 +10,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\Checkout;
 
 use CheckoutProcess;
 use CheckoutSession;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Contract for modules that provide their own checkout process.
@@ -30,6 +30,6 @@ interface CheckoutProcessProviderInterface
      */
     public function buildCheckoutProcess(
         CheckoutSession $session,
-        TranslatorComponent $translator
+        TranslatorInterface $translator
     ): CheckoutProcess;
 }

--- a/src/Adapter/Order/Checkout/CheckoutProcessProviderResolver.php
+++ b/src/Adapter/Order/Checkout/CheckoutProcessProviderResolver.php
@@ -11,7 +11,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\Checkout;
 use CheckoutProcess;
 use CheckoutSession;
 use Hook;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Resolves the checkout process provided by modules through the checkout hook.
@@ -23,11 +23,11 @@ class CheckoutProcessProviderResolver
      * or null to keep the native checkout.
      *
      * @param CheckoutSession $session
-     * @param TranslatorComponent $translator
+     * @param TranslatorInterface $translator
      *
      * @return CheckoutProcess|null
      */
-    public function resolve(CheckoutSession $session, TranslatorComponent $translator): ?CheckoutProcess
+    public function resolve(CheckoutSession $session, TranslatorInterface $translator): ?CheckoutProcess
     {
         $providers = $this->getValidProviders();
         $providersCount = count($providers);

--- a/tests/Integration/Adapter/Order/Checkout/CheckoutProcessProviderResolverTest.php
+++ b/tests/Integration/Adapter/Order/Checkout/CheckoutProcessProviderResolverTest.php
@@ -16,8 +16,8 @@ use Hook;
 use Module;
 use PrestaShop\PrestaShop\Adapter\Order\Checkout\CheckoutProcessProviderResolver;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
-use PrestaShopBundle\Translation\TranslatorComponent;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\Integration\Utility\ContextMocker;
 use Tests\Resources\DatabaseDump;
 
@@ -78,7 +78,7 @@ class CheckoutProcessProviderResolverTest extends KernelTestCase
     {
         $resolvedProcess = $this->checkoutProcessProviderResolver->resolve(
             $this->createMock(CheckoutSession::class),
-            $this->createMock(TranslatorComponent::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertNull($resolvedProcess);
@@ -91,7 +91,7 @@ class CheckoutProcessProviderResolverTest extends KernelTestCase
         $session = $this->createMock(CheckoutSession::class);
         $resolvedProcess = $this->checkoutProcessProviderResolver->resolve(
             $session,
-            $this->createMock(TranslatorComponent::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertInstanceOf(CheckoutProcess::class, $resolvedProcess);
@@ -105,7 +105,7 @@ class CheckoutProcessProviderResolverTest extends KernelTestCase
 
         $resolvedProcess = $this->checkoutProcessProviderResolver->resolve(
             $this->createMock(CheckoutSession::class),
-            $this->createMock(TranslatorComponent::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertNull($resolvedProcess);
@@ -118,7 +118,7 @@ class CheckoutProcessProviderResolverTest extends KernelTestCase
 
         $resolvedProcess = $this->checkoutProcessProviderResolver->resolve(
             $this->createMock(CheckoutSession::class),
-            $this->createMock(TranslatorComponent::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertNull($resolvedProcess);
@@ -131,7 +131,7 @@ class CheckoutProcessProviderResolverTest extends KernelTestCase
 
         $resolvedProcess = $this->checkoutProcessProviderResolver->resolve(
             $this->createMock(CheckoutSession::class),
-            $this->createMock(TranslatorComponent::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertNull($resolvedProcess);

--- a/tests/Resources/modules/ps_conflictingcheckoutprovider/ps_conflictingcheckoutprovider.php
+++ b/tests/Resources/modules/ps_conflictingcheckoutprovider/ps_conflictingcheckoutprovider.php
@@ -5,7 +5,7 @@
  */
 
 use PrestaShop\PrestaShop\Adapter\Order\Checkout\CheckoutProcessProviderInterface;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PsConflictingCheckoutTestProvider implements CheckoutProcessProviderInterface
 {
@@ -20,7 +20,7 @@ class PsConflictingCheckoutTestProvider implements CheckoutProcessProviderInterf
 
     public function buildCheckoutProcess(
         $session,
-        TranslatorComponent $translator
+        TranslatorInterface $translator
     ): CheckoutProcess {
         return new CheckoutProcess($this->context, $session);
     }

--- a/tests/Resources/modules/ps_onepagecheckoutprovider/ps_onepagecheckoutprovider.php
+++ b/tests/Resources/modules/ps_onepagecheckoutprovider/ps_onepagecheckoutprovider.php
@@ -5,7 +5,7 @@
  */
 
 use PrestaShop\PrestaShop\Adapter\Order\Checkout\CheckoutProcessProviderInterface;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PsOnePageCheckoutTestProvider implements CheckoutProcessProviderInterface
 {
@@ -22,7 +22,7 @@ class PsOnePageCheckoutTestProvider implements CheckoutProcessProviderInterface
 
     public function buildCheckoutProcess(
         $session,
-        TranslatorComponent $translator
+        TranslatorInterface $translator
     ): CheckoutProcess {
         return new CheckoutProcess($this->context, $session);
     }

--- a/tests/Unit/Adapter/Order/Checkout/CheckoutProcessProviderResolverTest.php
+++ b/tests/Unit/Adapter/Order/Checkout/CheckoutProcessProviderResolverTest.php
@@ -13,7 +13,7 @@ use CheckoutSession;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Order\Checkout\CheckoutProcessProviderInterface;
 use PrestaShop\PrestaShop\Adapter\Order\Checkout\CheckoutProcessProviderResolver;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StubCheckoutProcessProvider implements CheckoutProcessProviderInterface
 {
@@ -30,7 +30,7 @@ class StubCheckoutProcessProvider implements CheckoutProcessProviderInterface
 
     public function buildCheckoutProcess(
         $session,
-        TranslatorComponent $translator
+        TranslatorInterface $translator
     ): CheckoutProcess {
         return $this->checkoutProcess;
     }
@@ -57,7 +57,7 @@ class CheckoutProcessProviderResolverTest extends TestCase
 
         $resolvedProcess = $resolver->resolve(
             $this->createMock(CheckoutSession::class),
-            $this->createMock(TranslatorComponent::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertNull($resolvedProcess);
@@ -72,7 +72,7 @@ class CheckoutProcessProviderResolverTest extends TestCase
 
         $resolvedProcess = $resolver->resolve(
             $this->createMock(CheckoutSession::class),
-            $this->createMock(TranslatorComponent::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertSame($checkoutProcess, $resolvedProcess);
@@ -87,10 +87,27 @@ class CheckoutProcessProviderResolverTest extends TestCase
 
         $resolvedProcess = $resolver->resolve(
             $this->createMock(CheckoutSession::class),
-            $this->createMock(TranslatorComponent::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertNull($resolvedProcess);
+    }
+
+    public function testResolveAcceptsAnyTranslatorInterfaceImplementation(): void
+    {
+        $checkoutProcess = $this->createMock(CheckoutProcess::class);
+        $resolver = new TestableCheckoutProcessProviderResolver([
+            'provider' => $this->createProvider(true, $checkoutProcess),
+        ]);
+
+        // The checkout can run with a translator that is not the legacy TranslatorComponent
+        // (e.g. the one injected when the new front controller container is enabled).
+        $resolvedProcess = $resolver->resolve(
+            $this->createMock(CheckoutSession::class),
+            $this->createMock(TranslatorInterface::class)
+        );
+
+        $this->assertSame($checkoutProcess, $resolvedProcess);
     }
 
     private function createProvider(bool $enabled, ?CheckoutProcess $checkoutProcess = null): CheckoutProcessProviderInterface


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Before this change, checkout process didn't work with Symfony container enabled in the front office
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow the steps from the issue
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/29423939243
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42034
| Related PRs       | n/a
| Sponsor company   | PrestaShop
