### PR TITLE
Fix: Cannot create or edit an API client because the form theme cannot be used as a Twig trait

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/AdminAPI/ApiClient/form_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/AdminAPI/ApiClient/form_theme.html.twig
@@ -3,7 +3,7 @@
  # docs/licenses/LICENSE.txt file that was distributed with this source code.
  #}
 
-{% use '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+{% extends '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block accordion_widget %}
   {% if empty_scopes is not defined or empty_scopes == false %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | See below
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Log in to the Back Office.<br/>2. Go to **Advanced Parameters > Admin API**.<br/>3. Click **Add new API client**.<br/>4. You must not display errors and you must be able to create the API client.
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/29734489311
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42087
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41364
| Sponsor company   | Codencode snc


## Description

This PR fixes the API client form rendering error reported in #42087.

On PrestaShop 9.1.x, opening **Advanced Parameters > Admin API** and clicking **Add new API client** causes the following Twig error:

```text
Template "@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig" cannot be used as a trait in @PrestaShop/Admin/Configure/AdvancedParameters/AdminAPI/ApiClient/form_theme.html.twig at line 6.
```

The API client form theme imports the complete PrestaShop UI Kit theme using Twig's `{% use %}` tag. Twig therefore attempts to load the template as a trait and rejects it as non-traitable.

This PR replaces the trait usage with template inheritance, preserving the complete PrestaShop form layout while allowing the API client theme to override the required blocks.

## Target branch

The issue is reproducible on PrestaShop 9.1.x, including a clean PrestaShop 9.1.4 installation.

It is not reproducible on the 9.2.x branch. Therefore, this PR targets **9.1.x only** and should not be forward-ported to 9.2.x unless the same issue is confirmed there.

