### PR TITLE
Fix order left without a status when its message strips to empty

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -572,7 +572,7 @@ abstract class PaymentModuleCore extends Module
 
             // Specify order id for message
             $old_message = Message::getMessageByCartId((int) $this->context->cart->id);
-            if ($old_message && !$old_message['private']) {
+            if ($old_message && !$old_message['private'] && !empty($old_message['message'])) {
                 $update_message = new Message((int) $old_message['id_message']);
                 $update_message->id_order = (int) $order->id;
                 $update_message->update();

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -445,13 +445,13 @@ abstract class PaymentModuleCore extends Module
             }
             // Optional message to attach to this order
             if (!empty($message)) {
-                $message = strip_tags($message, '<br>');
-                if (Validate::isCleanHtml($message)) {
+                $strippedMessage = strip_tags($message, '<br>');
+                if (!empty($strippedMessage) && Validate::isCleanHtml($strippedMessage)) {
                     if (self::DEBUG_MODE) {
                         PrestaShopLogger::addLog('PaymentModule::validateOrder - Message is about to be added', 1, null, 'Cart', (int) $id_cart, true);
                     }
                     $msg = new Message();
-                    $msg->message = $message;
+                    $msg->message = $strippedMessage;
                     $msg->id_cart = (int) $id_cart;
                     $msg->id_customer = (int) $order->id_customer;
                     $msg->id_order = (int) $order->id;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | An order comment that strips to empty - e.g. a `<3` emoticon (the real production trigger on our end) or `<p></p>` - is stored as an empty message, because `Message::message` (`TYPE_STRING`) is tag-stripped on save via `pSQL()` / `Db::escape(htmlOK: false)`. On order placement, `PaymentModule::validateOrder()` loads that empty cart message and `update()`s it to set the order id, re-validating the now-empty required field → `ObjectModel::validateFields()` throws **after** the `orders` / `order_detail` / `order_carrier` rows are inserted. The order is left at `current_state = 0` with no `order_history` (blank status in **Sell > Orders**), and retries are rejected with *"…an order has already been placed using this cart"*. A no-comment order and a normal comment are unaffected. Observed on 9.1.4; code identical on 9.1.x / 9.2.x / develop. <br><br> **Fix:** only link/attach a message when it is still non-empty after stripping.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable the checkout comment field. <br> 2. Add a product, go through checkout, enter only `<3` (or `<p></p>`) as the comment. <br> 3. Place the order. <br><br> **Before:** order stuck at `current_state = 0`, blank status, cart retries rejected.<br>**After:** order reaches its normal status; the empty comment is skipped.
| UI Tests          | TBD
| Fixed issue or discussion?     | Related to #32743 (BO display fixed in #41950); complementary to #41697.
| Related PRs       | None