### PR TITLE
Apply the configured password length policy outside the back office form

### DIFF
--- a/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
@@ -8,15 +8,19 @@ namespace PrestaShop\PrestaShop\Adapter\Customer\CommandHandler;
 
 use Customer;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\CommandHandler\AddCustomerHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\DuplicateCustomerEmailException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\RequiredField;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 
 /**
  * Handles command that adds new customer
@@ -40,8 +44,11 @@ final class AddCustomerHandler extends AbstractCustomerHandler implements AddCus
      * @param Hashing $hashing
      * @param string $legacyCookieKey
      */
-    public function __construct(Hashing $hashing, $legacyCookieKey)
-    {
+    public function __construct(
+        Hashing $hashing,
+        $legacyCookieKey,
+        private readonly ?ConfigurationInterface $configuration = null,
+    ) {
         $this->hashing = $hashing;
         $this->legacyCookieKey = $legacyCookieKey;
     }
@@ -74,6 +81,7 @@ final class AddCustomerHandler extends AbstractCustomerHandler implements AddCus
 
         // Check if provided groups contain the correct data (the default group must be in group list)
         $this->assertCustomerCanAccessDefaultGroup($command);
+        $this->assertPasswordMeetsConfiguredPolicy($command->getPassword());
 
         $customer->add();
         if (null !== $command->getGroupIds()) {
@@ -138,6 +146,43 @@ final class AddCustomerHandler extends AbstractCustomerHandler implements AddCus
         $customer->outstanding_allow_amount = $command->getAllowedOutstandingAmount();
         $customer->max_payment_days = $command->getMaxPaymentDays();
         $customer->id_risk = $command->getRiskId();
+    }
+
+    /**
+     * The back office form applies the configured length policy through Symfony constraints, so a
+     * customer created there obeys it. Entry points that build the command directly - the Admin API
+     * among them - only met the Password value object's absolute bounds, which are wider. Applying
+     * the same configuration here makes both agree.
+     *
+     * Only the length is checked: PS_SECURITY_PASSWORD_POLICY_MINIMUM_SCORE is rendered as a
+     * data-minscore attribute for the client-side meter and is not enforced server-side anywhere,
+     * so enforcing it here would be stricter than the back office rather than consistent with it.
+     *
+     * @throws CustomerConstraintException
+     */
+    private function assertPasswordMeetsConfiguredPolicy(?Password $password): void
+    {
+        if (null === $password || null === $this->configuration) {
+            return;
+        }
+
+        $minLength = (int) $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH);
+        $maxLength = (int) $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
+        $length = mb_strlen($password->getValue(), 'UTF-8');
+
+        if ($minLength > 0 && $length < $minLength) {
+            throw new CustomerConstraintException(
+                sprintf('Customer password must be at least %d characters long', $minLength),
+                CustomerConstraintException::INVALID_PASSWORD
+            );
+        }
+
+        if ($maxLength > 0 && $length > $maxLength) {
+            throw new CustomerConstraintException(
+                sprintf('Customer password must not exceed %d characters', $maxLength),
+                CustomerConstraintException::INVALID_PASSWORD
+            );
+        }
     }
 
     /**

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -8,14 +8,18 @@ namespace PrestaShop\PrestaShop\Adapter\Customer\CommandHandler;
 
 use Customer;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\CommandHandler\EditCustomerHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\DuplicateCustomerEmailException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\RequiredField;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 
 /**
  * Handles commands which edits given customer with provided data.
@@ -39,8 +43,11 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
      * @param Hashing $hashing
      * @param string $legacyCookieKey
      */
-    public function __construct(Hashing $hashing, $legacyCookieKey)
-    {
+    public function __construct(
+        Hashing $hashing,
+        $legacyCookieKey,
+        private readonly ?ConfigurationInterface $configuration = null,
+    ) {
         $this->hashing = $hashing;
         $this->legacyCookieKey = $legacyCookieKey;
     }
@@ -63,6 +70,7 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
         }
 
         $this->assertCustomerCanAccessDefaultGroup($customer, $command);
+        $this->assertPasswordMeetsConfiguredPolicy($command->getPassword());
 
         $this->updateCustomerWithCommandData($customer, $command);
 
