### PR TITLE
Add free shipping hooks (improved shipments FF)

### DIFF
--- a/src/Adapter/Carrier/ShippingCost/Calculator/FreeShippingCalculator.php
+++ b/src/Adapter/Carrier/ShippingCost/Calculator/FreeShippingCalculator.php
@@ -8,20 +8,14 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Carrier\ShippingCost\Calculator;
 
-use PrestaShop\Decimal\DecimalNumber;
-use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
-use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Calculator\ShippingCostCalculatorInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Provider\FreeShippingCriteriaProviderInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\ShippingCostPriceInterface;
-use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 
 class FreeShippingCalculator implements ShippingCostCalculatorInterface
 {
     public function __construct(
         private readonly FreeShippingCriteriaProviderInterface $criteriaProvider,
-        private readonly Tools $tools,
-        private readonly CurrencyRepository $currencyRepository,
     ) {
     }
 
@@ -33,17 +27,10 @@ class FreeShippingCalculator implements ShippingCostCalculatorInterface
 
         $thresholds = $this->criteriaProvider->getCriteria($context);
 
-        if ($thresholds->hasFreePrice()) {
-            $convertedPrice = new DecimalNumber((string) $this->tools->convertPrice(
-                (float) (string) $thresholds->getFreePrice(),
-                $this->currencyRepository->get(new CurrencyId($context->getCurrencyId()))
-            ));
+        if ($thresholds->hasFreePrice() && $context->getShipmentTotal()->isGreaterOrEqualThan($thresholds->getFreePrice())) {
+            $context->setFreeShipping(true);
 
-            if ($context->getShipmentTotal()->isGreaterOrEqualThan($convertedPrice)) {
-                $context->setFreeShipping(true);
-
-                return;
-            }
+            return;
         }
 
         if ($thresholds->hasFreeWeight() && $context->getTotalWeight()->isGreaterOrEqualThan($thresholds->getFreeWeight())) {

--- a/src/Adapter/Carrier/ShippingCost/Calculator/FreeShippingCalculator.php
+++ b/src/Adapter/Carrier/ShippingCost/Calculator/FreeShippingCalculator.php
@@ -31,7 +31,7 @@ class FreeShippingCalculator implements ShippingCostCalculatorInterface
             return;
         }
 
-        $thresholds = $this->criteriaProvider->getCriteria();
+        $thresholds = $this->criteriaProvider->getCriteria($context);
 
         if ($thresholds->hasFreePrice()) {
             $convertedPrice = new DecimalNumber((string) $this->tools->convertPrice(

--- a/src/Adapter/Carrier/ShippingCost/Provider/ConfigFreeShippingCriteriaProvider.php
+++ b/src/Adapter/Carrier/ShippingCost/Provider/ConfigFreeShippingCriteriaProvider.php
@@ -10,30 +10,52 @@ namespace PrestaShop\PrestaShop\Adapter\Carrier\ShippingCost\Provider;
 
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Configuration as AdapterConfiguration;
+use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
 use PrestaShop\PrestaShop\Adapter\HookManager;
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Provider\FreeShippingCriteria;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Provider\FreeShippingCriteriaProviderInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\ShippingCostPriceInterface;
+use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 
 class ConfigFreeShippingCriteriaProvider implements FreeShippingCriteriaProviderInterface
 {
     public function __construct(
         private readonly HookManager $hookManager,
         private readonly AdapterConfiguration $configuration,
+        private readonly Tools $tools,
+        private readonly CurrencyRepository $currencyRepository,
     ) {
     }
 
     public function getCriteria(ShippingCostPriceInterface $context): FreeShippingCriteria
     {
         $freePrice = $this->configuration->get('PS_SHIPPING_FREE_PRICE');
-        $this->hookManager->exec('actionOverrideShippingFreePrice', ['shippingFreePrice' => &$freePrice, 'id_zone' => $context->getCountryZoneId(), 'id_currency' => $context->getCurrencyId()]);
+        if ($freePrice !== false && (float) $freePrice > 0) {
+            $freePrice = $this->tools->convertPrice(
+                (float) $freePrice,
+                $this->currencyRepository->get(new CurrencyId($context->getCurrencyId()))
+            );
+        }
+
+        $zoneId = $context->getResolvedZoneId() ?? $context->getCountryZoneId();
+
+        $this->hookManager->exec('actionOverrideShippingFreePrice', [
+            'shippingFreePrice' => &$freePrice,
+            'id_zone' => $zoneId,
+            'id_currency' => $context->getCurrencyId(),
+        ]);
 
         $freeWeight = $this->configuration->get('PS_SHIPPING_FREE_WEIGHT');
-        $this->hookManager->exec('actionOverrideShippingFreeWeight', ['shippingFreeWeight' => &$freeWeight, 'id_zone' => $context->getCountryZoneId(), 'id_currency' => $context->getCurrencyId()]);
+        $this->hookManager->exec('actionOverrideShippingFreeWeight', [
+            'shippingFreeWeight' => &$freeWeight,
+            'id_zone' => $zoneId,
+            'id_currency' => $context->getCurrencyId(),
+        ]);
 
         return new FreeShippingCriteria(
-            $freePrice !== false && $freePrice > 0 ? new DecimalNumber((string) $freePrice) : null,
-            $freeWeight !== false && $freeWeight > 0 ? new DecimalNumber((string) $freeWeight) : null,
+            $freePrice !== false && (float) $freePrice > 0 ? new DecimalNumber((string) $freePrice) : null,
+            $freeWeight !== false && (float) $freeWeight > 0 ? new DecimalNumber((string) $freeWeight) : null,
         );
     }
 }

--- a/src/Adapter/Carrier/ShippingCost/Provider/ConfigFreeShippingCriteriaProvider.php
+++ b/src/Adapter/Carrier/ShippingCost/Provider/ConfigFreeShippingCriteriaProvider.php
@@ -10,20 +10,26 @@ namespace PrestaShop\PrestaShop\Adapter\Carrier\ShippingCost\Provider;
 
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Configuration as AdapterConfiguration;
+use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Provider\FreeShippingCriteria;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Provider\FreeShippingCriteriaProviderInterface;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\ShippingCostPriceInterface;
 
 class ConfigFreeShippingCriteriaProvider implements FreeShippingCriteriaProviderInterface
 {
     public function __construct(
+        private readonly HookManager $hookManager,
         private readonly AdapterConfiguration $configuration,
     ) {
     }
 
-    public function getCriteria(): FreeShippingCriteria
+    public function getCriteria(ShippingCostPriceInterface $context): FreeShippingCriteria
     {
         $freePrice = $this->configuration->get('PS_SHIPPING_FREE_PRICE');
+        $this->hookManager->exec('actionOverrideShippingFreePrice', ['shippingFreePrice' => &$freePrice, 'id_zone' => $context->getCountryZoneId(), 'id_currency' => $context->getCurrencyId()]);
+
         $freeWeight = $this->configuration->get('PS_SHIPPING_FREE_WEIGHT');
+        $this->hookManager->exec('actionOverrideShippingFreeWeight', ['shippingFreeWeight' => &$freeWeight, 'id_zone' => $context->getCountryZoneId(), 'id_currency' => $context->getCurrencyId()]);
 
         return new FreeShippingCriteria(
             $freePrice !== false && $freePrice > 0 ? new DecimalNumber((string) $freePrice) : null,

--- a/src/Core/Domain/Carrier/ShippingCost/Provider/FreeShippingCriteriaProviderInterface.php
+++ b/src/Core/Domain/Carrier/ShippingCost/Provider/FreeShippingCriteriaProviderInterface.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Provider;
 
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\ShippingCostPriceInterface;
+
 interface FreeShippingCriteriaProviderInterface extends ShippingCostProviderInterface
 {
-    public function getCriteria(): FreeShippingCriteria;
+    public function getCriteria(ShippingCostPriceInterface $context): FreeShippingCriteria;
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
@@ -5,6 +5,8 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Configuration: ~
 
+  PrestaShop\PrestaShop\Adapter\HookManager: ~
+
   prestashop.adapter.legacy.configuration:
     alias: PrestaShop\PrestaShop\Adapter\Configuration
 

--- a/tests/Unit/Adapter/Carrier/ShippingCost/Calculator/FreeShippingCalculatorTest.php
+++ b/tests/Unit/Adapter/Carrier/ShippingCost/Calculator/FreeShippingCalculatorTest.php
@@ -8,29 +8,19 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Adapter\Carrier\ShippingCost\Calculator;
 
-use Currency;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Carrier\ShippingCost\Calculator\FreeShippingCalculator;
-use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
-use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Provider\FreeShippingCriteria;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Provider\FreeShippingCriteriaProviderInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\ShippingCostPrice;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\ShippingCostPriceInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\ShippingCalculationRequest;
-use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 
 class FreeShippingCalculatorTest extends TestCase
 {
     /** @var FreeShippingCriteriaProviderInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $criteriaProvider;
-
-    /** @var Tools|\PHPUnit\Framework\MockObject\MockObject */
-    private $tools;
-
-    /** @var CurrencyRepository|\PHPUnit\Framework\MockObject\MockObject */
-    private $currencyRepository;
 
     /** @var FreeShippingCalculator */
     private $calculator;
@@ -38,12 +28,8 @@ class FreeShippingCalculatorTest extends TestCase
     protected function setUp(): void
     {
         $this->criteriaProvider = $this->createMock(FreeShippingCriteriaProviderInterface::class);
-        $this->tools = $this->createMock(Tools::class);
-        $this->currencyRepository = $this->createMock(CurrencyRepository::class);
         $this->calculator = new FreeShippingCalculator(
-            $this->criteriaProvider,
-            $this->tools,
-            $this->currencyRepository
+            $this->criteriaProvider
         );
     }
 
@@ -71,15 +57,28 @@ class FreeShippingCalculatorTest extends TestCase
     {
         $context = $this->createContext(1, new DecimalNumber('50'));
         $criteria = new FreeShippingCriteria(new DecimalNumber('40'), null);
-        $this->criteriaProvider->method('getCriteria')->willReturn($criteria);
-
-        $currency = $this->createMock(Currency::class);
-        $this->currencyRepository->method('get')->with(new CurrencyId(1))->willReturn($currency);
-        $this->tools->method('convertPrice')->willReturn(40.0);
+        $this->criteriaProvider->expects($this->once())
+            ->method('getCriteria')
+            ->with($context)
+            ->willReturn($criteria);
 
         $this->calculator->compute($context);
 
         $this->assertTrue($context->isFreeShipping());
+    }
+
+    public function testItDoesNotSetFreeShippingIfPriceThresholdIsNotMet(): void
+    {
+        $context = $this->createContext(1, new DecimalNumber('30'));
+        $criteria = new FreeShippingCriteria(new DecimalNumber('40'), null);
+        $this->criteriaProvider->expects($this->once())
+            ->method('getCriteria')
+            ->with($context)
+            ->willReturn($criteria);
+
+        $this->calculator->compute($context);
+
+        $this->assertFalse($context->isFreeShipping());
     }
 
     public function testItSetsFreeShippingIfWeightThresholdIsMet(): void
@@ -87,7 +86,10 @@ class FreeShippingCalculatorTest extends TestCase
         $context = $this->createContext(1, new DecimalNumber('10'));
         $context->setTotalWeight(new DecimalNumber('10'));
         $criteria = new FreeShippingCriteria(null, new DecimalNumber('5'));
-        $this->criteriaProvider->method('getCriteria')->willReturn($criteria);
+        $this->criteriaProvider->expects($this->once())
+            ->method('getCriteria')
+            ->with($context)
+            ->willReturn($criteria);
 
         $this->calculator->compute($context);
 

--- a/tests/Unit/Adapter/Carrier/ShippingCost/Provider/ConfigFreeShippingCriteriaProviderTest.php
+++ b/tests/Unit/Adapter/Carrier/ShippingCost/Provider/ConfigFreeShippingCriteriaProviderTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Carrier\ShippingCost\Provider;
+
+use Currency;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Adapter\Carrier\ShippingCost\Provider\ConfigFreeShippingCriteriaProvider;
+use PrestaShop\PrestaShop\Adapter\Configuration as AdapterConfiguration;
+use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
+use PrestaShop\PrestaShop\Adapter\HookManager;
+use PrestaShop\PrestaShop\Adapter\Tools;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\ShippingCostPrice;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\ShippingCostPriceInterface;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\ShippingCalculationRequest;
+use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
+
+class ConfigFreeShippingCriteriaProviderTest extends TestCase
+{
+    /** @var HookManager|\PHPUnit\Framework\MockObject\MockObject */
+    private $hookManager;
+
+    /** @var AdapterConfiguration|\PHPUnit\Framework\MockObject\MockObject */
+    private $configuration;
+
+    /** @var Tools|\PHPUnit\Framework\MockObject\MockObject */
+    private $tools;
+
+    /** @var CurrencyRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $currencyRepository;
+
+    /** @var ConfigFreeShippingCriteriaProvider */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        $this->hookManager = $this->createMock(HookManager::class);
+        $this->configuration = $this->createMock(AdapterConfiguration::class);
+        $this->tools = $this->createMock(Tools::class);
+        $this->currencyRepository = $this->createMock(CurrencyRepository::class);
+
+        $this->provider = new ConfigFreeShippingCriteriaProvider(
+            $this->hookManager,
+            $this->configuration,
+            $this->tools,
+            $this->currencyRepository
+        );
+    }
+
+    public function testGetCriteriaConvertsPriceBeforeHookAndUsesResolvedZoneId(): void
+    {
+        $context = $this->createContext(2, 5); // currencyId = 2, resolvedZoneId = 5
+
+        $this->configuration->method('get')->willReturnCallback(function ($key) {
+            if ($key === 'PS_SHIPPING_FREE_PRICE') {
+                return '100.00';
+            }
+            if ($key === 'PS_SHIPPING_FREE_WEIGHT') {
+                return '10.5';
+            }
+
+            return false;
+        });
+
+        $currency = $this->createMock(Currency::class);
+        $this->currencyRepository->expects($this->once())
+            ->method('get')
+            ->with(new CurrencyId(2))
+            ->willReturn($currency);
+
+        $this->tools->expects($this->once())
+            ->method('convertPrice')
+            ->with(100.0, $currency)
+            ->willReturn(120.0);
+
+        $this->hookManager->expects($this->exactly(2))
+            ->method('exec')
+            ->willReturnCallback(function (string $hookName, array $params) {
+                if ($hookName === 'actionOverrideShippingFreePrice') {
+                    $this->assertEquals(120.0, $params['shippingFreePrice']);
+                    $this->assertEquals(5, $params['id_zone']);
+                    $this->assertEquals(2, $params['id_currency']);
+                } elseif ($hookName === 'actionOverrideShippingFreeWeight') {
+                    $this->assertEquals('10.5', $params['shippingFreeWeight']);
+                    $this->assertEquals(5, $params['id_zone']);
+                    $this->assertEquals(2, $params['id_currency']);
+                }
+            });
+
+        $criteria = $this->provider->getCriteria($context);
+
+        $this->assertTrue($criteria->hasFreePrice());
+        $this->assertEquals(new DecimalNumber('120'), $criteria->getFreePrice());
+        $this->assertTrue($criteria->hasFreeWeight());
+        $this->assertEquals(new DecimalNumber('10.5'), $criteria->getFreeWeight());
+    }
+
+    private function createContext(int $currencyId, ?int $resolvedZoneId = null): ShippingCostPriceInterface
+    {
+        $request = new ShippingCalculationRequest(
+            [], // products
+            1, // carrierId
+            1, // zoneId
+            null, // addressId
+            0, // countryZoneId
+            $currencyId,
+            null, // customerId
+            100.0 // orderTotal
+        );
+
+        $context = ShippingCostPrice::createFromRequest($request);
+        if ($resolvedZoneId !== null) {
+            $context->setResolvedZoneId($resolvedZoneId);
+        }
+
+        return $context;
+    }
+}

--- a/tests/Unit/Adapter/Carrier/ShippingCost/Provider/ConfigFreeShippingCriteriaProviderTest.php
+++ b/tests/Unit/Adapter/Carrier/ShippingCost/Provider/ConfigFreeShippingCriteriaProviderTest.php
@@ -55,7 +55,7 @@ class ConfigFreeShippingCriteriaProviderTest extends TestCase
 
     public function testGetCriteriaConvertsPriceBeforeHookAndUsesResolvedZoneId(): void
     {
-        $context = $this->createContext(2, 5); // currencyId = 2, resolvedZoneId = 5
+        $context = $this->createContext(2, 5); // currencyId = 2, zoneId = 5
 
         $this->configuration->method('get')->willReturnCallback(function ($key) {
             if ($key === 'PS_SHIPPING_FREE_PRICE') {
@@ -101,24 +101,86 @@ class ConfigFreeShippingCriteriaProviderTest extends TestCase
         $this->assertEquals(new DecimalNumber('10.5'), $criteria->getFreeWeight());
     }
 
-    private function createContext(int $currencyId, ?int $resolvedZoneId = null): ShippingCostPriceInterface
+    public function testGetCriteriaFallsBackToCountryZoneIdWhenResolvedZoneIdIsNull(): void
+    {
+        $context = $this->createContext(2, null, 7); // zoneId = null (unresolved), countryZoneId = 7
+
+        $this->configuration->method('get')->willReturn(false);
+
+        $zoneIdsPassedToHooks = [];
+        $this->hookManager->expects($this->exactly(2))
+            ->method('exec')
+            ->willReturnCallback(function (string $hookName, array $params) use (&$zoneIdsPassedToHooks) {
+                $zoneIdsPassedToHooks[$hookName] = $params['id_zone'];
+            });
+
+        $this->provider->getCriteria($context);
+
+        $this->assertSame(7, $zoneIdsPassedToHooks['actionOverrideShippingFreePrice']);
+        $this->assertSame(7, $zoneIdsPassedToHooks['actionOverrideShippingFreeWeight']);
+    }
+
+    public function testGetCriteriaDoesNotConvertPriceWhenFreePriceIsDisabled(): void
+    {
+        $context = $this->createContext(2, 5);
+
+        $this->configuration->method('get')->willReturn(false);
+
+        $this->currencyRepository->expects($this->never())->method('get');
+        $this->tools->expects($this->never())->method('convertPrice');
+
+        $criteria = $this->provider->getCriteria($context);
+
+        $this->assertFalse($criteria->hasFreePrice());
+        $this->assertFalse($criteria->hasFreeWeight());
+    }
+
+    public function testGetCriteriaAppliesModuleOverrideThroughHookReferenceParameters(): void
+    {
+        $context = $this->createContext(2, 5);
+
+        $this->configuration->method('get')->willReturnCallback(function ($key) {
+            if ($key === 'PS_SHIPPING_FREE_PRICE') {
+                return '100.00';
+            }
+            if ($key === 'PS_SHIPPING_FREE_WEIGHT') {
+                return '10.5';
+            }
+
+            return false;
+        });
+
+        $currency = $this->createMock(Currency::class);
+        $this->currencyRepository->method('get')->willReturn($currency);
+        $this->tools->method('convertPrice')->willReturn(120.0);
+
+        $this->hookManager->method('exec')->willReturnCallback(function (string $hookName, array $params) {
+            if ($hookName === 'actionOverrideShippingFreePrice') {
+                $params['shippingFreePrice'] = 42.0;
+            } elseif ($hookName === 'actionOverrideShippingFreeWeight') {
+                $params['shippingFreeWeight'] = 7.0;
+            }
+        });
+
+        $criteria = $this->provider->getCriteria($context);
+
+        $this->assertEquals(new DecimalNumber('42'), $criteria->getFreePrice());
+        $this->assertEquals(new DecimalNumber('7'), $criteria->getFreeWeight());
+    }
+
+    private function createContext(int $currencyId, ?int $zoneId = null, int $countryZoneId = 0): ShippingCostPriceInterface
     {
         $request = new ShippingCalculationRequest(
             [], // products
             1, // carrierId
-            1, // zoneId
+            $zoneId,
             null, // addressId
-            0, // countryZoneId
+            $countryZoneId,
             $currencyId,
             null, // customerId
             100.0 // orderTotal
         );
 
-        $context = ShippingCostPrice::createFromRequest($request);
-        if ($resolvedZoneId !== null) {
-            $context->setResolvedZoneId($resolvedZoneId);
-        }
-
-        return $context;
+        return ShippingCostPrice::createFromRequest($request);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add free shipping hooks (shippingFreePrice && actionOverrideShippingFreeWeight) in new shipping calculator
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | use shippingFreePrice and actionOverrideShippingFreeWeight hooks with improved shipments feature flag
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/30527705075
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -