### PR TITLE
Prevent disabling multiple selection in MaterialChoiceTableType

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
@@ -27,6 +27,8 @@ class MaterialChoiceTableType extends AbstractType
             'multiple' => true,
             'display_total_items' => false,
         ]);
+
+        $resolver->setAllowedValues('multiple', [true]);
     }
 
     /**

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableTypeTest.php
@@ -12,14 +12,20 @@ use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTableType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class MaterialChoiceTableTypeTest extends TestCase
 {
     /**
      * @dataProvider providerBuildView
      */
-    public function testBuildView(array $viewData, array $choices, bool $displayTotalItems, array $expectedReturn): void
-    {
+    public function testBuildView(
+        array $viewData,
+        array $choices,
+        bool $displayTotalItems,
+        array $expectedReturn
+    ): void {
         $mockForm = $this
             ->getMockBuilder(FormInterface::class)
             ->disableOriginalConstructor()
@@ -42,7 +48,13 @@ class MaterialChoiceTableTypeTest extends TestCase
             ]
         );
 
-        $this->assertEquals($expectedReturn, [$formView->vars['isCheckSelectAll'], $formView->vars['displayTotalItems']]);
+        $this->assertEquals(
+            $expectedReturn,
+            [
+                $formView->vars['isCheckSelectAll'],
+                $formView->vars['displayTotalItems'],
+            ]
+        );
     }
 
     public function providerBuildView(): array
@@ -61,5 +73,33 @@ class MaterialChoiceTableTypeTest extends TestCase
                 [false, true],
             ],
         ];
+    }
+
+    public function testMultipleOptionIsEnabledByDefault(): void
+    {
+        $resolver = new OptionsResolver();
+        $materialChoiceTableType = new MaterialChoiceTableType();
+
+        $materialChoiceTableType->configureOptions($resolver);
+
+        $options = $resolver->resolve();
+
+        $this->assertTrue($options['multiple']);
+        $this->assertTrue($options['expanded']);
+        $this->assertFalse($options['display_total_items']);
+    }
+
+    public function testMultipleOptionCannotBeDisabled(): void
+    {
+        $resolver = new OptionsResolver();
+        $materialChoiceTableType = new MaterialChoiceTableType();
+
+        $materialChoiceTableType->configureOptions($resolver);
+
+        $this->expectException(InvalidOptionsException::class);
+
+        $resolver->resolve([
+            'multiple' => false,
+        ]);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | see below
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see below
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/31479808711
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/prestaShop/issues/39273
| Related PRs       | https://github.com/PrestaShop/docs/pull/2160
| Sponsor company   | Codencode snc
## Description

`MaterialChoiceTableType` is designed for multiple selection: it displays checkboxes and provides a “Select all” feature.

However, the inherited `multiple` option could previously be set to `false`. In that case, the form view data was returned as a scalar value instead of an array, causing the following error in `buildView()`:

```text
count(): Argument #1 ($value) must be of type Countable|array, string given
```

This PR restricts the `multiple` option to `true`, preventing `MaterialChoiceTableType` from being configured for an unsupported single-selection use case.

For single expanded selections, Symfony's `ChoiceType` should be used with:

```php
'expanded' => true,
'multiple' => false,
```

Unit tests have also been added to verify that:

* multiple selection is enabled by default;
* setting `multiple` to `false` throws an `InvalidOptionsException`.


## How to test

### Verify the unsupported configuration is rejected

1. Open:

   ```text
   src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
   ```

2. In the `group_ids` field using `MaterialChoiceTableType`, add:

   ```php
   'multiple' => false,
   ```

3. Go to **Customers > Customers** in the Back Office.

4. Edit an existing customer.

5. Verify that the form configuration is rejected with an `InvalidOptionsException` explaining that the accepted value for the `multiple` option is `true`.

6. Remove the temporary `multiple => false` option.

### Verify there is no regression

1. Go to **Customers > Customers** in the Back Office.
2. Edit an existing customer.
3. Verify that the customer groups are displayed as checkboxes.
4. Select and unselect several groups.
5. Verify that the “Select all” feature still works.
6. Save the customer.
7. Reopen the customer and verify that the selected groups were correctly saved.

