### PR TITLE
Report the status the response carries in Admin API error bodies

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/Normalizer/ProblemStatusNormalizer.php
+++ b/src/PrestaShopBundle/ApiPlatform/Normalizer/ProblemStatusNormalizer.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\ApiPlatform\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Reports the status the response actually carries in the error body.
+ *
+ * WHY: API Platform maps a domain exception to its HTTP status and hands that status to the
+ * serializer under the `statusCode` key (ExceptionAction), while Symfony's ProblemNormalizer reads
+ * it from `status` and otherwise falls back to the status of the exception itself, which is 500 for
+ * any domain exception. A mapped response therefore answers 404 while its body says 500.
+ */
+final class ProblemStatusNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        private readonly NormalizerInterface $decorated,
+    ) {
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = []): mixed
+    {
+        if (isset($context['statusCode']) && !isset($context['status'])) {
+            $context['status'] = $context['statusCode'];
+        }
+
+        return $this->decorated->normalize($object, $format, $context);
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    {
+        return $this->decorated->supportsNormalization($data, $format);
+    }
+
+    /**
+     * @return array<class-string|'*'|'object'|string, bool|null>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return $this->decorated->getSupportedTypes($format);
+    }
+}

--- a/src/PrestaShopBundle/ApiPlatform/Processor/CommandProcessor.php
+++ b/src/PrestaShopBundle/ApiPlatform/Processor/CommandProcessor.php
@@ -57,7 +57,7 @@ class CommandProcessor implements ProcessorInterface
             $commandParameters = array_merge($normalizedApiResourceDTO, $uriVariables, $this->contextParametersProvider->getContextParameters());
 
             // Denormalize the command and let the bus handle it
-            $command = $this->domainSerializer->denormalize($commandParameters, $CQRSCommandClass, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSCommandMapping($operation)]);
+            $command = $this->domainSerializer->denormalize($commandParameters, $CQRSCommandClass, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSCommandMapping($operation), CQRSApiSerializer::CLIENT_INPUT => true]);
         }
         $commandResult = $this->commandBus->handle($command);
         $allowEmptyBody = $operation->getExtraProperties()['allowEmptyBody'] ?? null;

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryListProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryListProvider.php
@@ -158,7 +158,7 @@ class QueryListProvider implements ProviderInterface
             $getParameters,
             $this->contextParametersProvider->getContextParameters(),
         );
-        $CQRSQuery = $this->domainSerializer->denormalize($queryParameters, $CQRSQueryClass, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSQueryMapping($operation)]);
+        $CQRSQuery = $this->domainSerializer->denormalize($queryParameters, $CQRSQueryClass, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSQueryMapping($operation), CQRSApiSerializer::CLIENT_INPUT => true]);
         $CQRSQueryResult = $this->queryBus->handle($CQRSQuery);
 
         // Query result must be a structure that contains paginated elements (so a list of items and a count)

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -51,7 +51,7 @@ class QueryProvider implements ProviderInterface
         $filters = $context['filters'] ?? [];
         $queryParameters = array_merge($uriVariables, $filters, $this->contextParametersProvider->getContextParameters());
 
-        $CQRSQuery = $this->domainSerializer->denormalize($queryParameters, $CQRSQueryClass, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSQueryMapping($operation)]);
+        $CQRSQuery = $this->domainSerializer->denormalize($queryParameters, $CQRSQueryClass, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSQueryMapping($operation), CQRSApiSerializer::CLIENT_INPUT => true]);
         $CQRSQueryResult = $this->queryBus->handle($CQRSQuery);
         // The result may be null (for DELETE action for example)
         if (null === $CQRSQueryResult) {

--- a/src/PrestaShopBundle/ApiPlatform/Serializer/CQRSApiSerializer.php
+++ b/src/PrestaShopBundle/ApiPlatform/Serializer/CQRSApiSerializer.php
@@ -15,6 +15,7 @@ use PrestaShopBundle\ApiPlatform\PositionCollectionUpdater;
 use ReflectionNamedType;
 use Symfony\Component\Serializer\Encoder\ContextAwareDecoderInterface;
 use Symfony\Component\Serializer\Encoder\ContextAwareEncoderInterface;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Exception\UnsupportedFormatException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
@@ -30,6 +31,12 @@ use Symfony\Component\Serializer\SerializerInterface;
 class CQRSApiSerializer implements SerializerInterface, ContextAwareNormalizerInterface, ContextAwareDenormalizerInterface, ContextAwareEncoderInterface, ContextAwareDecoderInterface
 {
     public const CAST_BOOL = 'cast_bool';
+
+    /**
+     * Set on the denormalization of data that came from the request, as opposed to a CQRS result
+     * being turned into an ApiResource. Only the former is worth rephrasing for an API client.
+     */
+    public const CLIENT_INPUT = 'client_input';
 
     public function __construct(
         protected readonly Serializer $decorated,
@@ -91,7 +98,46 @@ class CQRSApiSerializer implements SerializerInterface, ContextAwareNormalizerIn
             $data = $this->denormalizeLocalizedValues($data, $type, $context);
         }
 
-        return $this->decorated->denormalize($data, $type, $format, $context);
+        try {
+            return $this->decorated->denormalize($data, $type, $format, $context);
+        } catch (NotNormalizableValueException $e) {
+            if (empty($context[self::CLIENT_INPUT])) {
+                throw $e;
+            }
+
+            throw $this->describeWithoutInternals($e);
+        }
+    }
+
+    /**
+     * The serializer's own message names the CQRS class the request is denormalized into, which
+     * tells an API client the internal namespace and the query or command behind the endpoint.
+     * The exception already carries the same information in a structured form, so the message can
+     * be rebuilt from that and describe the input instead.
+     */
+    private function describeWithoutInternals(NotNormalizableValueException $exception): NotNormalizableValueException
+    {
+        $path = $exception->getPath();
+        $expectedTypes = $exception->getExpectedTypes();
+
+        // Without a path there is nothing to name, and a hand-written message would say less than
+        // the original one.
+        if (null === $path || empty($expectedTypes)) {
+            return $exception;
+        }
+
+        return NotNormalizableValueException::createForUnexpectedDataType(
+            sprintf(
+                'The "%s" parameter must be of type %s, %s given.',
+                $path,
+                implode(' or ', $expectedTypes),
+                $exception->getCurrentType() ?? 'none'
+            ),
+            null,
+            $expectedTypes,
+            $path,
+            true
+        );
     }
 
     public function encode(mixed $data, string $format, array $context = []): string

