### PR TITLE
Use PDF template object returned by hook

### DIFF
--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -167,7 +167,9 @@ class PDFCore
 
         $templateObjectFromModule = $this->getTemplateObjectFromModules($object, $this->smarty, $this->send_bulk_flag, $this->template);
 
-        if (false === $templateObjectFromModule && class_exists($class_name)) {
+        if (false !== $templateObjectFromModule) {
+            $class = $templateObjectFromModule;
+        } elseif (class_exists($class_name)) {
             // Some HTMLTemplateXYZ implementations won't use the third param but this is not a problem (no warning in PHP),
             // the third param is then ignored if not added to the method signature.
             $class = new $class_name($object, $this->smarty, $this->send_bulk_flag);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      |This PR fixes the handling of the object returned by the `actionGetPdfTemplateObject` hook.<br/>When a module provides a custom PDF template object, the returned object is now assigned to `$class` and used to generate the PDF.<br/>If no module provides a custom template, the existing behavior is preserved and the default `HTMLTemplate` class is instantiated as a fallback.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the [issue42075.zip](https://github.com/user-attachments/files/30176970/issue42075.zip) test module, which implements the `actionGetPdfTemplateObject` hook.<br/>2. Open an order that has an invoice.<br/>3. Download the invoice PDF.<br/>4. Verify that the PDF is generated without errors and that the text `ADDITIONAL STRING` is displayed before the address section.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/31148988582
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42075
| Related PRs       | 
| Sponsor company   | Codencode snc


