### PR TITLE
Trim customer first and last names in the domain

### DIFF
--- a/src/Core/Domain/Customer/ValueObject/FirstName.php
+++ b/src/Core/Domain/Customer/ValueObject/FirstName.php
@@ -28,6 +28,10 @@ class FirstName
      */
     public function __construct($firstName)
     {
+        // The back office form trims these values before they ever reach the domain.
+        // Normalise here too so every entry point stores the same thing.
+        $firstName = is_string($firstName) ? trim($firstName) : $firstName;
+
         $this->assertFirstNameDoesNotExceedAllowedLength($firstName);
         $this->assertFirstNameIsValid($firstName);
 

--- a/src/Core/Domain/Customer/ValueObject/LastName.php
+++ b/src/Core/Domain/Customer/ValueObject/LastName.php
@@ -28,6 +28,10 @@ class LastName
      */
     public function __construct($lastName)
     {
+        // The back office form trims these values before they ever reach the domain.
+        // Normalise here too so every entry point stores the same thing.
+        $lastName = is_string($lastName) ? trim($lastName) : $lastName;
+
         $this->assertLastNameDoesNotExceedAllowedLength($lastName);
         $this->assertLastNameIsValid($lastName);
 

--- a/tests/Unit/Core/Domain/Customer/ValueObject/CustomerNameTrimTest.php
+++ b/tests/Unit/Core/Domain/Customer/ValueObject/CustomerNameTrimTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Customer\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\FirstName;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\LastName;
+
+/**
+ * The back office customer form trims names before they reach the domain, so a customer created
+ * there is stored without surrounding whitespace. Entry points that build the value objects
+ * directly - the Admin API among them - have to end up with the same value.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/42132
+ */
+class CustomerNameTrimTest extends TestCase
+{
+    /**
+     * @dataProvider provideNames
+     */
+    public function testFirstNameIsTrimmed(string $given, string $expected): void
+    {
+        $this->assertSame($expected, (new FirstName($given))->getValue());
+    }
+
+    /**
+     * @dataProvider provideNames
+     */
+    public function testLastNameIsTrimmed(string $given, string $expected): void
+    {
+        $this->assertSame($expected, (new LastName($given))->getValue());
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public function provideNames(): iterable
+    {
+        yield 'leading and trailing spaces' => ['  John  ', 'John'];
+        yield 'leading spaces' => ['   John', 'John'];
+        yield 'trailing spaces' => ['John   ', 'John'];
+        yield 'tab and newline' => ["\tJohn\n", 'John'];
+        yield 'inner spacing is preserved' => ['  Anne Marie  ', 'Anne Marie'];
+        yield 'already clean value is untouched' => ['John', 'John'];
+        yield 'accented characters survive' => ['  Zoé  ', 'Zoé'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `FirstName` and `LastName` now trim the value they are given. The back office form already trims before the domain is reached, so a customer created there is stored without surrounding whitespace, while entry points that build the value objects directly - the Admin API among them - stored whatever they were given. This makes both agree.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a customer through the Admin API with `"firstName": "  John  "`. Before this change the response and the database keep the spaces; after it they store `John`, which is what the back office already produces for the same input.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #42132
| Sponsor company   |

### Why this layer

The trimming that exists today is a side effect of Symfony's `TextType`, which trims by default and which the customer form does not disable. The API path goes through API Platform and the CQRS command, where no form is involved, so nothing normalises the value.

Putting it in the value objects rather than in the API resource has one practical consequence worth stating: it also removes a silent rewrite. An admin who opens an API-created customer and saves it - even to change something unrelated - currently changes the stored name, because the form trims on submit. With this change there is nothing left to rewrite.

### Behaviour

```
'  John  '     -> 'John'
'   John'      -> 'John'
'John   '      -> 'John'
"\tJohn\n"     -> 'John'
'  Anne Marie  ' -> 'Anne Marie'    (inner spacing preserved)
'John'         -> 'John'            (unchanged)
```

A name consisting only of whitespace becomes an empty string, which is what the back office form already produces for the same input.

### Tests

`tests/Unit/Core/Domain/Customer/ValueObject/CustomerNameTrimTest.php` covers both value objects.

```
with the change            -> Tests: 14, Assertions: 14, no failures
value objects reverted     -> Failed asserting that two strings are identical (x4)
```

Wider `Customer` unit scope is unaffected: `Tests: 192, Assertions: 312`, no failures. php-cs-fixer reports nothing to fix on the three files, and PHPStan on the two changed files returns `[OK] No errors`.

