### PR TITLE
Order checkout payment options by the merchant configuration

### DIFF
--- a/classes/checkout/PaymentOptionsFinder.php
+++ b/classes/checkout/PaymentOptionsFinder.php
@@ -33,7 +33,8 @@ class PaymentOptionsFinderCore extends HookFinder
         // Payment options coming from regular Advanced API
         $this->hookName = 'paymentOptions';
         $this->expectedInstanceClasses = ['PrestaShop\PrestaShop\Core\Payment\PaymentOption'];
-        $paymentOptions = array_merge($paymentOptions, parent::find());
+        $configurableOptions = parent::find();
+        $paymentOptions = array_merge($paymentOptions, $configurableOptions);
 
         // Safety check
         foreach ($paymentOptions as $moduleName => $paymentOption) {
@@ -42,7 +43,49 @@ class PaymentOptionsFinderCore extends HookFinder
             }
         }
 
-        return $paymentOptions;
+        return $this->putConfigurableOptionsFirst($paymentOptions, array_keys($configurableOptions));
+    }
+
+    /**
+     * The three hooks are merged in a fixed order, and a module's position only orders it against the
+     * other modules of its own hook - positions are a per-hook sequence, so they are not comparable
+     * across hooks. That left every module on the deprecated hooks ahead of every configured one,
+     * whatever the merchant had set.
+     *
+     * `paymentOptions` is the hook the merchant actually orders, and the one Module::getPaymentModules()
+     * treats as the payment hook, so it defines the order here. Modules that only supply options
+     * through the deprecated hooks keep their relative order and follow instead of leading.
+     *
+     * The merge itself is untouched, so which entry wins when a module answers on more than one hook
+     * is unchanged.
+     *
+     * @param array $paymentOptions merged options, keyed by module name
+     * @param string[] $configurableModules module names that answered on the paymentOptions hook
+     *
+     * @return array
+     */
+    protected function putConfigurableOptionsFirst(array $paymentOptions, array $configurableModules)
+    {
+        $configured = [];
+        $legacy = [];
+
+        foreach ($paymentOptions as $moduleName => $options) {
+            if (in_array($moduleName, $configurableModules, true)) {
+                $configured[$moduleName] = $options;
+            } else {
+                $legacy[$moduleName] = $options;
+            }
+        }
+
+        // Keep the merchant order inside the configured group.
+        $ordered = [];
+        foreach ($configurableModules as $moduleName) {
+            if (isset($configured[$moduleName])) {
+                $ordered[$moduleName] = $configured[$moduleName];
+            }
+        }
+
+        return $ordered + $legacy;
     }
 
     public function findFree()

