### PR TITLE
Offer no carrier for an order that has no cart

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/CarrierForOrderChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/CarrierForOrderChoiceProvider.php
@@ -27,6 +27,14 @@ final class CarrierForOrderChoiceProvider implements ConfigurableFormChoiceProvi
         $options = $this->resolveOptions($options);
 
         $cart = Cart::getCartByOrderId($options['order_id']);
+
+        // getCartByOrderId() answers false for an order with no cart. Reading properties off that is
+        // only a warning on PHP 8, so the carriers were computed from customer group 0 and address 0
+        // and the caller got a plausible looking list for an order that has none.
+        if (!$cart instanceof Cart) {
+            return [];
+        }
+
         $groups = Customer::getGroupsStatic((int) $cart->id_customer);
         $address = new Address((int) $cart->id_address_delivery);
 

--- a/tests/Integration/Adapter/Form/ChoiceProvider/CarrierForOrderChoiceProviderTest.php
+++ b/tests/Integration/Adapter/Form/ChoiceProvider/CarrierForOrderChoiceProviderTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\CarrierForOrderChoiceProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class CarrierForOrderChoiceProviderTest extends KernelTestCase
+{
+    private const UNKNOWN_ORDER_ID = 999999999;
+
+    /**
+     * `Cart::getCartByOrderId()` answers false for an order that has no cart. Reading properties off
+     * that is only a warning on PHP 8, so the provider used to compute carriers from customer group
+     * 0 and address 0 and hand back a plausible looking list for an order that has none.
+     */
+    public function testAnOrderWithoutACartOffersNoCarrier(): void
+    {
+        self::bootKernel();
+
+        $provider = new CarrierForOrderChoiceProvider();
+
+        $this->assertSame([], $provider->getChoices(['order_id' => self::UNKNOWN_ORDER_ID]));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CarrierForOrderChoiceProvider` read `id_customer` and `id_address_delivery` off the result of `Cart::getCartByOrderId()` without checking it. That call answers `false` for an order with no cart, and on PHP 8 reading a property off `false` is a warning rather than an error, so the provider returned carriers computed from customer group 0 and address 0 instead of failing.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `(new CarrierForOrderChoiceProvider())->getChoices(['order_id' => 999999999])`. Before, two `Attempt to read property ... on bool` warnings and a non-empty list; after, an empty list and no warnings. A real order id returns the same choices as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Follow-up to #42065
| Sponsor company   |

### Measured on 9.1.5

```
Warning: Attempt to read property "id_customer" on bool ... CarrierForOrderChoiceProvider.php on line 30
Warning: Attempt to read property "id_address_delivery" on bool ... line 31
unknown order -> 1 choice
```

after:

```
unknown order -> 0 choices, no warnings
real order    -> 1 choice   (unchanged)
```

`Carrier::getCarriersForOrder($id_zone, $groups = null, $cart = null, ...)` takes `$cart` untyped, which is why the `false` travelled all the way in rather than stopping at a type error. The failure is silent: the form gets a list that looks legitimate.

### Why an empty list rather than an exception

The sibling handlers throw when the cart is missing, and #42065 adds `OrderNotFoundException` to `DuplicateOrderCartHandler` for the same condition. That is right for a command handler. This is a form choice provider: its contract is to answer with the choices available, and for an order whose cart is gone there are none. Throwing would take the order page down instead of showing an empty carrier select, which is a worse trade for something already in a broken data state. Happy to switch it to an exception if you would rather have it loud.

### Scope

Found while QA-ing #42065. Two other callers of `getCartByOrderId()` are also unguarded - `UpdateOrderShippingDetailsHandler` (a method call on `false`, so a real fatal) and `AddCartRuleToOrderHandler` (property reads, same silent shape as this one). Both take their order from `getOrder()`, so an unknown id throws before reaching the cart and only a missing cart row triggers them. They are worth their own fix; I kept this PR to the one that has no order lookup in front of it at all.

### Tests

`CarrierForOrderChoiceProviderTest` asserts an unknown order id yields no choices. Reverting only the provider fails it with `Failed asserting that two arrays are identical` plus the two warnings above.

