### PR TITLE
Batch listing per-product lookups through a product presentation context

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1708,6 +1708,43 @@ class ProductCore extends ObjectModel
     }
 
     /**
+     * Batched equivalent of {@see isNewStatic}: resolves the "new" flag for several products at once.
+     * Returns a map keyed by product identifier (products that do not qualify are set to false), so a
+     * whole product listing's "new" flags can be resolved in a single query instead of one per product.
+     *
+     * @param int[] $idProducts
+     *
+     * @return array<int, bool>
+     */
+    public static function getNewProductsFlags(array $idProducts)
+    {
+        $idProducts = array_values(array_unique(array_map('intval', $idProducts)));
+        if (empty($idProducts)) {
+            return [];
+        }
+
+        $nbDaysNewProduct = Configuration::get('PS_NB_DAYS_NEW_PRODUCT');
+        if (!Validate::isUnsignedInt($nbDaysNewProduct)) {
+            $nbDaysNewProduct = 20;
+        }
+
+        $newProductRows = Db::getInstance()->executeS(
+            'SELECT p.id_product
+            FROM `' . _DB_PREFIX_ . 'product` p
+            ' . Shop::addSqlAssociation('product', 'p') . '
+            WHERE p.id_product IN (' . implode(',', $idProducts) . ')
+            AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . (int) $nbDaysNewProduct
+        ) ?: [];
+
+        $flags = array_fill_keys($idProducts, false);
+        foreach ($newProductRows as $row) {
+            $flags[(int) $row['id_product']] = true;
+        }
+
+        return $flags;
+    }
+
+    /**
      * Webservice getter : get if product is new.
      *
      * @return int

--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -3,6 +3,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresentationContext;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\FacetsRendererInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\Pagination;
@@ -94,6 +95,12 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
         // Prepare configuration
         $presenter = $this->getProductPresenter();
         $settings = $this->getProductPresentationSettings();
+
+        // Let the presenter resolve per-product lookups (new flag, colored variants, images) for the
+        // whole set with one batched query each, instead of one query per product on the listing.
+        $presenter->setPresentationContext(
+            new ProductPresentationContext(array_column($products, 'id_product'))
+        );
 
         // Present and return each product
         foreach ($products as &$product) {

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -7,7 +7,9 @@
 namespace PrestaShop\PrestaShop\Adapter\Image;
 
 use Category;
+use Combination;
 use Configuration;
+use Db;
 use Image;
 use ImageManager;
 use ImageType;
@@ -19,6 +21,7 @@ use PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration;
 use PrestaShopDatabaseException;
 use PrestaShopException;
 use Product;
+use Shop;
 use Store;
 use Supplier;
 
@@ -43,7 +46,7 @@ class ImageRetriever
      *
      * @return array
      */
-    public function getAllProductImages(array $product, Language $language)
+    public function getAllProductImages(array $product, Language $language, ?array $prefetchedImages = null, ?array $prefetchedCombinationImages = null)
     {
         $productInstance = new Product(
             $product['id_product'],
@@ -51,14 +54,16 @@ class ImageRetriever
             $language->id
         );
 
-        // Get all product images that are related to this object
-        $images = $productInstance->getImages($language->id);
+        // Get all product images that are related to this object.
+        // WHY: when the caller already loaded the image rows in bulk (see getProductsImages),
+        // reuse them instead of running one getImages() query per product on a listing.
+        $images = $prefetchedImages ?? $productInstance->getImages($language->id);
         if (empty($images)) {
             return [];
         }
 
-        // Load all pairs of images assigned to combinations
-        $combinationImages = $productInstance->getCombinationImages($language->id);
+        // Load all pairs of images assigned to combinations (bulk-provided by the caller when available).
+        $combinationImages = $prefetchedCombinationImages ?? $productInstance->getCombinationImages($language->id);
         if (!$combinationImages) {
             $combinationImages = [];
         }
@@ -100,6 +105,106 @@ class ImageRetriever
         }, $images);
 
         return $images;
