### PR TITLE
Consume single-use voucher before sending the remainder voucher email

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1224,6 +1224,11 @@ abstract class PaymentModuleCore extends Module
                 continue;
             }
 
+            // The "new remainder voucher" notification is captured here and only sent once the
+            // cart rule has been persisted and consumed below, so a failing/slow Mail::Send can
+            // never leave a paid order with a still-reusable single-use voucher.
+            $voucherEmail = null;
+
             // IF
             //  This is not multi-shipping
             //  The value of the voucher is greater than the total of the order
@@ -1283,28 +1288,20 @@ abstract class PaymentModuleCore extends Module
                     CartRule::copyConditions($cartRule->id, $voucher->id);
                     $orderLanguage = new Language((int) $order->id_lang);
 
-                    $params = [
-                        '{voucher_amount}' => Tools::getContextLocale($this->context)->formatPrice($voucher->reduction_amount, $this->context->currency->iso_code),
-                        '{voucher_num}' => $voucher->code,
-                        '{firstname}' => $this->context->customer->firstname,
-                        '{lastname}' => $this->context->customer->lastname,
-                        '{id_order}' => $order->id,
-                        '{order_name}' => $order->getUniqReference(),
+                    $voucherEmail = [
+                        'id_lang' => (int) $order->id_lang,
+                        'locale' => $orderLanguage->locale,
+                        'reference' => $order->reference,
+                        'id_shop' => (int) $order->id_shop,
+                        'params' => [
+                            '{voucher_amount}' => Tools::getContextLocale($this->context)->formatPrice($voucher->reduction_amount, $this->context->currency->iso_code),
+                            '{voucher_num}' => $voucher->code,
+                            '{firstname}' => $this->context->customer->firstname,
+                            '{lastname}' => $this->context->customer->lastname,
+                            '{id_order}' => $order->id,
+                            '{order_name}' => $order->getUniqReference(),
+                        ],
                     ];
-                    Mail::Send(
-                        (int) $order->id_lang,
-                        'voucher',
-                        Context::getContext()->getTranslator()->trans(
-                            'New voucher for your order %s',
-                            [$order->reference],
-                            'Emails.Subject',
-                            $orderLanguage->locale
-                        ),
-                        $params,
-                        $this->context->customer->email,
-                        $this->context->customer->firstname . ' ' . $this->context->customer->lastname,
-                        null, null, null, null, _PS_MAIL_DIR_, false, (int) $order->id_shop
-                    );
                 }
 
                 $values['tax_incl'] = $order->total_products_wt - $total_reduction_value_ti;
@@ -1329,6 +1326,29 @@ abstract class PaymentModuleCore extends Module
                     $cart_rule_to_update->quantity = max(0, $cart_rule_to_update->quantity - 1);
                 }
                 $cart_rule_to_update->update();
+            }
+
+            // The cart rule is now persisted and consumed: sending the remainder voucher email is
+            // best-effort and must not be able to interrupt the order flow.
+            if ($voucherEmail !== null) {
+                try {
+                    Mail::Send(
+                        $voucherEmail['id_lang'],
+                        'voucher',
+                        Context::getContext()->getTranslator()->trans(
+                            'New voucher for your order %s',
+                            [$voucherEmail['reference']],
+                            'Emails.Subject',
+                            $voucherEmail['locale']
+                        ),
+                        $voucherEmail['params'],
+                        $this->context->customer->email,
+                        $this->context->customer->firstname . ' ' . $this->context->customer->lastname,
+                        null, null, null, null, _PS_MAIL_DIR_, false, $voucherEmail['id_shop']
+                    );
+                } catch (Exception $e) {
+                    PrestaShopLogger::addLog('PaymentModule::createOrderCartRules - Could not send the remainder voucher email: ' . $e->getMessage(), 3, null, 'Order', (int) $order->id, true);
+                }
             }
 
             $cart_rules_list[] = [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run locally — happy to trigger a campaign if a maintainer requests it.
| Fixed issue or discussion?     | No public issue yet; reproduction and root cause are described below.
| Related PRs       | N/A
| Sponsor company   | Evolutive

### Problem

In `PaymentModule::createOrderCartRules()`, when a **single-use** (`partial_use = 1`) voucher whose amount exceeds the reducible base is applied, a *remainder* voucher is created and a "New voucher for your order" e-mail is sent — **before** the original cart rule is persisted and consumed. The order of operations today is:

1. remainder voucher created (`$voucher->add()`)
2. **`Mail::Send()`** for the remainder voucher
3. `$order->addCartRule()` → writes `order_cart_rule`
4. cart rule `quantity` decremented → single-use voucher consumed

Steps 3–4 (the ones that actually consume the single-use voucher) run **after** the e-mail. None of it is wrapped in a transaction or `try/catch`.

If `Mail::Send()` fails or hangs at step 2 — e.g. an unresponsive SMTP host causing `max_execution_time` to abort the request with a PHP fatal that no `try/catch` can catch — the process dies with the order and its payment already recorded, but with **no `order_cart_rule` row and the single-use voucher never decremented**. The voucher stays reusable, and a customer who doesn't reach the confirmation page and retries can reapply it on a second order.

This was observed in production: an order left `valid = 0`, `current_state = 0`, `order_payment` written, the 0.01 € remainder voucher created, but `order_cart_rule` / `order_history` absent, and the single-use voucher reused on a retry order minutes later.

### Fix

Capture the remainder-voucher notification and send it **only after** the cart rule is persisted (`addCartRule`) and consumed (quantity decrement), and make the send best-effort with a `try/catch` so a mail-layer failure can no longer strand the voucher. Behaviour is otherwise unchanged — same recipient, template, params and shop; only the timing of the send moves to the end of the loop iteration.

### How to test

1. Create a single-use cart rule (`partial_use = 1`, quantity = 1) with a fixed-amount reduction **greater** than a product's price (so a remainder voucher is generated), e.g. 10 € reduction on a 9.99 € product.
2. Temporarily make the voucher e-mail fail — e.g. point the shop's e-mail settings at an unreachable SMTP host, or throw inside `Mail::Send` for the `voucher` template.
3. Place and pay for an order using that voucher.
4. **Before the fix:** the order and its payment exist, but `order_cart_rule` is empty and the original voucher still shows `quantity = 1` (reusable).
5. **After the fix:** the `order_cart_rule` row is present and the voucher `quantity` is decremented to 0; the failed e-mail is logged and does not interrupt order creation.
