### PR TITLE
Drop the empty More section instead of linking it to nowhere

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3,6 +3,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+use PrestaShop\PrestaShop\Adapter\Module\Tab\ModuleTabRegister;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Action\ActionsBarButton;
 use PrestaShop\PrestaShop\Core\Action\ActionsBarButtonInterface;
@@ -2184,7 +2185,9 @@ class AdminControllerCore extends Controller
             $subTabHref = $this->getTabLinkFromSubTabs($tabs[$index]['sub_tabs']);
             if (!empty($subTabHref)) {
                 $tabs[$index]['href'] = $subTabHref;
-            } elseif (0 == $tabs[$index]['id_parent'] && '' == $tabs[$index]['icon']) {
+            } elseif (0 == $tabs[$index]['id_parent'] && ('' == $tabs[$index]['icon'] || ModuleTabRegister::DEFAULT_PARENT_CLASS_NAME === $tabs[$index]['class_name'])) {
+                // An icon is enough to keep a top level section that owns a page, but the catch-all
+                // parent owns none: linking to it lands on a controller that does not exist.
                 unset($tabs[$index]);
             } elseif (empty($tabs[$index]['icon'])) {
                 $tabs[$index]['icon'] = 'extension';

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -29,7 +29,13 @@ class ModuleTabRegister
     /**
      * @var string
      */
-    private $defaultParent = 'DEFAULT';
+    /**
+     * Class name of the catch-all parent tab that module tabs are attached to when they declare no
+     * parent. It is a container, not a controller, so it must never be linked to on its own.
+     */
+    public const DEFAULT_PARENT_CLASS_NAME = 'DEFAULT';
+
+    private $defaultParent = self::DEFAULT_PARENT_CLASS_NAME;
 
     /**
      * @var LangRepository

--- a/src/PrestaShopBundle/Twig/Component/NavBar.php
+++ b/src/PrestaShopBundle/Twig/Component/NavBar.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Twig\Component;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Adapter\Module\Tab\ModuleTabRegister;
 use PrestaShopBundle\Twig\Layout\MenuBuilder;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -112,7 +113,7 @@ class NavBar
 
         if (!empty($subTabHref)) {
             $tab['href'] = $subTabHref;
-        } elseif ($tab['id_parent'] === 0 && empty($tab['icon'])) {
+        } elseif ($this->isUnreachableTopLevelSection($tab)) {
             return [];
         } elseif (empty($tab['icon'])) {
             $tab['icon'] = 'extension';
@@ -127,6 +128,23 @@ class NavBar
         }
 
         return $tab;
+    }
+
+    /**
+     * A top level entry with no linkable child leads nowhere. An icon is enough to keep one that
+     * owns a page, but the catch-all parent that module tabs attach to owns none - linking to it
+     * lands on a controller that does not exist.
+     *
+     * @param array<string, mixed> $tab
+     */
+    protected function isUnreachableTopLevelSection(array $tab): bool
+    {
+        if ($tab['id_parent'] !== 0) {
+            return false;
+        }
+
+        return empty($tab['icon'])
+            || ModuleTabRegister::DEFAULT_PARENT_CLASS_NAME === $tab['class_name'];
     }
 
     protected function getTabLinkFromSubTabs(array $subtabs)

--- a/tests/Unit/PrestaShopBundle/Twig/Component/NavBarTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Component/NavBarTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig\Component;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Adapter\Module\Tab\ModuleTabRegister;
+use PrestaShopBundle\Twig\Component\NavBar;
+use PrestaShopBundle\Twig\Layout\MenuBuilder;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+class NavBarTest extends TestCase
+{
+    /**
+     * @dataProvider provideTopLevelSections
+     *
+     * @param array<string, mixed> $tab
+     */
+    public function testATopLevelSectionIsKeptOnlyWhenItLeadsSomewhere(array $tab, bool $expected, string $case): void
+    {
+        $navBar = new NavBar(
+            $this->createMock(LegacyContext::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(MenuBuilder::class),
+            '9.1.0'
+        );
+
+        $method = new ReflectionMethod(NavBar::class, 'isUnreachableTopLevelSection');
+        $method->setAccessible(true);
+
+        $this->assertSame($expected, $method->invoke($navBar, $tab), $case);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>, 1: bool, 2: string}>
+     */
+    public function provideTopLevelSections(): iterable
+    {
+        yield 'catch-all parent with an icon' => [
+            ['id_parent' => 0, 'icon' => 'extension', 'class_name' => ModuleTabRegister::DEFAULT_PARENT_CLASS_NAME],
+            true,
+            'The catch-all parent owns no page, so an icon must not keep it in the menu',
+        ];
+
+        yield 'catch-all parent without an icon' => [
+            ['id_parent' => 0, 'icon' => '', 'class_name' => ModuleTabRegister::DEFAULT_PARENT_CLASS_NAME],
+            true,
+            'Already dropped before, and still dropped',
+        ];
+
+        yield 'section owning a page, with an icon' => [
+            ['id_parent' => 0, 'icon' => 'shopping_cart', 'class_name' => 'AdminParentOrders'],
+            false,
+            'A real top level section with an icon is kept',
+        ];
+
+        yield 'section owning a page, without an icon' => [
+            ['id_parent' => 0, 'icon' => '', 'class_name' => 'AdminParentOrders'],
+            true,
+            'Unchanged behaviour: no icon and no linkable child means nothing to show',
+        ];
+
+        yield 'child tab' => [
+            ['id_parent' => 12, 'icon' => '', 'class_name' => ModuleTabRegister::DEFAULT_PARENT_CLASS_NAME],
+            false,
+            'The rule is about top level entries only',
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | "More" is the catch-all parent that module tabs attach to when they declare no parent. It owns no page, so its own link points at a controller called `DEFAULT`, which does not exist. Both menu builders already drop an empty top level section, but only when it has no icon - with one set, the entry stays in the menu and clicking it lands on the error page.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `UPDATE ps_tab SET icon = 'extension' WHERE class_name = 'DEFAULT';` on a shop where nothing is attached under it, then open the back office. Before, "More" is in the menu and goes to `?controller=DEFAULT`; after, it is not rendered. Restore the icon afterwards.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Relates to #41191
| Sponsor company   |

### What the guard does today

```php
} elseif ($tab['id_parent'] === 0 && empty($tab['icon'])) {
```

The icon is the wrong thing to hinge on for this one entry. It is a reasonable rule for a section that owns a page - an icon says "this is a real destination" - but the catch-all parent owns none, so an icon on it only hides the fact that it leads nowhere.

Measured on 9.1.5, tab `class_name = DEFAULT`, `id_parent = 0`, no children:

| `icon` | old verdict | new verdict | link it would render |
| --- | --- | --- | --- |
| `''` | dropped | dropped | - |
| `'extension'` | **kept** | dropped | `?controller=DEFAULT&token=...` |

`class_exists('DEFAULTController')` is false, and there is no route by that name, so the second row is a guaranteed broken page.

Ran the new condition against every top level tab on that install: 7 scanned, exactly 1 verdict changed, and it is `DEFAULT`. No section that owns a page is affected.

### Where it is applied

Both builders, because both render the menu depending on the page:

- `PrestaShopBundle\Twig\Component\NavBar::processTab()`
- `AdminController::getTabs()` for the legacy layout

The placeholder class name was already defined in `ModuleTabRegister` as a private property; it is now a public constant there, so the two builders reference it instead of repeating the literal.

### On #41191

That report is "More leads to a broken page" on 9.0.3 and 9.1. I could not reproduce it on a clean install, because the tab has no icon there and is correctly dropped, and I asked the reporter for the two queries that would tell us which case they are in. This PR fixes the case that is provable from the code either way: an icon must not turn an empty catch-all into a link. If their shop instead has something attached under "More", that is a different fault in whatever tab it links to and this does not address it.

### Tests

`NavBarTest` covers the decision with five cases: catch-all with and without an icon, a real section with and without an icon, and a child tab. Keeping the method but removing the placeholder check fails only the first, which is the bug.

