### PR TITLE
Run UserLocaleSubscriber strictly before LocaleAwareListener

### DIFF
--- a/src/PrestaShopBundle/EventListener/Admin/UserLocaleSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/UserLocaleSubscriber.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class UserLocaleSubscriber implements EventSubscriberInterface
 {
-    public const USER_LOCALE_PRIORITY = 15;
+    public const USER_LOCALE_PRIORITY = 16;
 
     public function __construct(
         private readonly ShopConfigurationInterface $configuration,
@@ -30,9 +30,12 @@ class UserLocaleSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            // Priority is set after Symfony LocaleListener, so it can override Symfony default locale
-            // setting based on request attributes, but before LocaleAwareListener where the translator
-            // locale is set, so we can define the chosen locale based on PrestaShop logic
+            // Must run before LocaleAwareListener, which is the listener that propagates the request
+            // locale into the kernel.locale_aware services (the translator among them). That listener
+            // sits at priority 15, so this one has to be strictly greater: at equal priority the order
+            // would depend on the order services happen to be registered in the compiled container.
+            // 16 ties with Symfony LocaleListener, which is harmless here - without a _locale request
+            // attribute it does not touch the request locale.
             KernelEvents::REQUEST => [['onKernelRequest', self::USER_LOCALE_PRIORITY]],
         ];
     }

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/UserLocalePriorityTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/UserLocalePriorityTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\EventListener\Admin;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\EventListener\Admin\UserLocaleSubscriber;
+use Symfony\Component\HttpKernel\EventListener\LocaleAwareListener;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * UserLocaleSubscriber sets the employee locale on the Request; LocaleAwareListener is what copies
+ * that locale into the kernel.locale_aware services, the translator included. The first has to run
+ * before the second.
+ *
+ * Priority is the only thing that orders them. At equal priority the dispatcher falls back to the
+ * order listeners were registered in the compiled container, which no code controls - so this test
+ * pins the relation rather than the number.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/42149
+ */
+class UserLocalePriorityTest extends TestCase
+{
+    public function testItRunsStrictlyBeforeTheListenerThatPropagatesTheLocale(): void
+    {
+        $this->assertGreaterThan(
+            $this->getLocaleAwareListenerPriority(),
+            UserLocaleSubscriber::USER_LOCALE_PRIORITY,
+            'UserLocaleSubscriber must outrank LocaleAwareListener, otherwise the translator can be '
+            . 'left on the previous locale for the whole request'
+        );
+    }
+
+    public function testTheSubscriberStillRegistersOnKernelRequestAtThatPriority(): void
+    {
+        $events = UserLocaleSubscriber::getSubscribedEvents();
+
+        $this->assertArrayHasKey(KernelEvents::REQUEST, $events);
+        $this->assertSame(
+            [['onKernelRequest', UserLocaleSubscriber::USER_LOCALE_PRIORITY]],
+            $events[KernelEvents::REQUEST]
+        );
+    }
+
+    /**
+     * Read from Symfony rather than hardcoded, so the test keeps meaning if the framework moves it.
+     */
+    private function getLocaleAwareListenerPriority(): int
+    {
+        $subscriptions = LocaleAwareListener::getSubscribedEvents()[KernelEvents::REQUEST];
+
+        // [['onKernelRequest', 15]]
+        return (int) $subscriptions[0][1];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `UserLocaleSubscriber` and Symfony's `LocaleAwareListener` were both registered on `kernel.request` at priority 15. At equal priority the dispatcher falls back to registration order, so which ran first was decided by the compiled container rather than by code. The subscriber only sets the locale on the Request; `LocaleAwareListener` is what propagates it into the `kernel.locale_aware` services. When that listener won the tie, the shared translator kept the previous locale for the whole request. Raising the constant to 16 makes the order a guarantee.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/PrestaShopBundle/EventListener/Admin/UserLocalePriorityTest.php` - it asserts the constant is strictly above Symfony's `LocaleAwareListener` priority, which is the whole fix. In the back office, an employee whose language differs from the shop default should get their own language on every page rather than intermittently.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #42149
| Sponsor company   |

### The tie

```
src/PrestaShopBundle/EventListener/Admin/UserLocaleSubscriber.php:20   USER_LOCALE_PRIORITY = 15
vendor/symfony/http-kernel/EventListener/LocaleAwareListener.php:62    ['onKernelRequest', 15]
```

`EventDispatcher::sortListeners()` sorts the buckets by priority and then appends each bucket in insertion order, so equal priority leaves the order to whatever the container produced. The existing comment on the constant already described the invariant the code needs - "before LocaleAwareListener where the translator locale is set" - but nothing enforced it.

### Why 16 is safe

16 ties with `LocaleListener::onKernelRequest` instead. That is harmless on admin routes:

```php
private function setLocale(Request $request): void
{
    if ($locale = $request->attributes->get('_locale')) {
        $request->setLocale($locale);
    } elseif ($this->useAcceptLanguageHeader) {
        ...
    }
}
```

With no `_locale` request attribute it does not touch the request locale, and `_locale` appears in 0 of 94 files under `src/PrestaShopBundle/Resources/config/routing/`. Its other call, `setRouterLocale($request->getLocale())`, only reads the request locale into the router context, so if the subscriber wins that tie the router gets the employee locale - an improvement rather than a regression.

### Verification

Order before and after, from `bin/console debug:event-dispatcher kernel.request` on 9.1.5:

```
before                                                          after
 #16  UserLocaleSubscriber::onKernelRequest()   15               #15  UserLocaleSubscriber::onKernelRequest()   16
 #17  LocaleAwareListener::onKernelRequest()    15               #16  LocaleListener::onKernelRequest()         16
                                                                 #17  LocaleAwareListener::onKernelRequest()    15
```

This install already happened to produce the working order, which is exactly why the priority needed fixing rather than the symptom - see #42149 for why "cannot reproduce" is uninformative here.

`tests/Unit/PrestaShopBundle/EventListener/Admin/UserLocalePriorityTest.php` pins the relation rather than the number: it reads `LocaleAwareListener`'s own priority from Symfony and asserts the subscriber outranks it, so the test keeps its meaning if the framework ever moves it.

```
with the change      -> Tests: 2, Assertions: 3, no failures
constant back to 15  -> Failed asserting that 15 is greater than 15
```

php-cs-fixer reports nothing to fix, PHPStan on the changed file returns `[OK] No errors`, and the back office and front office both still respond after the change.

### Alternative worth considering

If you would rather not depend on ordering at all, `UserLocaleSubscriber` could propagate to the locale-aware services itself after setting the request locale. That removes the tie as a class of problem instead of moving it, at the cost of duplicating what `LocaleAwareListener` exists to do. Happy to rework it that way if preferred.


