### PR TITLE
Keep translations intact when their sprintf placeholders were removed

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -231,7 +231,7 @@ class TranslateCore
     {
         if (!empty($args) && self::isSprintfString($string)) {
             return vsprintf($string, $args);
-        } elseif (!empty($args)) {
+        } elseif (!empty($args) && !array_is_list($args)) {
             return strtr($string, $args);
         }
 

--- a/tests/Unit/Classes/TranslateCoreTest.php
+++ b/tests/Unit/Classes/TranslateCoreTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\Classes;
+
+use PHPUnit\Framework\TestCase;
+use Translate;
+
+class TranslateCoreTest extends TestCase
+{
+    /**
+     * @dataProvider checkAndReplaceArgsDataProvider
+     */
+    public function testCheckAndReplaceArgs($expected, $string, $args)
+    {
+        $this->assertSame($expected, Translate::checkAndReplaceArgs($string, $args));
+    }
+
+    public function checkAndReplaceArgsDataProvider()
+    {
+        return [
+            // Positional placeholders are replaced as usual
+            ['OK: Hi Bye', 'OK: %1$s %2$s', ['Hi', 'Bye']],
+            ['OK: Hi Text2 Bye', 'OK: %1$s Text2 %2$s', ['Hi', 'Bye']],
+            ['OK: Hi', 'OK: %s', ['Hi']],
+            ['OK: Hi Bye', 'OK: %s %s', ['Hi', 'Bye']],
+
+            // A translation that dropped its placeholders is left untouched
+            ['NOK1: 100.00', 'NOK1: 100.00', ['Hi', 'Bye']],
+            ['NOK2: 100.00', 'NOK2: 100.00', ['Hi']],
+            ['Delivered in 10 days', 'Delivered in 10 days', ['Hi', 'Bye']],
+            ['No placeholder left', 'No placeholder left', ['Hi', 'Bye']],
+
+            // Only part of the placeholders was kept
+            ['NOK1: Bye', 'NOK1: %2$s', ['Hi', 'Bye']],
+
+            // Named parameters are still replaced by key
+            ['Hello Bob', 'Hello %name%', ['%name%' => 'Bob']],
+            ['3 items', '%count% items', ['%count%' => '3']],
+
+            // Nothing to replace
+            ['Untouched %s', 'Untouched %s', []],
+            ['Untouched', 'Untouched', []],
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `Translate::checkAndReplaceArgs()` falls back to `strtr()` when the string it receives has no sprintf placeholder left. The arguments coming from `{l s='...' sprintf=[$a, $b]}` are a positional list, so their keys are the integers `0` and `1`, and `strtr()` ends up replacing every `0` and `1` character of the translation. Any translation whose placeholders were removed by the translator therefore comes out mangled. More details below.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" below.
| Fixed issue or discussion?     | Fixes #31950
| Related PRs       | -
| Sponsor company   | idnovate

### The problem

Module template:

```smarty
{l s='OK: %1$s %2$s' sprintf=[$var1, $var2] d='Modules.Dummymodule.Dummy'}
{l s='NOK1: %1$s Text2 %2$s' sprintf=[$var1, $var2] d='Modules.Dummymodule.Dummy'}
{l s='NOK2: %s' sprintf=[$var1] d='Modules.Dummymodule.Dummy'}
```

with `$var1 = 'Hi'`, `$var2 = 'Bye'`, and translations where the placeholders were removed:

| Source string | Translation | Before | After |
| --- | --- | --- | --- |
| `OK: %1$s %2$s` | `OK: %1$s %2$s` | `OK: Hi Bye` | `OK: Hi Bye` |
| `NOK1: %1$s Text2 %2$s` | `NOK1: 100.00` | `NOKBye: ByeHiHi.HiHi` | `NOK1: 100.00` |
| `NOK2: %s` | `NOK2: 100.00` | `NOK2: 1HiHi.HiHi` | `NOK2: 100.00` |

Dropping the placeholders is a reasonable thing for a translator to do: the target language may not need the value, or the sentence gets rephrased and no longer has a spot for it. Rewriting the rest of the string is not.

What makes this nasty is that it is silent and depends on the text. A translation containing no `0` and no `1` comes out fine, so most strings look perfectly OK and only some get destroyed. `Delivered in 10 days` becomes `Delivered in ByeHi days`.

### Why it happens

```php
if (!empty($args) && self::isSprintfString($string)) {
    return vsprintf($string, $args);
} elseif (!empty($args)) {
    return strtr($string, $args);
}
```

`isSprintfString()` is checked against the translated string, which is correct, but the `strtr()` branch then receives arguments it was never meant to handle. It is there for named parameters (`%count%`, `%name%`), which are associative and matched by key. Positional sprintf arguments are a list, and `strtr()` casts their keys to `'0'`, `'1'`, ... and substitutes those digits everywhere in the text.

So the patch only takes the `strtr()` branch for associative arrays. Once the placeholders are gone there is nothing left to inject, and the translation is returned as it was written.

This has been the same code since at least 1.7.8, and it is identical in 8.x, 9.1.x and develop. I reproduced it on 9.1.3.

### How to test

Worth knowing before testing: this only shows up when the translation is served by the **legacy** module translation system, i.e. from `modules/<module>/translations/<iso>.php`. If the string lives in the Symfony catalogue (an `.xlf`, or the `ps_translation` table after saving from the BO translations page) another code path handles the sprintf arguments and the output is already correct. Editing the strings in the back office and hitting Save will therefore hide the bug.

1. Install [dummymodule.zip](https://github.com/PrestaShop/PrestaShop/files/11090306/dummymodule.zip) from the issue. It hooks into `displayHome` and ships a `translations/en.php` with the placeholders already removed.
2. Open the front page.
3. Before the patch the second line renders as `NOKBye: ByeHiHi.HiHi`, after it renders as `NOK1: 100.00`.

The same three strings rendered from a back office template (a module configuration page, for instance) are affected in exactly the same way.

Alternatively, without any module: `tests/Unit/Classes/TranslateCoreTest.php` is added by this PR. It fails with three failures on the current code and passes with the patch.

```
php vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter TranslateCoreTest
```
