### PR TITLE
Select the carrier price range from a tax included total for shipments

### DIFF
--- a/src/Adapter/Shipment/CommandHandler/CreateShipmentHandler.php
+++ b/src/Adapter/Shipment/CommandHandler/CreateShipmentHandler.php
@@ -74,7 +74,10 @@ class CreateShipmentHandler implements CreateShipmentHandlerInterface
                     countryZoneId: 0,
                     currencyId: (int) $order->id_currency,
                     customerId: (int) $order->id_customer,
-                    orderTotal: (float) $order->total_products,
+                    // WHY: total_products is tax excluded, and this total picks the carrier's price
+                    // range and is compared against the free shipping threshold. The cart uses a tax
+                    // included total for both, so the tax excluded one can select another range.
+                    orderTotal: (float) $order->total_products_wt,
                 );
 
                 $context = ShippingCostPrice::createFromRequest($request);

--- a/src/Adapter/Shipment/ShipmentShippingCostUpdater.php
+++ b/src/Adapter/Shipment/ShipmentShippingCostUpdater.php
@@ -60,8 +60,12 @@ class ShipmentShippingCostUpdater
             }
 
             $quantity = $shipmentProduct->getQuantity();
-            $unitPriceTaxExcl = (float) ($product['unit_price_tax_excl'] ?? 0);
-            $shipmentTotalProducts += $unitPriceTaxExcl * $quantity;
+            // WHY: this total selects the carrier's price range and is compared against the free
+            // shipping threshold. The cart does both with a tax included total
+            // (Cart::getPackageShippingCost uses getOrderTotal(true, ...)), so summing tax excluded
+            // prices here would pick a different range than the one the customer was charged.
+            $unitPriceTaxIncl = (float) ($product['unit_price_tax_incl'] ?? 0);
+            $shipmentTotalProducts += $unitPriceTaxIncl * $quantity;
 
             $products[] = [
                 'id_product' => (int) $product['product_id'],

--- a/tests/Unit/Adapter/Shipment/ShipmentShippingCostUpdaterTest.php
+++ b/tests/Unit/Adapter/Shipment/ShipmentShippingCostUpdaterTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Shipment;
+
+use Order;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Order\Repository\OrderRepository;
+use PrestaShop\PrestaShop\Adapter\Shipment\OrderShippingTotalUpdater;
+use PrestaShop\PrestaShop\Adapter\Shipment\ShipmentShippingCostUpdater;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\Calculator\ShippingCostCalculatorInterface;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ShippingCost\ShippingCostPriceInterface;
+use PrestaShopBundle\Entity\Repository\ShipmentRepository;
+use PrestaShopBundle\Entity\Shipment;
+use PrestaShopBundle\Entity\ShipmentProduct;
+
+/**
+ * The order total handed to the shipping cost pipeline selects the carrier's price range and is
+ * compared against the free shipping threshold. Cart::getPackageShippingCost() feeds both with a
+ * tax included total, so the recalculation has to use the same basis or an order can end up with a
+ * shipping cost taken from a different range than the one the customer was charged.
+ */
+class ShipmentShippingCostUpdaterTest extends TestCase
+{
+    public function testTheOrderTotalUsedForTheRangeLookupIsTaxIncluded(): void
+    {
+        $capturedOrderTotal = null;
+
+        $calculator = $this->createMock(ShippingCostCalculatorInterface::class);
+        $calculator->method('compute')->willReturnCallback(
+            function (ShippingCostPriceInterface $context) use (&$capturedOrderTotal): void {
+                $capturedOrderTotal = (float) (string) $context->getOrderTotal();
+            }
+        );
+
+        $this->buildUpdater($calculator)->recalculateForOrder(1);
+
+        // 2 x 96.00 tax excluded is 192.00, which would fall in another price range than the
+        // 2 x 115.20 tax included the cart used.
+        $this->assertSame(230.40, $capturedOrderTotal);
+    }
+
+    private function buildUpdater(ShippingCostCalculatorInterface $calculator): ShipmentShippingCostUpdater
+    {
+        $shipmentProduct = (new ShipmentProduct())
+            ->setOrderDetailId(7)
+            ->setQuantity(2);
+
+        $shipment = new Shipment();
+        $shipment->setOrderId(1);
+        $shipment->setCarrierId(2);
+        $shipment->setAddressId(3);
+        $shipment->addShipmentProduct($shipmentProduct);
+
+        $order = $this->createMock(Order::class);
+        $order->method('getProductsDetail')->willReturn([
+            [
+                'id_order_detail' => 7,
+                'product_id' => 11,
+                'product_attribute_id' => 0,
+                'product_weight' => 1.0,
+                'is_virtual' => false,
+                'additional_shipping_cost' => 0.0,
+                'unit_price_tax_excl' => 96.00,
+                'unit_price_tax_incl' => 115.20,
+            ],
+        ]);
+        $order->id = 1;
+        $order->id_currency = 1;
+        $order->id_customer = 4;
+
+        $shipmentRepository = $this->createMock(ShipmentRepository::class);
+        $shipmentRepository->method('findByOrderId')->willReturn([$shipment]);
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository->method('get')->willReturn($order);
+
+        $totalUpdater = $this->createMock(OrderShippingTotalUpdater::class);
+        $totalUpdater->method('update')->willReturn($order);
+
+        return new ShipmentShippingCostUpdater($shipmentRepository, $orderRepository, $calculator, $totalUpdater);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | With the improved shipment feature flag on, the order is stored with a shipping cost that can come from a different carrier price range than the one the customer was charged. The shipping cost pipeline uses the order total both to pick the carrier's price range and to compare against the free shipping threshold. `Cart::getPackageShippingCost()` feeds both with `getOrderTotal(true, ...)`, a **tax included** total, while `ShipmentShippingCostUpdater` summed `unit_price_tax_excl` and `CreateShipmentHandler` passed `total_products`, both **tax excluded**. `PaymentModule::validateOrder()` runs the recalculation right after the order is created, and `OrderShippingTotalUpdater` then overwrites `total_shipping*`, so the stored order no longer matches `total_paid`.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Give a carrier price ranges that a tax rate can straddle, for example 0-100 = 5 and 100-200 = 10, and order one product at 96.00 tax excluded / 115.20 tax included. With the feature flag off the order is stored with 12.00 shipping. With it on, before this change, the order is stored with 6.00 while the customer still paid 12.00. The added unit test asserts the total handed to the pipeline: `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Adapter/Shipment/ShipmentShippingCostUpdaterTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41794
| Related PRs       |
| Sponsor company   |

### Measured on 9.2

Same cart, one product at 96.00 tax excluded / 115.20 tax included, carrier ranges 0-100 = 5 and 100-200 = 10, order placed through `validateOrder()`:

```
FF OFF  cart shipping 12.00  ->  order total_shipping 12.00   total_paid 127.20
FF ON   cart shipping 12.00  ->  order total_shipping  6.00   total_paid 127.20   <- stored from range 0-100
```

96.00 falls in the 0-100 range, 115.20 falls in 100-200. The customer was charged the tax included range and the order kept the tax excluded one, so `total_shipping` and `total_paid` no longer agree. With this change both runs store 12.00.

The same total is what `FreeShippingCalculator` compares against `PS_SHIPPING_FREE_PRICE`, and legacy compares that threshold against `getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, ...)` as well, so a shop whose threshold sits between the two totals would also grant or refuse free shipping differently on the two paths. Both are fixed by the same change.

### Scope

Two call sites build the request, and both used a tax excluded total:

- `ShipmentShippingCostUpdater::recalculateShipment()` summed `unit_price_tax_excl` per shipment product
- `CreateShipmentHandler` passed `$order->total_products`

Not changed here: the two call sites also disagree about *which* products the total covers - the updater sums the shipment's own products, the handler passes the whole order's products total. That is a separate question from the tax basis and it does not affect a single shipment order, so it is left out of this fix rather than folded in. Happy to follow up on it if you want it settled in the same place.

