### PR TITLE
Report which cookie fields overflow the 4096 bytes limit

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -370,7 +370,13 @@ class CookieCore
          * count in case of multi-byte characters.
          */
         if (strlen($this->_name . $content) > 4096) {
-            throw new PrestaShopException('Error during setting a cookie. Combined size of name and value cannot exceed 4096 characters. Larger cookie is not compliant with RFC 2965 and will not be accepted by the browser.');
+            throw new PrestaShopException(sprintf(
+                'Error during setting a cookie. Combined size of name and value cannot exceed 4096 characters. Larger cookie is not compliant with RFC 2965 and will not be accepted by the browser. Cookie "%s" is %d bytes long after encryption, %d bytes before. Largest stored fields, in bytes: %s.',
+                $this->_name,
+                strlen((string) $content),
+                strlen((string) $cookie),
+                $this->getLargestFieldsSummary()
+            ));
         }
 
         return setcookie(
@@ -385,6 +391,39 @@ class CookieCore
                 'samesite' => in_array((string) $this->_sameSite, CookieOptions::SAMESITE_AVAILABLE_VALUES) ? (string) $this->_sameSite : CookieOptions::SAMESITE_NONE,
             ]
         );
+    }
+
+    /**
+     * Returns a summary of the largest fields currently stored in the cookie, sorted from
+     * the largest one. It is meant to identify which module or which part of the code is
+     * overflowing the cookie, because the exception alone gives no hint about it.
+     *
+     * Only field names and their sizes in bytes are returned. Values are never disclosed,
+     * because they can contain personal data.
+     *
+     * @param int $limit Maximum number of fields to describe
+     *
+     * @return string
+     */
+    protected function getLargestFieldsSummary($limit = 10)
+    {
+        $sizes = [];
+        foreach ($this->_content as $key => $value) {
+            // Same serialization as in write(), so the sizes add up to the cookie content
+            $sizes[$key] = strlen($key . '|' . $value . '¤');
+        }
+        arsort($sizes);
+
+        $summary = [];
+        foreach (array_slice($sizes, 0, $limit, true) as $key => $size) {
+            $summary[] = $key . ' = ' . $size;
+        }
+
+        if (count($sizes) > $limit) {
+            $summary[] = sprintf('and %d more field(s)', count($sizes) - $limit);
+        }
+
+        return implode(', ', $summary);
     }
 
     /**


### PR DESCRIPTION
| Questions       | Answers |
|-----------------|---------|
| Branch?         | develop |
| Description?    | Adds diagnostic details to the exception thrown when the PrestaShop cookie exceeds the 4096 bytes limit, so it is possible to tell which field is overflowing it. |
| Type?           | improvement |
| Category?       | CO |
| BC breaks?      | no |
| Deprecations?   | no |
| How to test?    | See below. |
| UI Tests        | N/A, no UI change. |
| Fixed issue or discussion? | N/A |
| Related PRs     | N/A |
| Sponsor company | [OpenServis.cz](https://www.openservis.cz/) |

### Why

When something overflows the PrestaShop cookie, `Cookie::encryptAndSetCookie()` throws:

> Error during setting a cookie. Combined size of name and value cannot exceed 4096 characters. Larger cookie is not compliant with RFC 2965 and will not be accepted by the browser.

The check itself is right and should stay. The problem is that the message is not actionable: it does not say which cookie, how big it actually got, or - most importantly - which stored field is responsible.

In production this is painful to debug. The symptom is random and intermittent (empty cart, customer logged out, the exception fires on an arbitrary URL, a different one every time, often only for some visitors), the culprit is usually a third party module, and the shop owner cannot reproduce it. Today the only way forward is to patch `classes/Cookie.php` by hand on the live shop, add a temporary log, and wait for the next occurrence. I had to do exactly that recently on a shop running 8.1.6.

Everything needed is already in scope at the point of the throw: `$this->_content` holds the stored fields and `$cookie` holds the serialized payload before encryption. This PR just puts them in the message.

### Before

```
Error during setting a cookie. Combined size of name and value cannot exceed 4096 characters. Larger cookie is not compliant with RFC 2965 and will not be accepted by the browser.
```

### After

```
Error during setting a cookie. Combined size of name and value cannot exceed 4096 characters. Larger cookie is not compliant with RFC 2965 and will not be accepted by the browser. Cookie "PrestaShop-8f14e45fceea167a5a36dedd4bea2543" is 11880 bytes long after encryption, 5856 bytes before. Largest stored fields, in bytes: viewed = 3165, ps_some_module_state = 2304, passwd = 49, email = 33, date_add = 30, customer_lastname = 28, last_visited_category = 26, customer_firstname = 25, id_connections = 23, id_customer = 18, and 6 more field(s).
```

The offending field is the first thing you read.

### Notes

- **No data is disclosed.** Only field names and their sizes in bytes are listed, never values, because values can contain personal data. The exception message ends up in logs and, in debug mode, on screen.
- **The message stays bounded.** Fields are sorted from the largest one and capped at 10 entries, followed by `and N more field(s)`, so a cookie with many dynamic keys cannot produce an endless message. With the example above the whole message is ~540 bytes.
- **Both sizes are reported on purpose.** `Crypto::encrypt()` returns a hex string, so the stored value is roughly `2 * plaintext + 168` bytes. The real budget is therefore about 1.9 kB of plaintext, not the 4096 the message mentions. Module authors reading the current message assume they have 4096 bytes to play with; showing the plaintext size next to the encrypted one makes the actual room visible.
- **No cost in the normal flow.** The summary is only computed inside the `if`, on the error path.
- The size of each field is computed with the same serialization `write()` uses (`key . '|' . value . '¤'`), so the listed sizes add up to the plaintext size, minus the checksum field which `write()` appends afterwards.

### How to test

1. Use a shop in debug mode.
2. Make some code write an oversized value to the cookie, for example from a module hook:
   ```php
   $this->context->cookie->overflow_test = str_repeat('a', 4000);
   ```
   The historical real world way to reach the same state is to browse ~450 products with `ps_viewedproduct` enabled, see #26996.
3. Reload the front office.
4. The `PrestaShopException` message now names the cookie, gives its encrypted and plaintext size, and lists `overflow_test` at the top of the field list.
5. Remove the oversized value, browse again, and check that nothing changed in the normal flow.
