### PR TITLE
Expose raw bulk-configuration map on ConfigurablePermissions

### DIFF
--- a/src/Core/Domain/Profile/Permission/QueryResult/ConfigurablePermissions.php
+++ b/src/Core/Domain/Profile/Permission/QueryResult/ConfigurablePermissions.php
@@ -91,6 +91,20 @@ class ConfigurablePermissions
     }
 
     /**
+     * Raw bulk-configuration map — { profileId: { view: bool, add: bool, edit: bool, delete: bool, all: bool } }.
+     *
+     * The existing per-profile-per-action `isBulk*Enabled(int $profileId)` methods are convenient for
+     * template consumers but they do not let API callers surface the whole map in one shot. This getter
+     * returns the underlying array as-is so it can be JSON-serialized.
+     *
+     * @return array<int, array<string, bool>>
+     */
+    public function getBulkConfiguration(): array
+    {
+        return $this->bulkConfiguration;
+    }
+
+    /**
      * @return array
      */
     public function getProfiles(): array


### PR DESCRIPTION
| Questions            | Answers                                                        |
|----------------------|----------------------------------------------------------------|
| Branch?              | develop                                                        |
| Description?         | Adds a plain \`getBulkConfiguration(): array\` accessor next to the existing per-profile-per-action \`isBulk*Enabled(int \$profileId)\` methods. The per-action methods are convenient for template consumers that already know the target profile, but they leave no way to surface the whole map in a single response — which the Admin API needs when the profile list can span many rows. |
| Type?                | improvement                                                    |
| Category?            | CO                                                             |
| BC breaks?           | no — pure additive read-only accessor. \`\$bulkConfiguration\` still private, existing per-action getters unchanged. |
| Deprecations?        | no                                                             |
| Fixed ticket?        | Related to PrestaShop/PrestaShop#39630                         |
| How to test?         | Existing behavior preserved. New: \`\$configurablePermissions->getBulkConfiguration()\` returns a \`{ profileId: { view: bool, add: bool, edit: bool, delete: bool, all: bool } }\` array. |

## Motivation

The Admin API module (\`ps_apiresources\`) wants to expose \`GET /profiles/{employeeProfileId}/permissions\` → \`GetPermissionsForConfiguration\`. That query returns \`ConfigurablePermissions\`, which today only exposes bulk state via per-profile-per-action methods. The API resource can't call \`isBulkViewConfigurationEnabled(int \$profileId)\` for every profile at normalization time — the normalizer expects plain public accessors.

Adding a single \`getBulkConfiguration()\` accessor is the smallest surgical change to unblock the endpoint.