### PR TITLE
Purify option labels in the legacy form helper instead of escaping them

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -281,13 +281,13 @@
 													{foreach $input.options.query AS $option}
 														{if is_object($option)}
 															{if !in_array($option->$input.options.id, $fields_value[$input.name])}
-																<option value="{$option->$input.options.id|escape:'html':'UTF-8'}">{$option->$input.options.name|escape:'html':'UTF-8'}</option>
+																<option value="{$option->$input.options.id|escape:'html':'UTF-8'}">{$option->$input.options.name|purify}</option>
 															{/if}
 														{elseif $option == "-"}
 															<option value="">-</option>
 														{else}
 															{if !in_array($option[$input.options.id], $fields_value[$input.name])}
-																<option value="{$option[$input.options.id]|escape:'html':'UTF-8'}">{$option[$input.options.name]|escape:'html':'UTF-8'}</option>
+																<option value="{$option[$input.options.id]|escape:'html':'UTF-8'}">{$option[$input.options.name]|purify}</option>
 															{/if}
 														{/if}
 													{/foreach}
@@ -299,13 +299,13 @@
 													{foreach $input.options.query AS $option}
 														{if is_object($option)}
 															{if in_array($option->$input.options.id, $fields_value[$input.name])}
-																<option value="{$option->$input.options.id|escape:'html':'UTF-8'}">{$option->$input.options.name|escape:'html':'UTF-8'}</option>
+																<option value="{$option->$input.options.id|escape:'html':'UTF-8'}">{$option->$input.options.name|purify}</option>
 															{/if}
 														{elseif $option == "-"}
 															<option value="">-</option>
 														{else}
 															{if in_array($option[$input.options.id], $fields_value[$input.name])}
-																<option value="{$option[$input.options.id]|escape:'html':'UTF-8'}">{$option[$input.options.name]|escape:'html':'UTF-8'}</option>
+																<option value="{$option[$input.options.id]|escape:'html':'UTF-8'}">{$option[$input.options.name]|purify}</option>
 															{/if}
 														{/if}
 													{/foreach}
@@ -343,7 +343,7 @@
 																{else}
 																	{if $fields_value[$input.name] == $option[$input.options.options.id]}selected="selected"{/if}
 																{/if}
-															>{$option[$input.options.options.name]|escape:'html':'UTF-8'}</option>
+															>{$option[$input.options.options.name]|purify}</option>
 														{/foreach}
 													</optgroup>
 												{/foreach}
@@ -378,7 +378,7 @@
 																	selected="selected"
 																{/if}
 															{/if}
-														>{$option[$input.options.name]|escape:'html':'UTF-8'}</option>
+														>{$option[$input.options.name]|purify}</option>
 
 													{/if}
 												{/foreach}
@@ -391,7 +391,7 @@
 											{strip}
 											<label>
 											<input type="radio"	name="{$input.name|escape:'html':'UTF-8'}" id="{$value.id}" value="{$value.value|escape:'html':'UTF-8'}"{if $fields_value[$input.name] == $value.value} checked="checked"{/if}{if (isset($input.disabled) && $input.disabled) or (isset($value.disabled) && $value.disabled)} disabled="disabled"{/if}/>
-												{$value.label|escape:'html':'UTF-8'}
+												{$value.label|purify}
 											</label>
 											{/strip}
 										</div>

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -125,6 +125,31 @@ function smarty_modifier_htmlentitiesUTF8($string)
     return Tools::htmlentitiesUTF8($string);
 }
 
