### PR TITLE
Stop treating an explicit "Decrement pack only" as an unset pack stock type

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -289,8 +289,10 @@ class PackCore extends Product
          * STOCK_TYPE_PACK_BOTH - pack 1pcs + product A 10pcs + product B 20pcs = 1 pcs
          */
 
-        // If no pack stock or shop default, set it from configuration
-        if (empty($packStockType) || $packStockType == self::STOCK_TYPE_DEFAULT) {
+        // If no pack stock or shop default, set it from configuration.
+        // STOCK_TYPE_PACK_ONLY is 0, so empty() used to swallow it and fall back to the shop
+        // default, making an explicit "Decrement pack only" indistinguishable from an unset value.
+        if (null === $packStockType || (int) $packStockType === self::STOCK_TYPE_DEFAULT) {
             $packStockType = Configuration::get('PS_PACK_STOCK_TYPE');
         }
 

--- a/tests/Integration/Classes/PackStockTypeTest.php
+++ b/tests/Integration/Classes/PackStockTypeTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Pack;
+use Product;
+use StockAvailable;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The pack's own pack_stock_type must win over the shop-wide PS_PACK_STOCK_TYPE, including when it
+ * is STOCK_TYPE_PACK_ONLY - which is 0, and was therefore swallowed by an empty() check.
+ */
+class PackStockTypeTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = [
+        'product', 'product_shop', 'product_lang', 'pack', 'stock_available', 'configuration',
+    ];
+
+    private const PACK_OWN_QUANTITY = 1;
+    private const ITEM_A_QUANTITY = 10;
+    private const ITEM_B_QUANTITY = 20;
+
+    private static int $packId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        self::bootKernel();
+
+        Configuration::updateValue('PS_PACK_FEATURE_ACTIVE', 1);
+        Configuration::updateValue('PS_STOCK_MANAGEMENT', 1);
+
+        $itemA = self::createProduct('pack-item-a', self::ITEM_A_QUANTITY);
+        $itemB = self::createProduct('pack-item-b', self::ITEM_B_QUANTITY);
+        self::$packId = self::createProduct('pack-under-test', self::PACK_OWN_QUANTITY);
+
+        // 2 x A + 1 x B, so the components allow min(floor(10/2), floor(20/1)) = 5 packs.
+        Pack::addItem(self::$packId, $itemA, 2);
+        Pack::addItem(self::$packId, $itemB, 1);
+        Pack::resetStaticCache();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        parent::tearDownAfterClass();
+    }
+
+    private static function createProduct(string $reference, int $quantity): int
+    {
+        $product = new Product();
+        $product->name = [(int) Configuration::get('PS_LANG_DEFAULT') => $reference];
+        $product->link_rewrite = [(int) Configuration::get('PS_LANG_DEFAULT') => $reference];
+        $product->reference = $reference;
+        $product->price = 10.0;
+        $product->id_category_default = 2;
+        $product->add();
+
+        // No stock movement: it would need an employee in the context, which this test has no use for.
+        StockAvailable::setQuantity((int) $product->id, 0, $quantity, null, false);
+
+        return (int) $product->id;
+    }
+
+    private function setPackStockType(int $packStockType): void
+    {
+        $pack = new Product(self::$packId);
+        $pack->pack_stock_type = $packStockType;
+        $pack->save();
+
+        Pack::resetStaticCache();
+        Product::flushPriceCache();
+    }
+
+    /**
+     * The pack explicitly decrements its own stock, while the shop default says to use the items.
+     * The pack's own setting must win, so the answer is the pack's own quantity and not the 5 packs
+     * its components would allow.
+     */
+    public function testExplicitPackOnlyIsNotOverriddenByShopDefault(): void
+    {
+        Configuration::updateValue('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PRODUCTS_ONLY);
+        $this->setPackStockType(Pack::STOCK_TYPE_PACK_ONLY);
+
+        $this->assertSame(self::PACK_OWN_QUANTITY, Pack::getQuantity(self::$packId));
+    }
+
+    /**
+     * The counterpart: STOCK_TYPE_DEFAULT really does mean "use the shop setting".
+     */
+    public function testDefaultStockTypeStillFollowsShopConfiguration(): void
+    {
+        Configuration::updateValue('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PRODUCTS_ONLY);
+        $this->setPackStockType(Pack::STOCK_TYPE_DEFAULT);
+
+        $this->assertSame(5, Pack::getQuantity(self::$packId));
+    }
+
+    /**
+     * And an explicit products-only pack is unaffected by a pack-only shop default.
+     */
+    public function testExplicitProductsOnlyIsNotOverriddenByShopDefault(): void
+    {
+        Configuration::updateValue('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PACK_ONLY);
+        $this->setPackStockType(Pack::STOCK_TYPE_PRODUCTS_ONLY);
+
+        $this->assertSame(5, Pack::getQuantity(self::$packId));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `Pack::getQuantity()` resolved the pack stock mode with `empty($packStockType)`, and `STOCK_TYPE_PACK_ONLY` is `0`. An explicit "Decrement pack only" was therefore indistinguishable from an unset value and always fell back to the shop-wide `PS_PACK_STOCK_TYPE`, so the pack's availability was computed from its components. The fallback now applies only to a genuinely absent value and to `STOCK_TYPE_DEFAULT`.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set Shop Parameters > Product Settings > "Default pack stock management" to "Decrement products in pack only". Create product A with quantity 10 and product B with quantity 20, then a pack of 2xA + 1xB with its own quantity 1 and its stock management option set to "Decrement pack only". The pack's available quantity is 5 before this change and 1 after it. `tests/Integration/Classes/PackStockTypeTest.php` covers the three modes.
| Fixed issue or discussion? | Fixes #42079
| Sponsor company   |

### Why this is more than a display difference

`StockManager::updatePackQuantity()` resolves the same setting with exact comparisons, so the decrement path already honours a per-pack `0`. For a pack set to "Decrement pack only" while the shop default says otherwise, ordering decrements the pack's own stock while the front office displays a quantity derived from the components. The displayed availability is computed from stock that sales of the pack never touch, and the two diverge with every order. `Pack::isInStock()` goes through the same method, so cart availability checks used the wrong mode as well.

### On the shape of the guard

The value is validated a few lines above against the four known stock types, and on PHP 8 an empty string does not match any of them, so it throws there and cannot reach this line. `null` does match `0` under that loose comparison, so it survives validation and is the case the fallback still has to cover. That is why the condition checks `null` rather than keeping a broader emptiness test.

### Tests

`tests/Integration/Classes/PackStockTypeTest.php` builds the reporter's scenario and asserts all three modes:

- an explicit "pack only" pack is not overridden by a "products only" shop default (the reported bug),
- `STOCK_TYPE_DEFAULT` still follows the shop configuration,
- an explicit "products only" pack is not overridden by a "pack only" shop default.

Reverting only `classes/Pack.php` fails the first test with `Failed asserting that 5 is identical to 1`, which is the number pair from the report; the other two stay green.
