### PR TITLE
Add product ID to catalog price rule edit URLs

### DIFF
--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -169,6 +169,10 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
             $this->object->price = -1;
         }
 
+        if (Tools::getIsset('id_product')) {
+            self::$currentIndex .= '&id_product=' . ((int) Tools::getValue('id_product'));
+        }
+
         $this->fields_form = [
             'legend' => [
                 'title' => $this->trans('Catalog price rules', [], 'Admin.Catalog.Feature'),
@@ -367,6 +371,14 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                 }
             }
             $object->apply();
+
+            if (Tools::getIsset('id_product')) {
+                $this->setRedirectAfter(
+                    $this->get('router')->generate('admin_products_edit', [
+                        'productId' => (int) Tools::getValue('id_product'),
+                    ])
+                );
+            }
 
             return $object;
         }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CatalogPriceRuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CatalogPriceRuleController.php
@@ -238,7 +238,14 @@ class CatalogPriceRuleController extends PrestaShopAdminController
         if ($result->isSubmitted() && $result->isValid()) {
             $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
 
-            return $this->redirectToRoute('admin_catalog_price_rules_index');
+            $productId = $request->query->getInt('id_product');
+            if ($productId > 0) {
+                return $this->redirectToRoute('admin_products_edit', [
+                    'productId' => $productId,
+                ]);
+            } else {
+                return $this->redirectToRoute('admin_catalog_price_rules_index');
+            }
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Catalog/CatalogPriceRule/edit.html.twig', [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
@@ -89,6 +89,7 @@ class EditProductFormType extends TranslatorAwareType
             ->add('shipping', ShippingType::class)
             ->add('pricing', PricingType::class, [
                 'tax_rules_group_id' => $options['tax_rules_group_id'],
+                'product_id' => $options['product_id'],
             ])
             ->add('seo', SEOType::class, [
                 'product_id' => $productId,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
@@ -11,6 +11,8 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -47,22 +49,15 @@ class CatalogPriceRulesType extends TranslatorAwareType
         $this->legacyContext = $legacyContext;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
-        parent::configureOptions($resolver);
+        parent::buildView($view, $form, $options);
 
         // When the Catalog price rules feature is enabled, links must point directly
         // to the new Symfony pages. Using getAdminLink() would resolve the legacy
         // controller to the Symfony route and attempt to generate it with a textual
         // placeholder that does not satisfy the route's numeric requirement.
         if ($this->featureFlagStateChecker->isEnabled('catalog_price_rule')) {
-            $catalogPriceRuleIndexLink = $this->urlGenerator->generate(
-                'admin_catalog_price_rules_index'
-            );
-
             // The edit route only accepts a numeric catalogPriceRuleId, so the final
             // JavaScript placeholder cannot be passed directly to the URL generator.
             // A temporary numeric value is used to generate a valid URL and is then
@@ -71,6 +66,7 @@ class CatalogPriceRulesType extends TranslatorAwareType
                 'admin_catalog_price_rules_edit',
                 [
                     'catalogPriceRuleId' => self::CATALOG_PRICE_RULE_ID_PLACEHOLDER,
+                    'id_product' => $options['product_id'],
                 ]
             );
 
@@ -87,20 +83,38 @@ class CatalogPriceRulesType extends TranslatorAwareType
             $catalogPriceRuleEditLink = $this->legacyContext->getAdminLink(
                 'AdminSpecificPriceRule',
                 true,
-                ['updatespecific_price_rule' => '', 'id_specific_price_rule' => 'catalog_price_rule_id']
+                ['updatespecific_price_rule' => '', 'id_specific_price_rule' => 'catalog_price_rule_id', 'id_product' => $options['product_id']]
             );
-            $catalogPriceRuleIndexLink = $this->legacyContext->getAdminLink('AdminSpecificPriceRule');
             /** Adding % to make link more unique */
             $catalogPriceRuleEditLink = str_replace('catalog_price_rule_id', '%catalog_price_rule_id%', $catalogPriceRuleEditLink);
+        }
+
+        $view->vars['attr']['data-catalog-price-url'] = $catalogPriceRuleEditLink;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        if ($this->featureFlagStateChecker->isEnabled('catalog_price_rule')) {
+            $catalogPriceRuleIndexLink = $this->urlGenerator->generate(
+                'admin_catalog_price_rules_index'
+            );
+        } else {
+            /**
+             * %catalog_price_rule_id% can't be used in this function, because getAdminLink adds unneeded stuff to % while creating url
+             * That's why catalog_price_rule_id is used and then string replaced.
+             */
+            $catalogPriceRuleIndexLink = $this->legacyContext->getAdminLink('AdminSpecificPriceRule');
         }
 
         $resolver->setDefaults([
             'form_theme' => '@PrestaShop/Admin/Sell/Catalog/Product/FormTheme/catalog_price_rules.html.twig',
             'label' => $this->trans('Catalog price rules', 'Admin.Catalog.Feature'),
             'label_tag_name' => 'h2',
-            'attr' => [
-                'data-catalog-price-url' => $catalogPriceRuleEditLink,
-            ],
             'external_link' => [
                 'text' => $this->trans('[1]Manage catalog price rules[/1]', 'Admin.Catalog.Feature'),
                 'href' => $catalogPriceRuleIndexLink,
@@ -110,6 +124,6 @@ class CatalogPriceRulesType extends TranslatorAwareType
                 'id' => 'catalog-price-rules-container',
                 'class' => 'd-none',
             ],
-        ]);
+        ])->setRequired('product_id');
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -92,7 +92,9 @@ class PricingType extends TranslatorAwareType
                     'data-show-label' => $this->trans('Show catalog price rules', 'Admin.Catalog.Feature'),
                 ],
             ])
-            ->add('catalog_price_rules', CatalogPriceRulesType::class)
+            ->add('catalog_price_rules', CatalogPriceRulesType::class, [
+                'product_id' => $options['product_id'],
+            ])
             ->add('priority_management', ProductSpecificPricePriorityType::class, [
                 'label' => $this->trans('Priority management', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h2',
@@ -113,6 +115,7 @@ class PricingType extends TranslatorAwareType
             ])
             ->setRequired([
                 'tax_rules_group_id',
+                'product_id',
             ]);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Pass the current product ID to catalog price rule edit links displayed in the product pricing form.<br/><br/>The product ID is propagated from `EditProductFormType` to `PricingType` and then to `CatalogPriceRulesType`.<br/><br/>The edit URL is generated in `CatalogPriceRulesType::buildView()`, where the product context is available through the resolved form options. Both the new Symfony catalog price rule page and the legacy `AdminSpecificPriceRule` controller are supported, depending on the `catalog_price_rule` feature flag.<br/><br/>This provides the catalog price rule edit page with the originating product context, allowing it to redirect the user back to the related product page after saving.
| Type?             | improvement
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1. Go to **Catalog > Discounts > Catalog Price Rules**.<br/>2. Create a catalog price rule that applies to the whole catalog.<br/>3. Open a product in the Back Office and go to the **Pricing** tab.<br/>4. Click **Show catalog price rules**.<br/>5. Check that the edit link of the catalog price rule contains the `id_product` parameter with the ID of the currently opened product.<br/>6. Click the edit link, save the catalog price rule, and check that you are redirected back to the product page.<br/>7. Go to **Advanced Parameters > New & Experimental Features** and enable **Catalog price rules**.<br/>8. Repeat steps 3, 4, 5, and 6.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/31156853585
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41929#issuecomment-5050649918
| Sponsor company   | Codencode snc