+    }
+
+    /**
+     * Load, for a whole set of products, the same image data that {@see getAllProductImages}
+     * returns for a single one - but with the per-product image and combination-image queries
+     * collapsed into one query each. Used by the product listing presenter to avoid an N+1.
+     *
+     * @param int[] $productIds
+     * @param Language $language
+     *
+     * @return array<int, array> Image lists keyed by product identifier (identical shape to getAllProductImages)
+     */
+    public function getProductsImages(array $productIds, Language $language): array
+    {
+        $productIds = array_values(array_unique(array_map('intval', $productIds)));
+        if (empty($productIds)) {
+            return [];
+        }
+
+        $imagesByProduct = $this->getImageRowsForProducts($productIds, (int) $language->id);
+        $combinationImagesByProduct = $this->getCombinationImageRowsForProducts($productIds, (int) $language->id);
+
+        $result = [];
+        foreach ($productIds as $idProduct) {
+            // A product with no image rows resolves to no images without loading the Product object.
+            if (empty($imagesByProduct[$idProduct])) {
+                $result[$idProduct] = [];
+
+                continue;
+            }
+
+            $result[$idProduct] = $this->getAllProductImages(
+                ['id_product' => $idProduct],
+                $language,
+                $imagesByProduct[$idProduct],
+                $combinationImagesByProduct[$idProduct] ?? []
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Batched equivalent of Product::getImages() for several products at once.
+     *
+     * @param int[] $productIds
+     *
+     * @return array<int, array> Image rows keyed by product identifier
+     */
+    private function getImageRowsForProducts(array $productIds, int $idLang): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT i.`id_product`, image_shop.`cover`, i.`id_image`, il.`legend`, i.`position`
+            FROM `' . _DB_PREFIX_ . 'image` i
+            ' . Shop::addSqlAssociation('image', 'i') . '
+            LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (i.`id_image` = il.`id_image` AND il.`id_lang` = ' . $idLang . ')
+            WHERE i.`id_product` IN (' . implode(',', $productIds) . ')
+            ORDER BY i.`id_product`, `position`'
+        ) ?: [];
+
+        $byProduct = [];
+        foreach ($rows as $row) {
+            $idProduct = (int) $row['id_product'];
+            unset($row['id_product']);
+            $byProduct[$idProduct][] = $row;
+        }
+
+        return $byProduct;
+    }
+
+    /**
+     * Batched equivalent of Product::getCombinationImages() for several products at once.
+     *
+     * @param int[] $productIds
+     *
+     * @return array<int, array> Combination-image rows grouped by id_product_attribute, keyed by product identifier
+     */
+    private function getCombinationImageRowsForProducts(array $productIds, int $idLang): array
+    {
+        if (!Combination::isFeatureActive()) {
+            return [];
+        }
+
+        $rows = Db::getInstance()->executeS(
+            'SELECT i.`id_product`, pai.`id_image`, pai.`id_product_attribute`, il.`legend`
+            FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai
+            LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (il.`id_image` = pai.`id_image`)
+            INNER JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
+            WHERE i.`id_product` IN (' . implode(',', $productIds) . ') AND il.`id_lang` = ' . $idLang . '
+            ORDER BY i.`id_product`, i.`position`'
+        ) ?: [];
+
+        $byProduct = [];
+        foreach ($rows as $row) {
+            $idProduct = (int) $row['id_product'];
+            unset($row['id_product']);
+            $byProduct[$idProduct][$row['id_product_attribute']][] = $row;
+        }
+
+        return $byProduct;
     }
 
     /**

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -92,6 +92,11 @@ class ProductLazyArray extends AbstractLazyArray
      */
     protected $configuration;
 
+    /**
+     * @var ProductPresentationContext|null
+     */
+    protected $presentationContext;
+
     public function __construct(
         ProductPresentationSettings $settings,
         array $product,
@@ -103,6 +108,7 @@ class ProductLazyArray extends AbstractLazyArray
         TranslatorInterface $translator,
         ?HookManager $hookManager = null,
         ?Configuration $configuration = null,
+        ?ProductPresentationContext $presentationContext = null,
     ) {
         $this->settings = $settings;
         $this->product = $product;
@@ -114,6 +120,7 @@ class ProductLazyArray extends AbstractLazyArray
         $this->translator = $translator;
         $this->hookManager = $hookManager ?? new HookManager();
         $this->configuration = $configuration ?? new Configuration();
+        $this->presentationContext = $presentationContext;
         $this->initExtraPropertiesBag(
             Product::class,
             (int) ($this->product['id_product'] ?? 0),
@@ -674,9 +681,17 @@ class ProductLazyArray extends AbstractLazyArray
     public function getNew()
     {
         if (!isset($this->product['new'])) {
-            $this->product['new'] = (int) Product::isNewStatic(
-                $this->product['id_product']
-            );
+            $idProduct = (int) $this->product['id_product'];
+
+            if ($this->presentationContext !== null) {
+                $newFlags = $this->presentationContext->remember(
+                    'new',
+                    fn (array $ids) => Product::getNewProductsFlags($ids)
+                );
+                $this->product['new'] = (int) ($newFlags[$idProduct] ?? false);
+            } else {
+                $this->product['new'] = (int) Product::isNewStatic($idProduct);
+            }
         }
 
         return $this->product['new'];
@@ -800,9 +815,17 @@ class ProductLazyArray extends AbstractLazyArray
     #[LazyArrayAttribute(arrayAccess: true)]
     public function getMainVariants()
     {
-        $colors = $this->productColorsRetriever->getColoredVariants(
-            $this->product['id_product']
-        );
+        $idProduct = (int) $this->product['id_product'];
+
+        if ($this->presentationContext !== null) {
+            $coloredVariants = $this->presentationContext->remember(
+                'colored_variants',
+                fn (array $ids) => Product::getAttributesColorList($ids)
+            );
+            $colors = $coloredVariants[$idProduct] ?? null;
+        } else {
+            $colors = $this->productColorsRetriever->getColoredVariants($idProduct);
+        }
 
         if (!is_array($colors)) {
             return [];
@@ -954,10 +977,18 @@ class ProductLazyArray extends AbstractLazyArray
     protected function fillImages(array $product, Language $language): void
     {
         // Get all product images assigned to this product.
-        $productImages = $this->imageRetriever->getAllProductImages(
-            $product,
-            $language
-        );
+        if ($this->presentationContext !== null) {
+            $imagesByProduct = $this->presentationContext->remember(
+                'images',
+                fn (array $ids) => $this->imageRetriever->getProductsImages($ids, $language)
+            );
+            $productImages = $imagesByProduct[(int) $product['id_product']] ?? [];
+        } else {
+            $productImages = $this->imageRetriever->getAllProductImages(
+                $product,
+                $language
+            );
+        }
 
         // Get filtered product images matching the specified id_product_attribute
         $this->product['images'] = $this->filterImagesForCombination(

--- a/src/Adapter/Presenter/Product/ProductListingPresenter.php
+++ b/src/Adapter/Presenter/Product/ProductListingPresenter.php
@@ -36,6 +36,7 @@ class ProductListingPresenter extends ProductPresenter
             $this->priceFormatter,
             $this->productColorsRetriever,
             $this->translator,
+            presentationContext: $this->presentationContext,
         );
 
         Hook::exec('actionPresentProductListing',

--- a/src/Adapter/Presenter/Product/ProductPresentationContext.php
+++ b/src/Adapter/Presenter/Product/ProductPresentationContext.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Product;
+
+/**
+ * Carries the set of product IDs known to be presented together (a category listing,
+ * search results, a "featured products" block, ...) so that the per-product lookups in
+ * {@see ProductLazyArray} (new flag, colored variants, images) can be resolved from a
+ * single batched query for the whole set instead of one query per product.
+ *
+ * It is an explicit, method-scoped context handed to the presenter for one presentation
+ * pass - not an ambient global - in line with the Context refactoring direction (ADR 0024).
+ */
+final class ProductPresentationContext
+{
+    /**
+     * @var int[]
+     */
+    private array $productIds;
+
+    /**
+     * Batch results memoized once for the whole set, keyed by an arbitrary concern key.
+     *
+     * @var array<string, mixed>
+     */
+    private array $cache = [];
+
+    /**
+     * @param int[] $productIds Identifiers of the products that will be presented together
+     */
+    public function __construct(array $productIds)
+    {
+        $this->productIds = array_values(array_unique(array_map('intval', $productIds)));
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getProductIds(): array
+    {
+        return $this->productIds;
+    }
+
+    /**
+     * Resolve a batched lookup for the whole presented set: the loader is invoked once with
+     * every presented product ID on first access, and its result is reused for every product
+     * afterwards. This is what turns a per-product query into a single query per listing.
+     *
+     * @param string $key Concern identifier (e.g. "new", "colored_variants", "images")
+     * @param callable(int[]): mixed $loader Receives all presented product IDs, returns the batch result
+     *
+     * @return mixed The memoized batch result
+     */
+    public function remember(string $key, callable $loader)
+    {
+        if (!array_key_exists($key, $this->cache)) {
+            $this->cache[$key] = $loader($this->productIds);
+        }
+
+        return $this->cache[$key];
+    }
+}

--- a/src/Adapter/Presenter/Product/ProductPresenter.php
+++ b/src/Adapter/Presenter/Product/ProductPresenter.php
@@ -54,6 +54,11 @@ class ProductPresenter
      */
     protected $translator;
 
+    /**
+     * @var ProductPresentationContext|null
+     */
+    protected $presentationContext;
+
     public function __construct(
         ImageRetriever $imageRetriever,
         Link $link,
@@ -72,6 +77,16 @@ class ProductPresenter
         $this->configuration = $configuration ?? new Configuration();
     }
 
+    /**
+     * Provide the set of products that will be presented together so that per-product
+     * lookups in the lazy array can be resolved from a single batched query. Optional:
+     * when left unset, the presenter falls back to resolving each product on its own.
+     */
+    public function setPresentationContext(?ProductPresentationContext $presentationContext): void
+    {
+        $this->presentationContext = $presentationContext;
+    }
+
     public function present(
         ProductPresentationSettings $settings,
         array $product,
@@ -87,7 +102,8 @@ class ProductPresenter
             $this->productColorsRetriever,
             $this->translator,
             $this->hookManager,
-            $this->configuration
+            $this->configuration,
+            $this->presentationContext
         );
 
         Hook::exec('actionPresentProduct',

--- a/tests/Integration/Adapter/Presenter/Product/ProductPresentationContextTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductPresentationContextTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Presenter\Product;
+
+use Configuration;
+use Db;
+use Language;
+use Link;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresentationContext;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
+use Product;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The presentation context lets the listing presenter resolve per-product lookups (new flag,
+ * colored variants, images) for a whole set with a single batched query each. These tests prove
+ * that the batched resolution returns exactly what the per-product resolution returned, and that
+ * the lazy array actually routes through the batch when a context is provided.
+ */
+class ProductPresentationContextTest extends KernelTestCase
+{
+    private ProductPresentationSettings $settings;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->settings = new ProductPresentationSettings();
+        $this->settings->catalog_mode = false;
+        $this->settings->restricted_country_mode = false;
+        $this->settings->showPrices = true;
+    }
+
+    public function testRememberInvokesLoaderOnceWithAllUniqueProductIds(): void
+    {
+        $context = new ProductPresentationContext([3, 1, 2, 2]);
+
+        $calls = 0;
+        $seenIds = null;
+        $loader = function (array $ids) use (&$calls, &$seenIds) {
+            ++$calls;
+            $seenIds = $ids;
+
+            return array_flip($ids);
+        };
+
+        $first = $context->remember('concern', $loader);
+        $second = $context->remember('concern', $loader);
+
+        $this->assertSame(1, $calls, 'The batch loader must run only once for the whole set.');
+        $this->assertSame($first, $second, 'The memoized result must be reused.');
+        $this->assertSame([3, 1, 2], $seenIds, 'The loader must receive every unique product id, de-duplicated.');
+        $this->assertSame([3, 1, 2], $context->getProductIds());
+    }
+
+    public function testListingContextRoutesImagesThroughTheBatchedLoader(): void
+    {
+        $product = $this->productData(1);
+
+        $batchedImages = [['id_image' => 111, 'cover' => 1, 'associatedVariants' => []]];
+        $perProductImages = [['id_image' => 999, 'cover' => 1, 'associatedVariants' => []]];
+
+        $imageRetriever = $this->createMock(ImageRetriever::class);
+        $imageRetriever->method('getProductsImages')->willReturn([1 => $batchedImages]);
+        $imageRetriever->method('getAllProductImages')->willReturn($perProductImages);
+
+        $withContext = $this->presentListing($product, $imageRetriever, new ProductPresentationContext([1]));
+        $this->assertSame(111, $withContext['cover']['id_image'], 'With a context, images must come from the batched loader.');
+
+        $withoutContext = $this->presentListing($product, $imageRetriever, null);
+        $this->assertSame(999, $withoutContext['cover']['id_image'], 'Without a context, images must fall back to the per-product loader.');
+    }
+
+    public function testBatchedImagesMatchPerProductResolution(): void
+    {
+        $ids = $this->productIdsWithImages();
+        $this->assertNotEmpty($ids, 'The test catalog must contain products with images.');
+
+        $language = $this->defaultLanguage();
+        $imageRetriever = new ImageRetriever(new Link());
+
+        $batched = $imageRetriever->getProductsImages($ids, $language);
+
+        foreach ($ids as $id) {
+            $this->assertEquals(
+                $this->normalizeImages($imageRetriever->getAllProductImages(['id_product' => $id], $language)),
+                $this->normalizeImages($batched[$id] ?? []),
+                sprintf('Batched images differ from per-product resolution for product %d.', $id)
+            );
+        }
+    }
+
+    /**
+     * The list of variant ids associated with an image is a set: several combination rows share a
+     * single image (hence an identical i.position), and getCombinationImages() orders only by
+     * position, so the order among them is engine-defined - already non-deterministic in the
+     * original per-product code. Compare it as a set.
+     *
+     * @param array<int, array> $images
+     *
+     * @return array<int, array>
+     */
+    private function normalizeImages(array $images): array
+    {
+        foreach ($images as &$image) {
+            if (isset($image['associatedVariants']) && is_array($image['associatedVariants'])) {
+                sort($image['associatedVariants']);
+            }
+        }
+
+        return $images;
+    }
+
+    public function testBatchedNewFlagsMatchPerProductResolution(): void
+    {
+        $ids = $this->productIdsWithImages();
+        $this->assertNotEmpty($ids);
+
+        $flags = Product::getNewProductsFlags($ids);
+
+        foreach ($ids as $id) {
+            $this->assertSame(
+                (bool) Product::isNewStatic($id),
+                $flags[$id] ?? null,
+                sprintf('Batched "new" flag differs from isNewStatic() for product %d.', $id)
+            );
+        }
+    }
+
+    public function testBatchedColoredVariantsMatchPerProductResolution(): void
+    {
+        $ids = $this->productIdsWithImages();
+        $this->assertNotEmpty($ids);
+
+        $colorsMap = Product::getAttributesColorList($ids);
+        $colorsRetriever = new ProductColorsRetriever();
+
+        foreach ($ids as $id) {
+            // getColoredVariants() returns false when a product has no colored variants;
+            // the batched map simply omits the key. Both mean "no variants" downstream.
+            $expected = $colorsRetriever->getColoredVariants($id);
+            if (!is_array($expected)) {
+                $expected = null;
+            }
+
+            $this->assertEquals(
+                $expected,
+                $colorsMap[$id] ?? null,
+                sprintf('Batched colored variants differ from getColoredVariants() for product %d.', $id)
+            );
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    private function productIdsWithImages(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT DISTINCT id_product FROM `' . _DB_PREFIX_ . 'image` ORDER BY id_product LIMIT 12'
+        ) ?: [];
+
+        return array_map('intval', array_column($rows, 'id_product'));
+    }
+
+    private function defaultLanguage(): Language
+    {
+        return new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function productData(int $idProduct): array
+    {
+        return [
+            'available_for_order' => true,
+            'id_product' => $idProduct,
+            'id_product_attribute' => 0,
+            'link_rewrite' => 'product',
+            'reference' => 'ref',
+            'price' => null,
+            'price_without_reduction' => null,
+            'price_tax_exc' => null,
+            'specific_prices' => null,
+            'customizable' => false,
+            'quantity' => 1,
+            'allow_oosp' => false,
+            'online_only' => false,
+            'reduction' => false,
+            'on_sale' => false,
+            'pack' => false,
+            'show_price' => true,
+            'active' => true,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $product
+     */
+    private function presentListing(array $product, ImageRetriever $imageRetriever, ?ProductPresentationContext $context)
+    {
+        $link = $this->createMock(Link::class);
+        $link->method('getAddToCartURL')->withAnyParameters()->willReturn('http://add-to-cart.url');
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->withAnyParameters()->willReturn('some label');
+
+        $priceFormatter = $this->createMock(PriceFormatter::class);
+        $priceFormatter->method('convertAmount')->withAnyParameters()->willReturnArgument(0);
+        $priceFormatter->method('format')->withAnyParameters()->willReturnCallback(function (?float $price) {
+            return '#' . $price;
+        });
+
+        $presenter = new ProductListingPresenter(
+            $imageRetriever,
+            $link,
+            $priceFormatter,
+            $this->createMock(ProductColorsRetriever::class),
+            $translator
+        );
+        $presenter->setPresentationContext($context);
+
+        return $presenter->present($this->settings, $product, $this->createMock(Language::class));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30771472325 - 46 of 46 jobs green
| Fixed issue or discussion?     | Follows up the suggestion on https://github.com/PrestaShop/PrestaShop/pull/42061#issuecomment-4970890211
| Related PRs       | #41957, #42060, #42061
| Sponsor company   |

### Context

The product listing presenter (`ProductListingPresenter` / `ProductLazyArray`) resolves three lookups one product at a time on every category, search and product-block listing:

- the "new" flag via `Product::isNewStatic()`,
- colored variants via `ProductColorsRetriever::getColoredVariants()`,
- images via `ImageRetriever::getAllProductImages()`.

That is a query (or more) per product. This follows up Hlavtox's suggestion on #42061 to solve it globally instead of one prefetch per concern.

### What this does

Introduces an optional `ProductPresentationContext` carrying the set of product ids being presented together. `ProductListingFrontController::prepareMultipleProductsForTemplate()` builds it from the assembled products and hands it to the presenter; the lazy array then resolves each lookup once for the whole set (a batched query memoized in the context) and reuses it for every product:

- new flag: one `Product::getNewProductsFlags()` query for the whole set,
- colored variants: one `Product::getAttributesColorList()` call for the whole set (already batch-shaped),
- images: `ImageRetriever::getProductsImages()` collapses the per-product image and combination-image queries into one query each.

When no context is set, the previous per-product path runs unchanged, so every other caller (single product page, cart, modules) is unaffected. All new parameters are optional and appended last; no BC break.

The context is an explicit, method-scoped object threaded through the presenter, not an ambient global, in keeping with the Context refactoring direction (ADR 0024).

### Honest scope

- The image path still instantiates one `Product` per product that has images (its image links are resolved from that instance), so this removes the two per-product image queries but not the product load. Dropping that too would be a further step.
- Only the main `ProductListingFrontController` opts in here. The standalone product-block modules (ps_featuredproducts, ps_bestsellers, ...) present through the same presenter and can adopt the one-line context set-up as a follow-up, once the shape is agreed.

### Relationship to #41957 / #42060 / #42061

Those three PRs each add a per-concern prefetch on `9.1.x`. This PR is the single mechanism suggested on #42061 instead of three. It targets `develop` because it adds a small abstraction and changes presenter constructor signatures (all optional). If this is the preferred direction, the three per-concern PRs should close in its favour; if you would rather take the quick wins on `9.1.x` first, this can replace them on `develop` later. Happy to go either way, and to adjust the shape of the context (data-holder vs the memoized loader used here) if you had a different one in mind.

### How to test

Browse any category or search listing: the output (new badges, colour swatches, thumbnails) is identical, now resolved with batched queries instead of one per product.

`tests/Integration/Adapter/Presenter/Product/ProductPresentationContextTest.php` asserts, on real catalog data, that the batched resolution of images, the new flag and colored variants equals the per-product resolution, and covers the context memoization and the presenter wiring (context vs per-product fallback).

