### PR TITLE
Refund shipping at the rate the order was charged

### DIFF
--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -7,7 +7,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Order\Refund;
 
 use Address;
-use Carrier;
 use Currency;
 use Customer;
 use Db;
@@ -23,7 +22,6 @@ use PrestaShop\PrestaShop\Core\Domain\Order\VoucherRefundType;
 use PrestaShopDatabaseException;
 use PrestaShopException;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use TaxCalculator;
 use TaxManagerFactory;
 use Tools;
 
@@ -179,25 +177,25 @@ class OrderSlipCreator
 
         if ($shipping_cost > 0) {
             $orderSlip->shipping_cost = true;
-            $carrier = new Carrier((int) $order->id_carrier);
-            // @todo: define if we use invoice or delivery address, or we use configuration PS_TAX_ADDRESS_TYPE
-            $address = Address::initialize($order->id_address_delivery, false);
-            $tax_calculator = $carrier->getTaxCalculator($address);
+            // Use the rate the order was charged with, not the one the carrier and the address
+            // resolve to today. Recomputing it puts tax on the slip that was never invoiced when the
+            // order was placed tax exempt, and the slip then totals more than the order. The credit
+            // slip PDF already reports $order->carrier_tax_rate, so this keeps the document
+            // consistent with the amounts stored for it.
+            $carrierTaxRate = (float) $order->carrier_tax_rate;
 
             if ($add_tax) {
                 $orderSlip->total_shipping_tax_excl = $shipping_cost;
-                if ($tax_calculator instanceof TaxCalculator) {
-                    $orderSlip->total_shipping_tax_incl = Tools::ps_round($tax_calculator->addTaxes($orderSlip->total_shipping_tax_excl), $precision);
-                } else {
-                    $orderSlip->total_shipping_tax_incl = $orderSlip->total_shipping_tax_excl;
-                }
+                $orderSlip->total_shipping_tax_incl = Tools::ps_round(
+                    $shipping_cost * (1 + $carrierTaxRate / 100),
+                    $precision
+                );
             } else {
                 $orderSlip->total_shipping_tax_incl = $shipping_cost;
-                if ($tax_calculator instanceof TaxCalculator) {
-                    $orderSlip->total_shipping_tax_excl = Tools::ps_round($tax_calculator->removeTaxes($orderSlip->total_shipping_tax_incl), $precision);
-                } else {
-                    $orderSlip->total_shipping_tax_excl = $orderSlip->total_shipping_tax_incl;
-                }
+                $orderSlip->total_shipping_tax_excl = Tools::ps_round(
+                    $shipping_cost / (1 + $carrierTaxRate / 100),
+                    $precision
+                );
             }
         } else {
             $orderSlip->shipping_cost = false;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `OrderSlipCreator` recomputed the shipping tax for a credit slip from the carrier and the delivery address, which yields the rate those resolve to today rather than the one the order was charged. On an order placed VAT exempt the slip stores tax that was never invoiced and its total exceeds the order total. It now uses `carrier_tax_rate`, the rate recorded on the order.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Place an order that is exempt from shipping tax while the carrier has a tax rules group covering the delivery address - an intra-EU B2B customer with a valid VAT number is the reported case. Refund it with shipping. Before, the slip's shipping is tax-included at the carrier's current rate; after, it matches what the order paid.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30759449414 - 45 of 45 jobs green
| Fixed issue or discussion? | Fixes #41315
| Sponsor company   |

### Measured on 9.1.x

Carrier 2 with the "FR Taux standard (20%)" rules group, a delivery address in France, 100.00 of shipping:

| order's `carrier_tax_rate` | | shipping tax incl. | shipping tax excl. |
| --- | --- | --- | --- |
| 0% - placed VAT exempt | before | **120.00** | **83.33** |
| | after | 100.00 | 100.00 |
| 20% - taxed normally | before | 120.00 | 83.33 |
| | after | 120.00 | 83.33 |

The second row is the control: when the order really was taxed, the recorded rate and the recomputed one are the same rate, so nothing changes.

### Why the recorded rate is the right source

Products already work this way - `createOrderSlip()` takes `$order_detail->getTaxCalculator()`, which replays what was applied at order time. Shipping was the odd one out.

`carrier_tax_rate` is written at order creation in `PaymentModule`, and the credit slip PDF already reads it: `HTMLTemplateOrderSlip` uses `$this->order->carrier_tax_rate` for the tax line and the tax breakdown. So before this change the document printed one rate while the amounts stored alongside it were computed from another.

`new Carrier(...)` and the address lookup were the only uses of the `Carrier` and `TaxCalculator` imports in the file, so those go with them. The `@todo` about which address to use goes too - the question does not arise once the rate is not derived from an address.

### Tests

There is no test class for `OrderSlipCreator` to extend, and the method is private on a service that needs a full order graph, so I verified against the real thing on a 9.1.x install rather than writing a fixture-heavy integration test around it - the numbers above are that run. If you would rather have it pinned automatically, I will add an integration test that builds the exempt order and asserts the stored slip amounts.

