### PR TITLE
Give the cache pool a configurable default lifetime

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -15,6 +15,11 @@ parameters:
   env(PS_LOG_OUTPUT): "%kernel.logs_dir%/%kernel.environment%.log"
   env(PS_LOG_MAX_FILES): '30'
   env(PS_TRUSTED_PROXIES): ''
+  # Lifetime, in seconds, given to entries of the application cache pool. Drivers that outlive the
+  # request (memcached, apcu) keep an entry forever when this is 0, so a deploy or a module
+  # update keeps serving the old value until someone clears the cache by hand.
+  env(PS_CACHE_DEFAULT_LIFETIME): '86400'
+  cache.default_lifetime: '%env(int:PS_CACHE_DEFAULT_LIFETIME)%'
   mail_themes_uri: "/mails/themes"
   mail_themes_dir: "%kernel.project_dir%%mail_themes_uri%"
   modules_translation_paths: [ ]

--- a/classes/container/LegacyCompilerPass.php
+++ b/classes/container/LegacyCompilerPass.php
@@ -49,11 +49,14 @@ class LegacyCompilerPass implements CompilerPassInterface
     private function buildCacheDefinition(string $cacheDriver, ContainerBuilder $container): void
     {
         $container->setDefinition(CacheAdapterFactory::class, new Definition(CacheAdapterFactory::class));
+        $defaultLifetime = $container->hasParameter('cache.default_lifetime')
+            ? (int) $container->getParameter('cache.default_lifetime')
+            : 0;
         $definition = new Definition(AdapterInterface::class);
         $definition
             ->setPublic(true)
             ->setFactory([new Reference(CacheAdapterFactory::class), 'getCacheAdapter'])
-            ->setArguments([$cacheDriver])
+            ->setArguments([$cacheDriver, $defaultLifetime])
         ;
 
         $container->setDefinition($cacheDriver, $definition);

--- a/src/PrestaShopBundle/DependencyInjection/CacheAdapterFactory.php
+++ b/src/PrestaShopBundle/DependencyInjection/CacheAdapterFactory.php
@@ -19,16 +19,25 @@ use Symfony\Component\Cache\Adapter\MemcachedAdapter;
  */
 class CacheAdapterFactory
 {
-    public function getCacheAdapter(string $driver): AdapterInterface
+    /**
+     * @param int $defaultLifetime Lifetime, in seconds, given to an entry that does not carry its own.
+     *                             0 means the entry never expires, which for a driver outliving the
+     *                             request leaves a stale value in place until the cache is cleared by
+     *                             hand.
+     */
+    public function getCacheAdapter(string $driver, int $defaultLifetime = 0): AdapterInterface
     {
         if ($driver === 'apcu') {
-            return new ApcuAdapter();
+            return new ApcuAdapter('', $defaultLifetime);
         } elseif ($driver === 'memcached') {
             return new MemcachedAdapter(
-                AbstractAdapter::createConnection('memcached://localhost', ['lazy' => true])
+                AbstractAdapter::createConnection('memcached://localhost', ['lazy' => true]),
+                '',
+                $defaultLifetime
             );
         }
 
+        // The array adapter only lives for the request, so an expiration would add nothing.
         return new ArrayAdapter();
     }
 }

--- a/tests/Unit/Classes/Container/LegacyCompilerPassCacheTest.php
+++ b/tests/Unit/Classes/Container/LegacyCompilerPassCacheTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Container;
+
+use LegacyCompilerPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * The cache adapter is built by a factory call assembled here, so the lifetime configured for the
+ * pool has to be handed to that call - otherwise an adapter that outlives the request keeps its
+ * entries forever.
+ */
+class LegacyCompilerPassCacheTest extends TestCase
+{
+    public function testTheConfiguredLifetimeIsPassedToTheFactory(): void
+    {
+        $container = $this->buildContainer(['cache.driver' => 'memcached', 'cache.default_lifetime' => 3600]);
+
+        $this->assertSame(['memcached', 3600], $container->getDefinition('memcached')->getArguments());
+    }
+
+    public function testAMissingParameterFallsBackToNoExpiration(): void
+    {
+        $container = $this->buildContainer(['cache.driver' => 'memcached']);
+
+        $this->assertSame(['memcached', 0], $container->getDefinition('memcached')->getArguments());
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function buildContainer(array $parameters): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        foreach ($parameters as $name => $value) {
+            $container->setParameter($name, $value);
+        }
+
+        (new LegacyCompilerPass())->process($container);
+
+        return $container;
+    }
+}

--- a/tests/Unit/PrestaShopBundle/DependencyInjection/CacheAdapterFactoryTest.php
+++ b/tests/Unit/PrestaShopBundle/DependencyInjection/CacheAdapterFactoryTest.php
@@ -10,6 +10,8 @@ namespace Tests\Unit\PrestaShopBundle\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\DependencyInjection\CacheAdapterFactory;
+use ReflectionProperty;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
@@ -48,5 +50,25 @@ class CacheAdapterFactoryTest extends TestCase
             ['array', ArrayAdapter::class],
             ['other', ArrayAdapter::class],
         ];
