### PR TITLE
Prefetch the listing products' colored variants in one query instead of per product

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -3,6 +3,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\FacetsRendererInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\Pagination;
@@ -90,6 +91,11 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
     {
         // Enrich data set of products
         $products = (new ProductAssembler($this->context))->assembleProducts($products);
+
+        // Prefetch every product's colored variants in one query instead of once per product during presentation.
+        (new ProductColorsRetriever())->prefetchColoredVariants(array_map(static function (array $product): int {
+            return (int) $product['id_product'];
+        }, $products));
 
         // Prepare configuration
         $presenter = $this->getProductPresenter();

--- a/src/Adapter/Product/ProductColorsRetriever.php
+++ b/src/Adapter/Product/ProductColorsRetriever.php
@@ -6,6 +6,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
+use Context;
 use Product;
 
 /**
@@ -14,14 +15,55 @@ use Product;
 class ProductColorsRetriever
 {
     /**
+     * Request-scoped cache of colored variants, keyed by "idProduct-idLang-idShop".
+     *
+     * @var array<string, mixed>
+     */
+    private static $prefetchedColoredVariants = [];
+
+    /**
      * @param int $id_product
      *
      * @return mixed|null
      */
     public function getColoredVariants($id_product)
     {
-        $attributesColorList = Product::getAttributesColorList([$id_product]);
+        $cacheKey = $this->cacheKey((int) $id_product);
+        if (array_key_exists($cacheKey, self::$prefetchedColoredVariants)) {
+            return self::$prefetchedColoredVariants[$cacheKey];
+        }
 
-        return (is_array($attributesColorList)) ? current($attributesColorList) : null;
+        $attributesColorList = Product::getAttributesColorList([(int) $id_product]);
+
+        return self::$prefetchedColoredVariants[$cacheKey] = is_array($attributesColorList) ? current($attributesColorList) : null;
+    }
+
+    /**
+     * Prefetches the colored variants of a whole set of products in a single query, so
+     * getColoredVariants() is not resolved once per product during listing presentation. The result
+     * is stored request-scoped and consumed by getColoredVariants().
+     *
+     * @param int[] $idProducts
+     */
+    public function prefetchColoredVariants(array $idProducts)
+    {
+        $idProducts = array_unique(array_filter(array_map('intval', $idProducts)));
+        if (empty($idProducts)) {
+            return;
+        }
+
+        $attributesColorList = Product::getAttributesColorList($idProducts);
+        $attributesColorList = is_array($attributesColorList) ? $attributesColorList : [];
+
+        foreach ($idProducts as $idProduct) {
+            self::$prefetchedColoredVariants[$this->cacheKey($idProduct)] = $attributesColorList[$idProduct] ?? null;
+        }
+    }
+
+    private function cacheKey(int $idProduct): string
+    {
+        $context = Context::getContext();
+
+        return $idProduct . '-' . (int) $context->language->id . '-' . (int) $context->shop->id;
     }
 }

--- a/tests/Integration/Adapter/Product/ProductColorsRetrieverPrefetchTest.php
+++ b/tests/Integration/Adapter/Product/ProductColorsRetrieverPrefetchTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Product;
+
+use Context;
+use Db;
+use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use ReflectionClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Listing pages prefetch every product's colored variants in one query instead of running
+ * Product::getAttributesColorList() once per product. This guards that the prefetched result of
+ * getColoredVariants() is identical to the per-product result for every product.
+ */
+class ProductColorsRetrieverPrefetchTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetPrefetchCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetPrefetchCache();
+        parent::tearDown();
+    }
+
+    public function testPrefetchedColoredVariantsAreIdenticalToPerProduct(): void
+    {
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+
+        $productIds = array_map('intval', array_column(
+            Db::getInstance()->executeS('SELECT id_product FROM ' . _DB_PREFIX_ . 'product ORDER BY id_product') ?: [],
+            'id_product'
+        ));
+        self::assertNotEmpty($productIds, 'the test database must contain products');
+
+        $retriever = new ProductColorsRetriever();
+
+        // Per-product result first, with an empty cache (the source of truth).
+        $this->resetPrefetchCache();
+        $perProduct = [];
+        foreach ($productIds as $idProduct) {
+            $perProduct[$idProduct] = $retriever->getColoredVariants($idProduct);
+        }
+
+        // Same products, now served from the batch prefetch.
+        $this->resetPrefetchCache();
+        $retriever->prefetchColoredVariants($productIds);
+        foreach ($productIds as $idProduct) {
+            self::assertEquals(
+                $perProduct[$idProduct],
+                $retriever->getColoredVariants($idProduct),
+                sprintf('prefetched colored variants differ from the per-product result for product %d', $idProduct)
+            );
+        }
+    }
+
+    private function resetPrefetchCache(): void
+    {
+        $property = (new ReflectionClass(ProductColorsRetriever::class))->getProperty('prefetchedColoredVariants');
+        $property->setAccessible(true);
+        $property->setValue(null, []);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On a product listing, `ProductLazyArray::getMainVariants()` calls `ProductColorsRetriever::getColoredVariants()` per product, which runs `Product::getAttributesColorList([id])` once per product — even though that query already uses `WHERE pa.id_product IN (...)`. This adds a request-scoped cache and a `prefetchColoredVariants()` that resolves the whole page in one query, called from `ProductListingFrontController::prepareMultipleProductsForTemplate()`. Results stay shop- and language-scoped.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a product listing containing products with color attributes. Before this change the SQL log shows one `getAttributesColorList` query per product; after it, a single batched query serves the whole page, and each product's color variants are unchanged. Covered by `tests/Integration/Adapter/Product/ProductColorsRetrieverPrefetchTest.php`, which asserts the prefetched result is identical to the per-product result for every product.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | 
| Related PRs       | Same listing-page batching approach as #41957 and #42060
| Sponsor company   | 

