### PR TITLE
Updated ps_onepagecheckout dependency to 0.6.4 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "prestashop/ps_linklist": "^7",
         "prestashop/ps_mainmenu": "^2",
         "prestashop/ps_newproducts": "^2",
-        "prestashop/ps_onepagecheckout": "0.6.2",
+        "prestashop/ps_onepagecheckout": "0.6.4",
         "prestashop/ps_searchbar": "^2",
         "prestashop/ps_sharebuttons": "^2",
         "prestashop/ps_shoppingcart": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5e99877b976b48992fc2de115178abf",
+    "content-hash": "34f1b13063758d6bbdc21a0d4ff911aa",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6429,16 +6429,16 @@
         },
         {
             "name": "prestashop/ps_onepagecheckout",
-            "version": "v0.6.2",
+            "version": "v0.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_onepagecheckout.git",
-                "reference": "521db0a4d459069b367b7be5292e5520632d2a09"
+                "reference": "49f564de4136e12fdfbfe1611493c8b9cfe938f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/521db0a4d459069b367b7be5292e5520632d2a09",
-                "reference": "521db0a4d459069b367b7be5292e5520632d2a09",
+                "url": "https://api.github.com/repos/PrestaShop/ps_onepagecheckout/zipball/49f564de4136e12fdfbfe1611493c8b9cfe938f6",
+                "reference": "49f564de4136e12fdfbfe1611493c8b9cfe938f6",
                 "shasum": ""
             },
             "require": {
@@ -6472,9 +6472,9 @@
             "homepage": "https://github.com/PrestaShop/ps_onepagecheckout",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_onepagecheckout/issues",
-                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.2"
+                "source": "https://github.com/PrestaShop/ps_onepagecheckout/tree/v0.6.4"
             },
-            "time": "2026-07-02T14:45:01+00:00"
+            "time": "2026-07-15T14:02:21+00:00"
         },
         {
             "name": "prestashop/ps_searchbar",
@@ -18501,5 +18501,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Adds the native ps_onepagecheckout module as a Core Composer dependency. This makes the beta OPC module available while keeping activation controlled by the module configuration flag.
| Type?             | new feature 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run composer install and verify that modules/ps_onepagecheckout/ps_onepagecheckout.php is installed and reports version 0.1.0. Install the module with php bin/console prestashop:module install ps_onepagecheckout --no-interaction, enable PS_ONE_PAGE_CHECKOUT_ENABLED, add a product to cart, go to /order, and verify that the OPC is displayed without errors. Also verify that the module can be disabled/uninstalled cleanly.
| UI Tests          | https://github.com/L3RAZ/ga.tests.ui.pr/actions/runs/29423550697
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop
