### PR TITLE
Feat: Resolve active tab and toolbar display for tab-less routes

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdminAPIController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdminAPIController.php
@@ -40,7 +40,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class AdminAPIController extends PrestaShopAdminController
 {
-    #[AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")]
+    #[AdminSecurity("is_granted('create', 'AdminAdminAPI') || is_granted('update', 'AdminAdminAPI') || is_granted('delete', 'AdminAdminAPI') || is_granted('read', 'AdminAdminAPI')")]
     public function indexAction(
         ApiClientFilters $apiClientFilters,
         #[Autowire(service: 'prestashop.adapter.admin_api.form_handler')]
@@ -51,7 +51,7 @@ class AdminAPIController extends PrestaShopAdminController
         return $this->renderIndex($apiClientFilters, $formHandler->getForm(), $gridFactory);
     }
 
-    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))")]
+    #[AdminSecurity("is_granted('update', 'AdminAdminAPI')")]
     public function processConfigurationAction(
         ApiClientFilters $apiClientFilters,
         Request $request,
@@ -79,7 +79,7 @@ class AdminAPIController extends PrestaShopAdminController
         return $this->renderIndex($apiClientFilters, $configurationForm, $gridFactory);
     }
 
-    #[AdminSecurity("is_granted('create', request.get('_legacy_controller'))", redirectRoute: 'admin_api_index')]
+    #[AdminSecurity("is_granted('create', 'AdminAdminAPI')", redirectRoute: 'admin_api_index')]
     public function createAction(
         Request $request,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.api_client_form_builder')]
@@ -119,7 +119,7 @@ class AdminAPIController extends PrestaShopAdminController
         );
     }
 
-    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_api_index')]
+    #[AdminSecurity("is_granted('update', 'AdminAdminAPI')", redirectRoute: 'admin_api_index')]
     public function editAction(
         Request $request,
         int $apiClientId,
@@ -156,7 +156,7 @@ class AdminAPIController extends PrestaShopAdminController
         ]);
     }
 
-    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_api_clients_edit')]
+    #[AdminSecurity("is_granted('update', 'AdminAdminAPI')", redirectRoute: 'admin_api_clients_edit')]
     public function regenerateSecretAction(int $apiClientId): RedirectResponse
     {
         try {
@@ -172,7 +172,7 @@ class AdminAPIController extends PrestaShopAdminController
         return $this->redirectToRoute('admin_api_clients_edit', ['apiClientId' => $apiClientId]);
     }
 
-    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_api_index')]
+    #[AdminSecurity("is_granted('update', 'AdminAdminAPI')", redirectRoute: 'admin_api_index')]
     public function toggleStatusAction(int $apiClientId): JsonResponse
     {
         /** @var EditableApiClient $editableApiClient */
@@ -195,7 +195,7 @@ class AdminAPIController extends PrestaShopAdminController
         ]);
     }
 
