### PR TITLE
Translate the option label, not its escaped form

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -534,7 +534,7 @@
 													{l s='December'}
 												*}
 												{foreach $select as $k => $v}
-													<option value="{$k}" {if $k == $fields_value[$key]}selected="selected"{/if}>{l s=$v|escape:'html':'UTF-8'}</option>
+													<option value="{$k}" {if $k == $fields_value[$key]}selected="selected"{/if}>{l s=$v}</option>
 												{/foreach}
 											{else}
 												{foreach $select as $v}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The select helper wrote `{l s=$v\|escape:'html':'UTF-8'}`. Smarty compiles the modifier before the translation tag sees it, so the string extracted for translation is the compiled PHP expression instead of the label, and at runtime the tag escapes a value that is already escaped.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | A back-office form built by the helper with a `select` field whose labels contain `&` or `<`. Before, the option reads `Men &amp;amp; Women`; after, `Men &amp; Women`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #41460
| Sponsor company   |

### What the tag receives

Ran the two forms through Smarty with the `l` tag stubbed to print what it was handed, `$v = 'Men & Women'`:

```
before  -> key handed to {l}: [Men &amp; Women]
after   -> key handed to {l}: [Men & Women]
```

That is both halves of the report in one line. The extractor reads what the tag is given, which is why Crowdin ended up with `htmlspecialchars((string)$_smarty_tpl->tpl_vars['v']->value, ENT_QUOTES, 'UTF-8', true)`, and the lookup could never match a real translation either.

### Why removing the modifier is safe

`smartyTranslate()` sets `$htmlEntities = !isset($params['html']) && !isset($params['js'])` and ends with `htmlspecialchars($translatedValue, ENT_COMPAT, 'UTF-8')`. Neither `html` nor `js` is passed here, so the tag already encodes its output. The modifier was not adding protection, it was adding a second pass:

| | rendered |
| --- | --- |
| before | `Men &amp;amp; Women &amp;lt;Special&amp;gt;` |
| after | `Men &amp; Women &lt;Special&gt;` |

So this also fixes labels that a merchant currently sees with visible entities.

### Scope

This is the only place in the admin templates where a modifier is applied to the `s=` argument - 6 templates pass a variable as the key, and the other 5 pass it bare. The nearby `{$v|escape:'html':'UTF-8'}` on the following line is plain output, not a translation key, and is left alone. Occurrences like `sprintf=[...|escape]` or `{l|escape s='...'}` apply the modifier to the arguments or to the tag's output, not to the key, so they do not have this problem.

### Tests

No automated test: the change is in a Smarty template, and there is no test harness rendering the form helper. The Smarty run above is the verification, and it exercises the real compiler rather than approximating it. `php-cs-fixer` and PHPStan do not cover `.tpl`, so I am not claiming a pass from either.


