### PR TITLE
Let the raw_purified filter render a null value

### DIFF
--- a/src/PrestaShopBundle/Twig/RawPurifiedExtension.php
+++ b/src/PrestaShopBundle/Twig/RawPurifiedExtension.php
@@ -29,11 +29,15 @@ final class RawPurifiedExtension extends AbstractExtension
         ];
     }
 
-    public function rawPurifier(string $toPurify): string
+    public function rawPurifier(?string $toPurify): string
     {
-        $pureHtml = $this->htmlPurifier->purify($toPurify);
+        // Twig resolves an undefined or null variable to null, and a filter that renders markup has
+        // no reason to fail on that - it has nothing to purify and nothing to print.
+        if (null === $toPurify) {
+            return '';
+        }
 
-        return $pureHtml;
+        return $this->htmlPurifier->purify($toPurify);
     }
 
     public function getName(): string

--- a/tests/Unit/PrestaShopBundle/Twig/RawPurifiedExtensionTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/RawPurifiedExtensionTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Twig\RawPurifiedExtension;
+use PrestaShopBundle\Utils\HTMLPurifier;
+
+class RawPurifiedExtensionTest extends TestCase
+{
+    /**
+     * Twig resolves an undefined or null variable to null, and the filter is applied to values that
+     * are legitimately absent - a flash message that was not set, a hook that rendered nothing. A
+     * non-nullable parameter turned that into a TypeError and took the page down with it.
+     */
+    public function testNullRendersAsAnEmptyStringWithoutPurifying(): void
+    {
+        $purifier = $this->createMock(HTMLPurifier::class);
+        $purifier->expects($this->never())->method('purify');
+
+        $extension = new RawPurifiedExtension($purifier);
+
+        $this->assertSame('', $extension->rawPurifier(null));
+    }
+
+    public function testAStringIsStillHandedToThePurifier(): void
+    {
+        $purifier = $this->createMock(HTMLPurifier::class);
+        $purifier
+            ->expects($this->once())
+            ->method('purify')
+            ->with('<b>kept</b><script>dropped</script>')
+            ->willReturn('<b>kept</b>')
+        ;
+
+        $extension = new RawPurifiedExtension($purifier);
+
+        $this->assertSame('<b>kept</b>', $extension->rawPurifier('<b>kept</b><script>dropped</script>'));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `raw_purified` declares `string`, so Twig handing it a null - an undefined variable, a flash message that was never set, a hook that rendered nothing - raises `Argument #1 ($toPurify) must be of type string, null given` and takes the page down. It now returns an empty string for null.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `tests/Unit/PrestaShopBundle/Twig/RawPurifiedExtensionTest.php`. Reverting only the extension fails it with the exact message from #41271.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Relates to #41271
| Sponsor company   |

### The change

```php
-    public function rawPurifier(string $toPurify): string
+    public function rawPurifier(?string $toPurify): string
```

with an early return of `''`. The purifier is not called for null, because there is nothing to purify.

A filter that renders markup is applied to whatever the template hands it, and in Twig an undefined variable is null. The filter is used in 83 places across the admin templates and is public, so modules and custom templates apply it too. Failing on null makes an absent value a fatal rather than an empty spot on the page.

### What I could not confirm

#41271 is reported against 8.2.5, with a module implementing `displayAdminProductsExtra`. I could not reproduce that path on 9.1.x: the product page renders extra module content through `modules-content.html.twig`, which uses `{{ module.content|raw }}`, not this filter. So the exact route in the report looks already changed on 9.x.

What is still true on 9.1.x is the filter's contract, and that is what this fixes. If the reporter can share the stack trace line that was cut off in the report, it would confirm whether their route still exists here - but the signature is wrong either way.

### Tests

Two cases: null renders as `''` and the purifier is never called, and a string is still handed to the purifier untouched. Reverting only `RawPurifiedExtension.php` fails the first with `must be of type string, null given` while the second stays green.