+    }
+
+    /**
+     * An adapter that outlives the request keeps an entry forever when its default lifetime is 0, so
+     * the lifetime configured for the pool has to reach the adapter.
+     */
+    public function testTheConfiguredLifetimeReachesTheAdapter(): void
+    {
+        if (!ApcuAdapter::isSupported()) {
+            $this->markTestSkipped('apcu is not supported');
+        }
+
+        $adapter = $this->cacheAdapterFactory->getCacheAdapter('apcu', 3600);
+
+        // Reflect on the class that declares it: the property is private and comes from a trait used
+        // by AbstractAdapter, so asking ApcuAdapter for it raises "property does not exist".
+        $property = new ReflectionProperty(AbstractAdapter::class, 'defaultLifetime');
+        $property->setAccessible(true);
+
+        $this->assertSame(3600, (int) $property->getValue($adapter));
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The application cache pool hands its adapter no default lifetime, so `MemcachedAdapter` and `ApcuAdapter` are built with `$defaultLifetime = 0` and their entries never expire. For a driver that outlives the request that means a module update or a configuration change keeps being served from the old entry until the cache is cleared by hand. The lifetime configured for the pool is now passed to the adapter, defaults to a day, and can be set with `PS_CACHE_DEFAULT_LIFETIME`.
| Type?             | bug fix
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With memcached selected under Advanced Parameters > Performance, store something through the cache and inspect the key (`stats cachedump`): its expiration was `0` and is now `now + 86400`. Setting `PS_CACHE_DEFAULT_LIFETIME=0` restores the previous behaviour. `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Classes/Container/LegacyCompilerPassCacheTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39491
| Related PRs       | #42166 touches the same factory call, see the note below
| Sponsor company   |

### Where the 0 comes from

`CacheAdapterFactory::getCacheAdapter()` builds the adapters without their third constructor argument:

```php
new MemcachedAdapter(AbstractAdapter::createConnection('memcached://localhost', ['lazy' => true]))
new ApcuAdapter()
```

and both signatures are `__construct(..., string $namespace = '', int $defaultLifetime = 0, ...)`. So every entry that does not carry its own lifetime is stored with no expiration, which is what the report observed on the socket. The `ArrayAdapter` branch is left as is - it only lives for the request, so an expiration would add nothing.

### The value

`86400` is a default, not a decision the merchant is stuck with: `PS_CACHE_DEFAULT_LIFETIME` overrides it, and setting it to `0` restores exactly today's behaviour. A finite default is the safer side of the trade: an expired entry costs one recomputation, an entry that never expires costs a support ticket about a module update that "did not apply". If you would rather ship this with the default kept at `0` and only the configurability added, say so and I will change the one line.

### Note on #42166

That PR also adds a second argument to the same `setArguments()` call, for the configured memcached servers. Whichever of the two lands first, the other needs a one line rebase to put both arguments in the call. Happy to fold them into a single PR instead if you prefer to touch that factory once.

### Tests

`LegacyCompilerPassCacheTest` asserts the factory call receives the configured lifetime, and falls back to `0` when the parameter is absent - it runs without the apcu or memcached extension, which the existing `CacheAdapterFactoryTest` cases need and skip without. That existing test also gained a case asserting the lifetime reaches the adapter, guarded the same way as its neighbours.

