### PR TITLE
Stamp image URLs with the moment the file was written

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -974,6 +974,7 @@ class LinkCore
         if (strpos($idImage, 'default') !== false) {
             $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . $idImage . $type . '-' . Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
             $uriPath = _THEME_PROD_DIR_ . $idImage . $type . $theme . '.' . $extension;
+            $filePath = _PS_PRODUCT_IMG_DIR_ . $idImage . $type . $theme . '.' . $extension;
 
         // Regular image with numeric ID
         } else {
@@ -998,9 +999,11 @@ class LinkCore
             } else {
                 $uriPath = _THEME_PROD_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . $type . $theme . '.' . $extension;
             }
+
+            $filePath = _PS_PRODUCT_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . $type . $theme . '.' . $extension;
         }
 
-        $url = $this->getMediaLink($uriPath);
+        $url = $this->addImageVersion($this->getMediaLink($uriPath), $filePath);
 
         Hook::exec(
             'adaptImageLink',
@@ -1102,6 +1105,25 @@ class LinkCore
      *
      * @return string
      */
+    /**
+     * Stamp an image URL with the moment the file was last written, so a cache in front of the shop
+     * can be told to hold it indefinitely and still pick up a replacement immediately. Without it a
+     * reverse proxy has no way to tell that an image changed, and can only cache for a fixed guess.
+     *
+     * The file is not always reachable from here - a media server or a CDN origin, for instance - and
+     * then the URL is returned untouched rather than stamped with something invented.
+     */
+    protected function addImageVersion(string $url, string $filePath): string
+    {
+        $modifiedAt = @filemtime($filePath);
+
+        if (false === $modifiedAt) {
+            return $url;
+        }
+
+        return $url . (false === strpos($url, '?') ? '?' : '&') . 'v=' . $modifiedAt;
+    }
+
     public function getMediaLink($filepath)
     {
         return $this->protocol_content . Tools::getMediaServer($filepath) . $filepath;

--- a/tests/Integration/Classes/LinkImageVersionTest.php
+++ b/tests/Integration/Classes/LinkImageVersionTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Link;
+use ReflectionMethod;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class LinkImageVersionTest extends KernelTestCase
+{
+    private const MODIFIED_AT = 1700000000;
+
+    /**
+     * @var string
+     */
+    private $imageFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->imageFile = tempnam(sys_get_temp_dir(), 'ps_image_') ?: '';
+        file_put_contents($this->imageFile, 'not really a jpeg');
+        touch($this->imageFile, self::MODIFIED_AT);
+        clearstatcache(true, $this->imageFile);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->imageFile !== '' && file_exists($this->imageFile)) {
+            unlink($this->imageFile);
+        }
+        parent::tearDown();
+    }
+
+    public function testTheVersionIsTheMomentTheFileWasLastWritten(): void
+    {
+        $this->assertSame(
+            'https://shop.test/1-home_default/product.jpg?v=' . self::MODIFIED_AT,
+            $this->addImageVersion('https://shop.test/1-home_default/product.jpg', $this->imageFile)
+        );
+    }
+
+    /**
+     * A media server URL or an override may already carry parameters, and the stamp must not turn
+     * them into a second question mark.
+     */
+    public function testAnExistingQueryStringIsExtendedRatherThanReplaced(): void
+    {
+        $this->assertSame(
+            'https://cdn.test/1-home_default/product.jpg?token=abc&v=' . self::MODIFIED_AT,
+            $this->addImageVersion('https://cdn.test/1-home_default/product.jpg?token=abc', $this->imageFile)
+        );
+    }
+
+    /**
+     * The file is not always reachable from the shop - a CDN origin, for instance. The URL is then
+     * left as it was rather than stamped with an invented value.
+     */
+    public function testAnUnreachableFileLeavesTheUrlAlone(): void
+    {
+        $url = 'https://shop.test/1-home_default/product.jpg';
+
+        $this->assertSame($url, $this->addImageVersion($url, '/does/not/exist/product.jpg'));
+    }
+
+    private function addImageVersion(string $url, string $filePath): string
+    {
+        $method = new ReflectionMethod(Link::class, 'addImageVersion');
+        $method->setAccessible(true);
+
+        return $method->invoke(new Link(), $url, $filePath);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Front-office image URLs carry nothing that changes when the image does, so a cache in front of the shop cannot tell a replacement from the original and is stuck guessing with a fixed expiry. `Link::getImageLink()` now appends the file's modification time as a `v` parameter, so the URL changes exactly when the file does.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a product page and look at an image URL: it ends with `?v=<timestamp>`. Replace the image in the back office, reload, and the value changes. A cache keyed on the URL therefore serves the new file immediately.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #39898
| Sponsor company   |

### Measured on 9.1.5

```
real image   -> http://localhost:8001/1-medium_default/demo.jpg?v=1782535247
after the file is rewritten
             -> http://localhost:8001/1-medium_default/demo.jpg?v=1785279177
file missing -> http://localhost:8001/99999999-medium_default/demo.jpg      (untouched)
default image-> http://localhost:8001/img/p/en-default-medium_default.jpg?v=1782535233
```

The third line is the degradation path: the file is not always reachable from the shop - a CDN origin, a media server - and then the URL is returned as it was rather than stamped with an invented value.

### Cost

One `filemtime()` per image URL. Measured over the images on a development shop: **0.0024 ms each**, 0.06 ms for 23. A listing rendering 200 images pays about half a millisecond, and the stat is served from the OS cache on repeat.

That measurement is why this reads the filesystem instead of adding a column. `image` has no date field, so the alternative is a schema change plus an upgrade script plus keeping the column in step with every image write, for a value the filesystem already holds accurately. Say the word if you would rather have the column and I will rework it that way.

### Placement

The stamp is applied before the `adaptImageLink` hook, so a module that rewrites image URLs still has the last word and can strip or replace it. `overrideImageLink` returns earlier and is untouched, so a module fully replacing the URL is unaffected.

### On making it optional

I did not put it behind a configuration flag. The point of the issue is that a proxy cannot cache confidently without it, and a setting that defaults to off would leave that unchanged for everyone who does not find it. It degrades safely on its own, and the hook above is the escape hatch for a shop that needs the old URLs. Happy to add the flag if you would rather stage it.

### Tests

`LinkImageVersionTest` covers the three cases: the version is the file's modification time, a URL that already has a query string gets `&v=` rather than a second `?`, and an unreachable file leaves the URL alone. Reverting only the append in `classes/Link.php` fails the first two and leaves the third green.