-    #[AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message: 'You do not have permission to delete this.', redirectRoute: 'admin_api_index')]
+    #[AdminSecurity("is_granted('delete', 'AdminAdminAPI')", message: 'You do not have permission to delete this.', redirectRoute: 'admin_api_index')]
     public function deleteAction(int $apiClientId): RedirectResponse
     {
         try {

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ExtraPropertyDefinitionController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ExtraPropertyDefinitionController.php
@@ -51,7 +51,7 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
      *
      * @return Response
      */
-    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+    #[AdminSecurity("is_granted('read', 'AdminExtraPropertyDefinitions')")]
     public function indexAction(
         ExtraPropertyDefinitionFilters $filters,
         #[Autowire(service: 'prestashop.core.grid.factory.extra_property_definition')]
@@ -80,7 +80,7 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
      *
      * @return Response|RedirectResponse
      */
-    #[AdminSecurity("is_granted('create', request.get('_legacy_controller'))")]
+    #[AdminSecurity("is_granted('create', 'AdminExtraPropertyDefinitions')")]
     public function createAction(
         Request $request,
         #[Autowire(service: 'prestashop.core.form.builder.extra_property_definition_form_builder')]
@@ -128,7 +128,7 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
      * Always responds 200: an unknown or un-introspectable form yields {"available": false}
      * and the UI falls back to a free-text path input.
      */
-    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+    #[AdminSecurity("is_granted('read', 'AdminExtraPropertyDefinitions')")]
     public function formFieldsAction(string $formId, FormFieldTreeProvider $treeProvider): JsonResponse
     {
         $fields = $treeProvider->getTree($formId);
@@ -155,7 +155,7 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
      *
      * @return Response|RedirectResponse
      */
-    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_extra_property_definitions_index')]
+    #[AdminSecurity("is_granted('update', 'AdminExtraPropertyDefinitions')", redirectRoute: 'admin_extra_property_definitions_index')]
     public function editAction(
         int $extraPropertyDefinitionId,
         Request $request,
@@ -223,7 +223,7 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
      *
      * @return Response|RedirectResponse
      */
-    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute: 'admin_extra_property_definitions_index')]
+    #[AdminSecurity("is_granted('read', 'AdminExtraPropertyDefinitions')", redirectRoute: 'admin_extra_property_definitions_index')]
     public function viewAction(
         int $extraPropertyDefinitionId,
         #[Autowire(service: 'prestashop.core.form.builder.extra_property_definition_form_builder')]
@@ -263,7 +263,7 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
      * @return RedirectResponse
      */
     #[DemoRestricted(redirectRoute: 'admin_extra_property_definitions_index')]
-    #[AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message: 'You do not have permission to delete this.')]
+    #[AdminSecurity("is_granted('delete', 'AdminExtraPropertyDefinitions')", message: 'You do not have permission to delete this.')]
     public function deleteAction(int $extraPropertyDefinitionId): RedirectResponse
     {
         return $this->doDelete($extraPropertyDefinitionId, false);
@@ -277,7 +277,7 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
      * @return RedirectResponse
      */
     #[DemoRestricted(redirectRoute: 'admin_extra_property_definitions_index')]
-    #[AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message: 'You do not have permission to delete this.')]
+    #[AdminSecurity("is_granted('delete', 'AdminExtraPropertyDefinitions')", message: 'You do not have permission to delete this.')]
     public function deleteDropColumnAction(int $extraPropertyDefinitionId): RedirectResponse
     {
         return $this->doDelete($extraPropertyDefinitionId, true);
@@ -309,7 +309,7 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
      * @return RedirectResponse
      */
     #[DemoRestricted(redirectRoute: 'admin_extra_property_definitions_index')]
-    #[AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message: 'You do not have permission to delete this.')]
+    #[AdminSecurity("is_granted('delete', 'AdminExtraPropertyDefinitions')", message: 'You do not have permission to delete this.')]
     public function bulkDeleteAction(Request $request): RedirectResponse
     {
         return $this->doBulkDelete($request, false);
@@ -323,7 +323,7 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
      * @return RedirectResponse
      */
     #[DemoRestricted(redirectRoute: 'admin_extra_property_definitions_index')]
-    #[AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message: 'You do not have permission to delete this.')]
+    #[AdminSecurity("is_granted('delete', 'AdminExtraPropertyDefinitions')", message: 'You do not have permission to delete this.')]
     public function bulkDeleteDropColumnAction(Request $request): RedirectResponse
     {
         return $this->doBulkDelete($request, true);

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/admin_api.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/admin_api.yml
@@ -3,49 +3,44 @@ admin_api_index:
   methods: [ GET ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdminAPIController::indexAction
-    _legacy_controller: AdminAdminAPI
 
 admin_api_clients_process_configuration:
   path: /
   methods: [ POST ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdminAPIController::processConfigurationAction
-    _legacy_controller: AdminAdminAPI
 
 admin_api_clients_create:
   path: /api-clients/create
   methods: [ GET, POST, PATCH ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdminAPIController::createAction
-    _legacy_controller: AdminAdminAPI
+    _parent: admin_api_index
 
 admin_api_clients_edit:
   path: /api-clients/{apiClientId}/edit
   methods: [ GET, POST, PATCH ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdminAPIController::editAction
-    _legacy_controller: AdminAdminAPI
+    _parent: admin_api_index
 
 admin_api_clients_toggle_active:
   path: /api-clients/{apiClientId}/toggle-active
   methods: [ POST ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdminAPIController::toggleStatusAction
-    _legacy_controller: AdminAdminAPI
 
 admin_api_clients_delete:
   path: /api-clients/{apiClientId}/delete
   methods: [ POST ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdminAPIController::deleteAction
-    _legacy_controller: AdminAdminAPI
 
 admin_api_clients_regenerate_secret:
   path: /api-clients/{apiClientId}/regenerate-secret
   methods: [ POST ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdminAPIController::regenerateSecretAction
-    _legacy_controller: AdminAdminAPI
 
 api_platform_doc:
   # We only load the routing for the API Swagger documentation, not the whole bundle routing

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/extra_property_definition.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/extra_property_definition.yml
@@ -3,7 +3,6 @@ admin_extra_property_definitions_index:
   methods: GET
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::indexAction'
-    _legacy_controller: AdminExtraPropertyDefinitions
 
 admin_extra_property_definitions_search:
   path: /
@@ -12,14 +11,12 @@ admin_extra_property_definitions_search:
     _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
     gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.extra_property_definition
     redirectRoute: admin_extra_property_definitions_index
-    _legacy_controller: AdminExtraPropertyDefinitions
 
 admin_extra_property_definitions_form_fields:
   path: /form-fields/{formId}
   methods: GET
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::formFieldsAction'
-    _legacy_controller: AdminExtraPropertyDefinitions
   requirements:
     formId: '[A-Za-z0-9_]+'
 
@@ -28,14 +25,14 @@ admin_extra_property_definitions_create:
   methods: [ GET, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::createAction'
-    _legacy_controller: AdminExtraPropertyDefinitions
+    _parent: admin_extra_property_definitions_index
 
 admin_extra_property_definitions_edit:
   path: /{extraPropertyDefinitionId}/edit
   methods: [ GET, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::editAction'
-    _legacy_controller: AdminExtraPropertyDefinitions
+    _parent: admin_extra_property_definitions_index
   requirements:
     extraPropertyDefinitionId: \d+
 
@@ -44,7 +41,6 @@ admin_extra_property_definitions_view:
   methods: GET
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::viewAction'
-    _legacy_controller: AdminExtraPropertyDefinitions
   requirements:
     extraPropertyDefinitionId: \d+
 
@@ -53,7 +49,6 @@ admin_extra_property_definitions_delete:
   methods: [ DELETE, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::deleteAction'
-    _legacy_controller: AdminExtraPropertyDefinitions
   requirements:
     extraPropertyDefinitionId: \d+
 
@@ -62,7 +57,6 @@ admin_extra_property_definitions_delete_drop_column:
   methods: [ DELETE, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::deleteDropColumnAction'
-    _legacy_controller: AdminExtraPropertyDefinitions
   requirements:
     extraPropertyDefinitionId: \d+
 
@@ -71,11 +65,9 @@ admin_extra_property_definitions_bulk_delete:
   methods: POST
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::bulkDeleteAction'
-    _legacy_controller: AdminExtraPropertyDefinitions
 
 admin_extra_property_definitions_bulk_delete_drop_column:
   path: /bulk-delete-drop-column
   methods: POST
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::bulkDeleteDropColumnAction'
-    _legacy_controller: AdminExtraPropertyDefinitions

--- a/src/PrestaShopBundle/Twig/Component/NavBar.php
+++ b/src/PrestaShopBundle/Twig/Component/NavBar.php
@@ -59,7 +59,7 @@ class NavBar
         $currentId = (int) Tab::getCurrentParentId();
 
         if ($currentId === -1) {
-            $currentId = $this->menuBuilder->getCurrentTab()?->getId() ?: -1;
+            $currentId = $this->menuBuilder->getCurrentTab()?->getId() ?: $this->menuBuilder->getParentTab()?->getId() ?: -1;
         }
 
         $controllerName = $this->menuBuilder->getLegacyControllerClassName();

--- a/src/PrestaShopBundle/Twig/Component/Toolbar.php
+++ b/src/PrestaShopBundle/Twig/Component/Toolbar.php
@@ -47,7 +47,7 @@ class Toolbar
         $this->sidebarEnabled = $enableSidebar;
         $this->helpLink = $helpLink;
         $this->layoutHeaderToolbarBtn = $layoutHeaderToolbarBtn;
-        $currentTab = $this->menuBuilder->getCurrentTab();
+        $currentTab = $this->menuBuilder->getCurrentTab() ?? $this->menuBuilder->getParentTab();
         $tabs = [];
         $ancestorsTab = [];
         if (null !== $currentTab) {

--- a/src/PrestaShopBundle/Twig/Layout/MenuBuilder.php
+++ b/src/PrestaShopBundle/Twig/Layout/MenuBuilder.php
@@ -20,6 +20,7 @@ use Tab as LegacyTab;
 class MenuBuilder
 {
     private ?Tab $currentTab = null;
+    private ?Tab $parentTab = null;
     /** @var array<int, Tab[]> */
     private array $ancestorsTab = [];
 
@@ -57,6 +58,29 @@ class MenuBuilder
         return $tab;
     }
 
+    /**
+     * Returns the Tab associated with the '_parent' route attribute, or null if none.
+     * Used as a fallback for pages (create/edit) that have no Tab of their own.
+     */
+    public function getParentTab(): ?Tab
+    {
+        if ($this->parentTab !== null) {
+            return $this->parentTab;
+        }
+
+        $request = $this->requestStack->getMainRequest();
+        if (!$request) {
+            return null;
+        }
+
+        $parentRoute = $request->attributes->get('_parent');
+        $this->parentTab = !empty($parentRoute)
+            ? $this->tabRepository->findOneByRouteName($parentRoute)
+            : null;
+
+        return $this->parentTab;
+    }
+
     public function getCurrentTabLevel(): int
     {
         $currentTab = $this->getCurrentTab();
@@ -86,7 +110,7 @@ class MenuBuilder
      */
     public function getBreadcrumbLinks(): array
     {
-        $currentTab = $this->getCurrentTab();
+        $currentTab = $this->getCurrentTab() ?? $this->getParentTab();
         if (null === $currentTab) {
             return [];
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR fixes the tab highlighting in the sidebar navigation, the breadcrumb, and the toolbar for pages (such as create/edit forms) that have no Tab entry of their own. Controllers for create/edit actions (e.g. AdminAPIController, ExtraPropertyDefinitionController) were previously identified via _legacy_controller hack in routing, which allowed the legacy menu system to resolve the active tab. With the migration away from legacy routing attributes, these pages lost their tab context, causing the sidebar to be unhighlighted and the toolbar to be empty.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use admin API and extra properties create / edit pages, active tab and breadcrumbs should work has expected
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/30360924141
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -

<img width="917" height="992" alt="Capture d’écran du 2026-07-28 11-44-25" src="https://github.com/user-attachments/assets/242eef50-d7b1-4325-a910-9b846c8690c6" />

<img width="886" height="1236" alt="Capture d’écran du 2026-07-28 11-44-43" src="https://github.com/user-attachments/assets/400084c6-6637-4bc7-a14f-9408862a5205" />
