### PR TITLE
Emit handleError instead of calling the non-existing trigger method

### DIFF
--- a/themes/_core/js/checkout-delivery.js
+++ b/themes/_core/js/checkout-delivery.js
@@ -56,7 +56,7 @@ export default function () {
         });
       })
       .fail((resp) => {
-        prestashop.trigger('handleError', {
+        prestashop.emit('handleError', {
           eventType: 'updateDeliveryOptions',
           resp,
         });


### PR DESCRIPTION
| Questions                  | Answers
| -------------------------- | -------------------------------------------------------
| Branch?                    | 8.2.x
| Description?               | The `.fail()` handler of the delivery options update calls `prestashop.trigger()`, which does not exist on the emitter, so the error handler itself throws and the real failure is never reported. Every other `handleError` in the core is emitted with `prestashop.emit()`.
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | On the checkout shipping step, make the delivery options request fail (go offline in devtools, then select another carrier). Before: `TypeError: prestashop.trigger is not a function`. After: `handleError` is emitted like everywhere else.
| Fixed issue or discussion? | #42118
| Sponsor company            | OpenServis.cz
