### PR TITLE
Give GetCmsPageCategoryNameForListing an explicit ctor arg

### DIFF
--- a/src/Adapter/CMS/PageCategory/QueryHandler/GetCmsPageCategoryNameForListingHandler.php
+++ b/src/Adapter/CMS/PageCategory/QueryHandler/GetCmsPageCategoryNameForListingHandler.php
@@ -46,7 +46,9 @@ final class GetCmsPageCategoryNameForListingHandler implements GetCmsPageCategor
      */
     public function handle(GetCmsPageCategoryNameForListing $query)
     {
-        $cmsCategory = new CMSCategory($this->getCmsCategoryIdFromRequest());
+        $explicitId = $query->getCmsPageCategoryId();
+        $categoryId = null !== $explicitId ? $explicitId->getValue() : $this->getCmsCategoryIdFromRequest();
+        $cmsCategory = new CMSCategory($categoryId);
 
         return isset($cmsCategory->name[$this->contextLanguageId]) ? $cmsCategory->name[$this->contextLanguageId] : '';
     }

--- a/src/Core/Domain/CmsPageCategory/Query/GetCmsPageCategoryNameForListing.php
+++ b/src/Core/Domain/CmsPageCategory/Query/GetCmsPageCategoryNameForListing.php
@@ -6,9 +6,31 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query;
 
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
+
 /**
  * Gets name by cms category which are used for display in cms listing.
  */
 class GetCmsPageCategoryNameForListing
 {
+    private ?CmsPageCategoryId $cmsPageCategoryId;
+
+    /**
+     * @param int|null $cmsPageCategoryId Explicit category id. Null (or 0)
+     *                                    keeps the legacy behavior: the
+     *                                    handler falls back to the current
+     *                                    HTTP request's `id_cms_category`
+     *                                    query parameter.
+     */
+    public function __construct(?int $cmsPageCategoryId = null)
+    {
+        $this->cmsPageCategoryId = ($cmsPageCategoryId !== null && $cmsPageCategoryId > 0)
+            ? new CmsPageCategoryId($cmsPageCategoryId)
+            : null;
+    }
+
+    public function getCmsPageCategoryId(): ?CmsPageCategoryId
+    {
+        return $this->cmsPageCategoryId;
+    }
 }

--- a/src/Core/Domain/CmsPageCategory/Query/GetCmsPageCategoryNameForListing.php
+++ b/src/Core/Domain/CmsPageCategory/Query/GetCmsPageCategoryNameForListing.php
@@ -16,15 +16,16 @@ class GetCmsPageCategoryNameForListing
     private ?CmsPageCategoryId $cmsPageCategoryId;
 
     /**
-     * @param int|null $cmsPageCategoryId Explicit category id. Null (or 0)
-     *                                    keeps the legacy behavior: the
-     *                                    handler falls back to the current
-     *                                    HTTP request's `id_cms_category`
-     *                                    query parameter.
+     * @param int|null $cmsPageCategoryId Explicit category id. Null keeps the
+     *                                    legacy behavior: the handler falls
+     *                                    back to the current HTTP request's
+     *                                    `id_cms_category` query parameter.
+     *                                    Any other value is validated by
+     *                                    CmsPageCategoryId (must be > 0).
      */
     public function __construct(?int $cmsPageCategoryId = null)
     {
-        $this->cmsPageCategoryId = ($cmsPageCategoryId !== null && $cmsPageCategoryId > 0)
+        $this->cmsPageCategoryId = $cmsPageCategoryId !== null
             ? new CmsPageCategoryId($cmsPageCategoryId)
             : null;
     }

--- a/tests/Unit/Core/Domain/CmsPageCategory/Query/GetCmsPageCategoryNameForListingTest.php
+++ b/tests/Unit/Core/Domain/CmsPageCategory/Query/GetCmsPageCategoryNameForListingTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\CmsPageCategory\Query;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageCategoryNameForListing;
+
+class GetCmsPageCategoryNameForListingTest extends TestCase
+{
+    public function testItCarriesAnExplicitCategoryId(): void
+    {
+        $query = new GetCmsPageCategoryNameForListing(5);
+
+        self::assertNotNull($query->getCmsPageCategoryId());
+        self::assertSame(5, $query->getCmsPageCategoryId()->getValue());
+    }
+
+    public function testNoArgumentKeepsTheRequestFallback(): void
+    {
+        self::assertNull((new GetCmsPageCategoryNameForListing())->getCmsPageCategoryId());
+    }
+
+    public function testZeroIsRejectedByTheValueObject(): void
+    {
+        $this->expectException(CmsPageCategoryException::class);
+
+        new GetCmsPageCategoryNameForListing(0);
+    }
+}


### PR DESCRIPTION
| Questions            | Answers                                                        |
|----------------------|----------------------------------------------------------------|
| Branch?              | develop                                                        |
| Description?         | The query object was declared without any constructor at all, and the handler read the target category id straight from the current HTTP request (`id_cms_category` query parameter) via a `RequestStack` lookup. That reliance on `RequestStack` blocks two use cases: (a) exposing the query through a REST-style Admin API — the incoming API request has no such query parameter — and (b) unit-testing the handler outside an HTTP context. |
| Type?                | improvement                                                    |
| Category?            | CO                                                             |
| BC breaks?           | no — the no-arg constructor is preserved, so existing callers (`CmsPageDefinitionFactory` is the only one) keep the `RequestStack` fallback. Passing an explicit id is new behavior; passing `0` now throws `CmsPageCategoryException` from `CmsPageCategoryId` rather than silently falling back to the request. |
| Deprecations?        | no                                                             |
| Fixed ticket?        | Related to PrestaShop/PrestaShop#39630                         |
| How to test?         | `vendor/bin/phpunit tests/Unit/Core/Domain/CmsPageCategory/Query/GetCmsPageCategoryNameForListingTest.php` covers the three cases: explicit id carried through, no-arg keeps the request fallback, `0` is rejected by the value object. Existing behavior preserved for legacy callers. |

## Changes

- `GetCmsPageCategoryNameForListing::__construct(?int $cmsPageCategoryId = null)`: wraps the id in a `CmsPageCategoryId` VO. Only `null` skips the wrap; any int (including `0`) is handed to the VO, which enforces `> 0`.
- The handler now prefers the explicit ctor value and only falls back to `getCmsCategoryIdFromRequest()` when the query is instantiated with no id.
- Unit test added under `tests/Unit/Core/Domain/CmsPageCategory/Query/`.

## Motivation

The Admin API module (`ps_apiresources`) wants to expose:
- `GET /cms-page-categories/{cmsPageCategoryId}/localized-name`

Without a ctor arg on the query, the API resource can't drive the target id: the handler ignored the query and read from the request instead. This PR is the smallest surgical change to unblock that endpoint while preserving all existing legacy call sites.
