### PR TITLE
Migrate Dashboard to Symfony behind a beta feature flag (initialization)

### DIFF
--- a/install-dev/data/xml/feature_flag.xml
+++ b/install-dev/data/xml/feature_flag.xml
@@ -32,5 +32,6 @@
     <feature_flag id="hook_module_v2" name="hook_module_v2" type="env,dotenv,db" label_wording="Hook a module" label_domain="Admin.Design.Feature" description_wording="Enable / Disable the migrated Hook a module form page." description_domain="Admin.Design.Help" state="1" stability="stable" />
     <feature_flag id="quick_access" name="quick_access" type="env,dotenv,db" label_wording="Quick access" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the migrated quick access page." description_domain="Admin.Advparameters.Help" state="1" stability="stable" />
     <feature_flag id="stats" name="stats" type="env,dotenv,db" label_wording="Stats" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the migrated stats page." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
+    <feature_flag id="dashboard" name="dashboard" type="env,dotenv,db" label_wording="Dashboard page" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the migrated Symfony dashboard page. Native dashboard modules are not yet compatible with the new page and will not display until they are migrated." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
   </entities>
 </entity_feature_flag>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -771,6 +771,31 @@
       <title>Dashboard Top</title>
       <description>Displays the content in the dashboard's top area</description>
     </hook>
+    <hook id="displayAdminDashboardZoneOne">
+      <name>displayAdminDashboardZoneOne</name>
+      <title>Symfony Dashboard - Zone one</title>
+      <description>Displays module content in the first column of the migrated (Symfony) dashboard page. Modern counterpart of the legacy dashboardZoneOne hook.</description>
+    </hook>
+    <hook id="displayAdminDashboardZoneTwo">
+      <name>displayAdminDashboardZoneTwo</name>
+      <title>Symfony Dashboard - Zone two</title>
+      <description>Displays module content in the second column of the migrated (Symfony) dashboard page. Modern counterpart of the legacy dashboardZoneTwo hook.</description>
+    </hook>
+    <hook id="displayAdminDashboardZoneThree">
+      <name>displayAdminDashboardZoneThree</name>
+      <title>Symfony Dashboard - Zone three</title>
+      <description>Displays module content in the third column of the migrated (Symfony) dashboard page. Modern counterpart of the legacy dashboardZoneThree hook.</description>
+    </hook>
+    <hook id="displayAdminDashboardTop">
+      <name>displayAdminDashboardTop</name>
+      <title>Symfony Dashboard - Top</title>
+      <description>Displays module content in the top area of the migrated (Symfony) dashboard page. Modern counterpart of the legacy displayDashboardTop hook.</description>
+    </hook>
+    <hook id="displayAdminDashboardToolbar">
+      <name>displayAdminDashboardToolbar</name>
+      <title>Symfony Dashboard - Toolbar</title>
+      <description>Displays module content in the toolbar area of the migrated (Symfony) dashboard page. Modern counterpart of the legacy displayDashboardToolbarTopMenu hook.</description>
+    </hook>
     <hook id="actionUpdateLangAfter">
       <name>actionUpdateLangAfter</name>
       <title>Update "lang" tables</title>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -791,6 +791,11 @@
       <title>Symfony Dashboard - Top</title>
       <description>Displays module content in the top area of the migrated (Symfony) dashboard page. Modern counterpart of the legacy displayDashboardTop hook.</description>
     </hook>
+    <hook id="displayAdminDashboardBottom">
+      <name>displayAdminDashboardBottom</name>
+      <title>Symfony Dashboard - Bottom</title>
+      <description>Displays module content in a full-width area at the bottom of the migrated (Symfony) dashboard page.</description>
+    </hook>
     <hook id="displayAdminDashboardToolbar">
       <name>displayAdminDashboardToolbar</name>
       <title>Symfony Dashboard - Toolbar</title>

