### PR TITLE
Backport #40575 to 9.2.x

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2332,13 +2332,13 @@ class CartCore extends ObjectModel
      *
      * @param array $products list of products to calculate on
      * @param array $cartRules list of cart rules to apply
-     * @param int $id_carrier carrier id (fees calculation)
+     * @param int|null $id_carrier carrier id (fees calculation)
      * @param int|null $computePrecision
      * @param bool $keepOrderPrices When true use the Order saved prices instead of the most recent ones from catalog (if Order exists)
      *
      * @return Calculator
      */
-    public function newCalculator($products, $cartRules, $id_carrier, $computePrecision = null, bool $keepOrderPrices = false)
+    public function newCalculator($products, $cartRules, $id_carrier = null, $computePrecision = null, bool $keepOrderPrices = false)
     {
         $orderId = null;
         if ($keepOrderPrices) {

--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -21,6 +21,7 @@ use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingLazyArray;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use PrestaShop\PrestaShop\Core\Cart\Calculator;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tools;
 
@@ -36,6 +37,8 @@ class CartLazyArray extends AbstractLazyArray
     private TranslatorInterface $translator;
 
     private PriceFormatter $priceFormatter;
+
+    private Calculator $calculator;
 
     private array $products;
 
@@ -87,6 +90,13 @@ class CartLazyArray extends AbstractLazyArray
             new ProductColorsRetriever(),
             $this->translator
         );
+        $this->calculator = $this->cart->newCalculator(
+            $this->cart->getProducts(),
+            $this->cart->getCartRules(CartRule::FILTER_ACTION_ALL, false),
+            null,
+            $context->getComputingPrecision()
+        );
+        $this->calculator->processCalculation();
         parent::__construct();
     }
 