--- a/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
@@ -46,6 +46,13 @@ services:
       $domainNamespaces:
         - 'PrestaShop\PrestaShop\Core\Domain'
 
+  # Puts the status the response carries into the error body, which ApiPlatform hands over under a
+  # key Symfony's ProblemNormalizer does not read
+  PrestaShopBundle\ApiPlatform\Normalizer\ProblemStatusNormalizer:
+    decorates: 'serializer.normalizer.problem'
+    arguments:
+      $decorated: '@.inner'
+
   # This is a custom serializer that handles localized values and normalization mapping
   PrestaShopBundle\ApiPlatform\Serializer\CQRSApiSerializer:
     autowire: true

--- a/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
+++ b/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
@@ -26,6 +26,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Command\EditCustomerGroupCo
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Query\GetCustomerGroupForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\QueryResult\EditableCustomerGroup;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\ValueObject\GroupId;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\AddDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountCommand;
@@ -52,6 +53,7 @@ use PrestaShopBundle\ApiPlatform\NormalizationMapper;
 use PrestaShopBundle\ApiPlatform\Serializer\CQRSApiSerializer;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Tests\Integration\Utility\LanguageTrait;
 use Tests\Resources\ApiPlatform\Resources\LocalizedResource;
 use Tests\Resources\ApiPlatform\Resources\UpdatePositionResource;
@@ -530,6 +532,34 @@ class CQRSApiSerializerTest extends KernelTestCase
             ],
             $addDiscountCommand,
         ];
