### PR TITLE
Scope the re-display-cart-at-login lookup to the current shop

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4324,7 +4324,9 @@ class CartCore extends ObjectModel
                 WHERE NOT EXISTS (SELECT 1 FROM ' . _DB_PREFIX_ . 'orders o WHERE o.`id_cart` = c.`id_cart`
                                     AND o.`id_customer` = ' . (int) $id_customer . ')
                 AND c.`id_customer` = ' . (int) $id_customer . '
-                AND c.`id_cart` = (SELECT `id_cart` FROM `' . _DB_PREFIX_ . 'cart` c2 WHERE c2.`id_customer` = ' . (int) $id_customer . ' ORDER BY `id_cart` DESC LIMIT 1)
+                AND c.`id_cart` = (SELECT `id_cart` FROM `' . _DB_PREFIX_ . 'cart` c2 WHERE c2.`id_customer` = ' . (int) $id_customer . '
+                                    ' . Shop::addSqlRestriction(Shop::SHARE_ORDER, 'c2') . '
+                                    ORDER BY `id_cart` DESC LIMIT 1)
                 AND c.`id_guest` != 0
                     ' . Shop::addSqlRestriction(Shop::SHARE_ORDER, 'c') . '
                 ORDER BY c.`date_upd` DESC';

--- a/tests/Integration/Classes/CartFollowingShopScopeTest.php
+++ b/tests/Integration/Classes/CartFollowingShopScopeTest.php
@@ -63,6 +63,13 @@ class CartFollowingShopScopeTest extends KernelTestCase
 
     public static function tearDownAfterClass(): void
     {
+        // Restoring the tables is not enough: the shop context is static, so leaving it pointed at
+        // the shop this class created makes every later test read through a shop that no longer
+        // exists once the rows are gone.
+        LegacyShop::setContext(LegacyShop::CONTEXT_ALL);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+
         DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
         parent::tearDownAfterClass();
     }

