### PR TITLE
Expose the attachment id and accept scalar ids in attachment for-editing CQRS

### DIFF
--- a/src/Adapter/Attachment/QueryHandler/GetAttachmentForEditingHandler.php
+++ b/src/Adapter/Attachment/QueryHandler/GetAttachmentForEditingHandler.php
@@ -46,6 +46,7 @@ final class GetAttachmentForEditingHandler implements GetAttachmentForEditingHan
         $file = file_exists($filePath) ? new SplFileInfo($filePath) : null;
 
         $editableAttachment = new EditableAttachment(
+            $attachmentIdValue,
             $attachment->file_name,
             $attachment->name,
             $attachment->description

--- a/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
+++ b/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
@@ -49,11 +49,11 @@ class EditAttachmentCommand
     private $fileSize;
 
     /**
-     * @param AttachmentId $attachmentId
+     * @param int $attachmentId
      */
-    public function __construct(AttachmentId $attachmentId)
+    public function __construct(int $attachmentId)
     {
-        $this->attachmentId = $attachmentId;
+        $this->attachmentId = new AttachmentId($attachmentId);
     }
 
     /**

--- a/src/Core/Domain/Attachment/Query/GetAttachmentForEditing.php
+++ b/src/Core/Domain/Attachment/Query/GetAttachmentForEditing.php
@@ -20,13 +20,13 @@ class GetAttachmentForEditing
     private $attachmentId;
 
     /**
-     * @param int $attachmentIdValue
+     * @param int $attachmentId
      *
      * @throws AttachmentConstraintException
      */
-    public function __construct(int $attachmentIdValue)
+    public function __construct(int $attachmentId)
     {
-        $this->attachmentId = new AttachmentId($attachmentIdValue);
+        $this->attachmentId = new AttachmentId($attachmentId);
     }
 
     /**

--- a/src/Core/Domain/Attachment/QueryResult/EditableAttachment.php
+++ b/src/Core/Domain/Attachment/QueryResult/EditableAttachment.php
@@ -14,6 +14,11 @@ use SplFileInfo;
 class EditableAttachment
 {
     /**
+     * @var int
+     */
+    private $attachmentId;
+
+    /**
      * @var string
      */
     private $fileName;
@@ -34,18 +39,29 @@ class EditableAttachment
     private $file;
 
     /**
+     * @param int $attachmentId
      * @param string $fileName
      * @param string[] $name
      * @param string[] $description
      */
     public function __construct(
+        int $attachmentId,
         string $fileName,
         array $name,
         array $description
     ) {
+        $this->attachmentId = $attachmentId;
         $this->fileName = $fileName;
         $this->name = $name;
         $this->description = $description;
+    }
+
+    /**
+     * @return int
+     */
+    public function getAttachmentId(): int
+    {
+        return $this->attachmentId;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataHandler/AttachmentFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/AttachmentFormDataHandler.php
@@ -73,7 +73,7 @@ final class AttachmentFormDataHandler implements FormDataHandlerInterface
         /** @var UploadedFile|null $fileObject */
         $fileObject = $data['file'];
 
-        $command = new EditAttachmentCommand($attachmentId);
+        $command = new EditAttachmentCommand($attachmentId->getValue());
         $command->setLocalizedNames($data['name']);
         $command->setLocalizedDescriptions($data['file_description']);
 

--- a/tests/Unit/Core/Domain/Attachment/AttachmentForEditingTest.php
+++ b/tests/Unit/Core/Domain/Attachment/AttachmentForEditingTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Attachment;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Command\EditAttachmentCommand;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Query\GetAttachmentForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\QueryResult\EditableAttachment;
+
+class AttachmentForEditingTest extends TestCase
+{
+    public function testEditableAttachmentExposesItsId(): void
+    {
+        $editableAttachment = new EditableAttachment(42, 'doc.pdf', [1 => 'Doc'], [1 => 'Description']);
+
+        $this->assertSame(42, $editableAttachment->getAttachmentId());
+        $this->assertSame('doc.pdf', $editableAttachment->getFileName());
+    }
+
+    public function testGetAttachmentForEditingAcceptsAScalarId(): void
+    {
+        $query = new GetAttachmentForEditing(42);
+
+        $this->assertSame(42, $query->getAttachmentId()->getValue());
+    }
+
+    public function testEditAttachmentCommandAcceptsAScalarId(): void
+    {
+        $command = new EditAttachmentCommand(42);
+
+        $this->assertSame(42, $command->getAttachmentId()->getValue());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | 9.1.x counterpart of #41889 (approved, targets `develop`). `EditableAttachment` now carries the attachment id (`getAttachmentId()`) like the other for-editing results (e.g. `EditableTitle::getTitleId`), and `GetAttachmentForEditing` / `EditAttachmentCommand` accept a scalar `int` id and build the `AttachmentId` value object internally — matching `GetTitleForEditing`, `EditTitleCommand`, `EditCatalogPriceRuleCommand`. The only internal callers (`AttachmentFormDataHandler`, `AttachmentController`, `AttachmentFormDataProvider`) are updated or already pass an `int`. No behaviour change.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/Domain/Attachment/AttachmentForEditingTest.php` covers the id accessor and both scalar-id constructors. Back-office attachment add/edit (Catalog > Files) is unaffected: the form data handler now passes `$attachmentId->getValue()`.
| UI Tests          | n/a (back-office CQRS, covered by a unit test)
| Fixed issue or discussion? | 9.1.x counterpart of #41889
| Related PRs       | #41889 (same change on `develop`), #39966 (earlier attempt on the now-deleted 9.0.x branch), PrestaShop/ps_apiresources#295
| Sponsor company   | Boring Investments

### Why this is needed on 9.1.x

Without it, `GetAttachmentForEditing::__construct(int $attachmentIdValue)` does not match the `attachmentId` key the CQRS API normalizer sends, so the Admin API Attachment endpoints fail on 9.1.x with:

```
Cannot create an instance of "...\Attachment\Query\GetAttachmentForEditing" from serialized data
because its constructor requires the following parameters to be present : "$attachmentIdValue".
```

PrestaShop/ps_apiresources#295 tests its Attachment endpoints against 9.0.3, 9.1.x and `develop`; the 9.1.x jobs cannot pass until this lands here. #41889 covers `develop` only, and this project has no automatic forward/backport, so 9.1.x needs its own PR.

This is also where the change was asked to go: #39966 proposed the same fix on 9.0.x and was asked to rebase onto 9.1.x, then closed when 9.0.x was deleted on 2026-04-06.

Note for reviewers: the `EditableAttachment` and `EditAttachmentCommand` constructor signatures change. Both are constructed only from core code, which is updated in this PR, so nothing in core or the bundled modules breaks; third-party code instantiating those two Core Domain classes directly would need the scalar id. Same shape as the approved #41889.