--- a/src/PrestaShopBundle/Controller/Admin/DashboardController.php
+++ b/src/PrestaShopBundle/Controller/Admin/DashboardController.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Controller\Admin;
+
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShopBundle\Entity\Employee\Employee;
+use PrestaShopBundle\Security\Attribute\AdminSecurity;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Responsible for the Symfony (migrated) "Dashboard" page.
+ *
+ * This page is gated behind the `dashboard` feature flag (beta). While the flag is
+ * disabled the legacy AdminDashboardController keeps serving the page unchanged.
+ *
+ * Unlike the legacy page, this controller makes no assumption about module internals:
+ * it neither registers Smarty template directories nor shims the legacy controller for
+ * `get_class()` checks. Instead it dispatches a new, dedicated hook family so a module
+ * knows which architecture it integrates with purely from which hook is called.
+ */
+class DashboardController extends PrestaShopAdminController
+{
+    /**
+     * Display the migrated dashboard: resolve the per-employee date range, dispatch the
+     * new dashboard zone hooks and render the Twig layout.
+     */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+    public function indexAction(
+        Request $request,
+        EntityManagerInterface $entityManager,
+        #[Autowire(service: HookDispatcherInterface::class)]
+        HookDispatcherInterface $hookDispatcher,
+    ): Response {
+        $legacyController = $request->attributes->get('_legacy_controller');
+
+        $employeeId = $this->getEmployeeContext()->getEmployee()?->getId();
+        $employee = null !== $employeeId
+            ? $entityManager->getRepository(Employee::class)->find($employeeId)
+            : null;
+
+        // Reuse the existing per-employee stats date configuration. When a valid range is
+        // submitted (GET form), persist it on the employee so the page reflects it. The
+        // write is skipped in demo mode (Doctrine's flush is a no-op when nothing changed).
+        $submittedFrom = $this->toDate($request->query->get('date_from'));
+        $submittedTo = $this->toDate($request->query->get('date_to'));
+        if (
+            null !== $employee
+            && null !== $submittedFrom
+            && null !== $submittedTo
+            && !$this->isDemoModeEnabled()
+        ) {
+            $employee->setStatsDateFrom($submittedFrom);
+            $employee->setStatsDateTo($submittedTo);
+            $entityManager->flush();
+        }
+
+        // Fall back to the same default range as the legacy page (last month → today)
+        // when the employee has no stored range yet.
+        $dateFrom = ($employee?->getStatsDateFrom() ?? new DateTime('-1 month'))->format('Y-m-d');
+        $dateTo = ($employee?->getStatsDateTo() ?? new DateTime())->format('Y-m-d');
+
+        $hookParameters = [
+            'date_from' => $dateFrom,
+            'date_to' => $dateTo,
+        ];
+
+        return $this->render('@PrestaShop/Admin/Dashboard/index.html.twig', [
+            'layoutTitle' => $this->trans('Dashboard', [], 'Admin.Navigation.Menu'),
+            'enableSidebar' => true,
+            'help_link' => $this->generateSidebarLink($legacyController),
+            'dateFrom' => $dateFrom,
+            'dateTo' => $dateTo,
+            'zoneOneContent' => $this->renderDashboardHook($hookDispatcher, 'displayAdminDashboardZoneOne', $hookParameters),
+            'zoneTwoContent' => $this->renderDashboardHook($hookDispatcher, 'displayAdminDashboardZoneTwo', $hookParameters),
+            'zoneThreeContent' => $this->renderDashboardHook($hookDispatcher, 'displayAdminDashboardZoneThree', $hookParameters),
+        ]);
+    }
+
+    /**
+     * Dispatch a rendering hook and return the concatenated HTML output of every listener.
+     */
+    private function renderDashboardHook(HookDispatcherInterface $hookDispatcher, string $hookName, array $parameters): string
+    {
+        return $hookDispatcher
+            ->dispatchRenderingWithParameters($hookName, $parameters)
+            ->outputContent();
+    }
+
+    /**
+     * Parse a strict `Y-m-d` string into a DateTime (time zeroed), or return null when invalid.
+     */
+    private function toDate(mixed $value): ?DateTime
+    {
+        if (!is_string($value) || '' === $value) {
+            return null;
+        }
+
+        $date = DateTime::createFromFormat('!Y-m-d', $value);
+
+        return $date && $date->format('Y-m-d') === $value ? $date : null;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/DashboardController.php
+++ b/src/PrestaShopBundle/Controller/Admin/DashboardController.php
@@ -10,6 +10,7 @@ namespace PrestaShopBundle\Controller\Admin;
 
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider;
 use PrestaShopBundle\Entity\Employee\Employee;
 use PrestaShopBundle\Form\Admin\Dashboard\DashboardDateRangeType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
@@ -28,6 +29,18 @@ use Symfony\Component\HttpFoundation\Response;
 class DashboardController extends PrestaShopAdminController
 {
     /**
+     * Dashboard hooks that receive the date range as parameters. The date range selector
+     * is only displayed when at least one module is registered on one of them.
+     */
+    private const DATE_RANGE_HOOKS = [
+        'displayAdminDashboardZoneOne',
+        'displayAdminDashboardZoneTwo',
+        'displayAdminDashboardZoneThree',
+        'displayAdminDashboardTop',
+        'displayAdminDashboardBottom',
+    ];
+
+    /**
      * Display the migrated dashboard: resolve the per-employee date range and render the
      * Twig layout, which dispatches the dashboard hooks.
      */
@@ -35,6 +48,7 @@ class DashboardController extends PrestaShopAdminController
     public function indexAction(
         Request $request,
         EntityManagerInterface $entityManager,
+        HookInformationProvider $hookInformationProvider,
     ): Response {
         $legacyController = $request->attributes->get('_legacy_controller');
 
@@ -48,35 +62,57 @@ class DashboardController extends PrestaShopAdminController
         $dateFrom = $employee?->getStatsDateFrom() ?? new DateTime('-1 month');
         $dateTo = $employee?->getStatsDateTo() ?? new DateTime();
 
-        $dateRangeForm = $this->createForm(DashboardDateRangeType::class, [
-            'date_from' => $dateFrom,
-            'date_to' => $dateTo,
-        ]);
-        $dateRangeForm->handleRequest($request);
+        // Only offer the date range selector when a module actually consumes the range,
+        // i.e. is registered on one of the date-aware hooks. A dashboard made only of, say,
+        // a toolbar banner should not display a useless date picker.
+        $dateRangeFormView = null;
+        if ($this->isDateRangeUsed($hookInformationProvider)) {
+            $dateRangeForm = $this->createForm(DashboardDateRangeType::class, [
+                'date_from' => $dateFrom,
+                'date_to' => $dateTo,
+            ]);
+            $dateRangeForm->handleRequest($request);
 
-        // Persist a submitted range on the employee so the page reflects it (skipped in
-        // demo mode; Doctrine's flush is a no-op when nothing actually changed).
-        if (
-            $dateRangeForm->isSubmitted()
-            && $dateRangeForm->isValid()
-            && null !== $employee
-            && !$this->isDemoModeEnabled()
-        ) {
-            $data = $dateRangeForm->getData();
-            $dateFrom = $data['date_from'];
-            $dateTo = $data['date_to'];
-            $employee->setStatsDateFrom($dateFrom);
-            $employee->setStatsDateTo($dateTo);
-            $entityManager->flush();
+            // Persist a submitted range on the employee so the page reflects it (skipped in
+            // demo mode; Doctrine's flush is a no-op when nothing actually changed).
+            if (
+                $dateRangeForm->isSubmitted()
+                && $dateRangeForm->isValid()
+                && null !== $employee
+                && !$this->isDemoModeEnabled()
+            ) {
+                $data = $dateRangeForm->getData();
+                $dateFrom = $data['date_from'];
+                $dateTo = $data['date_to'];
+                $employee->setStatsDateFrom($dateFrom);
+                $employee->setStatsDateTo($dateTo);
+                $entityManager->flush();
+            }
+
+            $dateRangeFormView = $dateRangeForm->createView();
         }
 
         return $this->render('@PrestaShop/Admin/Dashboard/index.html.twig', [
             'layoutTitle' => $this->trans('Dashboard', [], 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($legacyController),
-            'dateRangeForm' => $dateRangeForm->createView(),
+            'dateRangeForm' => $dateRangeFormView,
             'dateFrom' => $dateFrom->format('Y-m-d'),
             'dateTo' => $dateTo->format('Y-m-d'),
         ]);
+    }
+
+    /**
+     * Whether at least one module is registered on a hook that consumes the date range.
+     */
+    private function isDateRangeUsed(HookInformationProvider $hookInformationProvider): bool
+    {
+        foreach (self::DATE_RANGE_HOOKS as $hookName) {
+            if (!empty($hookInformationProvider->getRegisteredModulesByHookName($hookName))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/DashboardController.php
+++ b/src/PrestaShopBundle/Controller/Admin/DashboardController.php
@@ -10,36 +10,31 @@ namespace PrestaShopBundle\Controller\Admin;
 
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
-use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Entity\Employee\Employee;
+use PrestaShopBundle\Form\Admin\Dashboard\DashboardDateRangeType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Responsible for the Symfony (migrated) "Dashboard" page.
  *
- * This page is gated behind the `dashboard` feature flag (beta). While the flag is
- * disabled the legacy AdminDashboardController keeps serving the page unchanged.
- *
  * Unlike the legacy page, this controller makes no assumption about module internals:
  * it neither registers Smarty template directories nor shims the legacy controller for
- * `get_class()` checks. Instead it dispatches a new, dedicated hook family so a module
- * knows which architecture it integrates with purely from which hook is called.
+ * `get_class()` checks. Instead a new, dedicated hook family is dispatched (from the Twig
+ * layout, via `renderhook`) so a module knows which architecture it integrates with
+ * purely from which hook is called.
  */
 class DashboardController extends PrestaShopAdminController
 {
     /**
-     * Display the migrated dashboard: resolve the per-employee date range, dispatch the
-     * new dashboard zone hooks and render the Twig layout.
+     * Display the migrated dashboard: resolve the per-employee date range and render the
+     * Twig layout, which dispatches the dashboard hooks.
      */
     #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
     public function indexAction(
         Request $request,
         EntityManagerInterface $entityManager,
-        #[Autowire(service: HookDispatcherInterface::class)]
-        HookDispatcherInterface $hookDispatcher,
     ): Response {
         $legacyController = $request->attributes->get('_legacy_controller');
 
@@ -48,65 +43,40 @@ class DashboardController extends PrestaShopAdminController
             ? $entityManager->getRepository(Employee::class)->find($employeeId)
             : null;
 
-        // Reuse the existing per-employee stats date configuration. When a valid range is
-        // submitted (GET form), persist it on the employee so the page reflects it. The
-        // write is skipped in demo mode (Doctrine's flush is a no-op when nothing changed).
-        $submittedFrom = $this->toDate($request->query->get('date_from'));
-        $submittedTo = $this->toDate($request->query->get('date_to'));
-        if (
-            null !== $employee
-            && null !== $submittedFrom
-            && null !== $submittedTo
-            && !$this->isDemoModeEnabled()
-        ) {
-            $employee->setStatsDateFrom($submittedFrom);
-            $employee->setStatsDateTo($submittedTo);
-            $entityManager->flush();
-        }
+        // Effective range: the employee's stored stats range, or the same default as the
+        // legacy page (last month → today) when none has been set yet.
+        $dateFrom = $employee?->getStatsDateFrom() ?? new DateTime('-1 month');
+        $dateTo = $employee?->getStatsDateTo() ?? new DateTime();
 
-        // Fall back to the same default range as the legacy page (last month → today)
-        // when the employee has no stored range yet.
-        $dateFrom = ($employee?->getStatsDateFrom() ?? new DateTime('-1 month'))->format('Y-m-d');
-        $dateTo = ($employee?->getStatsDateTo() ?? new DateTime())->format('Y-m-d');
-
-        $hookParameters = [
+        $dateRangeForm = $this->createForm(DashboardDateRangeType::class, [
             'date_from' => $dateFrom,
             'date_to' => $dateTo,
-        ];
+        ]);
+        $dateRangeForm->handleRequest($request);
+
+        // Persist a submitted range on the employee so the page reflects it (skipped in
+        // demo mode; Doctrine's flush is a no-op when nothing actually changed).
+        if (
+            $dateRangeForm->isSubmitted()
+            && $dateRangeForm->isValid()
+            && null !== $employee
+            && !$this->isDemoModeEnabled()
+        ) {
+            $data = $dateRangeForm->getData();
+            $dateFrom = $data['date_from'];
+            $dateTo = $data['date_to'];
+            $employee->setStatsDateFrom($dateFrom);
+            $employee->setStatsDateTo($dateTo);
+            $entityManager->flush();
+        }
 
         return $this->render('@PrestaShop/Admin/Dashboard/index.html.twig', [
             'layoutTitle' => $this->trans('Dashboard', [], 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($legacyController),
-            'dateFrom' => $dateFrom,
-            'dateTo' => $dateTo,
-            'zoneOneContent' => $this->renderDashboardHook($hookDispatcher, 'displayAdminDashboardZoneOne', $hookParameters),
-            'zoneTwoContent' => $this->renderDashboardHook($hookDispatcher, 'displayAdminDashboardZoneTwo', $hookParameters),
-            'zoneThreeContent' => $this->renderDashboardHook($hookDispatcher, 'displayAdminDashboardZoneThree', $hookParameters),
+            'dateRangeForm' => $dateRangeForm->createView(),
+            'dateFrom' => $dateFrom->format('Y-m-d'),
+            'dateTo' => $dateTo->format('Y-m-d'),
         ]);
-    }
-
-    /**
-     * Dispatch a rendering hook and return the concatenated HTML output of every listener.
-     */
-    private function renderDashboardHook(HookDispatcherInterface $hookDispatcher, string $hookName, array $parameters): string
-    {
-        return $hookDispatcher
-            ->dispatchRenderingWithParameters($hookName, $parameters)
-            ->outputContent();
-    }
-
-    /**
-     * Parse a strict `Y-m-d` string into a DateTime (time zeroed), or return null when invalid.
-     */
-    private function toDate(mixed $value): ?DateTime
-    {
-        if (!is_string($value) || '' === $value) {
-            return null;
-        }
-
-        $date = DateTime::createFromFormat('!Y-m-d', $value);
-
-        return $date && $date->format('Y-m-d') === $value ? $date : null;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Dashboard/DashboardDateRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Dashboard/DashboardDateRangeType.php
@@ -8,10 +8,9 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Dashboard;
 
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Date range selector of the dashboard page (per-employee stats range).
@@ -20,29 +19,22 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * it from the query string). Kept intentionally simple; it can be extended by modules
  * through the form-building hooks like any other admin form.
  */
-class DashboardDateRangeType extends AbstractType
+class DashboardDateRangeType extends TranslatorAwareType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('date_from', DateType::class, [
-                'label' => 'From',
+                'label' => $this->trans('From', 'Admin.Global'),
                 'widget' => 'single_text',
                 'input' => 'datetime',
                 'html5' => true,
             ])
             ->add('date_to', DateType::class, [
-                'label' => 'To',
+                'label' => $this->trans('To', 'Admin.Global'),
                 'widget' => 'single_text',
                 'input' => 'datetime',
                 'html5' => true,
             ]);
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'translation_domain' => 'Admin.Global',
-        ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Dashboard/DashboardDateRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Dashboard/DashboardDateRangeType.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Dashboard;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Date range selector of the dashboard page (per-employee stats range).
+ *
+ * Submitted with POST so the admin security token is preserved (a GET form would drop
+ * it from the query string). Kept intentionally simple; it can be extended by modules
+ * through the form-building hooks like any other admin form.
+ */
+class DashboardDateRangeType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('date_from', DateType::class, [
+                'label' => 'From',
+                'widget' => 'single_text',
+                'input' => 'datetime',
+                'html5' => true,
+            ])
+            ->add('date_to', DateType::class, [
+                'label' => 'To',
+                'widget' => 'single_text',
+                'input' => 'datetime',
+                'html5' => true,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'Admin.Global',
+        ]);
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin.yml
@@ -1,3 +1,7 @@
+_admin_dashboard_routing:
+  resource: "admin/dashboard.yml"
+  prefix: /dashboard
+
 _admin_common_routing:
   resource: "admin/_common.yml"
   prefix: /common

--- a/src/PrestaShopBundle/Resources/config/routing/admin/dashboard.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/dashboard.yml
@@ -1,0 +1,10 @@
+admin_dashboard_index:
+  path: /
+  methods: [ GET ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\DashboardController::indexAction'
+    _legacy_controller: AdminDashboard
+    _legacy_link: AdminDashboard
+    _legacy_feature_flag: dashboard
+  options:
+    expose: true

--- a/src/PrestaShopBundle/Resources/config/routing/admin/dashboard.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/dashboard.yml
@@ -1,6 +1,6 @@
 admin_dashboard_index:
   path: /
-  methods: [ GET ]
+  methods: [ GET, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\DashboardController::indexAction'
     _legacy_controller: AdminDashboard

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -136,6 +136,7 @@ services:
     arguments:
       $localizationPackChoices: '@=service("prestashop.core.form.choice_provider.localization_pack_by_iso_code").getChoices()'
 
+  PrestaShopBundle\Form\Admin\Dashboard\DashboardDateRangeType:
   PrestaShopBundle\Form\Admin\Improve\International\Localization\LocalUnitsType:
   PrestaShopBundle\Form\Admin\Improve\International\Localization\AdvancedConfigurationType:
   PrestaShopBundle\Form\Admin\Improve\International\Geolocation\GeolocationByIpAddressType:

--- a/src/PrestaShopBundle/Resources/views/Admin/Dashboard/form_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Dashboard/form_theme.html.twig
@@ -9,8 +9,9 @@
  # line, instead of the stacked layout of the default admin form theme.
  #}
 {%- block form_row -%}
-  <div class="form-group d-inline-flex align-items-center mb-0 mr-3">
-    {{- form_label(form, null, {label_attr: {class: 'mb-0 mr-2'}}) -}}
+  <div class="form-group d-inline-flex align-items-center mb-2 mr-3">
+    {#- min-width keeps the inputs aligned when the fields wrap on narrow screens -#}
+    {{- form_label(form, null, {label_attr: {class: 'mb-0 mr-2', style: 'min-width: 3rem'}}) -}}
     {{- form_widget(form) -}}
     {{- form_errors(form) -}}
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Dashboard/form_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Dashboard/form_theme.html.twig
@@ -1,0 +1,17 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+{% extends '@PrestaShop/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig' %}
+
+{#
+ # Render each row inline (label next to the field) so the date range fits on a single
+ # line, instead of the stacked layout of the default admin form theme.
+ #}
+{%- block form_row -%}
+  <div class="form-group d-inline-flex align-items-center mb-0 mr-3">
+    {{- form_label(form, null, {label_attr: {class: 'mb-0 mr-2'}}) -}}
+    {{- form_widget(form) -}}
+    {{- form_errors(form) -}}
+  </div>
+{%- endblock -%}

--- a/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
@@ -1,0 +1,93 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% import _self as dashboard %}
+
+{#
+ # Placeholder shown when a single zone receives no content while others do.
+ #}
+{% macro empty_zone() %}
+  <div class="panel dashboard-zone-empty text-center">
+    <div class="panel-body text-muted">
+      <i class="material-icons">extension</i>
+      <p class="mb-0">{{ 'No module is displaying content here yet.'|trans({}, 'Admin.Dashboard.Feature') }}</p>
+    </div>
+  </div>
+{% endmacro %}
+
+{% block content %}
+  {% set toolbarContent = renderhook('displayAdminDashboardToolbar') %}
+  {% set topContent = renderhook('displayAdminDashboardTop', {date_from: dateFrom, date_to: dateTo}) %}
+  {% set hasZoneContent = zoneOneContent|trim is not empty or zoneTwoContent|trim is not empty or zoneThreeContent|trim is not empty %}
+
+  <div id="dashboard">
+    {% if toolbarContent|trim is not empty %}
+      <div class="row">
+        <div class="col-lg-12" id="displayAdminDashboardToolbar">{{ toolbarContent }}</div>
+      </div>
+    {% endif %}
+
+    <div class="row">
+      <div class="col-lg-12">
+        <div id="dashboard-calendar" class="panel">
+          <form action="{{ path('admin_dashboard_index') }}" method="get" id="dashboard_calendar_form" class="form-inline">
+            <div class="form-group">
+              <label class="mr-1" for="dashboard_date_from">{{ 'From'|trans({}, 'Admin.Global') }}</label>
+              <input type="date" name="date_from" id="dashboard_date_from" value="{{ dateFrom }}" class="form-control mr-2">
+              <label class="mr-1" for="dashboard_date_to">{{ 'To'|trans({}, 'Admin.Global') }}</label>
+              <input type="date" name="date_to" id="dashboard_date_to" value="{{ dateTo }}" class="form-control mr-2">
+            </div>
+            <button type="submit" class="btn btn-primary">{{ 'Apply'|trans({}, 'Admin.Actions') }}</button>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    {% if topContent|trim is not empty %}
+      <div class="row">
+        <div class="col-lg-12" id="displayAdminDashboardTop">{{ topContent }}</div>
+      </div>
+    {% endif %}
+
+    {% if not hasZoneContent %}
+      {# Nominal case in beta: no dashboard module has been migrated to the new hooks yet. #}
+      <div class="row">
+        <div class="col-lg-12">
+          <div class="panel dashboard-zone-empty text-center">
+            <div class="panel-body text-muted">
+              <i class="material-icons">dashboard_customize</i>
+              <p class="mt-2 mb-0">{{ 'No module is displaying content on the dashboard yet.'|trans({}, 'Admin.Dashboard.Feature') }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% else %}
+      <div class="row">
+        <div class="col-md-4 col-lg-3" id="displayAdminDashboardZoneOne">
+          {% if zoneOneContent|trim is not empty %}
+            {{ zoneOneContent|raw }}
+          {% else %}
+            {{ dashboard.empty_zone() }}
+          {% endif %}
+        </div>
+
+        <div class="col-md-8 col-lg-{{ zoneThreeContent|trim is not empty ? 7 : 9 }}" id="displayAdminDashboardZoneTwo">
+          {% if zoneTwoContent|trim is not empty %}
+            {{ zoneTwoContent|raw }}
+          {% else %}
+            {{ dashboard.empty_zone() }}
+          {% endif %}
+        </div>
+
+        {% if zoneThreeContent|trim is not empty %}
+          <div class="col-md-12 col-lg-2" id="displayAdminDashboardZoneThree">
+            {{ zoneThreeContent|raw }}
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
@@ -4,88 +4,51 @@
  #}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% import _self as dashboard %}
-
-{#
- # Placeholder shown when a single zone receives no content while others do.
- #}
-{% macro empty_zone() %}
-  <div class="panel dashboard-zone-empty text-center">
-    <div class="panel-body text-muted">
-      <i class="material-icons">extension</i>
-      <p class="mb-0">{{ 'No module is displaying content here yet.'|trans({}, 'Admin.Dashboard.Feature') }}</p>
-    </div>
-  </div>
-{% endmacro %}
-
 {% block content %}
   {% set toolbarContent = renderhook('displayAdminDashboardToolbar') %}
   {% set topContent = renderhook('displayAdminDashboardTop', {date_from: dateFrom, date_to: dateTo}) %}
-  {% set hasZoneContent = zoneOneContent|trim is not empty or zoneTwoContent|trim is not empty or zoneThreeContent|trim is not empty %}
+  {% set zoneOneContent = renderhook('displayAdminDashboardZoneOne', {date_from: dateFrom, date_to: dateTo}) %}
+  {% set zoneTwoContent = renderhook('displayAdminDashboardZoneTwo', {date_from: dateFrom, date_to: dateTo}) %}
+  {% set zoneThreeContent = renderhook('displayAdminDashboardZoneThree', {date_from: dateFrom, date_to: dateTo}) %}
+
+  {% set hasZoneOne = zoneOneContent|trim is not empty %}
+  {% set hasZoneTwo = zoneTwoContent|trim is not empty %}
+  {% set hasZoneThree = zoneThreeContent|trim is not empty %}
 
   <div id="dashboard">
     {% if toolbarContent|trim is not empty %}
       <div class="row">
-        <div class="col-lg-12" id="displayAdminDashboardToolbar">{{ toolbarContent }}</div>
+        <div class="col-lg-12" id="displayAdminDashboardToolbar">{{ toolbarContent|raw }}</div>
       </div>
     {% endif %}
 
     <div class="row">
       <div class="col-lg-12">
         <div id="dashboard-calendar" class="panel">
-          <form action="{{ path('admin_dashboard_index') }}" method="get" id="dashboard_calendar_form" class="form-inline">
-            <div class="form-group">
-              <label class="mr-1" for="dashboard_date_from">{{ 'From'|trans({}, 'Admin.Global') }}</label>
-              <input type="date" name="date_from" id="dashboard_date_from" value="{{ dateFrom }}" class="form-control mr-2">
-              <label class="mr-1" for="dashboard_date_to">{{ 'To'|trans({}, 'Admin.Global') }}</label>
-              <input type="date" name="date_to" id="dashboard_date_to" value="{{ dateTo }}" class="form-control mr-2">
-            </div>
+          {{ form_start(dateRangeForm, {attr: {class: 'form-inline'}}) }}
+            {{ form_widget(dateRangeForm) }}
             <button type="submit" class="btn btn-primary">{{ 'Apply'|trans({}, 'Admin.Actions') }}</button>
-          </form>
+          {{ form_end(dateRangeForm) }}
         </div>
       </div>
     </div>
 
     {% if topContent|trim is not empty %}
       <div class="row">
-        <div class="col-lg-12" id="displayAdminDashboardTop">{{ topContent }}</div>
+        <div class="col-lg-12" id="displayAdminDashboardTop">{{ topContent|raw }}</div>
       </div>
     {% endif %}
 
-    {% if not hasZoneContent %}
-      {# Nominal case in beta: no dashboard module has been migrated to the new hooks yet. #}
+    {% if hasZoneOne or hasZoneTwo or hasZoneThree %}
       <div class="row">
-        <div class="col-lg-12">
-          <div class="panel dashboard-zone-empty text-center">
-            <div class="panel-body text-muted">
-              <i class="material-icons">dashboard_customize</i>
-              <p class="mt-2 mb-0">{{ 'No module is displaying content on the dashboard yet.'|trans({}, 'Admin.Dashboard.Feature') }}</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    {% else %}
-      <div class="row">
-        <div class="col-md-4 col-lg-3" id="displayAdminDashboardZoneOne">
-          {% if zoneOneContent|trim is not empty %}
-            {{ zoneOneContent|raw }}
-          {% else %}
-            {{ dashboard.empty_zone() }}
-          {% endif %}
-        </div>
-
-        <div class="col-md-8 col-lg-{{ zoneThreeContent|trim is not empty ? 7 : 9 }}" id="displayAdminDashboardZoneTwo">
-          {% if zoneTwoContent|trim is not empty %}
-            {{ zoneTwoContent|raw }}
-          {% else %}
-            {{ dashboard.empty_zone() }}
-          {% endif %}
-        </div>
-
-        {% if zoneThreeContent|trim is not empty %}
-          <div class="col-md-12 col-lg-2" id="displayAdminDashboardZoneThree">
-            {{ zoneThreeContent|raw }}
-          </div>
+        {% if hasZoneOne %}
+          <div class="col-md-4 col-lg-3" id="displayAdminDashboardZoneOne">{{ zoneOneContent|raw }}</div>
+        {% endif %}
+        {% if hasZoneTwo %}
+          <div class="col-md-8 col-lg-{{ hasZoneThree ? 7 : 9 }}" id="displayAdminDashboardZoneTwo">{{ zoneTwoContent|raw }}</div>
+        {% endif %}
+        {% if hasZoneThree %}
+          <div class="col-md-12 col-lg-2" id="displayAdminDashboardZoneThree">{{ zoneThreeContent|raw }}</div>
         {% endif %}
       </div>
     {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
@@ -9,6 +9,7 @@
 {% block content %}
   {% set toolbarContent = renderhook('displayAdminDashboardToolbar') %}
   {% set topContent = renderhook('displayAdminDashboardTop', {date_from: dateFrom, date_to: dateTo}) %}
+  {% set bottomContent = renderhook('displayAdminDashboardBottom', {date_from: dateFrom, date_to: dateTo}) %}
   {% set zoneOneContent = renderhook('displayAdminDashboardZoneOne', {date_from: dateFrom, date_to: dateTo}) %}
   {% set zoneTwoContent = renderhook('displayAdminDashboardZoneTwo', {date_from: dateFrom, date_to: dateTo}) %}
   {% set zoneThreeContent = renderhook('displayAdminDashboardZoneThree', {date_from: dateFrom, date_to: dateTo}) %}
@@ -52,6 +53,12 @@
         {% if hasZoneThree %}
           <div class="col-12 col-xl-2" id="displayAdminDashboardZoneThree">{{ zoneThreeContent|raw }}</div>
         {% endif %}
+      </div>
+    {% endif %}
+
+    {% if bottomContent|trim is not empty %}
+      <div class="row">
+        <div class="col-12" id="displayAdminDashboardBottom">{{ bottomContent|raw }}</div>
       </div>
     {% endif %}
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
@@ -26,10 +26,10 @@
 
     <div class="row">
       <div class="col-lg-12">
-        <div id="dashboard-calendar" class="panel">
+        <div id="dashboard-calendar" class="panel mb-3">
           {{ form_start(dateRangeForm, {attr: {class: 'form-inline'}}) }}
             {{ form_widget(dateRangeForm) }}
-            <button type="submit" class="btn btn-primary">{{ 'Apply'|trans({}, 'Admin.Actions') }}</button>
+            <button type="submit" class="btn btn-primary mb-2">{{ 'Apply'|trans({}, 'Admin.Actions') }}</button>
           {{ form_end(dateRangeForm) }}
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
@@ -4,6 +4,8 @@
  #}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
+{% form_theme dateRangeForm '@PrestaShop/Admin/Dashboard/form_theme.html.twig' %}
+
 {% block content %}
   {% set toolbarContent = renderhook('displayAdminDashboardToolbar') %}
   {% set topContent = renderhook('displayAdminDashboardTop', {date_from: dateFrom, date_to: dateTo}) %}
@@ -42,13 +44,13 @@
     {% if hasZoneOne or hasZoneTwo or hasZoneThree %}
       <div class="row">
         {% if hasZoneOne %}
-          <div class="col-md-4 col-lg-3" id="displayAdminDashboardZoneOne">{{ zoneOneContent|raw }}</div>
+          <div class="col-12 col-xl-3" id="displayAdminDashboardZoneOne">{{ zoneOneContent|raw }}</div>
         {% endif %}
         {% if hasZoneTwo %}
-          <div class="col-md-8 col-lg-{{ hasZoneThree ? 7 : 9 }}" id="displayAdminDashboardZoneTwo">{{ zoneTwoContent|raw }}</div>
+          <div class="col-12 col-xl-{{ hasZoneThree ? 7 : 9 }}" id="displayAdminDashboardZoneTwo">{{ zoneTwoContent|raw }}</div>
         {% endif %}
         {% if hasZoneThree %}
-          <div class="col-md-12 col-lg-2" id="displayAdminDashboardZoneThree">{{ zoneThreeContent|raw }}</div>
+          <div class="col-12 col-xl-2" id="displayAdminDashboardZoneThree">{{ zoneThreeContent|raw }}</div>
         {% endif %}
       </div>
     {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Dashboard/index.html.twig
@@ -4,8 +4,6 @@
  #}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% form_theme dateRangeForm '@PrestaShop/Admin/Dashboard/form_theme.html.twig' %}
-
 {% block content %}
   {% set toolbarContent = renderhook('displayAdminDashboardToolbar') %}
   {% set topContent = renderhook('displayAdminDashboardTop', {date_from: dateFrom, date_to: dateTo}) %}
@@ -25,16 +23,19 @@
       </div>
     {% endif %}
 
-    <div class="row">
-      <div class="col-lg-12">
-        <div id="dashboard-calendar" class="panel mb-3">
-          {{ form_start(dateRangeForm, {attr: {class: 'form-inline'}}) }}
-            {{ form_widget(dateRangeForm) }}
-            <button type="submit" class="btn btn-primary mb-2">{{ 'Apply'|trans({}, 'Admin.Actions') }}</button>
-          {{ form_end(dateRangeForm) }}
+    {% if dateRangeForm is not null %}
+      <div class="row">
+        <div class="col-lg-12">
+          <div id="dashboard-calendar" class="panel mb-3">
+            {% form_theme dateRangeForm '@PrestaShop/Admin/Dashboard/form_theme.html.twig' %}
+            {{ form_start(dateRangeForm, {attr: {class: 'form-inline'}}) }}
+              {{ form_widget(dateRangeForm) }}
+              <button type="submit" class="btn btn-primary mb-2">{{ 'Apply'|trans({}, 'Admin.Actions') }}</button>
+            {{ form_end(dateRangeForm) }}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
 
     {% if topContent|trim is not empty %}
       <div class="row">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | First story of the Dashboard migration epic (spike #41522). Delivers the foundation to run the Back Office Dashboard on a Symfony controller rendering a Twig layout, gated behind a new `dashboard` feature flag (beta, disabled by default). No Smarty / legacy `Helper*` retro-compatibility: the Symfony page dispatches a **new dedicated hook family** (`displayAdminDashboard*`), so a module knows which architecture it integrates with purely from which hook is called. The native `dash*` modules are intentionally not displayed on the new page until they are migrated in subsequent stories.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. With the flag **off** (default): the legacy Dashboard is strictly unchanged (legacy controller, Smarty templates, legacy hooks, `dash*` widgets). 2. Enable the flag in *Advanced Parameters > New & Experimental Features* ("Dashboard page"), or `UPDATE ps_feature_flag SET state=1 WHERE name='dashboard';`. 3. Open the Dashboard from the BO menu or via `getAdminLink('AdminDashboard')` → lands on the Symfony page (`/dashboard/`, valid token). 4. A direct hit on the legacy Dashboard URL redirects to the Symfony route. 5. The page renders the three-zone layout with empty-state placeholders and no PHP error/warning. 6. Submitting the date range persists the employee configuration and the page reflects the new range. 7. After fresh install **and** after upgrade, the five new hooks exist in the `hook` table.
| UI Tests          | GA UI regression run (without cache), no new Playwright specs added by this PR:<br>MySQL :green_circle: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/29830117033<br>MariaDB :green_circle: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/29830118817
| Fixed issue or discussion?     | Fixes #41968
| Related PRs       | Example module `dashexample`: PrestaShop/example-modules#254. Devdocs hook reference update and the autoupgrade SQL entry (repo `PrestaShop/autoupgrade`) are separate deliverables of this story.
| Sponsor company   | @PrestaShopCorp

### Scope of this PR (core)

- **Feature flag** `dashboard` (beta, `state=0`): constant `FeatureFlagSettings::FEATURE_FLAG_DASHBOARD` + `feature_flag.xml` entry (label mentions the native dashboard modules are not yet compatible).
- **Symfony controller** `DashboardController::indexAction`: resolves the per-employee stats date range (reusing `stats_date_from`/`stats_date_to`), persists a submitted range, dispatches `displayAdminDashboardZoneOne/Two/Three`. No `AdminDashboardController` shim, no `smarty->addTemplateDir()`, no `actionAdminControllerSetMedia`.
- **Routing** `admin_dashboard_index` (`/dashboard/`) with `_legacy_controller`, `_legacy_link` and `_legacy_feature_flag: dashboard`. The legacy↔Symfony switch (308 redirect + `getAdminLink` conversion) is handled by the framework via the flag — the legacy controller is untouched.
- **Twig layout** `Admin/Dashboard/index.html.twig`: three-zone layout ported from `view.tpl`, empty-state placeholders, native date-range form, `displayAdminDashboardTop` / `displayAdminDashboardToolbar` dispatched from the template. No `HelperCalendar`, no legacy JS stack.
- **Hooks**: five new hooks registered in `install-dev/data/xml/hook.xml`. Legacy dashboard hooks are left untouched.

### Out of scope (subsequent stories)

Data-refresh contract (`hookDashboardData` + AJAX), JS stack modernisation, migration of the native `dash*` modules, simulation mode, and removal of the legacy controller.


