### PR TITLE
Decouple EmployeePasswordResetter from the admin router

### DIFF
--- a/src/Core/Domain/Employee/CommandHandler/SendEmployeePasswordResetEmailHandler.php
+++ b/src/Core/Domain/Employee/CommandHandler/SendEmployeePasswordResetEmailHandler.php
@@ -18,8 +18,8 @@ class SendEmployeePasswordResetEmailHandler implements SendEmployeePasswordReset
     ) {
     }
 
-    public function handle(SendEmployeePasswordResetEmailCommand $command): string
+    public function handle(SendEmployeePasswordResetEmailCommand $command): void
     {
-        return $this->employeePasswordResetter->sendResetEmail($command->getEmail()->getValue());
+        $this->employeePasswordResetter->sendResetEmail($command->getEmail()->getValue());
     }
 }

--- a/src/Core/Domain/Employee/CommandHandler/SendEmployeePasswordResetEmailHandlerInterface.php
+++ b/src/Core/Domain/Employee/CommandHandler/SendEmployeePasswordResetEmailHandlerInterface.php
@@ -15,5 +15,5 @@ interface SendEmployeePasswordResetEmailHandlerInterface
      *
      * @return string The url to reset the password
      */
-    public function handle(SendEmployeePasswordResetEmailCommand $command): string;
+    public function handle(SendEmployeePasswordResetEmailCommand $command): void;
 }

--- a/src/Core/Domain/Employee/CommandHandler/SendEmployeePasswordResetEmailHandlerInterface.php
+++ b/src/Core/Domain/Employee/CommandHandler/SendEmployeePasswordResetEmailHandlerInterface.php
@@ -12,8 +12,6 @@ interface SendEmployeePasswordResetEmailHandlerInterface
 {
     /**
      * @param SendEmployeePasswordResetEmailCommand $command
-     *
-     * @return string The url to reset the password
      */
     public function handle(SendEmployeePasswordResetEmailCommand $command): void;
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/security.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/security.yml
@@ -14,12 +14,16 @@ services:
   PrestaShopBundle\Security\Admin\SessionEmployeeProvider:
     autowire: true
 
+  PrestaShopBundle\Routing\AdminUrlGenerator:
+    autowire: true
+    arguments:
+      $adminFolderName: '%prestashop.admin_folder_name%'
+
   PrestaShopBundle\Security\Admin\EmployeePasswordResetter:
     autowire: true
     lazy: true
     arguments:
       $cookieKey: '%cookie_key%'
-      $adminFolderName: '%prestashop.admin_folder_name%'
 
   PrestaShopBundle\Security\Admin\EmployeeHomepageProvider:
     autowire: true

--- a/src/PrestaShopBundle/Resources/config/services/bundle/security.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/security.yml
@@ -19,6 +19,7 @@ services:
     lazy: true
     arguments:
       $cookieKey: '%cookie_key%'
+      $adminFolderName: '%prestashop.admin_folder_name%'
 
   PrestaShopBundle\Security\Admin\EmployeeHomepageProvider:
     autowire: true

--- a/src/PrestaShopBundle/Routing/AdminUrlGenerator.php
+++ b/src/PrestaShopBundle/Routing/AdminUrlGenerator.php
@@ -26,13 +26,13 @@ class AdminUrlGenerator
     ) {
     }
 
-    public function generateResetPasswordUrl(string $resetToken): string
+    public function generateAdminUrl(string $urlPath): string
     {
         return sprintf(
-            '%s/%s/index.php/reset-password/%s',
+            '%s/%s/index.php%s',
             rtrim($this->shopContext->getBaseURL(), '/'),
             trim($this->adminFolderName, '/'),
-            $resetToken,
+            $urlPath,
         );
     }
 }

--- a/src/PrestaShopBundle/Routing/AdminUrlGenerator.php
+++ b/src/PrestaShopBundle/Routing/AdminUrlGenerator.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShopBundle\Routing;
+
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+
+/**
+ * Builds absolute back-office URLs without depending on the admin Router.
+ *
+ * The admin routing collection is only registered in the admin kernel, so
+ * services triggered from other kernels (admin-api, CLI) cannot use
+ * $router->generate() to build admin URLs. This generator relies on the
+ * shop base URL and the "prestashop.admin_folder_name" container parameter
+ * (defined by AppKernel and therefore available everywhere) so the same URLs
+ * can be produced from any kernel.
+ */
+class AdminUrlGenerator
+{
+    public function __construct(
+        private readonly ShopContext $shopContext,
+        private readonly string $adminFolderName,
+    ) {
+    }
+
+    public function generateResetPasswordUrl(string $resetToken): string
+    {
+        return sprintf(
+            '%s/%s/index.php/reset-password/%s',
+            rtrim($this->shopContext->getBaseURL(), '/'),
+            trim($this->adminFolderName, '/'),
+            $resetToken,
+        );
+    }
+}

