### PR TITLE
Read and write the KPI configuration on its own table

### DIFF
--- a/src/Adapter/Configuration/KpiConfiguration.php
+++ b/src/Adapter/Configuration/KpiConfiguration.php
@@ -8,12 +8,45 @@ namespace PrestaShop\PrestaShop\Adapter\Configuration;
 
 use ConfigurationKPI;
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Class KpiConfiguration provides access to legacy ConfigurationKpi methods.
  */
 class KpiConfiguration extends Configuration
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key, $default = null, ?ShopConstraint $shopConstraint = null): mixed
+    {
+        return $this->onKpiTable(fn () => parent::get($key, $default, $shopConstraint));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $value, ?ShopConstraint $shopConstraint = null, array $options = [])
+    {
+        return $this->onKpiTable(fn () => parent::set($key, $value, $shopConstraint, $options));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($key, ?ShopConstraint $shopConstraint = null): bool
+    {
+        return $this->onKpiTable(fn () => parent::has($key, $shopConstraint));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($key)
+    {
+        return $this->onKpiTable(fn () => parent::remove($key));
+    }
+
     /**
      * Changes configuration definition before calling it's methods.
      *
@@ -25,11 +58,27 @@ class KpiConfiguration extends Configuration
     public function __call($name, $arguments)
     {
         if (is_callable([$this, $name])) {
-            ConfigurationKPI::setKpiDefinition();
-            $result = call_user_func([$this, $name], $arguments);
-            ConfigurationKPI::unsetKpiDefinition();
+            return $this->onKpiTable(fn () => call_user_func_array([$this, $name], $arguments));
+        }
+    }
 
-            return $result;
+    /**
+     * Runs a call against the KPI configuration table and restores the regular definition after it.
+     *
+     * WHY: the definition being swapped is static and shared by every Configuration call in the
+     * request, so it has to be restored even when the call throws, or the rest of the request reads
+     * the KPI table.
+     *
+     * @return mixed
+     */
+    private function onKpiTable(callable $call)
+    {
+        ConfigurationKPI::setKpiDefinition();
+
+        try {
+            return $call();
+        } finally {
+            ConfigurationKPI::unsetKpiDefinition();
         }
     }
 }

--- a/tests/Integration/Adapter/KpiConfigurationTest.php
+++ b/tests/Integration/Adapter/KpiConfigurationTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter;
+
+use Configuration as LegacyConfiguration;
+use ConfigurationKPI;
+use Db;
+use PrestaShop\PrestaShop\Adapter\Configuration\KpiConfiguration;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The KPI values live in their own table, and the legacy side writes them there through
+ * ConfigurationKPI. This adapter is the only way the migrated code reaches them, so it has to land on
+ * the same table or the two sides stop seeing each other's values.
+ */
+class KpiConfigurationTest extends KernelTestCase
+{
+    private const KEY = 'TEST_KPI_VALUE';
+
+    /** @var KpiConfiguration */
+    private $kpiConfiguration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+        $this->kpiConfiguration = self::getContainer()->get('prestashop.adapter.legacy.kpi_configuration');
+        $this->deleteTestedKey();
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(['configuration', 'configuration_kpi']);
+
+        parent::tearDown();
+    }
+
+    public function testSetWritesToTheKpiTable(): void
+    {
+        $this->kpiConfiguration->set(self::KEY, '42%');
+
+        $this->assertSame(1, $this->countRowsIn('configuration_kpi'));
+        $this->assertSame(0, $this->countRowsIn('configuration'));
+    }
+
+    public function testGetReadsWhatTheLegacySideWrote(): void
+    {
+        ConfigurationKPI::updateValue(self::KEY, '42%');
+        // The legacy write leaves the value in the shared static cache, where a reader pointed at the
+        // wrong table would still find it, so drop it and make the read go back to the database.
+        LegacyConfiguration::resetStaticCache();
+
+        $this->assertSame('42%', $this->kpiConfiguration->get(self::KEY));
+    }
+
+    public function testTheRegularConfigurationTableIsUsedAgainAfterwards(): void
+    {
+        $this->kpiConfiguration->get(self::KEY);
+
+        $configuration = self::getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set(self::KEY, 'plain');
+
+        $this->assertSame(1, $this->countRowsIn('configuration'));
+    }
+
+    private function countRowsIn(string $table): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM ' . _DB_PREFIX_ . $table . " WHERE `name` = '" . self::KEY . "'"
+        );
+    }
+
+    private function deleteTestedKey(): void
+    {
+        foreach (['configuration', 'configuration_kpi'] as $table) {
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . $table . " WHERE `name` = '" . self::KEY . "'");
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `KpiConfiguration` is meant to read and write the `configuration_kpi` table, and it does that by swapping `Configuration`'s static definition inside `__call()`. `__call()` only fires for **inaccessible** methods, and the class extends `Adapter\Configuration`, which declares `get()` and `set()` as public - so the swap never happens and every value that goes through the adapter lands in the regular `configuration` table. The legacy side writes the same keys through `ConfigurationKPI::updateValue()`, which does switch the table, so the two sides never see each other's values and the KPI cache never hits.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Write a KPI value the way `AdminStatsController` does (`ConfigurationKPI::updateValue('TEST_KPI_VALUE', '42%')`) and read it back in a **separate** request through `prestashop.adapter.legacy.kpi_configuration`. Before this change the read answers `null`; after it, `42%`. The same-process read is not a valid check, see below. `php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Adapter/KpiConfigurationTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | -
| Related PRs       | Found while reviewing #42106, which adds 28 providers that depend on this adapter
| Sponsor company   |

### Measured

`set()` through the service, before and after:

```
before   configuration_kpi=0   configuration=1
after    configuration_kpi=1   configuration=0
```

Legacy write followed by an adapter read in a fresh process:

```
before   ConfigurationKPI::updateValue('QA_PROBE_KPI','42%')  ->  adapter get() = NULL
after    ConfigurationKPI::updateValue('QA_PROBE_KPI','42%')  ->  adapter get() = '42%'
```

The `null` matters beyond a cache miss: `src/Adapter/Kpi/*Kpi.php` decide whether a value is cached with `if ($this->configuration->get('X') !== false)`, and `null !== false`, so the KPI renders with an empty value rather than falling back.

Proof that `__call()` is unreachable for these methods:

```
set() declared in: PrestaShop\PrestaShop\Adapter\Configuration   visibility: public
KpiConfiguration declares set() itself: false
```

### What changed

`get()`, `set()`, `has()` and `remove()` are now overridden explicitly and route through a private helper that swaps the definition, calls the parent and restores the definition in a `finally`. `__call()` is kept for anything else the parent may expose, and its `call_user_func()` is corrected to `call_user_func_array()` - it was passing the whole argument array as a single argument, so it would have failed had it ever been reached.

The `finally` is not decoration: `Configuration::$definition` is static and shared, so a parent call that throws while the definition is swapped would leave the rest of the request reading `configuration_kpi`.

### A note for anyone re-testing this

Writing and reading in the **same process** does not show the bug: `ConfigurationKPI::setKpiDefinition()` loads the KPI rows into the shared static cache, so a reader pointed at the wrong table still finds the value there. The included test calls `Configuration::resetStaticCache()` between the write and the read for that reason, and it is what makes that case fail without the fix.