--- a/tests/Integration/Classes/CartFollowingShopScopeTest.php
+++ b/tests/Integration/Classes/CartFollowingShopScopeTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Cart;
+use Configuration as LegacyConfiguration;
+use Db;
+use Shop as LegacyShop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * "Re-display cart at login" resolves the cart through Cart::lastNoneOrderedCart(), which is shop
+ * scoped. The customer's own cart on the current shop must be found even when a more recent cart of
+ * theirs exists on another shop.
+ */
+class CartFollowingShopScopeTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['cart', 'shop', 'shop_group', 'configuration'];
+
+    private const CUSTOMER_ID = 1;
+
+    private static int $secondShopId;
+
+    private static int $cartOnFirstShopId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        $configuration = self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        $db = Db::getInstance();
+
+        // A second shop in its own group, so nothing is shared with the first one.
+        $db->insert('shop_group', [
+            'name' => 'test_group_cart', 'color' => '', 'share_customer' => 0,
+            'share_order' => 0, 'share_stock' => 0, 'active' => 1, 'deleted' => 0,
+        ]);
+        $secondGroupId = (int) $db->Insert_ID();
+        $db->insert('shop', [
+            'id_shop_group' => $secondGroupId, 'name' => 'test_shop_cart', 'color' => '',
+            'id_category' => 2, 'theme_name' => 'classic', 'active' => 1, 'deleted' => 0,
+        ]);
+        self::$secondShopId = (int) $db->Insert_ID();
+        LegacyShop::resetStaticCache();
+
+        // The customer has a cart on the first shop, and then a more recent one on the second.
+        self::$cartOnFirstShopId = self::insertCart(1, $secondGroupId - 1);
+        self::insertCart(self::$secondShopId, $secondGroupId);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        parent::tearDownAfterClass();
+    }
+
+    private static function insertCart(int $shopId, int $shopGroupId): int
+    {
+        $db = Db::getInstance();
+        $db->insert('cart', [
+            'id_shop_group' => $shopGroupId,
+            'id_shop' => $shopId,
+            'id_customer' => self::CUSTOMER_ID,
+            'id_guest' => 1,
+            'id_lang' => (int) LegacyConfiguration::get('PS_LANG_DEFAULT'),
+            'id_currency' => (int) LegacyConfiguration::get('PS_CURRENCY_DEFAULT'),
+            'id_address_delivery' => 0,
+            'id_address_invoice' => 0,
+            'id_carrier' => 0,
+            'recyclable' => 0,
+            'gift' => 0,
+            'mobile_theme' => 0,
+            'date_add' => date('Y-m-d H:i:s'),
+            'date_upd' => date('Y-m-d H:i:s'),
+        ]);
+
+        return (int) $db->Insert_ID();
+    }
+
+    /**
+     * The newest cart of this customer belongs to the other shop, so a lookup that picks it before
+     * applying the shop restriction finds nothing and the customer loses their cart at login.
+     */
+    public function testTheCartOfTheCurrentShopIsFoundDespiteANewerCartElsewhere(): void
+    {
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, 1);
+
+        $this->assertSame(self::$cartOnFirstShopId, Cart::lastNoneOrderedCart(self::CUSTOMER_ID));
+    }
+
+    /**
+     * The counterpart, so the fix cannot be "return any cart of the customer": browsing the second
+     * shop must resolve that shop's cart, not the first one's.
+     */
+    public function testTheOtherShopResolvesItsOwnCart(): void
+    {
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, self::$secondShopId);
+
+        $resolved = Cart::lastNoneOrderedCart(self::CUSTOMER_ID);
+
+        $this->assertNotSame(self::$cartOnFirstShopId, $resolved);
+        $this->assertNotFalse($resolved);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Cart::lastNoneOrderedCart()` applies `Shop::addSqlRestriction()` to its outer query, but the subquery that picks the customer's most recent cart has no shop restriction at all. On a multishop install, when the customer's newest cart belongs to another shop, the subquery returns that cart id and the outer restriction then rejects it, so the query matches nothing and "Re-display cart at login" never restores the cart the customer has on the shop they are browsing.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Multishop enabled, two shops in separate groups, `PS_CART_FOLLOWING` on. Give a customer a cart on shop A, then a newer one on shop B. Log in on shop A: before this change the cart is not restored, after it is. `tests/Integration/Classes/CartFollowingShopScopeTest.php` covers both directions.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Relates to #41707
| Sponsor company   |

### The query

```sql
AND c.`id_cart` = (SELECT `id_cart` FROM `ps_cart` c2 WHERE c2.`id_customer` = X ORDER BY `id_cart` DESC LIMIT 1)
...
<shop restriction on c>
```

The subquery answers "the customer's latest cart anywhere", while the outer query only accepts carts of the current shop. The two disagree exactly when the customer has been active on more than one shop, and the disagreement is silent: the method returns `false`, which reads the same as "this customer has no cart".

Single-shop installs are unaffected: `Shop::addSqlRestriction()` returns an empty string when multishop is off, so the generated SQL is unchanged there.

### On the reported issue

#41707 describes a cart that exists in the database with the right customer and shop while the front office shows an empty cart and `cookie->id_cart` is 0, on shop 10 of a multishop install while shop 1 behaves correctly. That is what this produces at login, and the shop-dependence matches. The report does not include the shop group configuration, so I would not claim it is the whole of that issue - the query is wrong on its own terms and is worth fixing either way.

### Tests

`CartFollowingShopScopeTest` builds two shops in separate groups and gives the customer a cart on each, the second one newer:

- browsing the first shop must resolve the first shop's cart - fails before the change with `false is identical to 7`,
- browsing the second shop must resolve its own cart, so the fix cannot be "return any cart of the customer".

`CartTest` and `CartRuleTest` report the same 8 pre-existing errors before and after the change.

