### PR TITLE
Resolve order line images in two queries instead of one per line

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -641,6 +641,10 @@ class OrderCore extends ObjectModel
             return $products;
         }
 
+        // Resolve every line's image id in two queries instead of once per line during the loop below.
+        $combinationImageIds = $this->getProductsCombinationImageIds($products);
+        $coverImageIds = $this->getProductsCoverImageIds($products);
+
         $result_array = [];
         foreach ($products as $row) {
             // Change qty if selected
@@ -658,7 +662,7 @@ class OrderCore extends ObjectModel
                 }
             }
 
-            $this->setProductImageInformations($row);
+            $this->setProductImageInformations($row, $combinationImageIds, $coverImageIds);
             $this->setProductCurrentStock($row);
             $row = $this->setProductReduction($row);
 
@@ -752,24 +756,41 @@ class OrderCore extends ObjectModel
      *
      * @param array $product
      */
-    protected function setProductImageInformations(&$product)
+    /**
+     * @param array<string, mixed> $product
+     * @param array<int, int>|null $combinationImageIds prefetched [id_product_attribute => id_image] map
+     * @param array<int, int>|null $coverImageIds prefetched [id_product => id_image] map
+     */
+    protected function setProductImageInformations(&$product, ?array $combinationImageIds = null, ?array $coverImageIds = null)
     {
+        $id_image = null;
+
         if (isset($product['product_attribute_id']) && $product['product_attribute_id']) {
-            $id_image = Db::getInstance()->getValue('
-                SELECT `image_shop`.id_image
-                FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai' .
-                Shop::addSqlAssociation('image', 'pai', true) . '
-                LEFT JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
-                WHERE id_product_attribute = ' . (int) $product['product_attribute_id'] . ' ORDER by i.position ASC');
+            $idProductAttribute = (int) $product['product_attribute_id'];
+            if ($combinationImageIds !== null) {
+                $id_image = $combinationImageIds[$idProductAttribute] ?? null;
+            } else {
+                $id_image = Db::getInstance()->getValue('
+                    SELECT `image_shop`.id_image
+                    FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai' .
+                    Shop::addSqlAssociation('image', 'pai', true) . '
+                    LEFT JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
+                    WHERE id_product_attribute = ' . $idProductAttribute . ' ORDER by i.position ASC');
+            }
         }
 
-        if (!isset($id_image) || !$id_image) {
-            $id_image = Db::getInstance()->getValue(
-                'SELECT `image_shop`.id_image
-                FROM `' . _DB_PREFIX_ . 'image` i' .
-                Shop::addSqlAssociation('image', 'i', true, 'image_shop.cover=1') . '
-                WHERE i.id_product = ' . (int) $product['product_id']
-            );
+        if (!$id_image) {
+            $idProduct = (int) $product['product_id'];
+            if ($coverImageIds !== null) {
+                $id_image = $coverImageIds[$idProduct] ?? null;
+            } else {
+                $id_image = Db::getInstance()->getValue(
+                    'SELECT `image_shop`.id_image
+                    FROM `' . _DB_PREFIX_ . 'image` i' .
+                    Shop::addSqlAssociation('image', 'i', true, 'image_shop.cover=1') . '
+                    WHERE i.id_product = ' . $idProduct
+                );
+            }
         }
 
         $product['image'] = null;
@@ -778,6 +799,77 @@ class OrderCore extends ObjectModel
         if ($id_image) {
             $product['image'] = new Image((int) $id_image);
         }
+    }
+
+    /**
+     * Resolves, in a single query, the combination image id (lowest position) for a set of order lines,
+     * so setProductImageInformations() does not run one query per line.
+     *
+     * @param array<int, array<string, mixed>> $products
+     *
+     * @return array<int, int> [id_product_attribute => id_image]
+     */
+    protected function getProductsCombinationImageIds(array $products): array
+    {
+        $idProductAttributes = array_unique(array_filter(array_map(static function (array $product): int {
+            return (int) ($product['product_attribute_id'] ?? 0);
+        }, $products)));
+
+        if (empty($idProductAttributes)) {
+            return [];
+        }
+
+        $rows = Db::getInstance()->executeS('
+            SELECT pai.`id_product_attribute`, `image_shop`.id_image
+            FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai' .
+            Shop::addSqlAssociation('image', 'pai', true) . '
+            LEFT JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
+            WHERE pai.`id_product_attribute` IN (' . implode(',', $idProductAttributes) . ')
+            ORDER BY pai.`id_product_attribute`, i.position ASC') ?: [];
+
+        $imageIds = [];
+        foreach ($rows as $row) {
+            $idProductAttribute = (int) $row['id_product_attribute'];
+            // The result is ordered by position, so keep the first (lowest position) image per combination.
+            if (!isset($imageIds[$idProductAttribute])) {
+                $imageIds[$idProductAttribute] = (int) $row['id_image'];
+            }
+        }
+
+        return $imageIds;
+    }
+
+    /**
+     * Resolves, in a single query, the cover image id for a set of order lines, so
+     * setProductImageInformations() does not run one query per line.
+     *
+     * @param array<int, array<string, mixed>> $products
+     *
+     * @return array<int, int> [id_product => id_image]
+     */
+    protected function getProductsCoverImageIds(array $products): array
+    {
+        $idProducts = array_unique(array_filter(array_map(static function (array $product): int {
+            return (int) ($product['product_id'] ?? 0);
+        }, $products)));
+
+        if (empty($idProducts)) {
+            return [];
+        }
+
+        $rows = Db::getInstance()->executeS(
+            'SELECT i.`id_product`, `image_shop`.id_image
+            FROM `' . _DB_PREFIX_ . 'image` i' .
+            Shop::addSqlAssociation('image', 'i', true, 'image_shop.cover=1') . '
+            WHERE i.`id_product` IN (' . implode(',', $idProducts) . ')'
+        ) ?: [];
+
+        $imageIds = [];
+        foreach ($rows as $row) {
+            $imageIds[(int) $row['id_product']] = (int) $row['id_image'];
+        }
+
+        return $imageIds;
     }
 
     public function getTaxesAverageUsed()

--- a/tests/Integration/Classes/Order/OrderProductImagePrefetchTest.php
+++ b/tests/Integration/Classes/Order/OrderProductImagePrefetchTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Context;
+use Db;
+use Image;
+use Order;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Exposes the protected image helpers so the test can compare batched resolution to per-line resolution.
+ */
+class TestableImageOrder extends Order
+{
+    /**
+     * @param array<string, mixed> $product
+     * @param array<int, int>|null $combinationImageIds
+     * @param array<int, int>|null $coverImageIds
+     *
+     * @return array<string, mixed>
+     */
+    public function resolveImage(array $product, ?array $combinationImageIds = null, ?array $coverImageIds = null): array
+    {
+        $this->setProductImageInformations($product, $combinationImageIds, $coverImageIds);
+
+        return $product;
+    }
+
+    /** @param array<int, array<string, mixed>> $products @return array<int, int> */
+    public function combinationImageIds(array $products): array
+    {
+        return $this->getProductsCombinationImageIds($products);
+    }
+
+    /** @param array<int, array<string, mixed>> $products @return array<int, int> */
+    public function coverImageIds(array $products): array
+    {
+        return $this->getProductsCoverImageIds($products);
+    }
+}
+
+/**
+ * Order::getProducts() resolves every line's image id once per line. This guards that resolving the
+ * whole order in two batched queries yields the same image for every line.
+ */
+class OrderProductImagePrefetchTest extends KernelTestCase
+{
+    public function testBatchedImageIdsMatchPerLineResolution(): void
+    {
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+
+        $rows = [];
+        // Lines that resolve through the combination-image path.
+        foreach (Db::getInstance()->executeS('
+            SELECT pa.id_product, pa.id_product_attribute
+            FROM ' . _DB_PREFIX_ . 'product_attribute pa
+            JOIN ' . _DB_PREFIX_ . 'product_attribute_image pai ON pai.id_product_attribute = pa.id_product_attribute
+            GROUP BY pa.id_product_attribute LIMIT 15') ?: [] as $row) {
+            $rows[] = ['product_id' => (int) $row['id_product'], 'product_attribute_id' => (int) $row['id_product_attribute']];
+        }
+        // Lines that fall back to the product cover.
+        foreach (Db::getInstance()->executeS('SELECT id_product FROM ' . _DB_PREFIX_ . 'image WHERE cover = 1 LIMIT 15') ?: [] as $row) {
+            $rows[] = ['product_id' => (int) $row['id_product'], 'product_attribute_id' => 0];
+        }
+        self::assertNotEmpty($rows, 'the test database must contain products with images');
+
+        $order = new TestableImageOrder();
+        $combinationImageIds = $order->combinationImageIds($rows);
+        $coverImageIds = $order->coverImageIds($rows);
+
+        foreach ($rows as $row) {
+            $perLine = $order->resolveImage($row);
+            $batched = $order->resolveImage($row, $combinationImageIds, $coverImageIds);
+
+            self::assertSame(
+                $perLine['image'] instanceof Image ? (int) $perLine['image']->id : null,
+                $batched['image'] instanceof Image ? (int) $batched['image']->id : null,
+                sprintf('batched image differs from per-line for product %d / combination %d', $row['product_id'], $row['product_attribute_id'])
+            );
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Order::getProducts()` resolves each line's image with `setProductImageInformations()`, which runs one query for the combination image and one for the product cover fallback per line — around 100-150 queries on a 50-line order. This resolves the combination-image and cover-image ids for the whole order up front in two batched queries and passes them into `setProductImageInformations()`; the per-line queries stay as a fallback when no prefetched map is supplied. Both batched queries keep the original shop scoping.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a back-office order with several product lines (some with combination images, some using the product cover). Before this change the SQL log shows two image queries per line; after it, two batched queries serve the whole order and each line's image is unchanged. Covered by `tests/Integration/Classes/Order/OrderProductImagePrefetchTest.php`, which asserts the batched image id is identical to the per-line resolution for both the combination and cover paths.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30766535625 - 43 of 45 green; the 2 reds are clock-rollover and are detailed in the thread
| Fixed issue or discussion? | 
| Related PRs       | Same batching approach as #41957, #42060, #42061
| Sponsor company   | 

