### PR TITLE
Guard DuplicateOrderCartHandler against missing order cart

### DIFF
--- a/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
+++ b/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
@@ -15,6 +15,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\DuplicateOrderCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\DuplicateOrderCartHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateOrderCartException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use Shop;
 
 /**
@@ -43,6 +44,9 @@ final class DuplicateOrderCartHandler implements DuplicateOrderCartHandlerInterf
     {
         // IMPORTANT: context customer must be set in order to correctly fill the address
         $cart = Cart::getCartByOrderId($command->getOrderId()->getValue());
+        if (!$cart instanceof Cart) {
+            throw new OrderNotFoundException($command->getOrderId(), sprintf('Order "%s" was not found.', $command->getOrderId()->getValue()));
+        }
         $this->contextStateManager
             ->setCart($cart)
             ->setCustomer(new Customer($cart->id_customer))

--- a/tests/Integration/Adapter/Order/CommandHandler/DuplicateOrderCartHandlerTest.php
+++ b/tests/Integration/Adapter/Order/CommandHandler/DuplicateOrderCartHandlerTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Order\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\DuplicateOrderCartCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DuplicateOrderCartHandlerTest extends KernelTestCase
+{
+    /**
+     * @var object|CommandBusInterface|null
+     */
+    private $commandBus;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->commandBus = self::getContainer()->get('prestashop.core.command_bus');
+    }
+
+    /**
+     * Regression: Cart::getCartByOrderId() returns false for an unknown order id.
+     * The handler must translate that into an OrderNotFoundException instead of
+     * letting a TypeError bubble up from ContextStateManager::setCart(?Cart).
+     */
+    public function testUnknownOrderIdThrowsOrderNotFoundException(): void
+    {
+        $unknownOrderId = PHP_INT_MAX;
+
+        $this->expectException(OrderNotFoundException::class);
+
+        $this->commandBus->handle(new DuplicateOrderCartCommand($unknownOrderId));
+    }
+}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 9.1.x |
| Category? | BO |
| Description? | `Cart::getCartByOrderId()` returns `false` when the order id doesn't correspond to any order. That `false` was passed straight to `ContextStateManager::setCart(?Cart $cart)` and produced a `TypeError` (HTTP 500) instead of a proper domain exception. This PR adds a guard that throws `OrderNotFoundException` up front. |
| Type? | bug fix |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | — (spotted while reviewing PrestaShop/ps_apiresources#327) |
| How to test? | Dispatch `DuplicateOrderCartCommand` with an unknown order id → previously produced `TypeError: ContextStateManager::setCart(): Argument #1 ($cart) must be of type ?Cart, false given`; now throws `OrderNotFoundException`. Once merged, the negative test `testDuplicateNotFoundOrderCart` in ps_apiresources#327 asserts the 404 mapping end-to-end. |
| Possible impacts? | Any caller of `DuplicateOrderCartCommand` that swallowed the previous `TypeError` will now catch a domain exception instead. The `DuplicateOrderCartHandlerInterface` already documents `OrderException` (its parent) as a possible throw. |
