### PR TITLE
Fix changing an employee role when the default page is specific to the new role

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -122,6 +122,9 @@ export default class EmployeeForm {
       }
     });
     $tabsDropdown.prop('disabled', false);
+    // The default page field is rendered as a select2 component, which keeps its own rendering:
+    // trigger change so it re-syncs with the rebuilt options instead of showing the previous role's list.
+    $tabsDropdown.trigger('change');
   }
 
   /**

--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -241,6 +241,12 @@
       padding: var(--#{$cdk}size-8) var(--#{$cdk}size-32) var(--#{$cdk}size-8) var(--#{$cdk}size-16);
     }
   }
+
+  .select2-selection--single {
+    .select2-selection__rendered {
+      min-height: 2rem;
+    }
+  }
 }
 
 .small.form-external-link,

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -25,6 +25,8 @@ use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
@@ -105,10 +107,7 @@ final class EmployeeType extends AbstractType
         $maxLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
         $minLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH);
 
-        $profileId = $builder->getData()['profile'] ?? reset($this->profilesChoices);
-        $viewableTabs = $this->tabDataProvider->getViewableTabs($profileId, $this->languageContext->getId());
-
-        $tabChoices = $this->formatTabs($viewableTabs);
+        $profileId = (int) ($builder->getData()['profile'] ?? reset($this->profilesChoices));
 
         $builder
             ->add('firstname', TextType::class, [
@@ -206,18 +205,21 @@ final class EmployeeType extends AbstractType
                 ),
                 'required' => false,
             ])
-            ->add('default_page', ChoiceType::class, [
-                'label' => $this->trans('Default page', [], 'Admin.Advparameters.Feature'),
-                'help' => $this->trans(
-                    'This page will be displayed just after login.',
-                    [],
-                    'Admin.Advparameters.Help'
-                ),
-                'autocomplete' => true,
-                'autocomplete_minimum_choices' => 5,
-                'choices' => $tabChoices,
-            ])
+            ->add('default_page', ChoiceType::class, $this->getDefaultPageOptions($profileId))
         ;
+
+        // The default page choices depend on the selected profile. Rebuild them from the submitted
+        // profile so a page that is only accessible to the newly selected role is accepted instead
+        // of being rejected against the previously saved role (matches the command handler check).
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+            $submittedData = $event->getData();
+            // The profile field is not submitted in restricted-access mode, where the role cannot change.
+            if (!isset($submittedData['profile'])) {
+                return;
+            }
+
+            $event->getForm()->add('default_page', ChoiceType::class, $this->getDefaultPageOptions((int) $submittedData['profile']));
+        });
 
         if ($options['is_restricted_access']) {
             $builder
@@ -325,6 +327,26 @@ final class EmployeeType extends AbstractType
         return new NotBlank([
             'message' => $this->trans('This field cannot be empty.', [], 'Admin.Notifications.Error'),
         ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getDefaultPageOptions(int $profileId): array
+    {
+        $viewableTabs = $this->tabDataProvider->getViewableTabs($profileId, $this->languageContext->getId());
+
+        return [
+            'label' => $this->trans('Default page', [], 'Admin.Advparameters.Feature'),
+            'help' => $this->trans(
+                'This page will be displayed just after login.',
+                [],
+                'Admin.Advparameters.Help'
+            ),
+            'autocomplete' => true,
+            'autocomplete_minimum_choices' => 5,
+            'choices' => $this->formatTabs($viewableTabs),
+        ];
     }
 
     private function formatTabs(array $tabs): array

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeTypeTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeTypeTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeType;
+use Tests\Integration\PrestaShopBundle\Form\FormListenerTestCase;
+
+class EmployeeTypeTest extends FormListenerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopId(1);
+        $shopContextBuilder->setShopConstraint(\PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint::shop(1));
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+    }
+
+    /**
+     * The "Default page" choices depend on the selected role. When the role is changed to one that
+     * can access a page the previous role could not, that page must be accepted on submit instead of
+     * being rejected against the previously saved role.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/42015
+     */
+    public function testDefaultPageAccessibleOnlyToTheNewlySelectedProfileIsAccepted(): void
+    {
+        $superAdminProfileId = 1;
+        $restrictedProfileId = 4; // Salesman
+
+        // Determine, from the actual data, a page the super admin can pick but the restricted role
+        // cannot, so the test does not depend on a specific tab being (in)accessible in the fixture.
+        $restrictedPages = $this->defaultPageChoices($restrictedProfileId);
+        $newProfilePage = current(array_diff($this->defaultPageChoices($superAdminProfileId), $restrictedPages));
+        $restrictedPage = current($restrictedPages);
+
+        self::assertNotFalse($newProfilePage, 'Expected a page accessible only to the super admin profile.');
+        self::assertNotFalse($restrictedPage, 'Expected a page accessible to the restricted profile.');
+
+        // Editing an employee currently on the restricted role, with a default page that role can access.
+        $form = $this->createForm(EmployeeType::class, ['is_for_editing' => true], [
+            'profile' => $restrictedProfileId,
+            'default_page' => $restrictedPage,
+        ]);
+
+        // Change the role to the super admin one and pick a default page only that new role can access.
+        $form->submit([
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+            'email' => 'john.doe@example.com',
+            'language' => 1,
+            'active' => 1,
+            'profile' => $superAdminProfileId,
+            'default_page' => $newProfilePage,
+        ]);
+
+        $defaultPage = $form->get('default_page');
+
+        // Without the PRE_SUBMIT rebuild the value is not in the frozen (old role) choice list, so the
+        // field fails to reverse-transform; with the fix the value is a valid choice for the new role.
+        $this->assertTrue($defaultPage->isSynchronized());
+        $this->assertSame($newProfilePage, $defaultPage->getData());
+    }
+
+    /**
+     * @return int[] the selectable default page (tab) ids offered for the given profile
+     */
+    private function defaultPageChoices(int $profileId): array
+    {
+        $form = $this->createForm(EmployeeType::class, ['is_for_editing' => true], ['profile' => $profileId]);
+        $choices = $form->get('default_page')->getConfig()->getOption('choices');
+
+        $flat = [];
+        array_walk_recursive($choices, static function ($value) use (&$flat): void {
+            $flat[] = $value;
+        });
+
+        return $flat;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | The employee form built the "Default page" choices from the previously saved profile and never recomputed them on submit, so changing the role and picking a page accessible only to the new role failed validation and the employee could not be saved.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In **Advanced Parameters > Team**, edit an employee whose role is e.g. Salesman with a Default page that role can access (e.g. Orders). Change the role to e.g. Logistician and pick a Default page accessible only to the new role (e.g. Carriers), then save. Before this PR the save fails (the page is rejected against the old role) and the Default page list shows the old role's pages; after it, the employee saves and the list reflects the new role. Covered by a RED->GREEN integration test in `tests/Integration/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeTypeTest.php`.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/29581001954
| Fixed issue or discussion? | Fixes #42015
| Related PRs       | 
| Sponsor company   | 

### What was happening

`EmployeeType::buildForm()` computed the `default_page` `ChoiceType` choices once, from the persisted profile (`$builder->getData()['profile']`), and there was no listener recomputing them on submit. When a page valid only for the newly selected role was submitted, it was not in the frozen choice list, so Symfony's choice reverse-transformation failed and the form was invalid — the request never reached the command handler, whose `assertHomepageIsAccessible()` check already validates the page against the **submitted** profile and was therefore correct.

### Fix

- Server side: rebuild the `default_page` choices from the submitted profile in a `FormEvents::PRE_SUBMIT` listener (shared by create and edit), so the accepted choices track the newly selected role and match the handler's existing check. Restricted-access mode (no profile field) is left untouched.
- Front end: the `default_page` field is a select2 widget; after the existing JS reloads its options for the new role, trigger `change` so the widget re-syncs instead of showing the previous role's list.

