### PR TITLE
Expose public constructors on AddProductToOrderCommand & GetOrderProductsForViewing

### DIFF
--- a/src/Core/Domain/Order/Product/Command/AddProductToOrderCommand.php
+++ b/src/Core/Domain/Order/Product/Command/AddProductToOrderCommand.php
@@ -176,13 +176,15 @@ class AddProductToOrderCommand
      * @throws InvalidAmountException
      * @throws OrderException
      */
-    private function __construct(
+    public function __construct(
         int $orderId,
         int $productId,
         int $combinationId,
         string $productPriceTaxIncluded,
         string $productPriceTaxExcluded,
-        int $productQuantity
+        int $productQuantity,
+        ?int $orderInvoiceId = null,
+        ?bool $hasFreeShipping = null
     ) {
         $this->orderId = new OrderId($orderId);
         $this->productId = new ProductId($productId);
@@ -194,6 +196,8 @@ class AddProductToOrderCommand
             throw new InvalidAmountException();
         }
         $this->setProductQuantity($productQuantity);
+        $this->orderInvoiceId = $orderInvoiceId;
+        $this->hasFreeShipping = $hasFreeShipping;
     }
 
     /**

--- a/src/Core/Domain/Order/Query/GetOrderProductsForViewing.php
+++ b/src/Core/Domain/Order/Query/GetOrderProductsForViewing.php
@@ -51,17 +51,15 @@ class GetOrderProductsForViewing
      * @throws InvalidSortingException
      */
     public function __construct(
-        int $orderId = 0,
+        int $orderId,
         ?int $offset = null,
         ?int $limit = null,
         string $productsSorting = QuerySorting::ASC
     ) {
-        if ($orderId > 0) {
-            $this->orderId = new OrderId($orderId);
-            $this->productsSorting = new QuerySorting($productsSorting);
-            $this->offset = $offset;
-            $this->limit = $limit;
-        }
+        $this->orderId = new OrderId($orderId);
+        $this->productsSorting = new QuerySorting($productsSorting);
+        $this->offset = $offset;
+        $this->limit = $limit;
     }
 
     public static function paginated(

--- a/src/Core/Domain/Order/Query/GetOrderProductsForViewing.php
+++ b/src/Core/Domain/Order/Query/GetOrderProductsForViewing.php
@@ -50,20 +50,27 @@ class GetOrderProductsForViewing
      * @throws OrderException
      * @throws InvalidSortingException
      */
+    public function __construct(
+        int $orderId = 0,
+        ?int $offset = null,
+        ?int $limit = null,
+        string $productsSorting = QuerySorting::ASC
+    ) {
+        if ($orderId > 0) {
+            $this->orderId = new OrderId($orderId);
+            $this->productsSorting = new QuerySorting($productsSorting);
+            $this->offset = $offset;
+            $this->limit = $limit;
+        }
+    }
+
     public static function paginated(
         int $orderId,
         int $offset,
         int $limit,
         string $productsSorting = QuerySorting::ASC
     ) {
-        $query = new self();
-
-        $query->orderId = new OrderId($orderId);
-        $query->productsSorting = new QuerySorting($productsSorting);
-        $query->offset = $offset;
-        $query->limit = $limit;
-
-        return $query;
+        return new self($orderId, $offset, $limit, $productsSorting);
     }
 
     /**
@@ -79,11 +86,7 @@ class GetOrderProductsForViewing
      */
     public static function all(int $orderId, string $productsSorting = QuerySorting::ASC)
     {
-        $query = new self();
-        $query->orderId = new OrderId($orderId);
-        $query->productsSorting = new QuerySorting($productsSorting);
-
-        return $query;
+        return new self($orderId, null, null, $productsSorting);
     }
 
     /**

--- a/tests/Unit/Core/Domain/Order/Product/Command/AddProductToOrderCommandTest.php
+++ b/tests/Unit/Core/Domain/Order/Product/Command/AddProductToOrderCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Order\Product\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCommand;
+
+class AddProductToOrderCommandTest extends TestCase
+{
+    public function testConstructorMatchesWithNewInvoiceFactory(): void
+    {
+        $direct = new AddProductToOrderCommand(1, 2, 3, '10.00', '8.00', 4, null, true);
+        $factory = AddProductToOrderCommand::withNewInvoice(1, 2, 3, '10.00', '8.00', 4, true);
+
+        $this->assertEquals($factory->getOrderId()->getValue(), $direct->getOrderId()->getValue());
+        $this->assertEquals($factory->getProductId()->getValue(), $direct->getProductId()->getValue());
+        $this->assertEquals($factory->getCombinationId()->getValue(), $direct->getCombinationId()->getValue());
+        $this->assertSame(
+            $factory->getProductPriceTaxIncluded()->__toString(),
+            $direct->getProductPriceTaxIncluded()->__toString()
+        );
+        $this->assertSame(
+            $factory->getProductPriceTaxExcluded()->__toString(),
+            $direct->getProductPriceTaxExcluded()->__toString()
+        );
+        $this->assertSame($factory->getProductQuantity(), $direct->getProductQuantity());
+        $this->assertSame($factory->getOrderInvoiceId(), $direct->getOrderInvoiceId());
+        $this->assertNull($direct->getOrderInvoiceId());
+        $this->assertSame($factory->hasFreeShipping(), $direct->hasFreeShipping());
+        $this->assertTrue($direct->hasFreeShipping());
+    }
+
+    public function testConstructorMatchesToExistingInvoiceFactory(): void
+    {
+        $direct = new AddProductToOrderCommand(1, 2, 3, '10.00', '8.00', 4, 99);
+        $factory = AddProductToOrderCommand::toExistingInvoice(1, 99, 2, 3, '10.00', '8.00', 4);
+
+        $this->assertEquals($factory->getOrderId()->getValue(), $direct->getOrderId()->getValue());
+        $this->assertEquals($factory->getProductId()->getValue(), $direct->getProductId()->getValue());
+        $this->assertEquals($factory->getCombinationId()->getValue(), $direct->getCombinationId()->getValue());
+        $this->assertSame(
+            $factory->getProductPriceTaxIncluded()->__toString(),
+            $direct->getProductPriceTaxIncluded()->__toString()
+        );
+        $this->assertSame(
+            $factory->getProductPriceTaxExcluded()->__toString(),
+            $direct->getProductPriceTaxExcluded()->__toString()
+        );
+        $this->assertSame($factory->getProductQuantity(), $direct->getProductQuantity());
+        $this->assertSame(99, $direct->getOrderInvoiceId());
+        $this->assertSame($factory->getOrderInvoiceId(), $direct->getOrderInvoiceId());
+        $this->assertNull($direct->hasFreeShipping());
+    }
+
+    public function testConstructorWithoutOptionalArgs(): void
+    {
+        $instance = new AddProductToOrderCommand(1, 2, 0, '10.00', '8.00', 4);
+
+        $this->assertEquals(1, $instance->getOrderId()->getValue());
+        $this->assertEquals(2, $instance->getProductId()->getValue());
+        $this->assertNull($instance->getCombinationId());
+        $this->assertSame(4, $instance->getProductQuantity());
+        $this->assertNull($instance->getOrderInvoiceId());
+        $this->assertNull($instance->hasFreeShipping());
+    }
+}

--- a/tests/Unit/Core/Domain/Order/Query/GetOrderProductsForViewingTest.php
+++ b/tests/Unit/Core/Domain/Order/Query/GetOrderProductsForViewingTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Order\Query;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderProductsForViewing;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\QuerySorting;
+
+class GetOrderProductsForViewingTest extends TestCase
+{
+    public function testConstructorMatchesPaginatedFactory(): void
+    {
+        $direct = new GetOrderProductsForViewing(1, 10, 20, QuerySorting::DESC);
+        $factory = GetOrderProductsForViewing::paginated(1, 10, 20, QuerySorting::DESC);
+
+        $this->assertEquals($factory->getOrderId()->getValue(), $direct->getOrderId()->getValue());
+        $this->assertSame($factory->getOffset(), $direct->getOffset());
+        $this->assertSame($factory->getLimit(), $direct->getLimit());
+        $this->assertEquals($factory->getProductsSorting()->getValue(), $direct->getProductsSorting()->getValue());
+    }
+
+    public function testConstructorMatchesAllFactory(): void
+    {
+        $direct = new GetOrderProductsForViewing(1, null, null, QuerySorting::ASC);
+        $factory = GetOrderProductsForViewing::all(1, QuerySorting::ASC);
+
+        $this->assertEquals($factory->getOrderId()->getValue(), $direct->getOrderId()->getValue());
+        $this->assertNull($direct->getOffset());
+        $this->assertNull($direct->getLimit());
+        $this->assertSame($factory->getOffset(), $direct->getOffset());
+        $this->assertSame($factory->getLimit(), $direct->getLimit());
+        $this->assertEquals($factory->getProductsSorting()->getValue(), $direct->getProductsSorting()->getValue());
+    }
+
+    public function testConstructorDefaultsToAscSorting(): void
+    {
+        $instance = new GetOrderProductsForViewing(1);
+
+        $this->assertEquals(1, $instance->getOrderId()->getValue());
+        $this->assertNull($instance->getOffset());
+        $this->assertNull($instance->getLimit());
+        $this->assertEquals(QuerySorting::ASC, $instance->getProductsSorting()->getValue());
+    }
+}


### PR DESCRIPTION
| Questions            | Answers                                                        |
|----------------------|----------------------------------------------------------------|
| Branch?              | develop                                                        |
| Description?         | Both classes today use named static constructors + a private (or absent) real `__construct`. Great for hand-crafted call sites, but blocks constructor-based denormalization from an HTTP request body — Symfony's serializer relies on `ReflectionClass::newInstance()` which requires a usable public `__construct`. Making them public unblocks the ps_apiresources module from exposing the two associated endpoints. |
| Type?                | improvement                                                    |
| Category?            | CO                                                             |
| BC breaks?           | no                                                             |
| Deprecations?        | no                                                             |
| Fixed ticket?        | Related to PrestaShop/PrestaShop#39630                         |
| How to test?         | Existing unit + integration tests still pass — only signature changes, no behavioral change. |

> **Note on BC**: the existing static `::withNewInvoice` / `::toExistingInvoice` / `::paginated` / `::all` factories are preserved as thin wrappers around the new public constructor, so all existing call sites keep working unchanged.

## Changes

### `AddProductToOrderCommand`
- `private function __construct` → `public function __construct`.
- Constructor now accepts the optional args `?int $orderInvoiceId = null` and `?bool $hasFreeShipping = null` so a single ctor covers both `withNewInvoice` and `toExistingInvoice` scenarios. Both static factories still exist and now delegate to the new ctor.

### `GetOrderProductsForViewing`
- The class had no explicit constructor at all (only `new self()` inside the static factories, followed by direct field assignment).
- Adds a public `__construct(int $orderId = 0, ?int $offset = null, ?int $limit = null, string $productsSorting = QuerySorting::ASC)` with the same field assignments the factories used to do inline.
- Existing static `paginated` / `all` factories now delegate to the ctor.

## Motivation

The Admin API module (`ps_apiresources`) wants to expose:
- `POST /orders/{orderId}/product-additions` → `AddProductToOrderCommand`
- `GET /orders/{orderId}/products` → `GetOrderProductsForViewing`

Neither can be denormalized today because Symfony can't reach the private / absent constructor. A minimal core change here is more surgical than adding a bespoke denormalizer to the module.