+    }
+
+    /**
+     * A type error on request data must describe the parameter, not the CQRS class the request is
+     * denormalized into - that name is internal and tells an API client more than it needs.
+     */
+    public function testDenormalizeClientInputHidesTheCQRSClass(): void
+    {
+        $serializer = self::getContainer()->get(CQRSApiSerializer::class);
+        $badInput = ['phrases' => 'demo'];
+
+        try {
+            $serializer->denormalize($badInput, SearchCustomers::class, null, [
+                CQRSApiSerializer::CLIENT_INPUT => true,
+            ]);
+            self::fail('Denormalizing a string into the array parameter should have thrown');
+        } catch (NotNormalizableValueException $e) {
+            self::assertSame('The "phrases" parameter must be of type array, string given.', $e->getMessage());
+            self::assertStringNotContainsString(SearchCustomers::class, $e->getMessage());
+        }
+
+        // Without the flag the data did not come from a client, so the original message is kept.
+        try {
+            $serializer->denormalize($badInput, SearchCustomers::class, null, []);
+            self::fail('Denormalizing a string into the array parameter should have thrown');
+        } catch (NotNormalizableValueException $e) {
+            self::assertStringContainsString(SearchCustomers::class, $e->getMessage());
+        }
     }
 
     public function testNormalize(): void

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ProblemStatusNormalizerTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ProblemStatusNormalizerTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\ApiPlatform\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\ApiPlatform\Normalizer\ProblemStatusNormalizer;
+use RuntimeException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ProblemStatusNormalizerTest extends TestCase
+{
+    public function testTheMappedStatusIsHandedToTheDecoratedNormalizer(): void
+    {
+        $capturedContext = null;
+        $normalizer = new ProblemStatusNormalizer($this->buildDecorated($capturedContext));
+
+        // ApiPlatform's ExceptionAction resolves the domain exception to its mapped status and passes
+        // it as statusCode, while the exception itself still reports 500.
+        $normalizer->normalize(FlattenException::createFromThrowable(new RuntimeException('not found')), 'jsonproblem', ['statusCode' => 404]);
+
+        $this->assertSame(404, $capturedContext['status']);
+    }
+
+    public function testAnExplicitStatusIsNotOverwritten(): void
+    {
+        $capturedContext = null;
+        $normalizer = new ProblemStatusNormalizer($this->buildDecorated($capturedContext));
+
+        $normalizer->normalize(FlattenException::createFromThrowable(new RuntimeException('nope')), 'jsonproblem', ['statusCode' => 404, 'status' => 410]);
+
+        $this->assertSame(410, $capturedContext['status']);
+    }
+
+    public function testAContextWithoutAStatusCodeIsLeftAlone(): void
+    {
+        $capturedContext = null;
+        $normalizer = new ProblemStatusNormalizer($this->buildDecorated($capturedContext));
+
+        $normalizer->normalize(FlattenException::createFromThrowable(new RuntimeException('nope')), 'jsonproblem', []);
+
+        $this->assertArrayNotHasKey('status', $capturedContext);
+    }
+
+    private function buildDecorated(&$capturedContext): NormalizerInterface
+    {
+        $decorated = $this->createMock(NormalizerInterface::class);
+        $decorated->method('normalize')->willReturnCallback(
+            function ($object, ?string $format = null, array $context = []) use (&$capturedContext): array {
+                $capturedContext = $context;
+
+                return [];
+            }
+        );
+
+        return $decorated;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | An Admin API error response carries the status ApiPlatform mapped the domain exception to, but its body reports 500. `ExceptionAction` resolves the mapped status and passes it to the serializer as `statusCode`, while Symfony's `ProblemNormalizer` reads `status` and otherwise falls back to `FlattenException::getStatusCode()`, which is 500 for any domain exception. A small decorator on `serializer.normalizer.problem` puts the resolved status where the normalizer looks for it. The PR also stops naming the CQRS command class in the message returned to a client whose own input could not be denormalized.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `GET /admin-api/customers/99999999` with a valid token. The response is 404 both before and after; before this change the body reads `"status":500`, after it reads `"status":404`. `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ProblemStatusNormalizerTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | -
| Related PRs       |
| Sponsor company   |

### Measured

On a 9.2 shop, same request before and after:

```
GET /admin-api/customers/99999999
  before   HTTP 404, body "status": 500
  after    HTTP 404, body "status": 404
```

Verified that nothing else moves:

```
POST /customers with an invalid payload   -> 422, body still the bare list of 3 violations
DELETE /discounts/bulk-delete [999999]    -> 207, body still {type,status,message,errors:[...]}
```

### What this PR no longer does

An earlier revision fixed the status by turning on `rfc_7807_compliant_errors` globally. Measuring it showed that flag does more than reshape the body: with it on, `BulkCommandExceptionNormalizer` is bypassed and a bulk response loses its per-item `errors` array entirely, so a client can no longer tell which id failed. It also changed the validation body from a bare list to a problem document, which broke 32 tests in `ps_apiresources` and would have required a coordinated release there.

The decorator here fixes the reported defect without any of that. Moving the Admin API to RFC 7807 is still worth doing - ApiPlatform 4.0 makes it the only behaviour - but it needs the bulk normalizer ported to it and the module updated in lockstep, which is its own piece of work rather than a bug fix.

### Note on the exception class in the body

`class` and `trace` appear in error bodies only when the kernel runs in debug (`Symfony\Component\Serializer\Normalizer\ProblemNormalizer`, and `admin-api/index.php` passes `_PS_MODE_DEV_` as the debug flag), so they are not exposed on a production shop. The CQRS class name that *was* reaching clients in production came from denormalization failure messages, and that part is fixed here through `CQRSApiSerializer::CLIENT_INPUT`.