--- a/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
+++ b/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
@@ -14,12 +14,10 @@ use Mail;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Crypto\Hashing;
-use PrestaShop\PrestaShop\Core\Util\Url\UrlCleaner;
 use PrestaShopBundle\Entity\Employee\Employee;
 use PrestaShopBundle\Entity\Repository\EmployeeRepository;
 use PrestaShopBundle\Security\Admin\Exception\PasswordResetTemporarilyBlockedException;
 use RuntimeException;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -29,24 +27,20 @@ class EmployeePasswordResetter
         private readonly EmployeeRepository $employeeRepository,
         private readonly ConfigurationInterface $configuration,
         private readonly EntityManagerInterface $entityManager,
-        private readonly RouterInterface $router,
         private readonly TranslatorInterface $translator,
         private readonly ShopContext $shopContext,
         private readonly Hashing $hashing,
         private readonly string $cookieKey,
+        private readonly string $adminFolderName,
     ) {
     }
 
     /**
-     * @param string $email
-     *
-     * @return string
-     *
      * @throws PasswordResetTemporarilyBlockedException
      * @throws UserNotFoundException
      * @throws RuntimeException
      */
-    public function sendResetEmail(string $email): string
+    public function sendResetEmail(string $email): void
     {
         try {
             /** @var Employee|null $employee */
@@ -62,7 +56,7 @@ class EmployeePasswordResetter
         $this->checkLastPasswordGeneration($employee);
         $this->updateEmployeeResetData($employee);
 
-        return $this->doSendResetEmail($employee);
+        $this->doSendResetEmail($employee);
     }
 
     public function getEmployeeByValidResetPasswordToken(string $resetPasswordToken): ?Employee
@@ -122,11 +116,17 @@ class EmployeePasswordResetter
         }
     }
 
