### PR TITLE
Add defaults to AddOrderFromBackOfficeCommand employeeId and orderMessage

### DIFF
--- a/src/Core/Domain/Order/Command/AddOrderFromBackOfficeCommand.php
+++ b/src/Core/Domain/Order/Command/AddOrderFromBackOfficeCommand.php
@@ -50,7 +50,7 @@ class AddOrderFromBackOfficeCommand
      * @param string $paymentModuleName
      * @param int $orderStateId
      */
-    public function __construct($cartId, $employeeId, $orderMessage, $paymentModuleName, $orderStateId)
+    public function __construct($cartId, $employeeId = NoEmployeeId::NO_EMPLOYEE_ID_VALUE, $orderMessage = '', $paymentModuleName = '', $orderStateId = 0)
     {
         $this->assertIsModuleName($paymentModuleName);
         $this->assertOrderStateIsPositiveInt($orderStateId);

--- a/tests/Unit/Core/Domain/Order/Command/AddOrderFromBackOfficeCommandTest.php
+++ b/tests/Unit/Core/Domain/Order/Command/AddOrderFromBackOfficeCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Order\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\EmployeeId;
+use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\NoEmployeeId;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddOrderFromBackOfficeCommand;
+
+class AddOrderFromBackOfficeCommandTest extends TestCase
+{
+    /**
+     * Denormalization path (Admin API CQRSCreate) omits employeeId/orderMessage;
+     * the command must build and expose the documented defaults.
+     */
+    public function testConstructWithOnlyRequiredNamedArgumentsUsesDefaults(): void
+    {
+        $command = new AddOrderFromBackOfficeCommand(
+            1,
+            paymentModuleName: 'ps_checkpayment',
+            orderStateId: 2,
+        );
+
+        $this->assertSame(1, $command->getCartId()->getValue());
+        $this->assertInstanceOf(NoEmployeeId::class, $command->getEmployeeId());
+        $this->assertSame(NoEmployeeId::NO_EMPLOYEE_ID_VALUE, $command->getEmployeeId()->getValue());
+        $this->assertSame('', $command->getOrderMessage());
+        $this->assertSame('ps_checkpayment', $command->getPaymentModuleName());
+        $this->assertSame(2, $command->getOrderStateId());
+    }
+
+    /**
+     * Positional full-args construction (existing core call sites) must be unchanged.
+     */
+    public function testConstructWithAllPositionalArgumentsBehavesIdentically(): void
+    {
+        $command = new AddOrderFromBackOfficeCommand(1, 3, 'a message', 'ps_checkpayment', 2);
+
+        $this->assertSame(1, $command->getCartId()->getValue());
+        $this->assertInstanceOf(EmployeeId::class, $command->getEmployeeId());
+        $this->assertSame(3, $command->getEmployeeId()->getValue());
+        $this->assertSame('a message', $command->getOrderMessage());
+        $this->assertSame('ps_checkpayment', $command->getPaymentModuleName());
+        $this->assertSame(2, $command->getOrderStateId());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                                 |
|-------------------|-------------------------------------------------------------------------|
| Branch?           | 9.2.x                                                                   |
| Description?      | Give every parameter after `$cartId` on `AddOrderFromBackOfficeCommand::__construct` a sensible default so denormalization paths that omit them (Admin API resources built on `CQRSCreate`) can instantiate the command instead of failing with `MissingConstructorArgumentsException` before any exception mapping runs. Parameter order is unchanged. |
| Type?             | improvement                                                             |
| Category?         | CO                                                                      |
| BC breaks?        | no                                                                      |
| Deprecations?     | no                                                                      |
| Fixed ticket?     | Related to PrestaShop/ps_apiresources#389                               |
| How to test?      | Existing behat scenarios in `tests/Integration/Behaviour/Features/Scenario/Order/` covering back-office order creation should keep passing. Manual: create an order from the BO Carts page (`AdminCarts` → "Create order" flow) — the `CartSummaryFormDataHandler` positional call is exercised there. |

## Why

The command constructor previously had five required parameters. Admin API endpoints exposed via API Platform's `CQRSCreate` processor denormalize the request payload straight into the command; when a caller omits `employeeId` or `orderMessage` (both semantically optional — the domain already treats `NoEmployeeId::NO_EMPLOYEE_ID_VALUE` and empty `orderMessage` as valid), the deserializer fails at construction time with:

```
MissingConstructorArgumentsException: Cannot create an instance of
"…\Order\Command\AddOrderFromBackOfficeCommand" because its constructor
requires the following parameters to be present: "$employeeId", "$orderMessage".
```

That 500 happens before the exception mapping layer can turn a bad `paymentModuleName` into a proper 422, hiding actual validation errors.

## What

- `AddOrderFromBackOfficeCommand::__construct` signature is now `($cartId, $employeeId = NoEmployeeId::NO_EMPLOYEE_ID_VALUE, $orderMessage = '', $paymentModuleName = '', $orderStateId = 0)` — parameter order preserved, every parameter after `$cartId` gets a default.
- No call-site changes: existing positional callers keep working identically.

## Not BC-breaking

Parameter order is unchanged, so any existing positional consumer (core or external module) keeps compiling and behaving identically. The denormalizer matches parameters by name, so an Admin API payload providing `{cartId, paymentModuleName, orderStateId}` now instantiates the command successfully; the constructor assertions still reject empty `paymentModuleName` / non-positive `orderStateId`, so genuinely incomplete construction throws a clean domain exception (→ 422) instead of a 500.

Related to [PrestaShop/ps_apiresources#389](https://github.com/PrestaShop/ps_apiresources/pull/389), which surfaced the issue when adding the `POST /orders` Admin API endpoint.
