### PR TITLE
Describe the customer name rules accurately in the field help

### DIFF
--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -102,7 +102,7 @@ class CustomerFormatterCore implements FormFormatterInterface
             ->setRequired(true)
             ->addAvailableValue(
                 'comment',
-                $this->translator->trans('Only letters and the dot (.) character, followed by a space, are allowed.', [], 'Shop.Forms.Help')
+                $this->translator->trans('Letters, spaces, hyphens (-) and apostrophes (\') are allowed. Numbers are not, and a dot (.) must be followed by a space.', [], 'Shop.Forms.Help')
             );
 
         $format['lastname'] = (new FormField())
@@ -118,7 +118,7 @@ class CustomerFormatterCore implements FormFormatterInterface
             ->setRequired(true)
             ->addAvailableValue(
                 'comment',
-                $this->translator->trans('Only letters and the dot (.) character, followed by a space, are allowed.', [], 'Shop.Forms.Help')
+                $this->translator->trans('Letters, spaces, hyphens (-) and apostrophes (\') are allowed. Numbers are not, and a dot (.) must be followed by a space.', [], 'Shop.Forms.Help')
             );
 
         if (Configuration::get('PS_B2B_ENABLE')) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -158,7 +158,7 @@ class CustomerType extends TranslatorAwareType
             ->add('first_name', TextType::class, [
                 'label' => $this->trans('First name', 'Admin.Global'),
                 'help' => $this->trans(
-                    'Only letters and the dot (.) character, followed by a space, are allowed.',
+                    'Letters, spaces, hyphens (-) and apostrophes (\') are allowed. Numbers are not, and a dot (.) must be followed by a space.',
                     'Admin.Orderscustomers.Help'
                 ),
                 'constraints' => [
@@ -184,7 +184,7 @@ class CustomerType extends TranslatorAwareType
             ->add('last_name', TextType::class, [
                 'label' => $this->trans('Last name', 'Admin.Global'),
                 'help' => $this->trans(
-                    'Only letters and the dot (.) character, followed by a space, are allowed.',
+                    'Letters, spaces, hyphens (-) and apostrophes (\') are allowed. Numbers are not, and a dot (.) must be followed by a space.',
                     'Admin.Orderscustomers.Help'
                 ),
                 'constraints' => [

--- a/tests/Unit/Core/ConstraintValidator/CustomerNameValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/CustomerNameValidatorTest.php
@@ -142,4 +142,28 @@ class CustomerNameValidatorTest extends ConstraintValidatorTestCase
     {
         return new CustomerNameValidator();
     }
+
+    /**
+     * The help text shown next to these fields names hyphens and apostrophes, so the validator has
+     * to keep accepting them.
+     *
+     * @dataProvider provideNamesTheHelpTextPromises
+     */
+    public function testItAcceptsTheCharactersTheHelpTextNames(string $name)
+    {
+        $this->validator->validate($name, new CustomerName());
+
+        $this->assertNoViolation();
+    }
+
+    public function provideNamesTheHelpTextPromises(): array
+    {
+        return [
+            ['Jean-Luc'],
+            ["D'Angelo"],
+            ["Jean-Luc D'Angelo"],
+            ['Anne Marie'],
+            ['O. Brien'],
+        ];
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The name field help said "Only letters and the dot (.) character, followed by a space, are allowed." The validator is a blacklist, so hyphens and apostrophes are accepted as well - the text told customers a name like `Jean-Luc` or `D'Angelo` would be refused when it is not. Corrected in the storefront registration form and the back office customer form, which share the string.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Front office registration form, and Back office > Customers > Add new: the help under First name and Last name no longer claims only letters and the dot are accepted. `vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/ConstraintValidator/CustomerNameValidatorTest.php` covers the characters the wording now describes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #42133
| Sponsor company   |

### What the validator actually does

`CustomerNameValidator::PATTERN_NAME` excludes a set of characters rather than listing allowed ones, so anything not excluded passes. Measured against `Validate::isCustomerName()`:

```
letters        Ana          -> allowed
space          Anne Marie   -> allowed
hyphen         Jean-Luc     -> allowed
apostrophe     D'Angelo     -> allowed
ampersand      A&B          -> allowed
accented       Zoé          -> allowed
cyrillic       Иван         -> allowed
dot + space    O. Brien     -> allowed
dot, no space  O.Brien      -> rejected
digit          Jean5        -> rejected
underscore     Jean_Luc     -> rejected
slash          A/B          -> rejected
plus           A+B          -> rejected
comma          A,B          -> rejected
```

### Wording

```
- Only letters and the dot (.) character, followed by a space, are allowed.
+ Letters, spaces, hyphens (-) and apostrophes (') are allowed. Numbers are not, and a dot (.) must be followed by a space.
```

The word "Only" is what made the old sentence false. For a blacklist no positive list can be complete - `&` passes too, and nobody wants that in the help text - so the replacement names the characters people actually need, states the two restrictions that bite in practice, and stops claiming to be exhaustive. The "followed by a space" part of the original was accurate and is kept.

### Scope

The string appears four times in two files, and both entry points show it:

```
classes/form/CustomerFormatter.php:104, :119                              storefront registration
src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php:161, :187  back office customer form
```

Fixing only the storefront would leave the back office saying something untrue.

### Verification

Rendered on the storefront after the change, on both name fields:

```
Letters, spaces, hyphens (-) and apostrophes (') are allowed. Numbers are not, and a dot (.) must be followed by a space.
```

`CustomerNameValidatorTest` gains a case list for the characters the new text names, so the text and the validator cannot drift apart silently: `Tests: 58, Assertions: 106`, no failures. That test is a guard rather than a reproduction - the validator already accepted those characters, which is precisely why the text was wrong.

php-cs-fixer reports nothing to fix and PHPStan on the two changed source files returns `[OK] No errors`.

### One thing to be aware of

Changing the source string changes the translation key, so existing translations of the old sentence fall back to English until they are updated. That is unavoidable for a wording correction, but worth knowing before merge given both domains are affected (`Shop.Forms.Help` and `Admin.Orderscustomers.Help`).


