### PR TITLE
Describe the category in the breadcrumb stand-in entry

### DIFF
--- a/src/Adapter/Category/CategoryViewDataProvider.php
+++ b/src/Adapter/Category/CategoryViewDataProvider.php
@@ -78,7 +78,14 @@ class CategoryViewDataProvider
             && !$this->multishopFeature->isUsed()
             && $categoriesWithoutParentCount > 1
         ) {
-            $categoriesTree = [['name' => $categoryName]];
+            // The breadcrumb reads id_parent and id_category off every entry, so a stand-in that
+            // carries only the name breaks the template it is built for. This entry stands for the
+            // category being viewed, so it describes that category.
+            $categoriesTree = [[
+                'id_category' => $category->id,
+                'id_parent' => $category->id_parent,
+                'name' => $categoryName,
+            ]];
         }
 
         $categoriesTree = array_reverse($categoriesTree);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CategoryViewDataProvider` substitutes a single stand-in entry when `getParentsCategories()` returns nothing, so the breadcrumb is not blank. That entry carried only `name`, while the breadcrumb reads `id_parent` off every entry, so the category page died with `Key "id_parent" for sequence/mapping with keys "name" does not exist`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Reach a category whose parents lookup comes back empty while more than one parentless category exists - the report gets there with multishop enabled, a single shop, and a second main category. The category page renders its breadcrumb instead of a Twig runtime error.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #41234
| Sponsor company   |

### The entry

```php
-            $categoriesTree = [['name' => $categoryName]];
+            $categoriesTree = [[
+                'id_category' => $category->id,
+                'id_parent' => $category->id_parent,
+                'name' => $categoryName,
+            ]];
```

`breadcrumb.html.twig` reads three things off each entry: `id_parent` to decide whether it is at the root, `id_category` to compare against the category being viewed, and `name`. The stand-in supplied one of the three, so it broke the template it exists to feed. It represents the category being viewed, so it describes that category.

Reproduced against the template's own expression with Twig's `strict_variables` on, which is how the admin renders:

```
current fallback -> Twig\Error\RuntimeError: Key "id_parent" for sequence/mapping with keys "name" does not exist
fixed fallback   -> rendered: My category
```

The message is the one in #41234.

With the entry filled in, `isRootCategory` resolves from the real parent and `category.id_category == currentCategoryView.id` matches, so the category renders as a plain label - which is what a one-entry breadcrumb should show.

### Tests

`CategoryViewDataProvider` has no test class, and `getViewData()` constructs a legacy `Category` and calls `Category::getCategoriesWithoutParent()` statically, so it cannot be exercised without a database. The check above is at the template contract instead, which is where the failure was. If you want it pinned, an integration test that builds the second main category and asserts the returned `breadcrumb_tree` entry has `id_parent` would do it and I am happy to add it.

