### PR TITLE
Drop the unused id_country index on address

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -37,7 +37,6 @@ CREATE TABLE `PREFIX_address` (
   `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_address`),
   KEY `address_customer` (`id_customer`),
-  KEY `id_country` (`id_country`),
   KEY `id_state` (`id_state`),
   KEY `id_manufacturer` (`id_manufacturer`),
   KEY `id_supplier` (`id_supplier`),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Removes the `id_country` index on `address` from the install schema. It has no reader in core and it misleads the optimizer on the orders grid, which makes `country_lang` the driving table and reaches `address` through that index instead of driving from `orders` and satisfying the `ORDER BY` from the primary key.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with a large `orders` table, run the orders grid query and compare `EXPLAIN` and timings with and without the index. Measurements below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Relates to #41291
| Sponsor company   |

### Measured

On a development shop with 60 005 orders and 45 006 addresses, running the join shape the orders grid builds (`orders` + `customer` + `currency` + `address` + `country` + `country_lang` + `order_state`, `ORDER BY o.id_order DESC LIMIT 50`):

| | median of 3 | plan |
| --- | --- | --- |
| with `id_country` | 152 ms | drives `country_lang` (`ALL`), then `country`, then `address` via `id_country`, `Using temporary; Using filesort` |
| without it | **45 ms** | drives `orders` on `PRIMARY`, `rows=50`, backward index scan, no filesort |

The reporter of #41291 measures 4.7 s against 1.3 ms on 540k orders, which is the same plan flip at a larger scale.

### Why nothing needs it

Every core reference to `address.id_country` is a join against `country`, which resolves through `country.PRIMARY` and does not use this index: `Customer.php` twice, `CustomerAddressQueryBuilder`, `AddressQueryBuilder`, and `OrderCountriesChoiceProvider` where the equality is against `country_lang`. No core query filters `address` by a literal country. There is no foreign key on it either.

### Scope, and the half that is not here

This is the install schema, so it only affects new shops. Existing shops keep the index until it is dropped for them, and that path lives in the **autoupgrade module**, not in this repository - PrestaShop 9 has no `install-dev/upgrade/sql` directory. Happy to open that PR against `PrestaShop/autoupgrade` as the companion; say the word and I will.

Merchants who hit this before either lands can drop it directly:

```sql
ALTER TABLE `ps_address` DROP INDEX `id_country`;
```

### The alternative I did not take

The other way to fix the plan is to keep the index and restructure the grid query so `address` is not in the driving path - the id-first pagination in #41932 already does part of that, but its id-selection query still goes through `getBaseQueryBuilder()`, which joins `address` and `country` unconditionally, so it does not remove this. Taking `address` out of the id query would change the result set, because that join is an `INNER JOIN` and therefore also a filter. Removing an index nothing reads is the smaller and more honest change; if you would rather keep the index and redefine that join instead, I will rework it.

### Verification of the schema itself

Created the modified `address` table on a scratch database: it builds, and the remaining indexes are `PRIMARY`, `address_customer`, `id_state`, `id_manufacturer`, `id_supplier` and `id_warehouse`.

