### PR TITLE
Fix Pack::getQuantity ignoring 'Decrement pack only' stock type

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -290,6 +290,7 @@ class PackCore extends Product
          */
 
         // If no pack stock or shop default, set it from configuration
+        // Avoid using empty(), because it would treat STOCK_TYPE_PACK_ONLY (0) as STOCK_TYPE_DEFAULT
         if ($packStockType === null || $packStockType === '' || (int) $packStockType == self::STOCK_TYPE_DEFAULT) {
             $packStockType = Configuration::get('PS_PACK_STOCK_TYPE');
         }

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -290,7 +290,7 @@ class PackCore extends Product
          */
 
         // If no pack stock or shop default, set it from configuration
-        if (empty($packStockType) || $packStockType == self::STOCK_TYPE_DEFAULT) {
+        if ($packStockType === null || $packStockType === '' || (int) $packStockType == self::STOCK_TYPE_DEFAULT) {
             $packStockType = Configuration::get('PS_PACK_STOCK_TYPE');
         }
 


### PR DESCRIPTION
Pack::getQuantity() resolved the pack stock type with empty($packStockType), which treats the legitimate value 0 (PackStockType::STOCK_TYPE_PACK_ONLY, "Decrement pack only") as unset and falls back to the global PS_PACK_STOCK_TYPE configuration. Displayed pack availability was therefore computed with the wrong mode, while the stock decrement path (StockManager::updatePackQuantity) honors the per-pack setting, so the two diverge with every order.

Replace empty() with explicit null / empty-string checks so an explicit "Decrement pack only" is honored, keeping the legacy fallback for NULL values from old databases.

Fixes #42079

<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers                                                                 |
|-------------------|-------------------------------------------------------------------------|
| Branch?           | 9.2.x                                                                   |
| Description?      | Pack::getQuantity() resolved the pack stock type with empty($packStockType), which treats the legitimate value 0 (PackStockType::STOCK_TYPE_PACK_ONLY, "Decrement pack only") as unset and falls back to the global PS_PACK_STOCK_TYPE configuration. Displayed pack availability was therefore computed with the wrong mode, while the stock decrement path (StockManager::updatePackQuantity()) honors the per-pack setting, so the displayed stock and the actually decremented stock diverge with every order. This PR replaces empty() with explicit null / empty-string checks so an explicit "Decrement pack only" is honored, while keeping the legacy fallback for NULL values from old databases. |
| Type?             | bug fix                                                                 |
| Category?         | CO                                                                      |
| BC breaks?        | no                                                                      |
| Deprecations?     | no                                                                      |
| How to test?      | 1. Shop Parameters > Product Settings > set "Default pack stock management" to "Decrement products in pack only". 2. Create product A (qty 10) and product B (qty 20). 3. Create a pack containing 2×A + 1×B, set the pack's own quantity to 1 and its stock management (product page > Quantities) to "Decrement pack only". 4. Open the pack's page in FO. Before this fix the displayed quantity is 5 (computed from components per the global setting); after the fix it is 1 (the pack's own stock — per-pack setting honored). |
| UI Tests        |  https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/30270430790 |
| Fixed issue or discussion?     | Fixes #42079                                                            |
| Related PRs       |   |
| Sponsor company      |   |


Rebased version of #42080 onto `9.2.x`, as requested by @Hlavtox.
