### PR TITLE
Let a module declare the meta of its front controllers

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -119,7 +119,12 @@ abstract class ModuleCore implements ModuleInterface
     /** @var array to store the limited country */
     public $limited_countries = [];
 
-    /** @var array names of the controllers */
+    /**
+     * Key used by getDeclaredControllers() for a meta value that applies to every language.
+     */
+    public const CONTROLLER_META_ALL_LANGUAGES = '*';
+
+    /** @var array names of the controllers, or definitions carrying their meta */
     public $controllers = [];
 
     /** @var bool */
@@ -926,8 +931,8 @@ abstract class ModuleCore implements ModuleInterface
         }
 
         // Remove all configured meta data (titles, URLs etc.) for this module's front controllers
-        foreach ($this->controllers as $controller) {
-            $page_name = 'module-' . $this->name . '-' . $controller;
+        foreach ($this->getDeclaredControllers() as $controller) {
+            $page_name = 'module-' . $this->name . '-' . $controller['name'];
             $meta = Db::getInstance()->getValue('SELECT `id_meta` FROM `' . _DB_PREFIX_ . 'meta` WHERE `page`="' . pSQL($page_name) . '"');
             if ((int) $meta > 0) {
                 Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'meta_lang` WHERE `id_meta`=' . (int) $meta);
@@ -2952,8 +2957,10 @@ abstract class ModuleCore implements ModuleInterface
      */
     protected function installControllers()
     {
-        foreach ($this->controllers as $controller) {
-            $page = 'module-' . $this->name . '-' . $controller;
+        $languages = Language::getLanguages(false);
+
+        foreach ($this->getDeclaredControllers() as $controller) {
+            $page = 'module-' . $this->name . '-' . $controller['name'];
             $result = Db::getInstance()->getValue('SELECT * FROM `' . _DB_PREFIX_ . 'meta` WHERE `page`="' . pSQL($page) . '"');
             if ((int) $result > 0) {
                 continue;
@@ -2962,10 +2969,72 @@ abstract class ModuleCore implements ModuleInterface
             $meta = new Meta();
             $meta->page = $page;
             $meta->configurable = 1;
+
+            foreach ($languages as $language) {
+                $isoCode = $language['iso_code'];
+                $idLang = (int) $language['id_lang'];
+
+                foreach (['title', 'url_rewrite'] as $field) {
+                    $value = $controller[$field][$isoCode] ?? $controller[$field][self::CONTROLLER_META_ALL_LANGUAGES] ?? null;
+                    if (null !== $value) {
+                        $meta->{$field}[$idLang] = $value;
+                    }
+                }
+            }
+
             $meta->save();
         }
 
         return true;
+    }
+
+    /**
+     * Normalise the front controllers the module declares.
+     *
+     * A controller has always been declared by name alone, and still can be. It may also be declared
+     * as an array carrying the meta its page should be installed with:
+     *
+     *     public $controllers = [
+     *         'payment',
+     *         ['name' => 'validation', 'title' => 'Payment validation', 'url_rewrite' => 'payment-validation'],
+     *         ['name' => 'confirm', 'url_rewrite' => ['en' => 'order-confirmed', 'fr' => 'commande-confirmee']],
+     *     ];
+     *
+     * title and url_rewrite take either one value, used for every language, or a map keyed by the
+     * language ISO code. A language the map does not mention keeps the empty value it gets today, so
+     * declaring nothing behaves exactly as before.
+     *
+     * @return array<int, array{name: string, title: array<string, string>, url_rewrite: array<string, string>}>
+     */
+    protected function getDeclaredControllers(): array
+    {
+        $controllers = [];
+
+        foreach ($this->controllers as $controller) {
+            if (!is_array($controller)) {
+                $controllers[] = ['name' => (string) $controller, 'title' => [], 'url_rewrite' => []];
+
+                continue;
+            }
+
+            $definition = ['name' => (string) ($controller['name'] ?? ''), 'title' => [], 'url_rewrite' => []];
+
+            foreach (['title', 'url_rewrite'] as $field) {
+                if (!isset($controller[$field])) {
+                    continue;
+                }
+
+                $definition[$field] = is_array($controller[$field])
+                    ? $controller[$field]
+                    : [self::CONTROLLER_META_ALL_LANGUAGES => $controller[$field]];
+            }
+
+            if ('' !== $definition['name']) {
+                $controllers[] = $definition;
+            }
+        }
+
+        return $controllers;
     }
 
     /**

--- a/tests/Unit/Classes/Module/ModuleDeclaredControllersTest.php
+++ b/tests/Unit/Classes/Module/ModuleDeclaredControllersTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Module;
+
+use Module;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class ModuleDeclaredControllersTest extends TestCase
+{
+    /**
+     * The historical form. A module declaring names only must keep producing exactly what it did,
+     * with no meta attached, so its pages keep the URLs they have today.
+     */
+    public function testNamesAloneCarryNoMeta(): void
+    {
+        $this->assertSame(
+            [
+                ['name' => 'payment', 'title' => [], 'url_rewrite' => []],
+                ['name' => 'validation', 'title' => [], 'url_rewrite' => []],
+            ],
+            $this->declaredControllers(['payment', 'validation'])
+        );
+    }
+
+    public function testASingleValueAppliesToEveryLanguage(): void
+    {
+        $this->assertSame(
+            [[
+                'name' => 'validation',
+                'title' => [Module::CONTROLLER_META_ALL_LANGUAGES => 'Payment validation'],
+                'url_rewrite' => [Module::CONTROLLER_META_ALL_LANGUAGES => 'payment-validation'],
+            ]],
+            $this->declaredControllers([
+                ['name' => 'validation', 'title' => 'Payment validation', 'url_rewrite' => 'payment-validation'],
+            ])
+        );
+    }
+
+    public function testAMapIsKeptPerLanguage(): void
+    {
+        $this->assertSame(
+            [[
+                'name' => 'confirm',
+                'title' => [],
+                'url_rewrite' => ['en' => 'order-confirmed', 'fr' => 'commande-confirmee'],
+            ]],
+            $this->declaredControllers([
+                ['name' => 'confirm', 'url_rewrite' => ['en' => 'order-confirmed', 'fr' => 'commande-confirmee']],
+            ])
+        );
+    }
+
+    /**
+     * Both forms in one declaration, which is what a module gains a controller in mid-life.
+     */
+    public function testBothFormsCanBeMixed(): void
+    {
+        $this->assertSame(
+            [
+                ['name' => 'payment', 'title' => [], 'url_rewrite' => []],
+                ['name' => 'validation', 'title' => [], 'url_rewrite' => [Module::CONTROLLER_META_ALL_LANGUAGES => 'paid']],
+            ],
+            $this->declaredControllers(['payment', ['name' => 'validation', 'url_rewrite' => 'paid']])
+        );
+    }
+
+    /**
+     * A definition with no name cannot produce a page, and silently installing `module-x-` would be
+     * worse than skipping it.
+     */
+    public function testADefinitionWithoutANameIsSkipped(): void
+    {
+        $this->assertSame(
+            [['name' => 'payment', 'title' => [], 'url_rewrite' => []]],
+            $this->declaredControllers([['url_rewrite' => 'orphan'], 'payment'])
+        );
+    }
+
+    /**
+     * @param array<int, mixed> $controllers
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function declaredControllers(array $controllers): array
+    {
+        $module = new class() extends Module {
+            public function __construct()
+            {
+                // Module::__construct() reaches for the database and the shop context, neither of
+                // which this normalisation needs.
+            }
+        };
+        $module->controllers = $controllers;
+
+        $method = new ReflectionMethod(Module::class, 'getDeclaredControllers');
+        $method->setAccessible(true);
+
+        return $method->invoke($module);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Module::installControllers()` created the page with no `title` and no `url_rewrite` in any language, so a module front controller ships with empty meta and its author has to write the `meta_lang` rows afterwards with raw SQL to get a slug. A controller can now be declared as an array carrying that meta; declaring a name alone behaves exactly as before.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Declare `public $controllers = ['payment', ['name' => 'validation', 'url_rewrite' => 'payment-validation']];` in a module and install it. The first page gets the empty meta it gets today, the second gets the slug in every language. Uninstalling removes both.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #37349
| Sponsor company   |

### What a module can declare now

```php
public $controllers = [
    'payment',                                                                   // unchanged
    ['name' => 'validation', 'title' => 'Payment validation', 'url_rewrite' => 'payment-validation'],
    ['name' => 'confirm', 'url_rewrite' => ['en' => 'order-confirmed', 'fr' => 'commande-confirmee']],
];
```

`title` and `url_rewrite` take either one value, applied to every language, or a map keyed by the language ISO code. A language the map does not mention keeps the empty value it gets today.

ISO codes rather than `id_lang` on purpose: the ids differ from shop to shop, so a module cannot hard-code them, which is what makes the `url_rewrite_1` shape suggested in the issue awkward to ship.

### Measured on 9.1.5

Installing a module declaring all three forms, on a shop with `en` and `fr`:

```
plain     en  title=''                rewrite=''
plain     fr  title=''                rewrite=''
declared  en  title='Declared page'   rewrite='declared-page'
declared  fr  title='Declared page'   rewrite='declared-page'
perlang   en  title=''                rewrite='english-slug'
perlang   fr  title=''                rewrite=''
```

The first two rows are the BC guarantee: a module that declares names only produces byte-for-byte what it produces today.

### Why no default value is invented

Filling a default slug for controllers that declare nothing was the other option, and I rejected it after measuring: with an empty `url_rewrite` the page is still reachable, at `/module/ps_checkpayment/payment`, and giving it one changes that to `/module-ps_checkpayment-payment`. Every native module currently has an empty rewrite, so a default would silently move all of those URLs. This lets a module opt in instead.

### Uninstall

`uninstall()` builds the same page names from the same property, so it had to learn the new form too or it would leave orphan `meta` rows behind. Both call sites now go through `getDeclaredControllers()`.

### Tests

`ModuleDeclaredControllersTest` covers the normalisation: names alone carry no meta, a single value spreads to every language, a map is kept per language, both forms mix, and a definition with no name is skipped rather than installing `module-x-`.

