### PR TITLE
Update the AI context branch map after the 9.1.x closure

### DIFF
--- a/.ai/CONTEXT.md
+++ b/.ai/CONTEXT.md
@@ -11,11 +11,13 @@ PrestaShop is an open-source e-commerce platform built on Symfony. It follows a 
 
 ## Branching & Versioning
 
-PrestaShop follows [SemVer](https://semver.org/). Active branches merge upward: `9.1.x` → `develop`. Target the lowest applicable branch.
+PrestaShop follows [SemVer](https://semver.org/). Active branches merge upward: `9.2.x` → `develop`. Target the lowest applicable branch.
 
-- **`9.1.x`**: Current stable (patch releases). Bug fixes and minor improvements only — no new features.
-- **`develop`**: Next minor (9.2.0). New features and improvements go here. No breaking changes.
+- **`9.2.x`**: Next release (9.2.0). Bug fixes and improvements go here.
+- **`develop`**: Next minor (9.3.0). New features go here. No breaking changes.
 - **`8.2.x`**: LTS, security fixes only. Rarely modified.
+
+`9.1.x` was closed and deleted once 9.1.5 was finalised, so nothing targets it any more.
 
 Breaking changes are only allowed in major versions. See [ADR 0017](https://github.com/PrestaShop/adr/blob/master/0017-backward-compatibility-promise.md) for the backward compatibility promise. More architecture decisions at https://github.com/PrestaShop/adr.
 
@@ -73,7 +75,7 @@ Common slips unrelated to the feature itself — check before pushing:
 - **No IDE / local config files** (`.idea/`, editor settings) and no stray blank-line or missing-end-of-line changes.
 - **Keep lists alphabetically sorted** (interface members, imports where applicable, enum-like lists) — not all of this is caught by php-cs-fixer.
 - **Squash noise commits** (review fixups, reverts) so history stays readable.
-- **Target the lowest applicable branch** (`9.1.x` for bug fixes, `develop` for features) — see Branching & Versioning above.
+- **Target the lowest applicable branch** (`9.2.x` for bug fixes, `develop` for features) — see Branching & Versioning above.
 
 ## Skills
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `.ai/CONTEXT.md` still lists `9.1.x` as the current stable branch and tells contributors to target it, which is the routing instruction every AI assistant reads from this repo. With `9.1.x` closed and deleted after 9.1.5, that sends bug fixes to a branch that no longer exists. The map now runs `9.2.x` -> `develop`, bug fixes go to `9.2.x` and features to `develop`, and the PR-hygiene line further down that repeated the old routing is updated to match.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Documentation only. The branches named are the ones that exist: `8.2.x`, `9.1.x`, `9.2.x`, `develop`.
| UI Tests          | Not run yet: two campaigns at a time on `boo-code/ga.tests.ui.pr`, oldest PR first. The link goes here when this one runs.
| Fixed issue or discussion? | N/A
| Related PRs       | #42107 raises the same staleness from the other side (it bumps `develop` to 9.3.0, which is what makes the "Next minor (9.2.0)" line wrong). The two do not conflict, they touch different files.
| Sponsor company   |

### Why the version number is removed rather than updated

`- **develop**: Next minor (9.2.0)` is the only line in this file that has to be edited at every version bump, and it is the line that was missed: the file was added in July, after the previous bump, so this is the first bump since it exists. Naming the position in the chain instead keeps it correct across bumps, and the branch names already carry the versions.

### Branch targeted

`.ai/CONTEXT.md` exists on `9.2.x` and `develop` with identical content, and not on `9.1.x`, so `9.2.x` is the lowest applicable branch and the change reaches `develop` through the normal upward merge.

I left `.ai/skills/create-pr/SKILL.md` alone: it mentions `9.1.x` → `develop` only as an illustration of what a merge PR is, not as the branch map.

