### PR TITLE
Add bulk setProductImageSettings() to SetProductImagesForAllShopCommand

### DIFF
--- a/src/Core/Domain/Product/Image/Command/SetProductImagesForAllShopCommand.php
+++ b/src/Core/Domain/Product/Image/Command/SetProductImagesForAllShopCommand.php
@@ -38,6 +38,24 @@ class SetProductImagesForAllShopCommand
     }
 
     /**
+     * Bulk-replace the per-image settings.
+     *
+     * The existing addProductSetting() adder is fine for hand-crafted call sites
+     * that already have a stream of ProductImageSetting objects to feed in one at
+     * a time, but it does not let the Symfony serializer bind an incoming array
+     * of settings from a request body in a single hop: the denormalizer needs a
+     * matching public setter for the property to fill it.
+     *
+     * @param ProductImageSetting[] $productImageSettings
+     */
+    public function setProductImageSettings(array $productImageSettings): self
+    {
+        $this->productImageSettings = $productImageSettings;
+
+        return $this;
+    }
+
+    /**
      * @return ProductImageSetting[]
      */
     public function getProductImageSettings(): array


### PR DESCRIPTION
| Questions            | Answers                                                        |
|----------------------|----------------------------------------------------------------|
| Branch?              | develop                                                        |
| Description?         | The command already exposes `addProductSetting(ProductImageSetting)` — convenient for hand-crafted call sites, but does not let Symfony's serializer bind an incoming array of settings from a request body. Adds a matching public bulk setter so the CQRSApiSerializer can fill the collection directly. |
| Type?                | improvement                                                    |
| Category?            | CO                                                             |
| BC breaks?           | no — pure additive change, the private `$productImageSettings` backing store is unchanged, existing `addProductSetting()` callers are unaffected. |
| Deprecations?        | no                                                             |
| Fixed ticket?        | Related to PrestaShop/PrestaShop#39630                         |
| How to test?         | Existing behavior preserved. New: `$cmd->setProductImageSettings([$setting1, $setting2])` replaces the collection in one call. |

## Motivation

The Admin API module (`ps_apiresources`) wants to expose `PUT /products/{productId}/image-shop-associations` → `SetProductImagesForAllShopCommand`. Without a bulk setter, the CQRSApiSerializer can't fan out an incoming `productImageSettings` array from the request body into successive `addProductSetting()` calls — the denormalizer expects a matching public setter on the property.