+/**
+ * Keeps the markup of a label while removing anything that could be used to attack the page.
+ *
+ * This is the Smarty counterpart of the raw_purified Twig filter, for labels that legitimately carry
+ * markup but may also come from the database.
+ *
+ * WHY the fallback escapes instead of returning the value: without the container there is no
+ * purifier, and these labels are not trusted, so the only safe answer is the escaped string.
+ *
+ * @param string|null $string
+ *
+ * @return string
+ */
+function smarty_modifier_purify($string)
+{
+    $string = (string) $string;
+    $container = PrestaShop\PrestaShop\Adapter\SymfonyContainer::getInstance();
+
+    if ($container === null) {
+        return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+    }
+
+    return $container->get('prestashop.utils.html_purifier')->purify($string);
+}
+
 function smartyRegisterFunction($smarty, $type, $function, $params, $lazy = true, $initial_lazy_register = null)
 {
     if (!in_array($type, array('function', 'modifier', 'block'))) {

--- a/tests/Integration/Core/Smarty/PurifyModifierTest.php
+++ b/tests/Integration/Core/Smarty/PurifyModifierTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Smarty;
+
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The legacy form helper escapes option labels because they can come from the database. That also
+ * kills the markup a module legitimately puts in its own labels, so those labels go through this
+ * modifier instead: markup survives, anything dangerous does not.
+ */
+class PurifyModifierTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $bootedKernel = self::bootKernel();
+        // A real admin request assigns the kernel globally, which is where SymfonyContainer reads it
+        // from; a bare KernelTestCase does not, so the modifier would take its fallback branch.
+        global $kernel;
+        $kernel = $bootedKernel;
+    }
+
+    /**
+     * @dataProvider getLabels
+     */
+    public function testTheLabelKeepsItsMarkupWithoutWhatCouldAttackThePage(string $label, string $expectedToSurvive, ?string $expectedToDisappear): void
+    {
+        $purified = smarty_modifier_purify($label);
+
+        $this->assertStringContainsString($expectedToSurvive, $purified);
+
+        if ($expectedToDisappear !== null) {
+            $this->assertStringNotContainsString($expectedToDisappear, $purified);
+        }
+    }
+
+    public function getLabels(): iterable
+    {
+        yield 'plain text is untouched' => ['Delivery', 'Delivery', null];
+        yield 'emphasis survives' => ['<strong>Recommended</strong> option', '<strong>Recommended</strong>', null];
+        yield 'link survives' => ['See <a href="https://example.com">the guide</a>', '<a href="https://example.com">', null];
+        yield 'script is removed' => ['Label<script>alert(1)</script>', 'Label', '<script'];
+        yield 'inline handler is removed' => ['<span onclick="alert(1)">Label</span>', 'Label', 'onclick'];
+        yield 'javascript href is removed' => ['<a href="javascript:alert(1)">Label</a>', 'Label', 'javascript:'];
+    }
+
+    public function testANullLabelBecomesAnEmptyString(): void
+    {
+        $this->assertSame('', smarty_modifier_purify(null));
+    }
+
+    public function testTheLabelIsEscapedWhenThereIsNoContainerToPurifyWith(): void
+    {
+        global $kernel;
+        $bootedKernel = $kernel;
+        $kernel = null;
+        SymfonyContainer::resetStaticCache();
+
+        try {
+            $this->assertSame('&lt;strong&gt;Label&lt;/strong&gt;', smarty_modifier_purify('<strong>Label</strong>'));
+        } finally {
+            $kernel = $bootedKernel;
+            SymfonyContainer::resetStaticCache();
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The `escape:'html':'UTF-8'` on the legacy form helper's option labels is there because those labels can come from the database, but it also strips the markup a module puts in its own labels, so `<strong>Recommended</strong>` is rendered as source. This adds a `purify` Smarty modifier - the counterpart of the `raw_purified` Twig filter - and uses it on the **label** positions only. The `value=""` attributes keep their escape.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Give a module option a label containing markup, e.g. `<strong>Recommended</strong>`, and open its configuration page. Before, the tags are printed as text; after, the label renders and a label containing `<script>` or an `onclick` still has it removed. `php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Core/Smarty/PurifyModifierTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41357
| Related PRs       | #42167 touches the same template at line 534, a different region
| Sponsor company   |

### Which of the two options this is

@clotairer laid out two ways to fix it: each module works around it, or the core gets a purifying Smarty filter. This is the second one. The first leaves every module carrying a workaround for a core decision, and it does not help the labels core itself renders.

The escape is not simply rolled back - the labels still cannot carry anything dangerous:

```
<strong>Recommended</strong> option        -> kept
See <a href="https://example.com">…</a>    -> kept
Label<script>alert(1)</script>             -> script removed
<span onclick="alert(1)">Label</span>      -> handler removed
<a href="javascript:alert(1)">Label</a>    -> javascript: removed
```

### What changed

`smarty_modifier_purify()` in `config/smarty.config.inc.php` delegates to `prestashop.utils.html_purifier`, the same service behind the Twig `raw_purified` filter, so there is one purifier configuration in the codebase rather than two. It deliberately does **not** use `Tools::purifyHTML()`: that one is gated on `PS_USE_HTMLPURIFIER` and sets `HTML.Trusted`, which is the right level for CMS content written by a merchant and the wrong level for a label that may come from the database.

Seven label positions in `admin-dev/themes/default/template/helpers/form/form.tpl` now use it (lines 284, 290, 302, 308, 346, 381, 394). Every `value=""` attribute keeps `escape:'html':'UTF-8'`, because purifying an attribute value would leave quotes intact and break out of it.

When there is no container to purify with - a context that never booted the kernel - the modifier escapes instead of returning the label untouched. Failing closed matters here: the fallback is exactly the case where nothing else is protecting the page.

### Test

`tests/Integration/Core/Smarty/PurifyModifierTest.php`, 8 cases, covering both branches: with the kernel available the markup survives and the dangerous parts are removed, and with the global kernel nulled the label comes back escaped. Note the test assigns the kernel to the `$kernel` global in `setUp()` - a real admin request does that and `SymfonyContainer::getInstance()` reads it from there, so without it the test silently exercises only the fallback.