@@ -216,6 +224,43 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
             throw new DuplicateCustomerEmailException(
                 $command->getEmail(), sprintf('Registered customer with email "%s" already exists', $command->getEmail()->getValue()),
                 DuplicateCustomerEmailException::EDIT
+            );
+        }
+    }
+
+    /**
+     * The back office form applies the configured length policy through Symfony constraints, so a
+     * customer created there obeys it. Entry points that build the command directly - the Admin API
+     * among them - only met the Password value object's absolute bounds, which are wider. Applying
+     * the same configuration here makes both agree.
+     *
+     * Only the length is checked: PS_SECURITY_PASSWORD_POLICY_MINIMUM_SCORE is rendered as a
+     * data-minscore attribute for the client-side meter and is not enforced server-side anywhere,
+     * so enforcing it here would be stricter than the back office rather than consistent with it.
+     *
+     * @throws CustomerConstraintException
+     */
+    private function assertPasswordMeetsConfiguredPolicy(?Password $password): void
+    {
+        if (null === $password || null === $this->configuration) {
+            return;
+        }
+
+        $minLength = (int) $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH);
+        $maxLength = (int) $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
+        $length = mb_strlen($password->getValue(), 'UTF-8');
+
+        if ($minLength > 0 && $length < $minLength) {
+            throw new CustomerConstraintException(
+                sprintf('Customer password must be at least %d characters long', $minLength),
+                CustomerConstraintException::INVALID_PASSWORD
+            );
+        }
+
+        if ($maxLength > 0 && $length > $maxLength) {
+            throw new CustomerConstraintException(
+                sprintf('Customer password must not exceed %d characters', $maxLength),
+                CustomerConstraintException::INVALID_PASSWORD
             );
         }
     }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
@@ -34,6 +34,7 @@ services:
     arguments:
       - '@prestashop.core.crypto.hashing'
       - '@=service("prestashop.adapter.legacy.configuration").get("_COOKIE_KEY_")'
+      - '@prestashop.adapter.legacy.configuration'
 
   prestashop.adapter.customer.query_handler.get_customer_for_editing:
     class: 'PrestaShop\PrestaShop\Adapter\Customer\QueryHandler\GetCustomerForEditingHandler'
@@ -45,6 +46,7 @@ services:
     arguments:
       - '@prestashop.core.crypto.hashing'
       - '@=service("prestashop.adapter.legacy.configuration").get("_COOKIE_KEY_")'
+      - '@prestashop.adapter.legacy.configuration'
 
   prestashop.adapter.customer.command_handler.bulk_enable_customer_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Customer\CommandHandler\BulkEnableCustomerHandler'

