### PR TITLE
Save only the module whose translation was edited

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1362,6 +1362,12 @@ class AdminTranslationsControllerCore extends AdminController
                         // the previous behaviour is kept, so nothing that used to be saved is lost.
                         $selectedModule = Tools::getValue('module');
                         if ($selectedModule) {
+                            // The name reaches file paths that are read, included and written, so it
+                            // is checked the same way the mail translations above check theirs.
+                            if (!Validate::isModuleName($selectedModule)) {
+                                throw new PrestaShopException($this->trans('Invalid module name "%module%"', ['%module%' => Tools::safeOutput($selectedModule)], 'Admin.International.Notification'));
+                            }
+
                             $modules = [$selectedModule];
                         }
 

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1353,9 +1353,18 @@ class AdminTranslationsControllerCore extends AdminController
                 }
             } elseif (Tools::isSubmit('submitTranslationsModules')) {
                 if ($this->access('edit')) {
-                    // Get list of modules
+                    // Asserts the modules directory exists and is writable, and gives the fallback
+                    // list below.
                     if ($modules = $this->getListModules()) {
-                        // Get files of all modules
+                        // The form is edited one module at a time and the request says which one, so
+                        // only its files are rewritten. Writing every installed module on each save
+                        // rewrites files the merchant never edited. Without a module in the request
+                        // the previous behaviour is kept, so nothing that used to be saved is lost.
+                        $selectedModule = Tools::getValue('module');
+                        if ($selectedModule) {
+                            $modules = [$selectedModule];
+                        }
+
                         $arr_files = $this->getAllModuleFiles($modules, null, $this->lang_selected->iso_code, true);
 
                         // Find and write all translation modules files


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Saving a module translation took every installed module and rewrote its translation files. The form is edited one module at a time and the request carries which one - the page that renders the form already narrows to it, the save did not. It now narrows the same way.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | International > Translations, pick "Installed modules translations", a module and a language, and save. Only that module's files are written. With 67 modules installed on the test shop, the save previously walked all 67.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #39169
| Sponsor company   |

### The asymmetry

Rendering the form (`initFormModules`):

```php
$installed_modules = $this->getListModules();   // for the dropdown
$modules = [Tools::getValue('module')];         // the one being edited
$arr_files = $this->getAllModuleFiles($modules, ...);
```

Saving it, before this change:

```php
if ($modules = $this->getListModules()) {       // every installed module
    $arr_files = $this->getAllModuleFiles($modules, ...);
```

Same request, same selected module, two different scopes.

### Why this is about side effects more than speed

`findAndWriteTranslationsIntoFile()` rewrites each file it is given. Applied to every installed module, one edit rewrites translation files belonging to modules the merchant never opened - which is what the issue title says. Whatever those files looked like, they come back out of the writer's formatting.

I am not putting a timing figure on it. The controller needs a full request to run its file walk, and the numbers I could get outside one were not trustworthy enough to quote, so the argument here is the scope, not a benchmark: 67 modules processed instead of 1 on the test shop.

### The fallback

`getListModules()` is still called, because it also asserts that the modules directory exists and is writable and throws the error the surrounding `try` reports. If the request carries no module the list stays as it was, so a caller that somehow posts this form without one keeps the old behaviour rather than silently saving nothing.

### Tests

No automated test: this branch lives in `postProcess()` of a legacy admin controller, reached through a form post with `$_POST` state, and there is no harness for it in `tests/`. The change is the scope of one variable and the diff is readable on its own. If you would rather have it covered, the natural place is a functional test posting the module translation form, and I can add one.

