### PR TITLE
Expose public constructor on ForwardCustomerThreadCommand

### DIFF
--- a/src/Core/Domain/CustomerService/Command/ForwardCustomerThreadCommand.php
+++ b/src/Core/Domain/CustomerService/Command/ForwardCustomerThreadCommand.php
@@ -6,6 +6,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\CustomerService\Command;
 
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadId;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\EmployeeId;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
@@ -64,26 +65,33 @@ class ForwardCustomerThreadCommand
     }
 
     /**
-     * @param int         $customerThreadId
-     * @param string      $comment
-     * @param int|null    $employeeId Forward to another employee. Mutually exclusive with $email.
-     * @param string|null $email      Forward to someone else by email. Mutually exclusive with $employeeId.
+     * @param int $customerThreadId
+     * @param string $comment
+     * @param int|null $employeeId Forward to another employee. Mutually exclusive with $email.
+     * @param string|null $email Forward to someone else by email. Mutually exclusive with $employeeId.
+     *
+     * @throws CustomerServiceException if neither or both of $employeeId and $email are provided
      */
     public function __construct(
-        int $customerThreadId = 0,
-        string $comment = '',
+        int $customerThreadId,
+        string $comment,
         ?int $employeeId = null,
         ?string $email = null
     ) {
-        if ($customerThreadId > 0) {
-            $this->customerThreadId = new CustomerThreadId($customerThreadId);
-            $this->comment = $comment;
-            if (null !== $employeeId) {
-                $this->employeeId = new EmployeeId($employeeId);
-            }
-            if (null !== $email) {
-                $this->email = new Email($email);
-            }
+        if ((null === $employeeId) === (null === $email)) {
+            throw new CustomerServiceException(
+                'Exactly one of $employeeId or $email must be provided to forward a customer thread',
+                CustomerServiceException::INVALID_FORWARD_TARGET
+            );
+        }
+
+        $this->customerThreadId = new CustomerThreadId($customerThreadId);
+        $this->comment = $comment;
+        if (null !== $employeeId) {
+            $this->employeeId = new EmployeeId($employeeId);
+        }
+        if (null !== $email) {
+            $this->email = new Email($email);
         }
     }
 

--- a/src/Core/Domain/CustomerService/Command/ForwardCustomerThreadCommand.php
+++ b/src/Core/Domain/CustomerService/Command/ForwardCustomerThreadCommand.php
@@ -46,12 +46,7 @@ class ForwardCustomerThreadCommand
      */
     public static function toAnotherEmployee($customerThreadId, $employeeId, $comment)
     {
-        $command = new self();
-        $command->employeeId = new EmployeeId($employeeId);
-        $command->customerThreadId = new CustomerThreadId($customerThreadId);
-        $command->comment = $comment;
-
-        return $command;
+        return new self((int) $customerThreadId, (string) $comment, (int) $employeeId);
     }
 
     /**
@@ -65,19 +60,31 @@ class ForwardCustomerThreadCommand
      */
     public static function toSomeoneElse($customerThreadId, $email, $comment)
     {
-        $command = new self();
-        $command->email = new Email($email);
-        $command->customerThreadId = new CustomerThreadId($customerThreadId);
-        $command->comment = $comment;
-
-        return $command;
+        return new self((int) $customerThreadId, (string) $comment, null, (string) $email);
     }
 
     /**
-     * Command should be created using static factories
+     * @param int         $customerThreadId
+     * @param string      $comment
+     * @param int|null    $employeeId Forward to another employee. Mutually exclusive with $email.
+     * @param string|null $email      Forward to someone else by email. Mutually exclusive with $employeeId.
      */
-    private function __construct()
-    {
+    public function __construct(
+        int $customerThreadId = 0,
+        string $comment = '',
+        ?int $employeeId = null,
+        ?string $email = null
+    ) {
+        if ($customerThreadId > 0) {
+            $this->customerThreadId = new CustomerThreadId($customerThreadId);
+            $this->comment = $comment;
+            if (null !== $employeeId) {
+                $this->employeeId = new EmployeeId($employeeId);
+            }
+            if (null !== $email) {
+                $this->email = new Email($email);
+            }
+        }
     }
 
     /**

--- a/src/Core/Domain/CustomerService/Exception/CustomerServiceException.php
+++ b/src/Core/Domain/CustomerService/Exception/CustomerServiceException.php
@@ -27,4 +27,9 @@ class CustomerServiceException extends DomainException
      * Code is used when comment is invalid
      */
     public const INVALID_COMMENT = 30;
+
+    /**
+     * Code is used when a forward target (employee or email) is missing or ambiguous
+     */
+    public const INVALID_FORWARD_TARGET = 40;
 }

--- a/tests/Unit/Core/Domain/CustomerService/Command/ForwardCustomerThreadCommandTest.php
+++ b/tests/Unit/Core/Domain/CustomerService/Command/ForwardCustomerThreadCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\CustomerService\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\ForwardCustomerThreadCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
+
+class ForwardCustomerThreadCommandTest extends TestCase
+{
+    public function testConstructorMatchesToAnotherEmployeeFactory(): void
+    {
+        $viaFactory = ForwardCustomerThreadCommand::toAnotherEmployee(12, 34, 'please handle');
+        $viaConstructor = new ForwardCustomerThreadCommand(12, 'please handle', 34);
+
+        $this->assertEquals($viaFactory->getCustomerThreadId(), $viaConstructor->getCustomerThreadId());
+        $this->assertEquals($viaFactory->getEmployeeId(), $viaConstructor->getEmployeeId());
+        $this->assertSame($viaFactory->getEmail(), $viaConstructor->getEmail());
+        $this->assertSame($viaFactory->getComment(), $viaConstructor->getComment());
+        $this->assertTrue($viaConstructor->forwardToEmployee());
+    }
+
+    public function testConstructorMatchesToSomeoneElseFactory(): void
+    {
+        $viaFactory = ForwardCustomerThreadCommand::toSomeoneElse(12, 'someone@example.com', 'fyi');
+        $viaConstructor = new ForwardCustomerThreadCommand(12, 'fyi', null, 'someone@example.com');
+
+        $this->assertEquals($viaFactory->getCustomerThreadId(), $viaConstructor->getCustomerThreadId());
+        $this->assertSame($viaFactory->getEmployeeId(), $viaConstructor->getEmployeeId());
+        $this->assertEquals($viaFactory->getEmail(), $viaConstructor->getEmail());
+        $this->assertSame($viaFactory->getComment(), $viaConstructor->getComment());
+        $this->assertFalse($viaConstructor->forwardToEmployee());
+    }
+
+    public function testConstructorRejectsBothEmployeeAndEmail(): void
+    {
+        $this->expectException(CustomerServiceException::class);
+        $this->expectExceptionCode(CustomerServiceException::INVALID_FORWARD_TARGET);
+
+        new ForwardCustomerThreadCommand(12, 'comment', 34, 'someone@example.com');
+    }
+
+    public function testConstructorRejectsNeitherEmployeeNorEmail(): void
+    {
+        $this->expectException(CustomerServiceException::class);
+        $this->expectExceptionCode(CustomerServiceException::INVALID_FORWARD_TARGET);
+
+        new ForwardCustomerThreadCommand(12, 'comment');
+    }
+}


### PR DESCRIPTION
| Questions            | Answers                                                        |
|----------------------|----------------------------------------------------------------|
| Branch?              | develop                                                        |
| Description?         | Same private-ctor + static-factories pattern that #42045 addressed on `AddProductToOrderCommand` / `GetOrderProductsForViewing`. Blocks constructor-based denormalization from an HTTP request body — Symfony's serializer relies on `ReflectionClass::newInstance()` which requires a usable public `__construct`. |
| Type?                | improvement                                                    |
| Category?            | CO                                                             |
| BC breaks?           | no — the two `::toAnotherEmployee` / `::toSomeoneElse` static factories are preserved as thin wrappers around the new public constructor. |
| Deprecations?        | no                                                             |
| Fixed ticket?        | Related to PrestaShop/PrestaShop#39630                         |
| How to test?         | Existing unit + integration tests still pass — only signature changes, no behavioral change. |

## Change

- `__construct` is now public and accepts `(int $customerThreadId = 0, string $comment = '', ?int $employeeId = null, ?string $email = null)`. A single ctor covers both `toAnotherEmployee` (pass `$employeeId`) and `toSomeoneElse` (pass `$email`) cases.
- Both static factories now delegate to the new ctor.

## Motivation

The Admin API module (`ps_apiresources`) wants to expose `POST /customer-threads/{customerThreadId}/forwards` → `ForwardCustomerThreadCommand`. Without a public ctor Symfony can't build the command from an HTTP body. The minimal surgical change is preferred over adding a bespoke denormalizer to the module.