### PR TITLE
Reject customer groups that do not exist, and survive the ones already stored

### DIFF
--- a/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
@@ -7,16 +7,19 @@
 namespace PrestaShop\PrestaShop\Adapter\Customer\CommandHandler;
 
 use Customer;
+use Group;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\CommandHandler\AddCustomerHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerGroupNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\DuplicateCustomerEmailException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\RequiredField;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use Validate;
 
 /**
  * Handles command that adds new customer
@@ -74,6 +77,7 @@ final class AddCustomerHandler extends AbstractCustomerHandler implements AddCus
 
         // Check if provided groups contain the correct data (the default group must be in group list)
         $this->assertCustomerCanAccessDefaultGroup($command);
+        $this->assertGroupsExist($command->getGroupIds(), $command->getDefaultGroupId());
 
         $customer->add();
         if (null !== $command->getGroupIds()) {
@@ -138,6 +142,34 @@ final class AddCustomerHandler extends AbstractCustomerHandler implements AddCus
         $customer->outstanding_allow_amount = $command->getAllowedOutstandingAmount();
         $customer->max_payment_days = $command->getMaxPaymentDays();
         $customer->id_risk = $command->getRiskId();
+    }
+
+    /**
+     * A group id that does not resolve is accepted by the database, and only fails later when
+     * something loads the group - the customer view being the first place that does.
+     *
+     * @param int[]|null $groupIds
+     * @param int|string|null $defaultGroupId
+     *
+     * @throws CustomerGroupNotFoundException
+     */
+    private function assertGroupsExist(?array $groupIds, $defaultGroupId): void
+    {
+        $idsToCheck = $groupIds ?? [];
+        if (null !== $defaultGroupId && '' !== $defaultGroupId) {
+            $idsToCheck[] = $defaultGroupId;
+        }
+
+        $missing = [];
+        foreach (array_unique(array_map('intval', $idsToCheck)) as $groupId) {
+            if (!Validate::isLoadedObject(new Group($groupId))) {
+                $missing[] = $groupId;
+            }
+        }
+
+        if (!empty($missing)) {
+            throw CustomerGroupNotFoundException::fromGroupIds($missing);
+        }
     }
 
     /**

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -7,15 +7,18 @@
 namespace PrestaShop\PrestaShop\Adapter\Customer\CommandHandler;
 
 use Customer;
+use Group;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\CommandHandler\EditCustomerHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerGroupNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\DuplicateCustomerEmailException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\RequiredField;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use Validate;
 
 /**
  * Handles commands which edits given customer with provided data.
@@ -63,6 +66,7 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
         }
 
         $this->assertCustomerCanAccessDefaultGroup($customer, $command);
+        $this->assertGroupsExist($command->getGroupIds(), $command->getDefaultGroupId());
 
         $this->updateCustomerWithCommandData($customer, $command);
 
@@ -217,6 +221,34 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
                 $command->getEmail(), sprintf('Registered customer with email "%s" already exists', $command->getEmail()->getValue()),
                 DuplicateCustomerEmailException::EDIT
             );
+        }
+    }
+
+    /**
+     * A group id that does not resolve is accepted by the database, and only fails later when
+     * something loads the group - the customer view being the first place that does.
+     *
+     * @param int[]|null $groupIds
+     * @param int|string|null $defaultGroupId
+     *
+     * @throws CustomerGroupNotFoundException
+     */
+    private function assertGroupsExist(?array $groupIds, $defaultGroupId): void
+    {
+        $idsToCheck = $groupIds ?? [];
+        if (null !== $defaultGroupId && '' !== $defaultGroupId) {
+            $idsToCheck[] = $defaultGroupId;
+        }
+
+        $missing = [];
+        foreach (array_unique(array_map('intval', $idsToCheck)) as $groupId) {
+            if (!Validate::isLoadedObject(new Group($groupId))) {
+                $missing[] = $groupId;
+            }
+        }
+
+        if (!empty($missing)) {
+            throw CustomerGroupNotFoundException::fromGroupIds($missing);
         }
     }
 

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Localization\Locale;
 use Shop;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tools;
