### PR TITLE
Fix order payment conversion rate fallback

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1836,7 +1836,7 @@ class OrderCore extends ObjectModel
         $order_payment->order_reference = $this->reference;
         $order_payment->id_currency = ($currency ? $currency->id : $this->id_currency);
         // we kept the currency rate for historization reasons
-        $order_payment->conversion_rate = ($currency ? $currency->conversion_rate : 1);
+        $order_payment->conversion_rate = ($currency ? $currency->conversion_rate : ($this->conversion_rate ?: 1));
         // if payment_method is define, we used this
         $order_payment->payment_method = ($payment_method ? $payment_method : $this->payment);
         $order_payment->transaction_id = $payment_transaction_id;

--- a/tests/Integration/Classes/OrderAddPaymentConversionRateTest.php
+++ b/tests/Integration/Classes/OrderAddPaymentConversionRateTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Db;
+use Order;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Order::addOrderPayment() falls back to the order's own currency when no
+ * Currency object is passed. The conversion rate stored in the payment must
+ * therefore come from the order as well.
+ *
+ * This covers the front-office order creation path, where
+ * PaymentModule::validateOrder() calls addOrderPayment() without explicitly
+ * passing a Currency object.
+ */
+class OrderAddPaymentConversionRateTest extends TestCase
+{
+    private const ORDER_ID = 1;
+
+    private const ORDER_CONVERSION_RATE = 0.88;
+
+    private const TRANSACTION_ID = 'qa-conversion-rate-probe';
+
+    private float $originalConversionRate;
+
+    private float $originalTotalPaidReal;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->deleteTestPayment();
+
+        $order = new Order(self::ORDER_ID);
+
+        $this->assertTrue(
+            (bool) $order->id,
+            sprintf('Fixture order with ID %d was not found', self::ORDER_ID)
+        );
+
+        $this->originalConversionRate = (float) $order->conversion_rate;
+        $this->originalTotalPaidReal = (float) $order->total_paid_real;
+
+        $order->conversion_rate = self::ORDER_CONVERSION_RATE;
+
+        $this->assertTrue(
+            $order->update(),
+            'Unable to update the fixture order conversion rate'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTestPayment();
+
+        $order = new Order(self::ORDER_ID);
+
+        if ($order->id) {
+            $order->conversion_rate = $this->originalConversionRate;
+            $order->total_paid_real = $this->originalTotalPaidReal;
+            $order->update();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testItStoresTheOrderConversionRateWhenNoCurrencyIsGiven(): void
+    {
+        $order = new Order(self::ORDER_ID);
+
+        $this->assertSame(
+            self::ORDER_CONVERSION_RATE,
+            (float) $order->conversion_rate,
+            'Fixture order should carry a non-default conversion rate'
+        );
+
+        $result = $order->addOrderPayment(
+            '10.00',
+            'qa-test',
+            self::TRANSACTION_ID,
+            null
+        );
+
+        $this->assertTrue(
+            $result,
+            'The order payment could not be created'
+        );
+
+        $storedConversionRate = Db::getInstance()->getValue(
+            'SELECT `conversion_rate`
+            FROM `' . _DB_PREFIX_ . 'order_payment`
+            WHERE `transaction_id` = "' . pSQL(self::TRANSACTION_ID) . '"'
+        );
+
+        $this->assertNotFalse(
+            $storedConversionRate,
+            'The payment row was not created'
+        );
+
+        $this->assertSame(
+            self::ORDER_CONVERSION_RATE,
+            (float) $storedConversionRate,
+            'Payment recorded in the order currency must keep the order conversion rate, not the default 1'
+        );
+    }
+
+    private function deleteTestPayment(): void
+    {
+        Db::getInstance()->execute(
+            'DELETE FROM `' . _DB_PREFIX_ . 'order_payment`
+            WHERE `transaction_id` = "' . pSQL(self::TRANSACTION_ID) . '"'
+        );
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | This PR fixes the conversion rate stored in `order_payment` when an order payment is created without explicitly passing a `Currency` object.<br/><br/>Currently, `Order::addOrderPayment()` falls back to a conversion rate of `1` when `$currency` is not provided:<br/>`$orderPayment->conversion_rate = $currency ? $currency->conversion_rate : 1;`<br/><br/>However, the standard order creation flow calls `addOrderPayment()` without passing the currency. As a result, payments for orders created in a currency whose conversion rate differs from `1` are stored with an incorrect conversion rate.<br/><br/>This PR uses the conversion rate already stored in the order as the fallback value:<br/>`$orderPayment->conversion_rate = $currency ? $currency->conversion_rate : $this->conversion_rate;`<br/><br/>This keeps the `order_payment` conversion rate consistent with the rate used when the order was created.
| Type?             | bug fix
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | 1. Install and enable two currencies, for example EUR and USD.<br/>2. Make sure the USD conversion rate is different from `1`.<br/>3. From the Back Office, create a new order.<br/>4. Select USD as the order currency.<br/>5. Select `Bank transfer` as the payment method.<br/>6. Select `Payment accepted` as the order status.<br/>7. Complete the order creation.<br/>8. Check the corresponding record in the `order_payment` table.<br/>9. Confirm that the `conversion_rate` field is correctly populated with the conversion rate used for the order, instead of `1`.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/31106721421
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/prestaShop/issues/39303
| Related PRs       |
| Sponsor company   | Codencode snc
