### PR TITLE
Translate the shipping refund maximum on the order page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -205,9 +205,9 @@
                   <div class="input-group-text">{{ orderCurrency.symbol }}</div>
                 </div>
               </div>
-              <p class="text-center">(max
-                {{ orderForViewing.prices.shippingRefundableAmountFormatted }}
-                tax included)</p>
+              <p class="text-center">
+                {{ '(max %amount% tax included)'|trans({'%amount%': orderForViewing.prices.shippingRefundableAmountFormatted}, 'Admin.Orderscustomers.Feature') }}
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The hint under the shipping refund amount on the order page was literal template text - `(max ... tax included)` - instead of a translation call, so it stayed in English in every language while every label around it was translated.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Back office in a language other than English, open an order and start a partial refund with a refundable shipping amount. The hint under the shipping amount field is translated instead of English. Nothing else on the page changes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Relates to #41682
| Sponsor company   |

### The string

```twig
<p class="text-center">(max
  {{ orderForViewing.prices.shippingRefundableAmountFormatted }}
  tax included)</p>
```

It is the only literal of its kind left in that area - the rest of the file goes through `|trans`, and a search across the order templates finds no other one. The amount becomes a `%amount%` placeholder, following the convention already used in the neighbouring templates such as `'Reference: %reference%'`.

### On the reported issue

#41682 is about the order page showing tax wording when the order carries no tax. This is the part of it that is unambiguously a defect, and it is the only hardcoded string there, so I fixed that first rather than bundle it with the rest.

The other half of the report - the `Tax included` / `Tax excluded` note under the price columns - is not hardcoded: it comes from `orderForViewing.taxMethod`, which `GetOrderForViewingHandler` derives from the order's tax calculation method. That describes how prices are displayed for the customer's group, not whether the order has any tax, so it reads `Tax included` on a zero-tax order by design. Hiding it when the order's tax total is zero would be a deliberate change of meaning rather than a bug fix, so I left it out of here. Say the word if you want that behaviour and I will open it separately.


