### PR TITLE
Keep the HTML of legacy admin errors and confirmations

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/session_alert.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/session_alert.html.twig
@@ -7,7 +7,7 @@
 <div class="bootstrap">
   <div class="alert alert-success">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
-    {{ this.confirmationMessage }}
+    {{ this.confirmationMessage|raw_purified }}
   </div>
 </div>
 {% endif %}
@@ -16,7 +16,7 @@
 <div class="bootstrap">
   <div class="alert alert-danger">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
-    {{ this.errorMessage }}
+    {{ this.errorMessage|raw_purified }}
   </div>
 </div>
 {% endif %}
@@ -26,13 +26,13 @@
   <div class="alert alert-danger">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     {% if this.errors|length == 1 %}
-      {{ this.errors|first }}
+      {{ this.errors|first|raw_purified }}
     {% else %}
       {{ 'There are %d errors.'|trans({'%d': this.errors|length}, 'Admin.Notifications.Error') }}
       <br/>
       <ol>
         {% for error in this.errors %}
-        <li>{{ error }}</li>
+        <li>{{ error|raw_purified }}</li>
         {% endfor %}
       </ol>
     {% endif %}
@@ -57,7 +57,7 @@
 <div class="bootstrap">
   <div class="alert alert-success" style="display:block;">
     {% for confirmation in this.confirmations %}
-    {{ confirmation }}
+    {{ confirmation|raw_purified }}
     {% endfor %}
   </div>
 </div>

--- a/tests/Unit/PrestaShopBundle/Resources/LegacySessionAlertTest.php
+++ b/tests/Unit/PrestaShopBundle/Resources/LegacySessionAlertTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Resources;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFilter;
+
+/**
+ * Legacy admin controllers put HTML in their messages, typically a link to the page that fixes the
+ * problem being reported. Before PrestaShop 9 those messages were rendered by Smarty templates that
+ * never escaped them; they are now rendered by this component, so every channel has to go through
+ * raw_purified, which keeps the markup while running it past HTMLPurifier.
+ */
+class LegacySessionAlertTest extends TestCase
+{
+    private const TEMPLATE = 'Admin/Component/LegacyLayout/session_alert.html.twig';
+    private const LINK = '<a href="https://www.prestashop-project.org">a link</a>';
+
+    /**
+     * @dataProvider getMessageChannels
+     */
+    public function testTheMessageKeepsItsMarkup(string $channel, mixed $value): void
+    {
+        $html = $this->render([$channel => $value]);
+
+        $this->assertStringContainsString(self::LINK, $html, sprintf('%s should keep its markup', $channel));
+        $this->assertStringNotContainsString('&lt;a href', $html, sprintf('%s should not be escaped', $channel));
+    }
+
+    public function getMessageChannels(): iterable
+    {
+        $message = 'Message - ' . self::LINK;
+
+        yield 'confirmationMessage' => ['confirmationMessage', $message];
+        yield 'errorMessage' => ['errorMessage', $message];
+        yield 'single error' => ['errors', [$message]];
+        yield 'several errors' => ['errors', [$message, $message]];
+        yield 'confirmations' => ['confirmations', [$message]];
+        // Already rendered unescaped before this test existed, kept so a regression is caught.
+        yield 'informations' => ['informations', [$message]];
+        yield 'warnings' => ['warnings', [$message]];
+    }
+
+    /**
+     * @param array<string, mixed> $channels
+     */
+    private function render(array $channels): string
+    {
+        $twig = new Environment(new FilesystemLoader(__DIR__ . '/../../../../src/PrestaShopBundle/Resources/views'));
+        $twig->addFilter(new TwigFilter(
+            'trans',
+            static fn (string $message, array $parameters = [], ?string $domain = null): string => strtr($message, array_map('strval', $parameters))
+        ));
+        $twig->addFilter(new TwigFilter(
+            'raw_purified',
+            static fn (?string $value): string => (string) $value,
+            ['is_safe' => ['all']]
+        ));
+
+        $controller = new class($channels) {
+            public mixed $confirmationMessage = null;
+            public mixed $errorMessage = null;
+            public array $errors = [];
+            public array $informations = [];
+            public array $confirmations = [];
+            public array $warnings = [];
+
+            /**
+             * @param array<string, mixed> $channels
+             */
+            public function __construct(array $channels)
+            {
+                foreach ($channels as $name => $value) {
+                    $this->{$name} = $value;
+                }
+            }
+        };
+
+        return $twig->render(self::TEMPLATE, ['this' => $controller]);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Legacy admin controllers put markup in their messages, typically a link to the page that fixes the problem being reported. Before PrestaShop 9 those messages were rendered by Smarty (`error_messages.tpl`, `confirmation_messages.tpl`), which never escaped them. They are now rendered by the `LegacySessionAlert` component, where `warnings` and `informations` go through `raw_purified` but `errors`, `confirmations`, `errorMessage` and `confirmationMessage` do not, so Twig escapes them and the link is displayed as source. This sends every channel through the same filter, which keeps the markup while still running it past HTMLPurifier.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In any legacy `ModuleAdminController`, push the same message with a link into all four channels from `initContent()` and open the page. Before this change only the warning and the information render the link; the error and the confirmation show `&lt;a href=...&gt;`. The added test renders the template itself: `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/PrestaShopBundle/Resources/LegacySessionAlertTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42111
| Related PRs       | #42164
| Sponsor company   |

### What changes

Five outputs in `session_alert.html.twig` gain the filter that the two other channels already had:

| line | channel |
| --- | --- |
| 10 | `this.confirmationMessage` |
| 19 | `this.errorMessage` |
| 29 | `this.errors|first`, the single error case |
| 35 | `error`, the several errors case |
| 60 | `confirmation` |

The template is byte identical on `9.1.x`, `9.2.x` and `develop`, so the fix applies to all of them from the lowest branch.

### On escaping

`raw_purified` is not `raw`. It runs the value through `HTMLPurifier`, which is the same protection `warnings` and `informations` have relied on since the component was introduced, so this restores the pre-9 rendering without opening the channels to arbitrary markup. Escaping of these messages was already removed once for this reason, in #12788 for 1.7.6, back when they were rendered by Smarty.

`RawPurifiedExtension::rawPurifier()` is typed `string`, so a channel holding null would fail. #42164 makes that filter accept null; it is independent of this PR but worth landing alongside it, since this change puts four more callers on that filter.

### Test

`tests/Unit/PrestaShopBundle/Resources/LegacySessionAlertTest.php` renders the real template with a stub `raw_purified` and asserts the anchor survives in every channel. It carries its own control: `informations` and `warnings` are in the data set too, and they pass with and without the change, while the five fixed channels fail without it.