+use Validate;
 
 /**
  * Handles commands which gets customer for viewing in Back Office.
@@ -341,6 +342,14 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
 
         foreach ($groups as $groupId) {
             $group = new Group($groupId);
+
+            // Rows in customer_group are not constrained, so a group can be missing - deleted
+            // directly in database, or written by a client that did not check it existed.
+            // Skipping keeps the customer page usable instead of failing on a null name.
+            if (!Validate::isLoadedObject($group)) {
+                continue;
+            }
+
             $customerGroups[] = new GroupInformation(
                 (int) $group->id,
                 $group->name[$this->contextLangId],

--- a/src/Core/Domain/Customer/Exception/CustomerGroupNotFoundException.php
+++ b/src/Core/Domain/Customer/Exception/CustomerGroupNotFoundException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Customer\Exception;
+
+/**
+ * Exception is thrown when a customer is assigned to a group that does not exist.
+ *
+ * Nothing constrains ps_customer_group at database level, so an unknown group id is accepted
+ * silently and only surfaces later, when something tries to load the group.
+ */
+class CustomerGroupNotFoundException extends CustomerException
+{
+    /**
+     * @param int[] $groupIds
+     */
+    public static function fromGroupIds(array $groupIds): self
+    {
+        return new self(sprintf(
+            'Customer cannot be assigned to non-existing group(s) "%s"',
+            implode('", "', $groupIds)
+        ));
+    }
+}

