### PR TITLE
Fix release healthcheck for pre-release tags

### DIFF
--- a/.github/release-healthcheck/cross-repo-readiness.sh
+++ b/.github/release-healthcheck/cross-repo-readiness.sh
@@ -16,6 +16,12 @@ HC_GROUP="Cross-repo / external readiness"
 # OPEN PR's diff adds it. Never relies on the PR title.
 check_autoupgrade_max_version_pr() {
   local id="cross-repo/autoupgrade-max-version-pr" title="Autoupgrade max-version" af="public/json/autoupgrade.json" maxes n patch
+  # autoupgrade.json only ever lists stable versions as prestashop_max — a pre-release is
+  # never an upgrade target, so there is nothing to add for it.
+  if [ "$RELEASE_TYPE" = "pre-release" ]; then
+    emit "$id" "$title" "$HC_NA" "$HC_SEV_WARN" "autoupgrade never targets pre-releases (this is $RELEASE_TYPE)"
+    return
+  fi
   # Default verify link: the canonical file (used by the merged + not-found outcomes).
   HC_LINK="https://github.com/PrestaShop/distribution-api/blob/HEAD/$af"
   # 1. Merged: the live file lists the version as a max upgrade target.

--- a/.github/release-healthcheck/derive.sh
+++ b/.github/release-healthcheck/derive.sh
@@ -79,18 +79,28 @@ else
 fi
 
 # --- runtime flags -------------------------------------------------------------
-# release_published: a non-draft GH release for CORE_VERSION exists on the public target.
+# release_published: a non-draft GH release for the actual tag exists on the public target.
+# The release tag IS the full target version (9.2.0-beta.1), never the semver core (9.2.0).
 RELEASE_PUBLISHED="false"
-if gh_release_published "$UPSTREAM_REPO" "$CORE_VERSION"; then
+if gh_release_published "$UPSTREAM_REPO" "$TARGET_VERSION"; then
   RELEASE_PUBLISHED="true"
 fi
 
 # classic_released: a non-draft PrestaShopCorp/prestashop-classic release exists for the version.
-# Classic appends its own scope version to the tag (e.g. 9.1.4 ships as "9.1.4-5.0"), so match
-# the core version as a prefix. Best-effort: needs token access to the private repo.
+# Classic inserts its own scope version between the core and the prerelease label (9.1.4 ships
+# as "9.1.4-5.0", 9.2.0-beta.1 as "9.2.0-6.0-beta.1"; old releases may be bare "8.2.7"), so match
+# core + optional scope + the target's exact prerelease suffix — a plain core-prefix match would
+# let a beta tag satisfy a stable run and vice versa. Best-effort: needs token access to the
+# private repo.
+CORE_RE="${CORE_VERSION//./\\.}"
+if [ -n "${SV_PRERELEASE_LABEL:-}" ]; then
+  CLASSIC_TAG_RE="^${CORE_RE}-[0-9][0-9.]*-${SV_PRERELEASE_LABEL}\.${SV_PRERELEASE_NUM}\$"
+else
+  CLASSIC_TAG_RE="^${CORE_RE}(-[0-9][0-9.]*)?\$"
+fi
 CLASSIC_RELEASED="false"
 if gh release list --repo PrestaShopCorp/prestashop-classic --limit 100 --json tagName,isDraft \
-     -q '.[] | select(.isDraft==false) | .tagName' 2>/dev/null | grep -qE "^${CORE_VERSION}(-|\$)"; then
+     -q '.[] | select(.isDraft==false) | .tagName' 2>/dev/null | grep -qE "$CLASSIC_TAG_RE"; then
   CLASSIC_RELEASED="true"
 fi
 

--- a/.github/release-healthcheck/lib.sh
+++ b/.github/release-healthcheck/lib.sh
@@ -121,10 +121,12 @@ gh_json() {
 }
 
 # gh_tag_exists <owner/repo> <tag>  -> returns 0 if the tag ref exists (tries with and without a leading "v").
+# Uses the singular git/ref endpoint: git/refs/tags/<tag> PREFIX-matches (tag "9.2.0" would
+# be reported present because "9.2.0-beta.1" exists); git/ref/tags/<tag> matches exactly.
 gh_tag_exists() {
   local repo="$1" tag="$2"
-  if gh api "repos/${repo}/git/refs/tags/${tag}" >/dev/null 2>&1; then return 0; fi
-  if gh api "repos/${repo}/git/refs/tags/v${tag}" >/dev/null 2>&1; then return 0; fi
+  if gh api "repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>&1; then return 0; fi
+  if gh api "repos/${repo}/git/ref/tags/v${tag}" >/dev/null 2>&1; then return 0; fi
   return 1
 }
 

--- a/.github/release-healthcheck/post-release.sh
+++ b/.github/release-healthcheck/post-release.sh
@@ -40,26 +40,35 @@ check_build_branch_merged_back() {
   fi
 }
 
-# spec ref: G2 — tag + non-draft GitHub release published (== release_published)
+# spec ref: G2 — tag + non-draft GitHub release published (== release_published).
+# The release tag is the FULL target version (9.2.0-beta.1), never the semver core.
 check_tag_and_release_published() {
-  local id="post-release/tag-and-release-published" title="Tag & GitHub release published"
-  HC_LINK="https://github.com/$UPSTREAM_REPO/releases/tag/$CORE_VERSION"
-  if [ "$RELEASE_PUBLISHED" = "true" ]; then
-    emit "$id" "$title" "$HC_PASS" "$HC_SEV_FAIL" "tag $CORE_VERSION published with a non-draft release"
+  local id="post-release/tag-and-release-published" title="Tag & GitHub release published" pre expected
+  HC_LINK="https://github.com/$UPSTREAM_REPO/releases/tag/$TARGET_VERSION"
+  if [ "$RELEASE_PUBLISHED" != "true" ]; then
+    emit "$id" "$title" "$HC_PENDING" "$HC_SEV_FAIL" "pending — no published release for $TARGET_VERSION yet"
+    return
+  fi
+  # The GitHub "pre-release" flag must match the release type (beta/RC flagged, stable not).
+  pre="$(gh release view "$TARGET_VERSION" --repo "$UPSTREAM_REPO" --json isPrerelease -q '.isPrerelease' 2>/dev/null)"
+  expected="false"; [ "$RELEASE_TYPE" = "pre-release" ] && expected="true"
+  if [ -z "$pre" ] || [ "$pre" = "$expected" ]; then
+    emit "$id" "$title" "$HC_PASS" "$HC_SEV_FAIL" "tag $TARGET_VERSION published with a non-draft release"
   else
-    emit "$id" "$title" "$HC_PENDING" "$HC_SEV_FAIL" "pending — no published release for $CORE_VERSION yet"
+    emit "$id" "$title" "$HC_FAIL" "$HC_SEV_WARN" "release $TARGET_VERSION published but its pre-release flag is '$pre' (expected '$expected' for a $RELEASE_TYPE)"
   fi
 }
 
-# spec ref: G3 — distribution API lists core_version (independent of the Classic release)
+# spec ref: G3 — distribution API lists the released version (independent of the Classic
+# release). The API carries the full tag, pre-release suffix included ("9.2.0-beta.1").
 check_distribution_api_fresh_install() {
   local id="post-release/distribution-api" title="Distribution API — fresh install"
   HC_LINK="https://api.prestashop-project.org/prestashop"
   _gate_published "$id" "$title" "$HC_SEV_WARN" || return
-  if http_body_contains "https://api.prestashop-project.org/prestashop" "\"version\":\"$CORE_VERSION\""; then
-    emit "$id" "$title" "$HC_PASS" "$HC_SEV_WARN" "distribution API lists $CORE_VERSION"
+  if http_body_contains "https://api.prestashop-project.org/prestashop" "\"version\":\"$TARGET_VERSION\""; then
+    emit "$id" "$title" "$HC_PASS" "$HC_SEV_WARN" "distribution API lists $TARGET_VERSION"
   else
-    emit "$id" "$title" "$HC_FAIL" "$HC_SEV_WARN" "distribution API does not list $CORE_VERSION yet"
+    emit "$id" "$title" "$HC_FAIL" "$HC_SEV_WARN" "distribution API does not list $TARGET_VERSION yet"
   fi
 }
 
@@ -69,6 +78,19 @@ check_docker_images_published() {
   HC_LINK="https://hub.docker.com/r/prestashop/prestashop/tags?name=$CORE_VERSION"
   _gate_published "$id" "$title" "$HC_SEV_WARN" || return
   # Docker PRs have generic titles ("Sync backlog …") — verify the published image tag instead.
+  if [ "$RELEASE_TYPE" = "pre-release" ]; then
+    # Pre-releases never get a plain core tag; they ship only as classic-edition images with
+    # the edition scope inserted before the prerelease label (e.g. 9.1.0-3.0-beta.1-classic).
+    parse_semver "$TARGET_VERSION"
+    local tags core_re="${CORE_VERSION//./\\.}"
+    tags=$(http_get "https://hub.docker.com/v2/repositories/prestashop/prestashop/tags/?name=${CORE_VERSION}-&page_size=100" | jq -r '.results[].name' 2>/dev/null)
+    if printf '%s\n' "$tags" | grep -qE "^${core_re}-[0-9][0-9.]*-${SV_PRERELEASE_LABEL}\.${SV_PRERELEASE_NUM}(-|\$)"; then
+      emit "$id" "$title" "$HC_PASS" "$HC_SEV_WARN" "Docker Hub has classic-edition images for $TARGET_VERSION"
+    else
+      emit "$id" "$title" "$HC_FAIL" "$HC_SEV_WARN" "no Docker Hub image for $TARGET_VERSION yet"
+    fi
+    return
+  fi
   local name
   name=$(http_get "https://hub.docker.com/v2/repositories/prestashop/prestashop/tags/$CORE_VERSION" | jq -r '.name // empty' 2>/dev/null)
   if [ -n "$name" ]; then
@@ -78,16 +100,33 @@ check_docker_images_published() {
   fi
 }
 
-# spec ref: G5 — classic feeds updated (independent of the Classic-release flag)
+# spec ref: G5 — classic feeds updated (independent of the Classic-release flag).
+# Classic version strings insert the edition scope between core and prerelease label
+# (9.1.4 → "9.1.4-5.0", 9.2.0-beta.1 → "9.2.0-6.0-beta.1"). Feed entries are extracted as
+# whole version tokens and matched exactly, so a beta entry can never satisfy a stable run
+# (or beta.1 a beta.10).
 check_classic_feeds_updated() {
   local id="post-release/classic-feeds" title="Classic feeds updated"
   local base="https://assets.prestashop3.com/dst/edition/corporate"
   HC_LINK="$base/edition_versions.js"
   _gate_published "$id" "$title" "$HC_SEV_WARN" || return
+  local core_re="${CORE_VERSION//./\\.}"
+  local token_re="${core_re}-[0-9][0-9.]*(-(alpha|beta|rc)\.[0-9]+)?"
+  if [ "$RELEASE_TYPE" = "pre-release" ]; then
+    # latest-classic.js only ever points at the latest STABLE — edition_versions.js alone.
+    parse_semver "$TARGET_VERSION"
+    if http_get "$base/edition_versions.js" | grep -oE "$token_re" \
+         | grep -qxE "${core_re}-[0-9][0-9.]*-${SV_PRERELEASE_LABEL}\.${SV_PRERELEASE_NUM}"; then
+      emit "$id" "$title" "$HC_PASS" "$HC_SEV_WARN" "edition_versions.js references $TARGET_VERSION (latest-classic is stable-only)"
+    else
+      emit "$id" "$title" "$HC_FAIL" "$HC_SEV_WARN" "edition_versions.js does not reference $TARGET_VERSION yet"
+    fi
+    return
+  fi
   # BOTH feeds must reference the version — one alone is an incomplete update.
   local ev="no" lc="no"
-  http_body_contains "$base/edition_versions.js" "$CORE_VERSION" && ev="yes"
-  http_body_contains "$base/latest-classic.js"   "$CORE_VERSION" && lc="yes"
+  http_get "$base/edition_versions.js" | grep -oE "$token_re" | grep -qxE "${core_re}-[0-9][0-9.]*" && ev="yes"
+  http_get "$base/latest-classic.js"   | grep -oE "$token_re" | grep -qxE "${core_re}-[0-9][0-9.]*" && lc="yes"
   if [ "$ev" = "yes" ] && [ "$lc" = "yes" ]; then
     emit "$id" "$title" "$HC_PASS" "$HC_SEV_WARN" "both classic feeds reference $CORE_VERSION"
   else
@@ -116,6 +155,11 @@ check_localization_packs() {
 # max upgrade target (the end state of merging public/json/autoupgrade.json).
 check_autoupgrade_pr_merged() {
   local id="post-release/autoupgrade-pr-merged" title="Autoupgrade max-version live" maxes
+  # The autoupgrade API only ever lists stable versions as max upgrade targets.
+  if [ "$RELEASE_TYPE" = "pre-release" ]; then
+    emit "$id" "$title" "$HC_NA" "$HC_SEV_WARN" "autoupgrade never targets pre-releases (this is $RELEASE_TYPE)"
+    return
+  fi
   HC_LINK="https://api.prestashop-project.org/autoupgrade"
   _gate_published "$id" "$title" "$HC_SEV_WARN" || return
   maxes=$(http_get "https://api.prestashop-project.org/autoupgrade" | jq -r '.prestashop[]?.prestashop_max' 2>/dev/null)

--- a/.github/release-healthcheck/release-content.sh
+++ b/.github/release-healthcheck/release-content.sh
@@ -11,17 +11,18 @@ HC_GROUP="Release content artifacts"
 
 CHANGELOG_FILE="docs/CHANGELOG.txt"   # NB: under docs/, not repo root
 
-# spec ref: D1 — CHANGELOG.txt has an entry for core_version (header e.g. "#   v9.1.4 - (2026-06-03)")
+# spec ref: D1 — CHANGELOG.txt has an entry for the full target version (header e.g.
+# "#   v9.1.4 - (2026-06-03)"; pre-releases keep their suffix: "v9.2.0-beta.1")
 check_changelog_updated() {
   HC_LINK="https://github.com/$REPO/blob/$REF/$CHANGELOG_FILE"
   if [ ! -f "$CHANGELOG_FILE" ]; then
     emit "release/changelog-updated" "Changelog updated" "$HC_FAIL" "$HC_SEV_FAIL" "$CHANGELOG_FILE not found"
     return
   fi
-  if grep -qF "v$CORE_VERSION" "$CHANGELOG_FILE"; then
-    emit "release/changelog-updated" "Changelog updated" "$HC_PASS" "$HC_SEV_FAIL" "$CHANGELOG_FILE has an entry for v$CORE_VERSION"
+  if grep -qF "v$TARGET_VERSION" "$CHANGELOG_FILE"; then
+    emit "release/changelog-updated" "Changelog updated" "$HC_PASS" "$HC_SEV_FAIL" "$CHANGELOG_FILE has an entry for v$TARGET_VERSION"
   else
-    emit "release/changelog-updated" "Changelog updated" "$HC_FAIL" "$HC_SEV_FAIL" "no v$CORE_VERSION entry in $CHANGELOG_FILE"
+    emit "release/changelog-updated" "Changelog updated" "$HC_FAIL" "$HC_SEV_FAIL" "no v$TARGET_VERSION entry in $CHANGELOG_FILE"
   fi
 }
 

--- a/.github/release-healthcheck/render.sh
+++ b/.github/release-healthcheck/render.sh
@@ -76,7 +76,7 @@ esac
 
 # --- Markdown report -----------------------------------------------------------
 {
-  echo "## 🩺 Release Healthcheck — ${CORE_VERSION:-?} on \`${REF:-?}\`"
+  echo "## 🩺 Release Healthcheck — ${TARGET_VERSION:-?} on \`${REF:-?}\`"
   echo
   echo "**Target:** \`${TARGET_VERSION:-?}\` · **Type:** ${RELEASE_TYPE:-?} · **Mode:** ${MODE}"
   echo "**Release published:** ${RELEASE_PUBLISHED:-?} · **Classic released:** ${CLASSIC_RELEASED:-?}"

--- a/.github/release-healthcheck/version-integrity.sh
+++ b/.github/release-healthcheck/version-integrity.sh
@@ -117,18 +117,19 @@ check_branch_naming() {
 check_tag_state_vs_publication() {
   local tag_present=0
   HC_LINK="https://github.com/$REPO/tags"
-  gh_tag_exists "$REPO" "$CORE_VERSION" && tag_present=1
+  # The release tag is the FULL target version (9.2.0-beta.1), not the semver core.
+  gh_tag_exists "$REPO" "$TARGET_VERSION" && tag_present=1
   if [ "$RELEASE_PUBLISHED" = "true" ]; then
     if [ "$tag_present" = 1 ]; then
-      emit "version/tag-state" "Tag state vs publication" "$HC_PASS" "$HC_SEV_WARN" "tag $CORE_VERSION present (release published)"
+      emit "version/tag-state" "Tag state vs publication" "$HC_PASS" "$HC_SEV_WARN" "tag $TARGET_VERSION present (release published)"
     else
-      emit "version/tag-state" "Tag state vs publication" "$HC_FAIL" "$HC_SEV_WARN" "release published but tag $CORE_VERSION missing"
+      emit "version/tag-state" "Tag state vs publication" "$HC_FAIL" "$HC_SEV_WARN" "release published but tag $TARGET_VERSION missing"
     fi
   else
     if [ "$tag_present" = 0 ]; then
-      emit "version/tag-state" "Tag state vs publication" "$HC_PASS" "$HC_SEV_WARN" "tag $CORE_VERSION absent (not yet published)"
+      emit "version/tag-state" "Tag state vs publication" "$HC_PASS" "$HC_SEV_WARN" "tag $TARGET_VERSION absent (not yet published)"
     else
-      emit "version/tag-state" "Tag state vs publication" "$HC_FAIL" "$HC_SEV_WARN" "tag $CORE_VERSION already exists before publication"
+      emit "version/tag-state" "Tag state vs publication" "$HC_FAIL" "$HC_SEV_WARN" "tag $TARGET_VERSION already exists before publication"
     fi
   fi
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Type?             | bug fix
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" section below.
| UI Tests          | N/A (release tooling only, no application code changed)
| Fixed issue or discussion?     | N/A (follow-up to #41804)
| Related PRs       | N/A
| Sponsor company   | PrestaShop

### Problem

After releasing 9.2.0-beta.1, the Release Healthcheck ([run 29907585355](https://github.com/PrestaShop/PrestaShop/actions/runs/29907585355), dispatched with `ref=9.2.0-beta.1`, `target_version=9.2.0-beta.1`) still reported the whole "Post-release verification" section as ➖ *pending — release not yet published*, even though the tag and the non-draft GitHub release both exist.

Root cause: `derive.sh` computed `release_published` by looking up a GitHub release named after the **semver core** (`9.2.0`, the pre-release suffix is stripped by `parse_semver`) instead of the **actual tag** (`9.2.0-beta.1`). The lookup found nothing, `release_published` stayed `false`, and `_gate_published` short-circuited every post-release check to PENDING.

The same run also exposed a second bug: *"⚠️ Tag state vs publication — tag 9.2.0 already exists before publication"*. `gh_tag_exists` used the `git/refs/tags/<tag>` API endpoint, which **prefix-matches** (`9.2.0` matched `9.2.0-beta.1`).

### Fix

The release tag is always the full `target_version` input, so tag/release lookups now use `TARGET_VERSION`; `CORE_VERSION` remains correct for file-content checks (`Version.php` on the beta tag legitimately holds `9.2.0`).

- **`derive.sh`** — `release_published` matches the release by the full tag. `classic_released` uses an exact, pre-release-aware pattern (Classic inserts its edition scope between core and label: `9.1.4-5.0`, `9.2.0-6.0-beta.1`); the previous prefix grep let `9.1.0-4.0-rc.1` satisfy a stable `9.1.0` run.
- **`lib.sh`** — `gh_tag_exists` switched to the singular `git/ref/tags/<tag>` endpoint (exact match, 404 when absent).
- **`post-release.sh`**
  - G2 uses the full tag in the link/details and additionally verifies the GitHub *pre-release* flag matches the release type.
  - G3: the distribution API lists the full tag (`"version":"9.2.0-beta.1"`), so the needle now uses it.
  - G4: pre-releases never get a plain `prestashop/prestashop:<version>` Docker tag — they ship only as classic-edition images (`9.1.0-3.0-beta.1-classic*`), so the pre-release path matches that naming against the tag list.
  - G5: `latest-classic.js` only ever points at the latest **stable**, so it is only required for stable releases; feed entries are extracted as whole version tokens and matched exactly, so a beta entry can no longer satisfy a stable run (or `beta.1` a `beta.10`).
  - G7: the autoupgrade API never lists pre-releases as max upgrade targets → N/A for pre-releases.
- **`cross-repo-readiness.sh`** — same N/A short-circuit for the F1 `autoupgrade.json` max-version check (the run wrongly reported ⚠️ *"no distribution-api change adds 9.2.0"*).
- **`version-integrity.sh`** — the tag-state check compares the full tag.
- **`release-content.sh`** — the changelog needle is the full version (`v9.2.0-beta.1` is the actual header at the tag).
- **`render.sh`** — the report header shows the full target version.

All ecosystem behaviors above were verified against the live endpoints (GitHub, distribution API, Docker Hub, Classic feeds, autoupgrade API).

### How to test

1. Dispatch **Release Healthcheck** from this branch with `ref=9.2.0-beta.1` and `target_version=9.2.0-beta.1`.
2. The "Post-release verification" section is now graded instead of all-pending. Expected: *Build branch merged back* ✅, *Tag & GitHub release published* ✅, *Distribution API* ✅, *Classic feeds* ✅, *Docker images* ⚠️ (genuine — no 9.2.0-beta.1 images on Docker Hub yet), *Localization packs* / *Autoupgrade max-version live* ➖ N/A; the cross-repo *Autoupgrade max-version* check is ➖ N/A instead of ⚠️.
3. Stable regression: dispatch with `ref=9.1.4`, `target_version=9.1.4` — every post-release check passes as before. Equivalent local dry-runs (read-only):

```bash
cd .github/release-healthcheck
HC_REF=9.2.0-beta.1 HC_TARGET_VERSION=9.2.0-beta.1 bash derive.sh   # release_published=true classic_released=true
HC_REF=9.1.4 HC_TARGET_VERSION=9.1.4 bash derive.sh                 # release_published=true classic_released=true
HC_REF=9.1.5 HC_TARGET_VERSION=9.1.5 bash derive.sh                 # both false (unreleased)
```
