### PR TITLE
Fix HTTP 500 when a search term contains outfile or dumpfile

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -589,8 +589,7 @@ abstract class DbCore
         // This method must be used only with queries which display results
         if (
             !preg_match('#^\s*\(?\s*(select|show|explain|describe|desc|checksum)\s#i', $sql)
-            || stripos($sql, 'outfile') !== false
-            || stripos($sql, 'dumpfile') !== false
+            || $this->hasWriteToFileClause($sql)
         ) {
             throw new PrestaShopDatabaseException('Db->executeS() must be used only with select, show, explain or describe queries');
         }
@@ -614,6 +613,37 @@ abstract class DbCore
         }
 
         return $result;
+    }
+
+    /**
+     * Tells whether the query contains a MySQL "INTO OUTFILE"/"INTO DUMPFILE" clause, which would
+     * let a read query write to the filesystem. Quoted string literals are ignored first, so a
+     * legitimate value such as a product searched with the term "outfile" no longer trips the guard;
+     * the real write clause never sits inside a literal, so it is still detected.
+     *
+     * @param string $sql
+     *
+     * @return bool
+     */
+    protected function hasWriteToFileClause($sql)
+    {
+        // Fast path: keep the hot query path as cheap as before when neither keyword is present.
+        if (stripos($sql, 'outfile') === false && stripos($sql, 'dumpfile') === false) {
+            return false;
+        }
+
+        // Strip single/double/backtick quoted spans (honouring backslash escaping) so the keyword
+        // is only matched when it is part of the SQL itself, not a searched/stored value. The
+        // possessive quantifier prevents catastrophic backtracking on hostile input.
+        $sqlOutsideLiterals = preg_replace('#([\'"`])(?:\\\\.|(?!\1).)*+\1#s', ' ', $sql);
+
+        // Fail closed: if the literals could not be stripped (e.g. a PCRE error), keep blocking.
+        if ($sqlOutsideLiterals === null) {
+            return true;
+        }
+
+        return stripos($sqlOutsideLiterals, 'outfile') !== false
+            || stripos($sqlOutsideLiterals, 'dumpfile') !== false;
     }
 
     /**

--- a/tests/Integration/Classes/db/DbTest.php
+++ b/tests/Integration/Classes/db/DbTest.php
@@ -10,6 +10,7 @@ namespace Tests\Integration\Classes\db;
 
 use Db;
 use PHPUnit\Framework\TestCase;
+use PrestaShopDatabaseException;
 
 class DbTest extends TestCase
 {
@@ -75,5 +76,62 @@ class DbTest extends TestCase
         for ($i = 0; $i <= $nbServers; ++$i) {
             Db::$_servers[] = ['server' => _DB_SERVER_, 'user' => _DB_USER_, 'password' => _DB_PASSWD_, 'database' => _DB_NAME_];
         }
+    }
+
+    /**
+     * A legitimate read query whose values merely contain "outfile"/"dumpfile" (for example a shop
+     * search for such a term) must not be rejected by the write-to-file guard.
+     *
+     * @dataProvider provideReadQueriesContainingFileKeywords
+     */
+    public function testExecuteSAcceptsReadQueriesContainingFileKeywordsInValues(string $sql): void
+    {
+        $result = Db::getInstance()->executeS($sql);
+
+        $this->assertIsArray($result);
+    }
+
+    public function provideReadQueriesContainingFileKeywords(): iterable
+    {
+        yield 'outfile inside a LIKE value' => [
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` WHERE `reference` LIKE \'%outfile%\'',
+        ];
+        yield 'dumpfile inside a LIKE value' => [
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` WHERE `reference` LIKE \'%dumpfile%\'',
+        ];
+        yield 'keyword split across an escaped quote' => [
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` WHERE `reference` LIKE \'%out\\\'file%\'',
+        ];
+    }
+
+    /**
+     * A real "INTO OUTFILE"/"INTO DUMPFILE" write clause must still be rejected by executeS(),
+     * including when whitespace is obfuscated with a comment.
+     *
+     * @dataProvider provideWriteToFileQueries
+     */
+    public function testExecuteSRejectsWriteToFileClause(string $sql): void
+    {
+        $this->expectException(PrestaShopDatabaseException::class);
+        $this->expectExceptionMessage('must be used only');
+
+        Db::getInstance()->executeS($sql);
+    }
+
+    public function provideWriteToFileQueries(): iterable
+    {
+        yield 'into outfile' => [
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` INTO OUTFILE \'/tmp/ps-guard-test\'',
+        ];
+        yield 'into dumpfile' => [
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` INTO DUMPFILE \'/tmp/ps-guard-test\'',
+        ];
+        yield 'into outfile obfuscated with a comment' => [
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` INTO/**/OUTFILE \'/tmp/ps-guard-test\'',
+        ];
+        // Hostile input crafted to make the literal-stripping regex bail must fail closed, not open.
+        yield 'into outfile with a backslash-flood unterminated literal' => [
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` INTO OUTFILE \'' . str_repeat('\\', 60),
+        ];
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Db::executeS()` guards against write-to-file read queries, but it rejected any query that merely contained the substring `outfile` or `dumpfile`. A legitimate shop search for such a term therefore threw a `PrestaShopDatabaseException` (HTTP 500). This restricts the check to the real `INTO OUTFILE` / `INTO DUMPFILE` write clause by ignoring quoted string literals first, so searched or stored values no longer trip it while the protection stays intact.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. In the Back Office, go to **Catalog > Products** and edit an active product that is available for search.<br/>2. Add `dumpfile` to its **Short description**.<br/>3. Add `outfile` to its **Description**.<br/>4. Save the product.<br/>5. Go to **Shop Parameters > Search** and add the missing products to the search index, or rebuild the entire index.<br/>6. In the Front Office, search separately for:<br/> - `outfile`<br/>  - `dumpfile`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42052
| Related PRs       | Raised by @matrixino on https://github.com/PrestaShop/PrestaShop/pull/41840#issuecomment-4957216612 ; earlier attempt in the closed https://github.com/PrestaShop/PrestaShop/pull/39967
| Sponsor company   | 

### Notes on the security guard

The guard's purpose is to stop a read query from writing to disk via `SELECT ... INTO OUTFILE/DUMPFILE`. The change only makes it **more precise**, never weaker:

- Quoted string literals (single, double and backtick) are stripped before the keyword is matched, so a value like a product searched with the term `outfile` is ignored, but a real `INTO OUTFILE` clause (which never sits inside a literal) is still detected.
- The cheap `stripos` keyword test is kept as a fast path, so the hot query path is unchanged when neither keyword is present.
- Literal stripping uses a possessive quantifier to avoid catastrophic backtracking, and **fails closed**: if the pattern cannot be evaluated the query is still blocked.

This is defense-in-depth in front of the usual `pSQL()` escaping, not the primary SQL-injection defense.