-    private function doSendResetEmail(Employee $employee): string
+    private function doSendResetEmail(Employee $employee): void
     {
-        $resetUrl = $this->router->generate('admin_reset_password', ['resetToken' => $employee->getResetPasswordToken()]);
-        // We remove thr CSRF token that is automatically added by the router and is useless for this url, and we need an absolute url
-        $resetUrl = rtrim($this->shopContext->getBaseURL(), '/') . '/' . trim(UrlCleaner::cleanUrl($resetUrl, ['_token', 'token']), '/');
+        // Build the reset URL manually so it works regardless of the current request context
+        // (admin, admin-api, CLI): both kernels expose the "prestashop.admin_folder_name" container
+        // parameter, but the "admin_reset_password" route is only registered in the admin kernel.
+        $resetUrl = sprintf(
+            '%s/%s/index.php/reset-password/%s',
+            rtrim($this->shopContext->getBaseURL(), '/'),
+            trim($this->adminFolderName, '/'),
+            $employee->getResetPasswordToken(),
+        );
 
         $params = [
             '{email}' => $employee->getEmail(),
@@ -151,8 +151,6 @@ class EmployeePasswordResetter
         if (!$mailSent) {
             throw new RuntimeException('Unable to send reset email.');
         }
-
-        return $resetUrl;
     }
 
     private function updateEmployeeResetData(Employee $employee): void

--- a/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
+++ b/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
@@ -117,7 +117,7 @@ class EmployeePasswordResetter
 
     private function doSendResetEmail(Employee $employee): void
     {
-        $resetUrl = $this->adminUrlGenerator->generateResetPasswordUrl($employee->getResetPasswordToken());
+        $resetUrl = $this->adminUrlGenerator->generateAdminUrl('/reset-password/' . $employee->getResetPasswordToken());
 
         $params = [
             '{email}' => $employee->getEmail(),

--- a/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
+++ b/src/PrestaShopBundle/Security/Admin/EmployeePasswordResetter.php
@@ -12,10 +12,10 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\UnexpectedResultException;
 use Mail;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use PrestaShopBundle\Entity\Employee\Employee;
 use PrestaShopBundle\Entity\Repository\EmployeeRepository;
+use PrestaShopBundle\Routing\AdminUrlGenerator;
 use PrestaShopBundle\Security\Admin\Exception\PasswordResetTemporarilyBlockedException;
 use RuntimeException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
@@ -28,10 +28,9 @@ class EmployeePasswordResetter
         private readonly ConfigurationInterface $configuration,
         private readonly EntityManagerInterface $entityManager,
         private readonly TranslatorInterface $translator,
-        private readonly ShopContext $shopContext,
+        private readonly AdminUrlGenerator $adminUrlGenerator,
         private readonly Hashing $hashing,
         private readonly string $cookieKey,
-        private readonly string $adminFolderName,
     ) {
     }
 
@@ -118,15 +117,7 @@ class EmployeePasswordResetter
 
     private function doSendResetEmail(Employee $employee): void
     {
-        // Build the reset URL manually so it works regardless of the current request context
-        // (admin, admin-api, CLI): both kernels expose the "prestashop.admin_folder_name" container
-        // parameter, but the "admin_reset_password" route is only registered in the admin kernel.
-        $resetUrl = sprintf(
-            '%s/%s/index.php/reset-password/%s',
-            rtrim($this->shopContext->getBaseURL(), '/'),
-            trim($this->adminFolderName, '/'),
-            $employee->getResetPasswordToken(),
-        );
+        $resetUrl = $this->adminUrlGenerator->generateResetPasswordUrl($employee->getResetPasswordToken());
 
         $params = [
             '{email}' => $employee->getEmail(),

--- a/tests/Integration/Behaviour/Features/Context/Domain/EmployeeFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/EmployeeFeatureContext.php
@@ -234,23 +234,27 @@ class EmployeeFeatureContext extends AbstractDomainFeatureContext
         $mailDevClient = $this->getMailDevClient();
         $mailDevClient->deleteAllEmails();
 
-        $resetUrl = $this->getCommandBus()->handle(new SendEmployeePasswordResetEmailCommand($employeeEmail));
-        $resetUrl = str_replace('http://localhost', '', $resetUrl);
-        /** @var UrlMatcherInterface $router */
-        $router = CommonFeatureContext::getContainer()->get('router');
-        $matchedRoute = $router->match($resetUrl);
-        Assert::assertEquals('admin_reset_password', $matchedRoute['_route']);
-        Assert::assertNotEmpty($matchedRoute['resetToken']);
+        $this->getCommandBus()->handle(new SendEmployeePasswordResetEmailCommand($employeeEmail));
 
         $emails = $mailDevClient->getAllEmails();
         Assert::assertCount(1, $emails);
         $resetEmail = $emails[0];
         Assert::assertStringContainsString('Your new password', $resetEmail['subject']);
-        Assert::assertStringContainsString($resetUrl, $resetEmail['text']);
-        Assert::assertStringContainsString($resetUrl, $resetEmail['html']);
         Assert::assertEquals($employeeEmail, $resetEmail['to'][0]['address']);
 
-        $this->getSharedStorage()->set($tokenReference, $matchedRoute['resetToken']);
+        if (!preg_match('#/reset-password/([^\s"\'<]+)#', $resetEmail['text'], $matches)) {
+            throw new \RuntimeException('Reset URL not found in email body');
+        }
+        $resetToken = $matches[1];
+        Assert::assertNotEmpty($resetToken);
+        Assert::assertStringContainsString('/reset-password/' . $resetToken, $resetEmail['html']);
+
+        /** @var UrlMatcherInterface $router */
+        $router = CommonFeatureContext::getContainer()->get('router');
+        $matchedRoute = $router->match('/reset-password/' . $resetToken);
+        Assert::assertEquals('admin_reset_password', $matchedRoute['_route']);
+
+        $this->getSharedStorage()->set($tokenReference, $resetToken);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/EmployeeFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/EmployeeFeatureContext.php
@@ -243,7 +243,7 @@ class EmployeeFeatureContext extends AbstractDomainFeatureContext
         Assert::assertEquals($employeeEmail, $resetEmail['to'][0]['address']);
 
         if (!preg_match('#/reset-password/([^\s"\'<]+)#', $resetEmail['text'], $matches)) {
-            throw new \RuntimeException('Reset URL not found in email body');
+            throw new RuntimeException('Reset URL not found in email body');
         }
         $resetToken = $matches[1];
         Assert::assertNotEmpty($resetToken);

--- a/tests/Unit/PrestaShopBundle/Routing/AdminUrlGeneratorTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/AdminUrlGeneratorTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Routing;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShopBundle\Routing\AdminUrlGenerator;
+
+class AdminUrlGeneratorTest extends TestCase
+{
+    /**
+     * @dataProvider provideAdminUrlCases
+     */
+    public function testGenerateAdminUrl(string $baseUrl, string $adminFolder, string $urlPath, string $expected): void
+    {
+        $shopContext = $this->createMock(ShopContext::class);
+        $shopContext->method('getBaseURL')->willReturn($baseUrl);
+
+        $generator = new AdminUrlGenerator($shopContext, $adminFolder);
+
+        self::assertSame($expected, $generator->generateAdminUrl($urlPath));
+    }
+
+    public static function provideAdminUrlCases(): iterable
+    {
+        yield 'reset password route' => [
+            'https://example.com/',
+            'admin123',
+            '/reset-password/some-token',
+            'https://example.com/admin123/index.php/reset-password/some-token',
+        ];
+
+        yield 'legacy controller query string' => [
+            'https://example.com',
+            'admin123',
+            '?controller=LegacyAdminController',
+            'https://example.com/admin123/index.php?controller=LegacyAdminController',
+        ];
+
+        yield 'trims trailing slash on base URL and slashes on admin folder' => [
+            'https://example.com/shop/',
+            '/admin123/',
+            '/reset-password/token',
+            'https://example.com/shop/admin123/index.php/reset-password/token',
+        ];
+
+        yield 'empty url path' => [
+            'https://example.com',
+            'admin123',
+            '',
+            'https://example.com/admin123/index.php',
+        ];
+    }
+}


### PR DESCRIPTION
| Questions       | Answers                                                                     |
|-----------------|-----------------------------------------------------------------------------|
| Branch?         | develop                                                                     |
| Description?    | See below                                                                   |
| Type?           | improvement                                                                 |
| Category?       | CO                                                                          |
| BC breaks?      | no                                                                          |
| Deprecations?   | no                                                                          |
| UI tests | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/31103271468 |
| Fixed ticket?   | none                                                                        |
| How to test?    | Trigger a BO password reset request (Forgot password on the login page) and verify the email is sent with a working `<shop>/<admin folder>/index.php/reset-password/<token>` link. |

## What

- `EmployeePasswordResetter::doSendResetEmail()` no longer depends on Symfony's router. It builds the reset URL from `ShopContext::getBaseURL()` and the `prestashop.admin_folder_name` container parameter.
- `EmployeePasswordResetter::sendResetEmail()` and `SendEmployeePasswordResetEmailHandler::handle()` now return `void` instead of `string`.

## Why

The resetter used `$router->generate('admin_reset_password', ['resetToken' => ...])`. That route is only registered in the admin kernel (`src/PrestaShopBundle/Resources/config/routing/admin/_login.yml`), so any code triggering `SendEmployeePasswordResetEmailCommand` from another kernel — typically the admin-api kernel — died with:

```
Unable to generate a URL for the named route "admin_reset_password" as such route does not exist.
```

Building the URL from the `prestashop.admin_folder_name` container parameter works from every kernel (the parameter is set by `AppKernel`, which every kernel extends). The produced URL matches what the router used to return: `<shopBase>/<adminFolder>/index.php/reset-password/<token>`.

Returning `void`: no caller consumes the returned URL — `LoginController::requestPasswordResetAction` and `RequestPasswordResetFormDataProvider::save()` both discard the command bus result. Beyond removing dead output, this unblocks exposing `SendEmployeePasswordResetEmailCommand` through the Admin API: `CQRSCommandProcessor::process()` calls `array_merge($uriVariables, normalize($commandResult), ...)` and throws on a scalar command result.

## Impact

- BC-safe: the admin BO forgot-password flow keeps working; email format unchanged.
- Unblocks [PrestaShop/ps_apiresources#363](https://github.com/PrestaShop/ps_apiresources/pull/363) (`POST /employees/password-resets` Admin API endpoint).
- Behat scenario `sendPasswordReset` updated: the reset token is now read from the email body instead of the (now-removed) command return value; the URL is still matched against the `admin_reset_password` route to keep the invariant covered.