### PR TITLE
Match the exact translation key when saving or resetting a translation

### DIFF
--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -237,7 +237,16 @@ class TranslationService
             } else {
                 $queryBuilder->andWhere('t.theme IS NULL');
             }
-            $translation = $queryBuilder->getQuery()->getOneOrNullResult();
+            // WHY: the `key` column collation is case and accent insensitive, so the SQL equality
+            // also matches expressions that only differ by case ("show details" when saving
+            // "Show details") or by accents. Narrow the candidates in SQL, then keep the exact one.
+            foreach ($queryBuilder->getQuery()->getResult() as $candidate) {
+                if ($candidate->getKey() === $key) {
+                    $translation = $candidate;
+
+                    break;
+                }
+            }
         } catch (Exception $exception) {
             $logger->error($exception->getMessage(), $log_context);
         }
@@ -310,15 +319,27 @@ class TranslationService
             $searchTranslation['theme'] = $theme;
         }
 
-        $translation = $entityManager->getRepository(Translation::class)->findOneBy($searchTranslation);
-
-        $resetTranslationSuccessfully = false;
-        if (null === $translation) {
-            $resetTranslationSuccessfully = true;
+        $translations = [];
+        // WHY: same insensitive collation as in saveTranslationMessage - without the exact match a
+        // reset of "Show details" removes the merchant's translation of "show details". Every row
+        // is collected because shops that ran with that bug hold several rows under one key, and
+        // leaving one behind would report a successful reset that changes nothing.
+        foreach ($entityManager->getRepository(Translation::class)->findBy($searchTranslation) as $candidate) {
+            if ($candidate->getKey() === $key) {
+                $translations[] = $candidate;
+            }
         }
 
+        if (empty($translations)) {
+            return true;
+        }
+
+        $resetTranslationSuccessfully = false;
+
         try {
-            $entityManager->remove($translation);
+            foreach ($translations as $translation) {
+                $entityManager->remove($translation);
+            }
             $entityManager->flush();
 
             $resetTranslationSuccessfully = true;

--- a/tests/Integration/PrestaShopBundle/Service/TranslationServiceKeyCaseTest.php
+++ b/tests/Integration/PrestaShopBundle/Service/TranslationServiceKeyCaseTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\PrestaShopBundle\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShopBundle\Entity\Lang;
+use PrestaShopBundle\Entity\Translation;
+use PrestaShopBundle\Service\TranslationService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The `key` column of the translation table uses a case and accent insensitive collation, so two
+ * expressions that differ only by case are a single value as far as SQL equality is concerned.
+ * Both wordings really do coexist in the catalogue, e.g. "Show details" and "show details" in
+ * Shop.Theme.Actions.
+ */
+class TranslationServiceKeyCaseTest extends KernelTestCase
+{
+    private const DOMAIN = 'ShopThemeActions';
+    private const LOWERCASE_KEY = 'show details';
+    private const UPPERCASE_KEY = 'Show details';
+
+    /** @var TranslationService */
+    private $translationService;
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /** @var Lang */
+    private $lang;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $this->translationService = $container->get('prestashop.service.translation');
+        $this->entityManager = $container->get('doctrine')->getManager();
+        $this->lang = $this->entityManager->getRepository(Lang::class)->findOneBy([]);
+
+        $this->deleteTestedKeys();
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(['translation']);
+
+        parent::tearDown();
+    }
+
+    public function testSavingAnUppercaseKeyDoesNotOverwriteItsLowercaseSibling(): void
+    {
+        $this->translationService->saveTranslationMessage($this->lang, self::DOMAIN, self::LOWERCASE_KEY, 'lowercase translation');
+        $this->translationService->saveTranslationMessage($this->lang, self::DOMAIN, self::UPPERCASE_KEY, 'uppercase translation');
+
+        $this->assertSame('lowercase translation', $this->findTranslation(self::LOWERCASE_KEY));
+        $this->assertSame('uppercase translation', $this->findTranslation(self::UPPERCASE_KEY));
+    }
+
+    public function testEditingOneOfTwoStoredCasesDoesNotAddADuplicateRow(): void
+    {
+        $this->translationService->saveTranslationMessage($this->lang, self::DOMAIN, self::LOWERCASE_KEY, 'lowercase translation');
+        $this->translationService->saveTranslationMessage($this->lang, self::DOMAIN, self::UPPERCASE_KEY, 'uppercase translation');
+
+        $this->translationService->saveTranslationMessage($this->lang, self::DOMAIN, self::UPPERCASE_KEY, 'edited uppercase translation');
+
+        $this->assertCount(2, $this->findTestedRows());
+        $this->assertSame('lowercase translation', $this->findTranslation(self::LOWERCASE_KEY));
+        $this->assertSame('edited uppercase translation', $this->findTranslation(self::UPPERCASE_KEY));
+    }
+
+    /**
+     * A shop that already hit this bug ends up with both cases stored, which is the state where the
+     * SQL lookup matches two rows at once.
+     */
+    public function testSavingWhenBothCasesAreAlreadyStoredDoesNotCreateADuplicate(): void
+    {
+        $this->storeTranslation(self::LOWERCASE_KEY, 'lowercase translation');
+        $this->storeTranslation(self::UPPERCASE_KEY, 'uppercase translation');
+
+        $this->translationService->saveTranslationMessage($this->lang, self::DOMAIN, self::UPPERCASE_KEY, 'edited uppercase translation');
+
+        $this->assertCount(2, $this->findTestedRows());
+        $this->assertSame('lowercase translation', $this->findTranslation(self::LOWERCASE_KEY));
+        $this->assertSame('edited uppercase translation', $this->findTranslation(self::UPPERCASE_KEY));
+    }
+
+    public function testResettingAnUppercaseKeyDoesNotDeleteItsLowercaseSibling(): void
+    {
+        $this->translationService->saveTranslationMessage($this->lang, self::DOMAIN, self::LOWERCASE_KEY, 'lowercase translation');
+
+        $this->assertTrue($this->translationService->resetTranslationMessage($this->lang, self::DOMAIN, self::UPPERCASE_KEY));
+
+        $this->assertSame('lowercase translation', $this->findTranslation(self::LOWERCASE_KEY));
+    }
+
+    /**
+     * Shops that ran with the bug accumulated several rows under the very same key, so a reset has
+     * to remove all of them - leaving one behind would report success and change nothing.
+     */
+    public function testResettingRemovesEveryRowStoredUnderThatKey(): void
+    {
+        $this->storeTranslation(self::UPPERCASE_KEY, 'first duplicate');
+        $this->storeTranslation(self::UPPERCASE_KEY, 'second duplicate');
+
+        $this->assertTrue($this->translationService->resetTranslationMessage($this->lang, self::DOMAIN, self::UPPERCASE_KEY));
+
+        $this->assertCount(0, $this->findTestedRows());
+    }
+
+    public function testResettingAKeyStillRemovesItsOwnTranslation(): void
+    {
+        $this->translationService->saveTranslationMessage($this->lang, self::DOMAIN, self::LOWERCASE_KEY, 'lowercase translation');
+
+        $this->assertTrue($this->translationService->resetTranslationMessage($this->lang, self::DOMAIN, self::LOWERCASE_KEY));
+
+        $this->assertNull($this->findTranslation(self::LOWERCASE_KEY));
+    }
+
+    private function findTranslation(string $key): ?string
+    {
+        foreach ($this->findTestedRows() as $translation) {
+            if ($translation->getKey() === $key) {
+                return $translation->getTranslation();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Reads the rows back without relying on the collation of the `key` column, which is exactly
+     * what is under test here.
+     *
+     * @return Translation[]
+     */
+    private function findTestedRows(): array
+    {
+        $this->entityManager->clear();
+
+        $rows = $this->entityManager->getRepository(Translation::class)->createQueryBuilder('t')
+            ->where('t.lang = :lang')->setParameter('lang', $this->lang)
+            ->andWhere('t.domain = :domain')->setParameter('domain', self::DOMAIN)
+            ->getQuery()->getResult();
+
+        return array_values(array_filter(
+            $rows,
+            static fn (Translation $translation): bool => in_array($translation->getKey(), [self::LOWERCASE_KEY, self::UPPERCASE_KEY], true)
+        ));
+    }
+
+    private function storeTranslation(string $key, string $value): void
+    {
+        $translation = new Translation();
+        $translation->setLang($this->lang);
+        $translation->setDomain(self::DOMAIN);
+        $translation->setKey($key);
+        $translation->setTranslation($value);
+
+        $this->entityManager->persist($translation);
+        $this->entityManager->flush();
+    }
+
+    private function deleteTestedKeys(): void
+    {
+        $this->entityManager->createQueryBuilder()
+            ->delete(Translation::class, 't')
+            ->where('t.domain = :domain')->setParameter('domain', self::DOMAIN)
+            ->getQuery()->execute();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The `key` column of the `translation` table uses `utf8mb4_0900_ai_ci`, a case and accent insensitive collation, so the SQL equality used to look a translation up also matches an expression that differs only by case. Both wordings genuinely coexist in the catalogue - `Shop.Theme.Actions` ships both `Show details` and `show details`. Saving the translation of one therefore overwrites the other, resetting one deletes the other, and once both cases are stored the lookup matches two rows, `getOneOrNullResult()` throws, the exception is swallowed and every further save appends a duplicate row.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | International > Translations > Front office translations > Core > any language > Modify. Search for `show details` and open Theme > Actions: the right panel lists both `show details` and `Show details`. Translate `Show details`, save, reopen the page - before this change the translation appears under `show details` and `Show details` is still untranslated. The added integration test covers the same flow: `php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/PrestaShopBundle/Service/TranslationServiceKeyCaseTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42169
| Related PRs       |
| Sponsor company   |

### Measured behaviour

Against 9.1.x, calling the service the way `TranslationController::translationEditAction()` does:

```
saveTranslationMessage(lang, ShopThemeActions, 'show details', 'LOWER-TRANS')
   -> id=1 key='show details' translation='LOWER-TRANS'
saveTranslationMessage(lang, ShopThemeActions, 'Show details', 'UPPER-TRANS')
   -> id=1 key='show details' translation='UPPER-TRANS'      <- the other expression was overwritten
```

`resetTranslationMessage()` has the same lookup through `findOneBy()`, with a worse outcome - resetting `Show details`, which was never translated, removes the merchant's translation of `show details`:

```
before: key='show details' -> 'LOWER-TRANS'
resetTranslationMessage(lang, ShopThemeActions, 'Show details') -> true
after:  0 rows
```

And in the state a shop is left in once both cases exist, the lookup matches two rows, so `getOneOrNullResult()` throws `NonUniqueResultException`, the `catch (Exception)` logs it, `$translation` stays null and a third row is inserted. The added test asserts this directly: on the base branch it reports `actual size 3 matches expected size 2`.

### The fix

Both methods now narrow the candidates in SQL and pick the exact key in PHP. That also removes the `NonUniqueResultException` path, so no duplicate is created.

`resetTranslationMessage()` removes every row stored under that exact key rather than the first one. Shops that ran with this bug hold several rows under one key, and stopping at the first would report a successful reset while the surviving duplicate keeps overriding the wording - `DatabaseTranslationLoader` iterates the rows and the last one read wins.

`resetTranslationMessage()` returns early when nothing matched. Previously the null branch set the success flag but fell through to `$entityManager->remove(null)`, which only worked because Doctrine ORM 2.x throws `ORMInvalidArgumentException` there and the surrounding `catch (Exception)` swallows it. With the exact match that path becomes routine rather than unreachable, and it would be an uncaught `TypeError` under ORM 3.

### Alternative considered

Changing the column to a binary collation would fix it in SQL, but it means an `ALTER TABLE` on a `text` column that is large on real shops, it only helps once the migration has run, and it changes the semantics of every other query against that column. The PHP-side exact match works immediately on existing installs whatever their collation. If you would rather have the collation change instead, say so and I will rework it.

Not covered here: a shop that already hit this has translations sitting under the wrong-cased key, and possibly several rows under the same key. This PR does not migrate them - a reset now clears them, but saving over them keeps the extra rows.

### Scope

The read path is unaffected. `DatabaseTranslationLoader` selects by lang, theme and domain and builds the catalogue keyed by each row's own key, so a case sensitive PHP array already separates the two expressions correctly. Only the two write paths in `TranslationService` compared keys in SQL.

