### PR TITLE
Functional Tests : Bump @prestashop-core/ui-testing

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -547,7 +547,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#c9ef920127e4d6ba66a9ff0834e9068d36342470",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a781d9f4fb2c930bdc150d5f626050ca9e74a2a3",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8975,7 +8975,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#c9ef920127e4d6ba66a9ff0834e9068d36342470",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a781d9f4fb2c930bdc150d5f626050ca9e74a2a3",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Moves the locked `@prestashop-core/ui-testing` commit to the library's current `main`, which now carries the create-product iframe fix. `tests/UI/package.json` tracks `#main`, but the Sanity job installs with `npm ci`, so the lock decides what actually gets installed and the merged fix does not reach CI until it moves.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The Sanity jobs on this PR. The failures being addressed are the `Sanity (…, firefox, …)` ones, where `page.frame({url})` intermittently returned null.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30430454928
| Fixed issue or discussion? | Relates to #42072
| Related PRs       | PrestaShop/ui-testing-library#1083 (merged)
| Sponsor company   |

### What the bump contains

The locked commit is three commits behind the library's `main`, and those three are only that fix:

```
b3740360  fix: resolve the create-product iframe from its element instead of its URL
f349d05a  Apply review: rename to getProductCreateFrame and make it private
a781d9f4  Merge pull request #1083
```

The package version is `0.0.12` at both commits, so the diff is the two `resolved` / `version` lines and nothing else - the same shape as the previous bump commits.

### Why re-running the red jobs would not have helped

`.github/actions/ui-test` runs `npm ci`, which installs exactly the commit in `package-lock.json` and ignores that `package.json` points at `#main`. Until this lands, a re-run reinstalls the same pre-fix library.

### Other branches

Each branch pins its own commit, all older than the fix: `9.1.x` at `c9ef9201`, `9.2.x` at `6cca3abe`, `develop` at `9861904d`. This targets `9.1.x` as the lowest one. Happy to open the same two-line change against `9.2.x` and `develop` rather than leaving it to the upward merge, if that is easier on your side.
