### PR TITLE
Connect the cache adapter to the configured memcached servers

### DIFF
--- a/classes/container/LegacyCompilerPass.php
+++ b/classes/container/LegacyCompilerPass.php
@@ -53,10 +53,32 @@ class LegacyCompilerPass implements CompilerPassInterface
         $definition
             ->setPublic(true)
             ->setFactory([new Reference(CacheAdapterFactory::class), 'getCacheAdapter'])
-            ->setArguments([$cacheDriver])
+            ->setArguments([$cacheDriver, $this->getMemcachedServers($cacheDriver)])
         ;
 
         $container->setDefinition($cacheDriver, $definition);
+    }
+
+    /**
+     * Read here rather than in the factory: the factory lives in the bundle, which is not allowed to
+     * call legacy code, and this container has no service exposing these rows. The driver itself is
+     * already resolved at compile time, so the servers follow the same lifecycle - both are picked
+     * up when the container is rebuilt, which is what saving the Performance page triggers.
+     *
+     * @return array<int, array{ip: string, port: int|string}>
+     */
+    private function getMemcachedServers(string $cacheDriver): array
+    {
+        if ($cacheDriver !== 'memcached') {
+            return [];
+        }
+
+        try {
+            return CacheMemcached::getMemcachedServers() ?: [];
+        } catch (Throwable $e) {
+            // No database yet, during installation for instance. The factory falls back to localhost.
+            return [];
+        }
     }
 
     private function buildSyntheticDefinitions(array $keys, ContainerBuilder $container): void

--- a/src/PrestaShopBundle/DependencyInjection/CacheAdapterFactory.php
+++ b/src/PrestaShopBundle/DependencyInjection/CacheAdapterFactory.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\DependencyInjection;
 
-use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -19,16 +18,43 @@ use Symfony\Component\Cache\Adapter\MemcachedAdapter;
  */
 class CacheAdapterFactory
 {
-    public function getCacheAdapter(string $driver): AdapterInterface
+    /**
+     * @param array<int, array{ip: string, port: int|string}> $memcachedServers servers configured in
+     *                                                                          Advanced Parameters > Performance
+     */
+    public function getCacheAdapter(string $driver, array $memcachedServers = []): AdapterInterface
     {
         if ($driver === 'apcu') {
             return new ApcuAdapter();
         } elseif ($driver === 'memcached') {
             return new MemcachedAdapter(
-                AbstractAdapter::createConnection('memcached://localhost', ['lazy' => true])
+                MemcachedAdapter::createConnection($this->buildServerDsn($memcachedServers), ['lazy' => true])
             );
         }
 
         return new ArrayAdapter();
+    }
+
+    /**
+     * The servers set in Configure > Advanced Parameters > Performance are the ones the legacy cache
+     * connects to. Pointing this adapter at localhost regardless meant a shop with a custom host or
+     * port had one half of its caching honour the setting and the other half ignore it.
+     *
+     * @param array<int, array{ip: string, port: int|string}> $servers
+     *
+     * @return string[]|string
+     */
+    protected function buildServerDsn(array $servers)
+    {
+        if (empty($servers)) {
+            return 'memcached://localhost';
+        }
+
+        return array_map(
+            static function (array $server): string {
+                return sprintf('memcached://%s:%d', $server['ip'], (int) $server['port']);
+            },
+            $servers
+        );
     }
 }

--- a/tests/Unit/PrestaShopBundle/DependencyInjection/CacheAdapterFactoryTest.php
+++ b/tests/Unit/PrestaShopBundle/DependencyInjection/CacheAdapterFactoryTest.php
@@ -10,6 +10,7 @@ namespace Tests\Unit\PrestaShopBundle\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\DependencyInjection\CacheAdapterFactory;
+use ReflectionMethod;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
@@ -38,6 +39,41 @@ class CacheAdapterFactoryTest extends TestCase
             $this->markTestSkipped('apcu is not supported');
         }
         $this->assertTrue($this->cacheAdapterFactory->getCacheAdapter($driver) instanceof $expectedClass);
+    }
+
+    /**
+     * The servers configured in Advanced Parameters > Performance decide where the adapter connects.
+     * Before, the DSN was the localhost literal whatever they were set to.
+     */
+    public function testConfiguredServersBecomeTheConnectionDsn(): void
+    {
+        $servers = [
+            ['ip' => '10.0.0.5', 'port' => '11222'],
+            ['ip' => 'cache.internal', 'port' => 11333],
+        ];
+
+        $this->assertSame(
+            ['memcached://10.0.0.5:11222', 'memcached://cache.internal:11333'],
+            $this->buildServerDsn($servers)
+        );
+    }
+
+    public function testLocalhostIsUsedWhenNoServerIsConfigured(): void
+    {
+        $this->assertSame('memcached://localhost', $this->buildServerDsn([]));
+    }
+
+    /**
+     * @param array<int, array{ip: string, port: int|string}> $servers
+     *
+     * @return string[]|string
+     */
+    private function buildServerDsn(array $servers)
+    {
+        $method = new ReflectionMethod(CacheAdapterFactory::class, 'buildServerDsn');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->cacheAdapterFactory, $servers);
     }
 
     public function getAdapterClassesForDriver(): array


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CacheAdapterFactory` built its memcached connection from the literal `memcached://localhost`, so the Symfony side of the cache ignored the servers configured in Advanced Parameters > Performance while the legacy cache honoured them. A shop on a custom host or port ends up talking to both.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run memcached on a non-default port only, configure that server in Advanced Parameters > Performance, and watch the traffic. Before, part of the caching still goes to 11211; after, everything goes to the configured server.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #41442
| Sponsor company   |

### The two paths

`CacheMemcached::__construct()` calls `addServer()` for each row of `memcached_servers`, so the legacy cache connects where the merchant asked. The factory that builds the Symfony adapter did this instead:

```php
AbstractAdapter::createConnection('memcached://localhost', ['lazy' => true])
```

That is the "it uses both, your defined port for some things and the default one too" in the report.

### Where the servers are read

Not in the factory. It lives in `PrestaShopBundle`, and static analysis enforces that the bundle makes no legacy calls - `Namespace CacheMemcached is forbidden, No legacy calls inside the bundle`. The container that registers the factory also has no service exposing those rows: it loads `config/services/<container>/services_<env>.yml`, where `MemcacheServerManager` is not defined.

So the lookup sits in `LegacyCompilerPass`, which is legacy code and already resolves the cache driver for the same definition. The servers now follow the same lifecycle as the driver: both are read when the container is built, which is what saving the Performance page triggers. Reading them at compile time is not a new constraint, it is the one the driver already has.

The lookup is wrapped so a missing database - during installation, for instance - falls back to localhost rather than breaking container compilation.

### The DSN

One DSN per configured server, passed to `MemcachedAdapter::createConnection()`, which accepts an array. `AbstractAdapter::createConnection()` only takes a single string, which is part of why this was stuck on one hardcoded host.

Weights are not carried over. `addServer()` uses them on the legacy side, and the DSN form does not express them; if you want them honoured here too I will add them as connection options.

### Tests

Two cases on the DSN builder: configured servers become `memcached://host:port` in order, and an empty list falls back to `memcached://localhost`. Keeping the method but ignoring the servers fails the first with `Failed asserting that 'memcached://localhost' is identical to Array`, which is the bug itself. The pre-existing driver test is untouched and still passes.