--- a/tests/Integration/Adapter/Customer/CustomerGroupIntegrityTest.php
+++ b/tests/Integration/Adapter/Customer/CustomerGroupIntegrityTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Customer;
+
+use Configuration;
+use Context;
+use Currency;
+use Db;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerGroupNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * customer_group has no foreign key, so an unknown group id used to be accepted on write and only
+ * failed later, when the customer view loaded the group and read a name off null.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/42130
+ */
+class CustomerGroupIntegrityTest extends KernelTestCase
+{
+    private const MISSING_GROUP_ID = 999999;
+    private const EMAIL = 'group.integrity.probe@example.com';
+
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    /**
+     * @var CommandBusInterface
+     */
+    private $queryBus;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->commandBus = self::getContainer()->get('prestashop.core.command_bus');
+        $this->queryBus = self::getContainer()->get('prestashop.core.query_bus');
+
+        // The view handler formats amounts, which needs a currency in context - the CLI kernel
+        // does not set one.
+        $context = Context::getContext();
+        if (null === $context->currency || !$context->currency->id) {
+            $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        }
+
+        $this->removeProbeCustomer();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeProbeCustomer();
+    }
+
+    public function testItRefusesToCreateACustomerInAGroupThatDoesNotExist(): void
+    {
+        $this->assertFalse(
+            $this->groupExists(self::MISSING_GROUP_ID),
+            sprintf('Group %d must not exist for this test to mean anything', self::MISSING_GROUP_ID)
+        );
+
+        $this->expectException(CustomerGroupNotFoundException::class);
+
+        $this->commandBus->handle($this->buildCommand([self::MISSING_GROUP_ID], self::MISSING_GROUP_ID));
+    }
+
+    /**
+     * Rows written before this check existed still have to render.
+     */
+    public function testTheCustomerViewSurvivesAGroupThatWasRemovedAfterwards(): void
+    {
+        $validGroupId = (int) Db::getInstance()->getValue(
+            'SELECT `id_group` FROM `' . _DB_PREFIX_ . 'group` ORDER BY `id_group`'
+        );
+        $this->assertGreaterThan(0, $validGroupId, 'The fixtures should provide at least one group');
+
+        /** @var CustomerId $customerId */
+        $customerId = $this->commandBus->handle($this->buildCommand([$validGroupId], $validGroupId));
+
+        // Simulate the row surviving a group removal, which is what the database allows today.
+        Db::getInstance()->execute(
+            'UPDATE `' . _DB_PREFIX_ . 'customer_group` SET `id_group` = ' . self::MISSING_GROUP_ID
+            . ' WHERE `id_customer` = ' . $customerId->getValue()
+        );
+
+        $viewable = $this->queryBus->handle(new GetCustomerForViewing($customerId->getValue()));
+
+        $this->assertNotNull($viewable, 'Viewing a customer with a dangling group must not fail');
+    }
+
+    /**
+     * @param int[] $groupIds
+     */
+    private function buildCommand(array $groupIds, int $defaultGroupId): AddCustomerCommand
+    {
+        $command = new AddCustomerCommand(
+            'Group',
+            'Integrity',
+            self::EMAIL,
+            'Str0ng!Passw0rd',
+            $defaultGroupId,
+            $groupIds,
+            1
+        );
+
+        return $command;
+    }
+
+    private function groupExists(int $groupId): bool
+    {
+        return (bool) Db::getInstance()->getValue(
+            'SELECT `id_group` FROM `' . _DB_PREFIX_ . 'group` WHERE `id_group` = ' . $groupId
+        );
+    }
+
+    private function removeProbeCustomer(): void
+    {
+        $id = (int) Db::getInstance()->getValue(
+            'SELECT `id_customer` FROM `' . _DB_PREFIX_ . 'customer` WHERE `email` = "' . pSQL(self::EMAIL) . '"'
+        );
+
+        if ($id) {
+            Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer_group` WHERE `id_customer` = ' . $id);
+            Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer` WHERE `id_customer` = ' . $id);
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `customer_group` has no foreign key, so a customer can be assigned to a group id that resolves to nothing. It is accepted on write and only fails later: the customer view loads the group and reads a name off `null`, producing an HTTP 500. The command handlers now reject unknown group ids, and the view no longer fails on rows that already contain one.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a customer through the Admin API with `"defaultGroupId": 999, "groupIds": [999]`. Before this change the call returns 201 and opening that customer in the back office returns HTTP 500; after it the call is rejected with `CustomerGroupNotFoundException`. For the read side, point an existing `customer_group` row at a non-existent group directly in database and open the customer - the page renders instead of failing.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #42130
| Sponsor company   |

### What it does

**Write side.** `AddCustomerHandler` and `EditCustomerHandler` gain `assertGroupsExist()`, called right after the existing `assertCustomerCanAccessDefaultGroup()`. It follows the same shape as that check - a handler-level invariant throwing a domain exception - rather than a form or API-resource constraint, so every entry point is covered instead of only the one that reported the problem.

New `CustomerGroupNotFoundException` in the Customer domain, alongside `CustomerDefaultGroupAccessException`.

**Read side.** `GetCustomerForViewingHandler::getCustomerGroups()` skips a group that does not load. Rejecting on write does nothing for rows already in the database, written before this check or by a module writing directly, and those still have to render. The failure being fixed is:

```
GroupInformation::__construct(): Argument #2 ($name) must be of type string, null given
```

### Tests

`tests/Integration/Adapter/Customer/CustomerGroupIntegrityTest.php` covers both halves.

```
with the change    -> Tests: 2, Assertions: 4, no failures

handlers reverted  -> Failed asserting that exception of type "CustomerGroupNotFoundException" is thrown
                      TypeError: GroupInformation::__construct(): Argument #2 ($name)
                      must be of type string, null given
                      Tests: 2, Errors: 1, Failures: 1
```

The second failure is the reported 500 reproduced as a test, so both halves are pinned rather than assumed.

Wider `Customer` unit scope is unaffected: `Tests: 178, Assertions: 298`, no failures. php-cs-fixer reports nothing left to fix, and PHPStan on the four changed source files returns `[OK] No errors`.

