### PR TITLE
Prefetch the listing products' new flag in one query instead of per product

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1691,8 +1691,20 @@ class ProductCore extends ObjectModel
      *
      * @return bool
      */
+    /**
+     * Request-scoped cache of the "new" flag, keyed by "idProduct-idShop".
+     *
+     * @var array<string, bool>
+     */
+    protected static $cacheIsNew = [];
+
     public static function isNewStatic($idProduct)
     {
+        $cacheKey = (int) $idProduct . '-' . (int) Context::getContext()->shop->id;
+        if (isset(static::$cacheIsNew[$cacheKey])) {
+            return static::$cacheIsNew[$cacheKey];
+        }
+
         $nbDaysNewProduct = Configuration::get('PS_NB_DAYS_NEW_PRODUCT');
         if (!Validate::isUnsignedInt($nbDaysNewProduct)) {
             $nbDaysNewProduct = 20;
@@ -1704,7 +1716,44 @@ class ProductCore extends ObjectModel
             WHERE p.id_product = ' . (int) $idProduct . '
             AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct;
 
-        return (bool) Db::getInstance()->getValue($query, false);
+        return static::$cacheIsNew[$cacheKey] = (bool) Db::getInstance()->getValue($query, false);
+    }
+
+    /**
+     * Prefetches the "new" flag for a whole set of products (e.g. a listing page) in a single query,
+     * so isNewStatic() does not run a COUNT query once per product during presentation. The result is
+     * stored request-scoped and consumed by isNewStatic().
+     *
+     * @param int[] $idProducts
+     */
+    public static function prefetchIsNew(array $idProducts)
+    {
+        $idProducts = array_unique(array_filter(array_map('intval', $idProducts)));
+        if (empty($idProducts)) {
+            return;
+        }
+
+        $nbDaysNewProduct = Configuration::get('PS_NB_DAYS_NEW_PRODUCT');
+        if (!Validate::isUnsignedInt($nbDaysNewProduct)) {
+            $nbDaysNewProduct = 20;
+        }
+
+        $idShop = (int) Context::getContext()->shop->id;
+
+        $rows = Db::getInstance()->executeS(
+            'SELECT p.id_product
+            FROM `' . _DB_PREFIX_ . 'product` p
+            ' . Shop::addSqlAssociation('product', 'p') . '
+            WHERE p.id_product IN (' . implode(',', $idProducts) . ')
+            AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . (int) $nbDaysNewProduct,
+            true,
+            false
+        ) ?: [];
+        $newProductIds = array_flip(array_map('intval', array_column($rows, 'id_product')));
+
+        foreach ($idProducts as $idProduct) {
+            static::$cacheIsNew[$idProduct . '-' . $idShop] = isset($newProductIds[$idProduct]);
+        }
     }
 
     /**

--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -91,6 +91,11 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
         // Enrich data set of products
         $products = (new ProductAssembler($this->context))->assembleProducts($products);
 
+        // Prefetch every product's "new" flag in one query instead of once per product during presentation.
+        Product::prefetchIsNew(array_map(static function (array $product): int {
+            return (int) $product['id_product'];
+        }, $products));
+
         // Prepare configuration
         $presenter = $this->getProductPresenter();
         $settings = $this->getProductPresentationSettings();

--- a/tests/Integration/Classes/ProductIsNewPrefetchTest.php
+++ b/tests/Integration/Classes/ProductIsNewPrefetchTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Context;
+use Db;
+use Product;
+use ReflectionClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Listing pages prefetch every product's "new" flag in one query instead of running
+ * Product::isNewStatic() (a COUNT query) once per product during presentation. This guards that the
+ * prefetched flag is identical to the per-product flag for every product.
+ */
+class ProductIsNewPrefetchTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetIsNewCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetIsNewCache();
+        parent::tearDown();
+    }
+
+    public function testPrefetchedIsNewFlagIsIdenticalToPerProductFlag(): void
+    {
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+
+        $productIds = array_map('intval', array_column(
+            Db::getInstance()->executeS('SELECT id_product FROM ' . _DB_PREFIX_ . 'product ORDER BY id_product') ?: [],
+            'id_product'
+        ));
+        self::assertNotEmpty($productIds, 'the test database must contain products');
+
+        // Per-product result first, with an empty cache (the source of truth).
+        $this->resetIsNewCache();
+        $perProduct = [];
+        foreach ($productIds as $idProduct) {
+            $perProduct[$idProduct] = Product::isNewStatic($idProduct);
+        }
+
+        // Same products, now served from the batch prefetch.
+        $this->resetIsNewCache();
+        Product::prefetchIsNew($productIds);
+        foreach ($productIds as $idProduct) {
+            self::assertSame(
+                $perProduct[$idProduct],
+                Product::isNewStatic($idProduct),
+                sprintf('prefetched new flag differs from the per-product flag for product %d', $idProduct)
+            );
+        }
+    }
+
+    private function resetIsNewCache(): void
+    {
+        $property = (new ReflectionClass(Product::class))->getProperty('cacheIsNew');
+        $property->setAccessible(true);
+        $property->setValue(null, []);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On a product listing, `ProductLazyArray::getNew()` calls `Product::isNewStatic()` during presentation, which runs a `COUNT`/`DATEDIFF` query per product (12-50 per page). This adds a request-scoped cache to `isNewStatic()` and a `Product::prefetchIsNew()` that resolves the whole page in one query, called from `ProductListingFrontController::prepareMultipleProductsForTemplate()`. The flag stays shop-scoped (same `Shop::addSqlAssociation`), so multishop results are unchanged.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open any product listing (category/search/new-products). Before this change the SQL log shows one `SELECT COUNT(p.id_product) ... DATEDIFF(...)` per product on the page; after it, a single `SELECT p.id_product ... IN (...)` prefetch replaces them, and each product's "new" flag is unchanged. Covered by `tests/Integration/Classes/ProductIsNewPrefetchTest.php`, which asserts the prefetched flag is identical to the per-product flag for every product.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/29581118233
| Fixed issue or discussion? | 
| Related PRs       | Same listing-page batching approach as #41957 (image prefetch)
| Sponsor company   | 


