### PR TITLE
Stop reading a password the webservice never asks for

### DIFF
--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -21,14 +21,16 @@ Context::getContext()->currency = Context::getContext()->currency ?? Currency::g
 
 //set http auth headers for apache+php-cgi work around
 if (isset($_SERVER['HTTP_AUTHORIZATION']) && preg_match('/Basic\s+(.*)$/i', $_SERVER['HTTP_AUTHORIZATION'], $matches)) {
-    list($name, $password) = explode(':', base64_decode($matches[1]));
-    $_SERVER['PHP_AUTH_USER'] = strip_tags($name);
+    // The key is sent as the user name and no password is expected, so the header does not have to
+    // carry a colon at all. Reading the second part unconditionally warns when it does not.
+    $credentials = explode(':', base64_decode($matches[1]), 2);
+    $_SERVER['PHP_AUTH_USER'] = strip_tags($credentials[0]);
 }
 
 //set http auth headers for apache+php-cgi work around if variable gets renamed by apache
 if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']) && preg_match('/Basic\s+(.*)$/i', $_SERVER['REDIRECT_HTTP_AUTHORIZATION'], $matches)) {
-    list($name, $password) = explode(':', base64_decode($matches[1]));
-    $_SERVER['PHP_AUTH_USER'] = strip_tags($name);
+    $credentials = explode(':', base64_decode($matches[1]), 2);
+    $_SERVER['PHP_AUTH_USER'] = strip_tags($credentials[0]);
 }
 
 // Use for image management (using the POST method of the browser to simulate the PUT method)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `webservice/dispatcher.php` destructures the decoded Basic `Authorization` header into a name and a password, but only the name is ever used - the webservice key is sent as the user name, and the realm string in the same file says no password is required. When the decoded value carries no colon, reading the second element raises `Undefined array key 1` on every request while authentication succeeds.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Call the webservice with a Basic header whose decoded value has no colon, for example `base64_encode('YOURKEY')` rather than `base64_encode('YOURKEY:')`, with debug mode on. The warning is gone and the request still authenticates.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #41302
| Sponsor company   |

### The change

```php
-    list($name, $password) = explode(':', base64_decode($matches[1]));
-    $_SERVER['PHP_AUTH_USER'] = strip_tags($name);
+    $credentials = explode(':', base64_decode($matches[1]), 2);
+    $_SERVER['PHP_AUTH_USER'] = strip_tags($credentials[0]);
```

`$password` was written at both header variants and read nowhere in the file, so this drops it rather than defaulting it. The limit of 2 keeps the intent visible - the value is a user and an optional password, not an arbitrary list.

Reproduced on 9.1.x:

```php
$header = 'Basic ' . base64_encode('MYWEBSERVICEKEY');
preg_match('/Basic\s+(.*)$/i', $header, $matches);
list($name, $password) = explode(':', base64_decode($matches[1]));
// Warning: Undefined array key 1
```

The same two lines exist for `HTTP_AUTHORIZATION` and for `REDIRECT_HTTP_AUTHORIZATION`, and both are changed.

### Tests

No automated test: `webservice/dispatcher.php` is a procedural entry script that boots the container and dispatches immediately, so there is nothing to call into without standing up a full webservice request. The snippet above is the whole defect and fails on the current branch.

Worth flagging while I was here: `webservice/` is outside the php-cs-fixer finder in `.php-cs-fixer.dist.php`, which only covers `app`, `src`, `classes`, `controllers`, `tests` and `tools/profiling`. So this file is not style-checked by that job either way - I am not claiming a cs-fixer pass on it. PHPStan does analyse it and reports no errors.

