### PR TITLE
Check escapeshellarg before shelling out to detect a mime type

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -421,7 +421,7 @@ class ImageManagerCore
             $mimeType = mime_content_type($filename);
         }
         // Try with exec command and file binary
-        if (!$mimeType && function_exists('exec')) {
+        if (!$mimeType && function_exists('exec') && function_exists('escapeshellarg')) {
             $mimeType = trim(exec('file -b --mime-type ' . escapeshellarg($filename)));
             if (!$mimeType) {
                 $mimeType = trim(exec('file --mime ' . escapeshellarg($filename)));

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -1054,7 +1054,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                     finfo_close($finfo);
                 } elseif (Tools::isCallable('mime_content_type')) {
                     $mime_type = mime_content_type($file['tmp_name']);
-                } elseif (Tools::isCallable('exec')) {
+                } elseif (Tools::isCallable('exec') && Tools::isCallable('escapeshellarg')) {
                     $mime_type = trim(exec('file -b --mime-type ' . escapeshellarg($file['tmp_name'])));
                 }
                 if (empty($mime_type) || $mime_type == 'regular file') {

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -291,7 +291,7 @@ class GetFileControllerCore extends FrontController
             @finfo_close($finfo);
         } elseif (function_exists('mime_content_type')) {
             $mimeType = @mime_content_type($file);
-        } elseif (function_exists('exec')) {
+        } elseif (function_exists('exec') && function_exists('escapeshellarg')) {
             $mimeType = trim(@exec('file -b --mime-type ' . escapeshellarg($file)));
             if (!$mimeType) {
                 $mimeType = trim(@exec('file --mime ' . escapeshellarg($file)));


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Three places fall back to the `file` binary to detect a mime type. They guard on `exec` being callable and then call `escapeshellarg()` unconditionally. A host that disables only `escapeshellarg` still has `exec`, so the guard passes and the next statement raises `Call to undefined function escapeshellarg()`.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the reproduction below - one command, no shop state needed beyond an install.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/35213145146
| Fixed issue or discussion? | Relates to #41574
| Sponsor company   |

### Reproduction

`getimagesize()` answers first for real images, so the fallback is reached with a non-image, and `finfo`/`mime_content_type` have to be out of the way as well:

```
php -d disable_functions=escapeshellarg,finfo_open,mime_content_type -r '
  define("_PS_ADMIN_DIR_", __DIR__."/admin-dev");
  require "config/config.inc.php";
  var_export(ImageManager::getMimeType("/tmp/probe.txt"));'
```

Before: `Error: Call to undefined function escapeshellarg()`.
After: `false`, which is a value `getMimeType()` already returns when none of its three detection methods answer, so the callers handle it.

Worth noting that `function_exists('exec')` stays `true` while `function_exists('escapeshellarg')` is `false` in that configuration - that is precisely why guarding on `exec` alone does not protect the call.

### The three sites

- `ImageManager::getMimeType()` - reached on image upload and validation.
- `GetFileController` - front office, serving a customization file.
- `WebserviceSpecificManagementImages` - webservice image upload.

Each keeps the check style it already used, `function_exists()` in the first two and `Tools::isCallable()` in the third.

### On the reported issue

#41574 reports the same class of failure but its trace is in `symfony/http-client`'s data collector, which runs only with the profiler on and is not PrestaShop code. This does not fix that trace. It fixes the same assumption where PrestaShop makes it itself, and those paths run in production rather than only in debug.

### Tests

No unit test: a PHPUnit process cannot undefine a global function, and `disable_functions` is not settable at runtime, so the condition only exists in a separate process started with that ini. The reproduction above is a one-liner and fails on the current branch, which is how I verified it. If you would rather have it covered automatically I can add an integration test that shells out to a subprocess with that ini - say the word and I will add it.