@@ -94,11 +104,9 @@ class CartLazyArray extends AbstractLazyArray
     public function getProducts(): array
     {
         // Get raw products
-        if ($this->shouldSeparateGifts) {
-            $rawProducts = $this->cart->getProductsWithSeparatedGifts();
-        } else {
-            $rawProducts = $this->cart->getProducts();
-        }
+        $rawProducts = $this->shouldSeparateGifts
+            ? $this->cart->getProductsWithSeparatedGifts()
+            : $this->cart->getProducts();
 
         /*
          * Now, we will fetch additional product data by the assembler, like we do when presenting
@@ -302,24 +310,19 @@ class CartLazyArray extends AbstractLazyArray
     public function getDiscounts(): array
     {
         $vouchers = $this->getVouchers();
-        $cartRulesIds = array_flip(array_map(
-            function ($voucher) {
-                return $voucher['id_cart_rule'];
-            },
-            $vouchers['added']
-        ));
+        $cartRulesIds = array_keys($vouchers['added']);
 
         $discounts = $this->cart->getDiscounts();
-        $cart = $this->cart;
-        $discounts = array_filter($discounts, function ($discount) use ($cartRulesIds, $cart) {
+        $customerId = $this->cart->id_customer;
+        $discounts = array_filter($discounts, function ($discount) use ($cartRulesIds, $customerId) {
             $voucherCustomerId = (int) $discount['id_customer'];
             $voucherIsRestrictedToASingleCustomer = ($voucherCustomerId !== 0);
             $voucherIsEmptyCode = empty($discount['code']);
-            if ($voucherIsRestrictedToASingleCustomer && $cart->id_customer !== $voucherCustomerId && $voucherIsEmptyCode) {
+            if ($voucherIsRestrictedToASingleCustomer && $customerId !== $voucherCustomerId && $voucherIsEmptyCode) {
                 return false;
             }
 
-            return !array_key_exists($discount['id_cart_rule'], $cartRulesIds);
+            return !in_array($discount['id_cart_rule'], $cartRulesIds);
         });
 
         $this->discounts = $discounts;
@@ -413,13 +416,31 @@ class CartLazyArray extends AbstractLazyArray
 
     private function getTemplateVarVouchers(): array
     {
-        $cartVouchers = $this->cart->getCartRules();
         $vouchers = [];
 
         $cartHasTax = null === $this->cart->id ? false : $this->cart->getAverageProductsTaxRate() * 100;
         $freeShippingAlreadySet = false;
-        /** @var array{id_cart_rule:int, name: string, code: string, reduction_percent: float, reduction_currency: int, free_shipping: bool, reduction_tax: bool, reduction_amount:float, value_real:float|int|string, value_tax_exc:float|int|string} $cartVoucher */
-        foreach ($cartVouchers as $cartVoucher) {
+        
+        foreach ($this->calculator->getCartRulesData() as $cartRuleData) {
+            /** @var array{id_cart_rule:int, name: string, code: string, reduction_percent: float, reduction_currency: int, free_shipping: bool, reduction_tax: bool, reduction_amount:float, value_real:float|int|string, value_tax_exc:float|int|string} $cartVoucher */
+            $cartVoucher = $cartRuleData->getRuleData();
+            $discountApplied = $cartRuleData->getDiscountApplied();
+
+            $freeShippingOnly = false;
+            $totalCartVoucherReduction = 0;
+
+            if ($this->cartVoucherHasFreeShippingOnly($cartVoucher)) {
+                $freeShippingOnly = true;
+                if ($freeShippingAlreadySet) {
+                    continue;
+                }
+                $freeShippingAlreadySet = true;
+            } else {
+                $totalCartVoucherReduction = $this->cartPresenter->includeTaxes()
+                    ? $discountApplied->getTaxIncluded()
+                    : $discountApplied->getTaxExcluded();
+            }
+
             $vouchers[$cartVoucher['id_cart_rule']]['id_cart_rule'] = $cartVoucher['id_cart_rule'];
             $vouchers[$cartVoucher['id_cart_rule']]['name'] = $cartVoucher['name'];
             $vouchers[$cartVoucher['id_cart_rule']]['code'] = $cartVoucher['code'];
@@ -439,32 +460,11 @@ class CartLazyArray extends AbstractLazyArray
                 $cartVoucher['reduction_amount'] = $cartVoucher['value_real'];
             }
 
-            $totalCartVoucherReduction = 0;
-
-            if ($this->cartVoucherHasFreeShippingOnly($cartVoucher)) {
-                $freeShippingOnly = true;
-                if ($freeShippingAlreadySet) {
-                    unset($vouchers[$cartVoucher['id_cart_rule']]);
-                    continue;
-                } else {
-                    $freeShippingAlreadySet = true;
-                }
-            } else {
-                $freeShippingOnly = false;
-                $totalCartVoucherReduction = $this->cartPresenter->includeTaxes() ? $cartVoucher['value_real'] : $cartVoucher['value_tax_exc'];
-            }
-
             // when a voucher has only a shipping reduction, the value displayed must be "Free Shipping"
-            if ($freeShippingOnly) {
-                $cartVoucher['reduction_formatted'] = $this->translator->trans(
-                    'Free shipping',
-                    [],
-                    'Shop.Theme.Checkout'
-                );
-            } else {
-                $cartVoucher['reduction_formatted'] = '-' . $this->priceFormatter->format($totalCartVoucherReduction);
-            }
-            $vouchers[$cartVoucher['id_cart_rule']]['reduction_formatted'] = $cartVoucher['reduction_formatted'];
+            $vouchers[$cartVoucher['id_cart_rule']]['reduction_formatted'] = $freeShippingOnly
+                ? $this->translator->trans('Free shipping', [], 'Shop.Theme.Checkout')
+                : '-' . $this->priceFormatter->format($totalCartVoucherReduction);
+            
             $vouchers[$cartVoucher['id_cart_rule']]['delete_url'] = $this->link->getPageLink(
                 'cart',
                 null,

--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -420,7 +420,7 @@ class CartLazyArray extends AbstractLazyArray
 
         $cartHasTax = null === $this->cart->id ? false : $this->cart->getAverageProductsTaxRate() * 100;
         $freeShippingAlreadySet = false;
-        
+
         foreach ($this->calculator->getCartRulesData() as $cartRuleData) {
             /** @var array{id_cart_rule:int, name: string, code: string, reduction_percent: float, reduction_currency: int, free_shipping: bool, reduction_tax: bool, reduction_amount:float, value_real:float|int|string, value_tax_exc:float|int|string} $cartVoucher */
             $cartVoucher = $cartRuleData->getRuleData();
@@ -464,7 +464,7 @@ class CartLazyArray extends AbstractLazyArray
             $vouchers[$cartVoucher['id_cart_rule']]['reduction_formatted'] = $freeShippingOnly
                 ? $this->translator->trans('Free shipping', [], 'Shop.Theme.Checkout')
                 : '-' . $this->priceFormatter->format($totalCartVoucherReduction);
-            
+
             $vouchers[$cartVoucher['id_cart_rule']]['delete_url'] = $this->link->getPageLink(
                 'cart',
                 null,

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -24,7 +24,7 @@ class Calculator
     protected $cart;
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $id_carrier;
 
@@ -67,11 +67,11 @@ class Calculator
 
     /**
      * @param CartCore $cart
-     * @param int $carrierId
+     * @param int|null $carrierId
      * @param int|null $computePrecision
      * @param int|null $orderId
      */
-    public function __construct(CartCore $cart, $carrierId, ?int $computePrecision = null, ?int $orderId = null, ?FeatureFlagStateCheckerInterface $featureFlagManager = null)
+    public function __construct(CartCore $cart, ?int $carrierId = null, ?int $computePrecision = null, ?int $orderId = null, ?FeatureFlagStateCheckerInterface $featureFlagManager = null)
     {
         $this->setCart($cart);
         $this->setCarrierId($carrierId);

--- a/tests/Integration/Adapter/Cart/CartVoucherSummaryTest.php
+++ b/tests/Integration/Adapter/Cart/CartVoucherSummaryTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Cart;
+
+use Address;
+use Cart;
+use CartRule;
+use Configuration;
+use Context;
+use Currency;
+use DateTime;
+use Db;
+use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter;
+use Product;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class CartVoucherSummaryTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        // ContainerFinder (used by Cart::getCartRules) reads the global $kernel.
+        global $kernel;
+        $kernel = self::$kernel;
+        Context::getContext()->currency = Currency::getDefaultCurrency();
+        Configuration::updateValue('PS_ORDER_OUT_OF_STOCK', true);
+        Configuration::updateValue('PS_TAX_ADDRESS_TYPE', 'id_address_invoice');
+        // Pre-existing (auto-applied) cart rules would pollute the cart summary.
+        Db::getInstance()->execute('UPDATE ' . _DB_PREFIX_ . 'cart_rule SET active = 0');
+        Configuration::set('PS_CART_RULE_FEATURE_ACTIVE', true);
+    }
+
+    /**
+     * Two percentage vouchers restricted to the same product stack: the first takes 10% of the
+     * price, the second takes 10% of the already-reduced price. The cart summary must show each
+     * voucher's actually-applied reduction, so the per-voucher figures sum to the cart's real
+     * discount - not the naive per-rule value that double-counts (10 + 10 instead of 10 + 9).
+     */
+    public function testProductRestrictedPercentageVouchersSummarizeTheAppliedReduction(): void
+    {
+        $lang = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        $address = new Address();
+        $address->id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $address->firstname = 'Unit';
+        $address->lastname = 'Tester';
+        $address->address1 = '55 rue Raspail';
+        $address->alias = microtime() . getmypid();
+        $address->city = 'Levallois';
+        $address->save();
+
+        $product = new Product(null, false, $lang);
+        $product->id_tax_rules_group = 0;
+        $product->name = 'Voucher summary product';
+        $product->price = 100;
+        $product->link_rewrite = 'voucher-summary-product';
+        $product->save();
+
+        $cart = new Cart(null, $lang);
+        $cart->id_currency = Currency::getDefaultCurrencyId();
+        $cart->id_address_invoice = (int) $address->id;
+        $cart->save();
+        Context::getContext()->cart = $cart;
+        $cart->updateQty(1, (int) $product->id);
+
+        foreach (['A', 'B'] as $suffix) {
+            $cartRule = new CartRule(null, $lang);
+            $cartRule->name = 'Ten percent ' . $suffix;
+            $from = (new DateTime())->modify('-2 days');
+            $to = (new DateTime())->modify('+2 days');
+            $cartRule->date_from = $from->format('Y-m-d H:i:s');
+            $cartRule->date_to = $to->format('Y-m-d H:i:s');
+            $cartRule->quantity = 100;
+            $cartRule->quantity_per_user = 100;
+            $cartRule->reduction_percent = 10;
+            $cartRule->reduction_product = (int) $product->id;
+            $cartRule->active = true;
+            $cartRule->save();
+            $cart->addCartRule((int) $cartRule->id);
+        }
+
+        $presented = (new CartPresenter())->present($cart);
+
+        $vouchers = $presented['vouchers']['added'];
+        self::assertCount(2, $vouchers, 'Both vouchers should be listed in the summary.');
+
+        $displayedReductions = array_map(
+            static function (array $voucher): float {
+                // reduction_formatted is a signed, currency-formatted string, e.g. "-$9.00".
+                return (float) preg_replace('/[^\d.]/', '', $voucher['reduction_formatted']);
+            },
+            array_values($vouchers)
+        );
+
+        $cartDiscount = (float) $presented['subtotals']['discounts']['amount'];
+
+        self::assertEqualsWithDelta(
+            $cartDiscount,
+            array_sum($displayedReductions),
+            0.001,
+            'The reductions shown per voucher must sum to the cart discount actually applied.'
+        );
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | This PR backports #40575 to the `9.2.x` branch.<br/>It updates the cart summary voucher amounts to use the values calculated by the cart calculator as the source of truth.<br/><br/>Previously, when multiple percentage-based cart rules were applied to the same product, the amounts displayed for each voucher could be calculated independently and therefore not match the reductions actually applied to the cart.<br/><br/>For example, with a €10 product and two consecutive 10% discounts, the cart summary could display both vouchers as €1, even though the second discount is applied to the already discounted amount and should therefore be €0.90.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add two restricted product discount codes to reduce the product price by 10%. Add the selected product to your cart, apply both codes, and verify that the cart rules summary displays the cascading values.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/30093513171
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/40575
| Sponsor company   | Codencode snc