--- a/tests/Unit/Classes/Checkout/PaymentOptionsOrderTest.php
+++ b/tests/Unit/Classes/Checkout/PaymentOptionsOrderTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Checkout;
+
+use PaymentOptionsFinder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Payment options are collected from three hooks and merged in a fixed order, with the deprecated
+ * ones first. A module's position only orders it against the other modules of its own hook, so the
+ * merchant order configured on paymentOptions never applied to a module answering on a legacy hook.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/42097
+ */
+class PaymentOptionsOrderTest extends TestCase
+{
+    /**
+     * @var PaymentOptionsOrderTestFinder
+     */
+    private $finder;
+
+    protected function setUp(): void
+    {
+        $this->finder = new PaymentOptionsOrderTestFinder();
+    }
+
+    public function testConfiguredModulesKeepTheirOrderAndComeFirst(): void
+    {
+        // What the merge produces today: the legacy module leads, the configured ones follow.
+        $merged = [
+            'stripe_official' => ['legacy option'],
+            'paybox' => ['option'],
+            'ps_wirepayment' => ['option'],
+            'ps_checkpayment' => ['option'],
+        ];
+
+        // The order the merchant set on the paymentOptions hook.
+        $configured = ['paybox', 'ps_wirepayment', 'ps_checkpayment'];
+
+        $this->assertSame(
+            ['paybox', 'ps_wirepayment', 'ps_checkpayment', 'stripe_official'],
+            array_keys($this->finder->order($merged, $configured))
+        );
+    }
+
+    public function testLegacyOnlyModulesKeepTheirRelativeOrder(): void
+    {
+        $merged = [
+            'legacy_a' => ['option'],
+            'legacy_b' => ['option'],
+            'ps_wirepayment' => ['option'],
+        ];
+
+        $this->assertSame(
+            ['ps_wirepayment', 'legacy_a', 'legacy_b'],
+            array_keys($this->finder->order($merged, ['ps_wirepayment']))
+        );
+    }
+
+    public function testNothingMovesWhenEveryModuleIsConfigured(): void
+    {
+        $merged = [
+            'ps_wirepayment' => ['option'],
+            'ps_checkpayment' => ['option'],
+        ];
+        $configured = ['ps_wirepayment', 'ps_checkpayment'];
+
+        $this->assertSame($merged, $this->finder->order($merged, $configured));
+    }
+
+    public function testAConfiguredModuleThatReturnedNothingIsNotInvented(): void
+    {
+        $merged = ['ps_wirepayment' => ['option']];
+
+        // ps_checkpayment is registered on the hook but produced no option for this cart.
+        $ordered = $this->finder->order($merged, ['ps_wirepayment', 'ps_checkpayment']);
+
+        $this->assertSame(['ps_wirepayment'], array_keys($ordered));
+    }
+}
+
+/**
+ * Exposes the protected ordering step; the surrounding find() needs a booted shop context.
+ */
+class PaymentOptionsOrderTestFinder extends PaymentOptionsFinder
+{
+    public function __construct()
+    {
+        // The ordering step does not touch any collaborator.
+    }
+
+    public function order(array $paymentOptions, array $configurableModules): array
+    {
+        return $this->putConfigurableOptionsFirst($paymentOptions, $configurableModules);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Checkout payment options are collected from three hooks and merged in a fixed order, with the two deprecated ones first, so any module answering on a deprecated hook preceded every configured one regardless of the merchant's ordering. `paymentOptions` - the hook merchants actually order, and the one `Module::getPaymentModules()` treats as the payment hook - now defines the order; modules that only supply options through the deprecated hooks keep their relative order and follow instead of leading.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With a module answering on `displayPaymentEU` (Stripe Official is the reported case) alongside modules on `paymentOptions`, open the checkout payment step. Before this change the legacy module is always first; after it, the configured modules appear in the merchant's order and the legacy one follows.
| UI Tests          | Queued on `boo-code/ga.tests.ui.pr` behind two runs already in flight; the fork executes about 20 jobs concurrently and a campaign is 45, so dispatching a third now would only starve all three. The link goes here when it is dispatched.
| Fixed issue or discussion?     | Fixes #42097
| Related PRs       |
| Sponsor company   |

### Why sorting by position does not work

The obvious fix - sort the merged list by `hook_module.position` - is provably wrong. Positions are a per-hook sequence starting at 1, so they are not comparable across hooks. On a stock install:

```
paymentOptions: ps_wirepayment 1, ps_checkpayment 2, ps_cashondelivery 3
```

A module that is alone on `displayPaymentEU` holds position 1 in that hook, so sorting by position would still place it first - the exact behaviour being reported. There is no cross-hook order in the data model to sort by.

### The semantic this PR defines

> Payment options are ordered by the merchant-configured position of the `paymentOptions` hook. Modules that only supply options through the deprecated hooks keep their relative order and follow the configured ones.

That is a choice rather than something the model already encodes, so it is worth stating plainly. The reasoning:

- `paymentOptions` is where merchants set the order, and `Module::getPaymentModules()` already treats it as *the* payment hook, falling back to legacy `Payment` only when it does not exist.
- The other two are described in this very method as the "intermediate, deprecated version of the Advanced API". Giving the deprecated path unconditional precedence over the configured one is not something any setting expresses.
- Appending rather than prepending is the smallest change that makes the configured order authoritative.

### What is deliberately not changed

The merge itself. `array_merge` on string keys keeps the last value, so today a module answering on both a deprecated hook and `paymentOptions` is represented by its `paymentOptions` entry. Reordering the merge calls would have flipped that silently, so the ordering is applied afterwards instead.

### Tests

`tests/Unit/Classes/Checkout/PaymentOptionsOrderTest.php` covers the ordering step: configured modules keep their order and lead, legacy-only modules keep their relative order and follow, an all-configured list is untouched, and a module registered on the hook but returning nothing is not invented into the list.

```
with the change              -> Tests: 4, Assertions: 4, no failures
ordering stubbed to a no-op  -> Failed asserting that two arrays are identical (x2)
```

The stub reproduces the old behaviour exactly, so the test pins the ordering rather than the method's existence.

`Payment` unit scope is unaffected: `Tests: 17, Assertions: 45`, no failures. php-cs-fixer reports nothing to fix and PHPStan on the changed class returns `[OK] No errors`.

### If you would rather have a different rule

The alternative is to give the payment hooks a real shared ordering in the data model, which is a larger change and a product decision about what merchants see and set. This PR takes the smaller route; if you prefer the model change, say so and I will rework it.

