### PR TITLE
Fix delivery option cache for changed delivery addresses

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2918,8 +2918,10 @@ class CartCore extends ObjectModel
      */
     public function getDeliveryOptionList(?Country $default_country = null, $flush = false)
     {
-        if (isset(static::$cacheDeliveryOptionList[$this->id]) && !$flush) {
-            return static::$cacheDeliveryOptionList[$this->id];
+        $cacheKey = (int) $this->id . '_' . (int) $this->id_address_delivery;
+
+        if (isset(static::$cacheDeliveryOptionList[$cacheKey]) && !$flush) {
+            return static::$cacheDeliveryOptionList[$cacheKey];
         }
 
         $delivery_option_list = [];
@@ -2974,9 +2976,7 @@ class CartCore extends ObjectModel
                  * We can't just use empty($package['carrier_list']) because it looks like [0 => 0] if there are no carriers.
                  */
                 if (count($package['carrier_list']) == 1 && current($package['carrier_list']) == 0) {
-                    $cache[$this->id] = [];
-
-                    return $cache[$this->id];
+                    return [];
                 }
 
                 $carriers_price[$id_address][$id_package] = [];
@@ -3223,9 +3223,9 @@ class CartCore extends ObjectModel
             ]
         );
 
-        static::$cacheDeliveryOptionList[$this->id] = $delivery_option_list;
+        static::$cacheDeliveryOptionList[$cacheKey] = $delivery_option_list;
 
-        return static::$cacheDeliveryOptionList[$this->id];
+        return static::$cacheDeliveryOptionList[$cacheKey];
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2692,14 +2692,16 @@ class CartCore extends ObjectModel
      */
     public function getNbOfPackages()
     {
-        if (!isset(static::$cacheNbPackages[$this->id])) {
-            static::$cacheNbPackages[$this->id] = 0;
+        $cacheKey = (int) $this->id . '_' . (int) $this->id_address_delivery;
+
+        if (!isset(static::$cacheNbPackages[$cacheKey])) {
+            static::$cacheNbPackages[$cacheKey] = 0;
             foreach ($this->getPackageList() as $by_address) {
-                static::$cacheNbPackages[$this->id] += count($by_address);
+                static::$cacheNbPackages[$cacheKey] += count($by_address);
             }
         }
 
-        return static::$cacheNbPackages[$this->id];
+        return static::$cacheNbPackages[$cacheKey];
     }
 
     /**

--- a/tests/Integration/Classes/CartTest.php
+++ b/tests/Integration/Classes/CartTest.php
@@ -349,6 +349,73 @@ class CartTest extends KernelTestCase
         $this->assertEquals(13.2, $cart->getOrderTotal(true, Cart::BOTH, null, $id_carrier));
     }
 
+    public function testDeliveryOptionListCacheIsScopedByDeliveryAddress(): void
+    {
+        Cart::resetStaticCache();
+
+        $firstAddress = self::makeAddress();
+        $secondAddress = self::makeAddress();
+
+        $this->assertNotSame(
+            (int) $firstAddress->id,
+            (int) $secondAddress->id
+        );
+
+        $product = self::makeProduct(
+            'Delivery option cache product',
+            10,
+            self::getIdTaxRulesGroup(20)
+        );
+
+        // Passing a shipping cost also associates the carrier with all zones.
+        self::getIdCarrier('Delivery option cache carrier', 2);
+
+        $cart = self::makeCart();
+        $cart->id_address_delivery = (int) $firstAddress->id;
+        $cart->id_address_invoice = (int) $firstAddress->id;
+
+        $this->assertTrue($cart->update());
+
+        $cart->updateQty(1, (int) $product->id);
+
+        // Warm the delivery option cache using the first address.
+        $firstAddressDeliveryOptions = $cart->getDeliveryOptionList();
+
+        $this->assertArrayHasKey(
+            (int) $firstAddress->id,
+            $firstAddressDeliveryOptions
+        );
+        $this->assertArrayNotHasKey(
+            (int) $secondAddress->id,
+            $firstAddressDeliveryOptions
+        );
+
+        /*
+        * Change the delivery address in the same PHP process.
+        *
+        * Cart::update() does not reset the delivery option cache, so the next
+        * call must use a cache entry scoped by the new delivery address.
+        */
+        $cart->id_address_delivery = (int) $secondAddress->id;
+
+        $this->assertTrue($cart->update());
+
+        /*
+        * Do not use $flush = true here: forcing a recalculation would hide
+        * the cache-key regression.
+        */
+        $secondAddressDeliveryOptions = $cart->getDeliveryOptionList();
+
+        $this->assertArrayHasKey(
+            (int) $secondAddress->id,
+            $secondAddressDeliveryOptions
+        );
+        $this->assertArrayNotHasKey(
+            (int) $firstAddress->id,
+            $secondAddressDeliveryOptions
+        );
+    }
+
     public function testBasicRoundTypeLine(): void
     {
         self::setRoundingType('line');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Cart::getDeliveryOptionList()` cached delivery options using only the cart ID.<br/><br/>When the delivery address changed during the same request, the method could therefore return delivery options previously calculated for another address. This caused the checkout to display no available carriers until the page was fully refreshed.<br/><br/>This PR scopes the delivery option cache by both the cart ID and the delivery address ID, ensuring that delivery options are recalculated when the delivery address changes.<br/><br/>An integration test has also been added to verify that changing the delivery address on the same cart does not reuse delivery options cached for the previous address.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install and enable the `ps_onepagecheckout` module.<br/>2. Configure the module to use the **One-page checkout** layout.<br/>3. Create a customer with at least two delivery addresses.<br/>4. Make sure at least one carrier is available for both addresses.<br/>5. Add a physical product to the cart.<br/>6. Log in with the customer and proceed to checkout.<br/>7. Select the first delivery address and verify that the available carriers are displayed.<br/>8. Change the delivery address without manually refreshing the page.<br/>9. Verify that the available carriers are still correctly displayed for the newly selected address.<br/>10. Switch back to the first address and verify that the available carriers remain visible.<br/><br/>Before this fix, changing the delivery address during the same checkout request could result in no carriers being displayed until the page was refreshed.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/30369367891
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42141
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/40575 https://github.com/PrestaShop/PrestaShop/pull/42114
| Sponsor company   | Codencode snc