--- a/tests/Integration/Adapter/Customer/CustomerPasswordPolicyTest.php
+++ b/tests/Integration/Adapter/Customer/CustomerPasswordPolicyTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Customer;
+
+use Configuration;
+use Db;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
+use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The back office customer form applies PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH through a Symfony
+ * constraint. Entry points that dispatch the command directly only met the Password value object's
+ * own bounds, so the same shop accepted a password through the API that it refused in the form.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/42129
+ */
+class CustomerPasswordPolicyTest extends KernelTestCase
+{
+    private const EMAIL = 'password.policy.probe@example.com';
+
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    /**
+     * @var string
+     */
+    private $originalMinLength;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->commandBus = self::getContainer()->get('prestashop.core.command_bus');
+
+        $this->originalMinLength = (string) Configuration::get(
+            PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH
+        );
+        Configuration::updateValue(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH, 8);
+
+        $this->removeProbeCustomer();
+    }
+
+    protected function tearDown(): void
+    {
+        Configuration::updateValue(
+            PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH,
+            $this->originalMinLength
+        );
+
+        $this->removeProbeCustomer();
+    }
+
+    public function testItRefusesAPasswordShorterThanTheConfiguredMinimum(): void
+    {
+        $this->expectException(CustomerConstraintException::class);
+
+        // Six characters: above the value object's own floor, below the configured minimum of 8.
+        $this->commandBus->handle($this->buildCommand('abcdef'));
+    }
+
+    public function testItAcceptsAPasswordThatMeetsTheConfiguredMinimum(): void
+    {
+        $customerId = $this->commandBus->handle($this->buildCommand('Str0ng!Passw0rd'));
+
+        $this->assertGreaterThan(0, $customerId->getValue());
+    }
+
+    private function buildCommand(string $password): AddCustomerCommand
+    {
+        $groupId = (int) Db::getInstance()->getValue(
+            'SELECT `id_group` FROM `' . _DB_PREFIX_ . 'group` ORDER BY `id_group`'
+        );
+
+        return new AddCustomerCommand(
+            'Password',
+            'Policy',
+            self::EMAIL,
+            $password,
+            $groupId,
+            [$groupId],
+            1
+        );
+    }
+
+    private function removeProbeCustomer(): void
+    {
+        $id = (int) Db::getInstance()->getValue(
+            'SELECT `id_customer` FROM `' . _DB_PREFIX_ . 'customer` WHERE `email` = "' . pSQL(self::EMAIL) . '"'
+        );
+
+        if ($id) {
+            Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer_group` WHERE `id_customer` = ' . $id);
+            Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer` WHERE `id_customer` = ' . $id);
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | The back office customer form applies `PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH` and `MAXIMUM_LENGTH` as Symfony constraints. Entry points that dispatch the customer commands directly - the Admin API among them - only met the `Password` value object's own bounds of 5 to 72, so the same shop refused a password in the form and accepted it through the API. The check moves to the command handlers, where the configuration is available.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With the default policy (minimum length 8), create a customer through the Admin API with a six-character password. Before this change it is accepted; after it the command is rejected with `CustomerConstraintException`. The back office form is unchanged.
| Fixed issue or discussion? | Fixes #42129
| Sponsor company   |

### Where the asymmetry was

```php
// src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php:107
$minScore  = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_SCORE);
$maxLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
$minLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH);
```

Measured against a shop configured with minimum length 8:

```
POST /admin-api/customers, 4 chars  -> 422
POST /admin-api/customers, 5 chars  -> 201
POST /admin-api/customers, 6 chars  -> 201
```

5 is `Password::MIN_LENGTH`, a hardcoded constant. The configured 8 was never consulted on that path.

### Length only, deliberately

`MINIMUM_SCORE` is **not** enforced server-side anywhere. All four usages in the codebase pass it to the template as `data-minscore` for the client-side strength meter:

```
CustomerType.php:233            'data-minscore' => $minScore,
ResetPasswordType.php           'data-minscore' => $minScore,
EmployeeType.php                'data-minscore' => $minScore,
ChangePasswordType.php          'data-minscore' => $minScore,
```

Applying it in the handler would make the command path *stricter* than the back office rather than consistent with it, so this PR aligns the length and leaves score alone. My earlier comment on the issue said this change would close "both the length and the score gap" - that was wrong, and the distinction only became clear after checking each usage.

### Where the check lives

In the command handlers, next to the existing `assertCustomerCanAccessDefaultGroup()`. Same reasoning as that check: the configuration is not available inside a value object, and putting it in the API resource would fix only the entry point that reported the problem.

The configuration is injected as a trailing nullable argument, so anything constructing these handlers directly keeps working and simply skips the check.

### Tests

`tests/Integration/Adapter/Customer/CustomerPasswordPolicyTest.php` sets the policy to 8, then:

```
with the change      -> Tests: 2, Assertions: 2, no failures
handlers reverted    -> Failed asserting that exception of type
                        "CustomerConstraintException" is thrown
```

Wider scopes are unaffected: `Customer` unit scope `Tests: 178, Assertions: 298`, no failures. One integration test in that filter (`ModuleHtmlAuthorizationCheckerTest`) fails on this machine for a missing `ps_featuredproducts` fixture - it fails identically without this change, so it is unrelated.

php-cs-fixer reports nothing left to fix and PHPStan on both handlers returns `[OK] No errors`.

### Worth a maintainer's opinion

This tightens what the API accepts, so an integration currently creating customers with short passwords starts getting a rejection. That is the point of the issue, but it is a behaviour change on a public surface - if you would rather stage it (warn first, enforce in 10.0), say so and I will rework it.
