### PR TITLE
Expose public ctor on OrderDetailRefund VO

### DIFF
--- a/src/Core/Domain/Order/ValueObject/OrderDetailRefund.php
+++ b/src/Core/Domain/Order/ValueObject/OrderDetailRefund.php
@@ -77,7 +77,7 @@ class OrderDetailRefund
      *
      * @throws OrderException
      */
-    private function __construct(int $orderDetailId, int $productQuantity, ?DecimalNumber $refundedAmount)
+    public function __construct(int $orderDetailId, int $productQuantity, ?DecimalNumber $refundedAmount = null)
     {
         $this->assertOrderDetailIdIsGreaterThanZero($orderDetailId);
         if (0 >= $productQuantity) {


### PR DESCRIPTION
| Questions            | Answers                                                        |
|----------------------|----------------------------------------------------------------|
| Branch?              | develop                                                        |
| Description?         | Same private-ctor + static-factories pattern that #42045 addressed on `AddProductToOrderCommand` / `GetOrderProductsForViewing` (and #42047 on `ForwardCustomerThreadCommand`). Blocks constructor-based denormalization of an array of `OrderDetailRefund` entries from an HTTP request body. |
| Type?                | improvement                                                    |
| Category?            | CO                                                             |
| BC breaks?           | no — the `createPartialRefund` / `createStandardRefund` static factories are unchanged; the third ctor param defaults to `null`, matching what `createStandardRefund` used to do inline. |
| Deprecations?        | no                                                             |
| Fixed ticket?        | Related to PrestaShop/PrestaShop#39630                         |
| How to test?         | Existing unit + integration tests still pass — only visibility changes. |

## Motivation

The Admin API module (`ps_apiresources`) wants to expose:
- `POST /orders/{orderId}/refunds` → `IssueStandardRefundCommand`
- `POST /orders/{orderId}/product-returns` → `IssueReturnProductCommand`

Both commands take `array $orderDetailRefunds` which is expected to be `OrderDetailRefund[]`. Symfony's serializer needs a usable public ctor on `OrderDetailRefund` to instantiate each entry from a JSON body.