### PR TITLE
Update mobiledetect/mobiledetectlib to 3.74.4 to clear PHP 8.4 deprecations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3695,16 +3695,16 @@
         },
         {
             "name": "mobiledetect/mobiledetectlib",
-            "version": "3.74.3",
+            "version": "3.74.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/serbanghita/Mobile-Detect.git",
-                "reference": "39582ab62f86b40e4edb698159f895929a29c346"
+                "reference": "e72098eba91e5f16278b17d42ca193ae71e4ae0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/39582ab62f86b40e4edb698159f895929a29c346",
-                "reference": "39582ab62f86b40e4edb698159f895929a29c346",
+                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/e72098eba91e5f16278b17d42ca193ae71e4ae0a",
+                "reference": "e72098eba91e5f16278b17d42ca193ae71e4ae0a",
                 "shasum": ""
             },
             "require": {
@@ -3747,7 +3747,7 @@
             ],
             "support": {
                 "issues": "https://github.com/serbanghita/Mobile-Detect/issues",
-                "source": "https://github.com/serbanghita/Mobile-Detect/tree/3.74.3"
+                "source": "https://github.com/serbanghita/Mobile-Detect/tree/3.74.4"
             },
             "funding": [
                 {
@@ -3755,7 +3755,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-27T16:28:04+00:00"
+            "time": "2026-04-15T08:43:14+00:00"
         },
         {
             "name": "monolog/monolog",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `mobiledetect/mobiledetectlib` 3.74.3 declares implicitly nullable parameters, which PHP 8.4 reports as deprecated on every request that initialises device detection. Upstream 3.74.4 converts them to explicit nullable types. It satisfies the existing `^3.74.0` constraint, so `composer.json` does not change and only the lock file moves.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On PHP 8.4 with debug mode on, load any page before the change and the log carries `Deprecated: ... implicitly nullable parameter` from `mobiledetect`; after `composer install` with this lock it does not. `composer.json` is untouched, so no constraint is relaxed.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #42110
| Sponsor company   |

### What changes

```
mobiledetect/mobiledetectlib  3.74.3 -> 3.74.4
```

Lock file only - one package, 12 lines, `content-hash` untouched because `composer.json` is unchanged.

### Why

The reported warning:

```
Deprecated: Detection\MobileDetect::__construct(): Implicitly marking parameter $headers as
nullable is deprecated, the explicit nullable type must be used instead
```

comes from:

```php
// 3.74.3
public function __construct(array $headers = null, string $userAgent = null)
```

3.74.4 changes it to:

```php
public function __construct(?array $headers = null, ?string $userAgent = null)
```

The conversion is complete rather than partial, so the upgrade clears every occurrence and not only the constructor:

```
3.74.3   implicit-nullable params = 13   explicit = 3
3.74.4   implicit-nullable params = 0    explicit = 16
```

The locked reference `e72098eb` is the commit the upstream `3.74.4` tag points to, and that exact commit carries the fixed signatures.

### How to test

`composer install`, then confirm `vendor/mobiledetect/mobiledetectlib/src/MobileDetect.php` declares `?array $headers = null, ?string $userAgent = null`. On PHP 8.4 with debug mode on, loading a front-office or back-office page no longer emits the deprecation.

Note: I verified the signatures and the release contents rather than observing the warning at runtime - my environment runs PHP 8.1, where the notice is not emitted.


