### PR TITLE
Count orders in the statistics when their status issues no invoice

### DIFF
--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -207,13 +207,16 @@ class AdminStatsControllerCore extends AdminStatsTabController
      *
      * @return string
      */
-    protected static function getCountedBetweenSql($dateFrom, $dateTo)
+    protected static function getCountedBetweenSql($dateFrom, $dateTo, string $alias = '')
     {
+        // WHY the alias: getBestCategory() joins the orders table next to the product table, which
+        // carries a date_add of its own, so the columns have to be qualified there.
+        $prefix = '' === $alias ? '' : '`' . $alias . '`.';
         $from = '"' . pSQL($dateFrom) . ' 00:00:00"';
         $to = '"' . pSQL($dateTo) . ' 23:59:59"';
 
-        return '(`invoice_date` BETWEEN ' . $from . ' AND ' . $to
-            . ' OR (`invoice_date` <= "1000-01-01 00:00:00" AND `date_add` BETWEEN ' . $from . ' AND ' . $to . '))';
+        return '(' . $prefix . '`invoice_date` BETWEEN ' . $from . ' AND ' . $to
+            . ' OR (' . $prefix . '`invoice_date` <= "1000-01-01 00:00:00" AND ' . $prefix . '`date_add` BETWEEN ' . $from . ' AND ' . $to . '))';
     }
 
     public static function getTotalSales($date_from, $date_to, $granularity = false)
@@ -385,7 +388,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 				FROM `' . _DB_PREFIX_ . 'product` pr
 				LEFT OUTER JOIN `' . _DB_PREFIX_ . 'order_detail` cp ON pr.`id_product` = cp.`product_id`
 				LEFT JOIN `' . _DB_PREFIX_ . 'orders` o ON o.`id_order` = cp.`id_order`
-				WHERE o.invoice_date BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59"
+				WHERE ' . self::getCountedBetweenSql($date_from, $date_to, 'o') . '
 				GROUP BY pr.`id_product`
 			) t ON t.`id_product` = pr.`id_product`
 		) t	ON t.`id_product` = capr.`id_product`
@@ -902,9 +905,10 @@ class AdminStatsControllerCore extends AdminStatsTabController
 					COUNT(`id_order`) AS orders,
 					SUM(`total_paid_tax_excl` / `conversion_rate`) AS total_paid_tax_excl
 				FROM `' . _DB_PREFIX_ . 'orders`
-				WHERE `invoice_date` BETWEEN "' . pSQL(date('Y-m-d', strtotime('-31 day'))) . ' 00:00:00" AND "' . pSQL(
+				WHERE ' . self::getCountedBetweenSql(
+                        date('Y-m-d', strtotime('-31 day')),
                         date('Y-m-d', strtotime('-1 day'))
-                    ) . ' 23:59:59"
+                    ) . '
 				' . Shop::addSqlRestriction()
                 );
                 $value = $this->context->getCurrentLocale()->formatPrice(

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -182,18 +182,52 @@ class AdminStatsControllerCore extends AdminStatsTabController
         );
     }
 
+    /**
+     * The date a statistic counts an order at.
+     *
+     * WHY: an order only receives an invoice date when its status issues invoices. With invoices
+     * turned off for a status, the column keeps the zero date, which is outside every range, so the
+     * order disappeared from every statistic. It is counted at its creation date in that case.
+     *
+     * @return string
+     */
+    protected static function getCountedAtSql()
+    {
+        return '(CASE WHEN `invoice_date` > "1000-01-01 00:00:00" THEN `invoice_date` ELSE `date_add` END)';
+    }
+
+    /**
+     * Restricts a statistic to the orders counted inside the given range.
+     *
+     * WHY two comparisons instead of a condition on getCountedAtSql(): both columns are indexed and
+     * a CASE around them would not be, which matters on a shop with a large order table.
+     *
+     * @param string $dateFrom
+     * @param string $dateTo
+     *
+     * @return string
+     */
+    protected static function getCountedBetweenSql($dateFrom, $dateTo)
+    {
+        $from = '"' . pSQL($dateFrom) . ' 00:00:00"';
+        $to = '"' . pSQL($dateTo) . ' 23:59:59"';
+
+        return '(`invoice_date` BETWEEN ' . $from . ' AND ' . $to
+            . ' OR (`invoice_date` <= "1000-01-01 00:00:00" AND `date_add` BETWEEN ' . $from . ' AND ' . $to . '))';
+    }
+
     public static function getTotalSales($date_from, $date_to, $granularity = false)
     {
         if ($granularity == 'day') {
             $sales = [];
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
-			SELECT LEFT(`invoice_date`, 10) AS date, SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate) AS sales
+			SELECT LEFT(' . self::getCountedAtSql() . ', 10) AS date, SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate) AS sales
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . ' AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 10)'
+			GROUP BY LEFT(' . self::getCountedAtSql() . ', 10)'
             );
             foreach ($result as $row) {
                 $sales[strtotime($row['date'])] = $row['sales'];
@@ -204,12 +238,12 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $sales = [];
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
-			SELECT LEFT(`invoice_date`, 7) AS date, SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate) AS sales
+			SELECT LEFT(' . self::getCountedAtSql() . ', 7) AS date, SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate) AS sales
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . ' AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 7)'
+			GROUP BY LEFT(' . self::getCountedAtSql() . ', 7)'
             );
             foreach ($result as $row) {
                 $sales[strtotime($row['date'] . '-01')] = $row['sales'];
@@ -222,7 +256,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			SELECT SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate)
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . ' AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o')
             );
         }
@@ -234,7 +268,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
             'SELECT COUNT(DISTINCT od.product_id)
 		FROM `' . _DB_PREFIX_ . 'orders` o
 		LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order
-		WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59"
+		WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . '
 		' . Shop::addSqlRestriction(false, 'o')
         );
         if (!$distinct_products) {
@@ -250,12 +284,12 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $orders = [];
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
-			SELECT LEFT(`invoice_date`, 10) AS date, COUNT(*) AS orders
+			SELECT LEFT(' . self::getCountedAtSql() . ', 10) AS date, COUNT(*) AS orders
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . ' AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 10)'
+			GROUP BY LEFT(' . self::getCountedAtSql() . ', 10)'
             );
             foreach ($result as $row) {
                 $orders[strtotime($row['date'])] = $row['orders'];
@@ -266,12 +300,12 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $orders = [];
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
-			SELECT LEFT(`invoice_date`, 7) AS date, COUNT(*) AS orders
+			SELECT LEFT(' . self::getCountedAtSql() . ', 7) AS date, COUNT(*) AS orders
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . ' AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 7)'
+			GROUP BY LEFT(' . self::getCountedAtSql() . ', 7)'
             );
             foreach ($result as $row) {
                 $orders[strtotime($row['date'] . '-01')] = $row['orders'];
@@ -284,7 +318,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			SELECT COUNT(*) AS orders
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . ' AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o')
             );
         }
@@ -372,7 +406,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 		SELECT a.id_country, COUNT(*) AS orders
 		FROM `' . _DB_PREFIX_ . 'orders` o
 		LEFT JOIN `' . _DB_PREFIX_ . 'address` a ON o.id_address_delivery = a.id_address
-		WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59"
+		WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . '
 		' . Shop::addSqlRestriction()
         );
         $row['orders'] = round(100 * $row['orders'] / $total_orders, 1);
@@ -457,7 +491,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
 			SELECT
-				LEFT(`invoice_date`, 10) as date,
+				LEFT(' . self::getCountedAtSql() . ', 10) as date,
 				SUM(od.`product_quantity` * IF(
 					od.`purchase_supplier_price` > 0,
 					od.`purchase_supplier_price` / `conversion_rate`,
@@ -466,9 +500,9 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . ' AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 10)'
+			GROUP BY LEFT(' . self::getCountedAtSql() . ', 10)'
             );
             foreach ($result as $row) {
                 $purchases[strtotime($row['date'])] = $row['total_purchase_price'];
@@ -486,7 +520,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . ' AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o')
             );
         }
@@ -499,7 +533,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
         $orders = Db::getInstance()->executeS(
             '
 		SELECT
-			LEFT(`invoice_date`, 10) AS date,
+			LEFT(' . self::getCountedAtSql() . ', 10) AS date,
 			total_paid_tax_incl / o.conversion_rate AS total_paid_tax_incl,
 			total_shipping_tax_excl / o.conversion_rate AS total_shipping_tax_excl,
 			o.module,
@@ -510,7 +544,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 		LEFT JOIN `' . _DB_PREFIX_ . 'address` a ON o.id_address_delivery = a.id_address
 		LEFT JOIN `' . _DB_PREFIX_ . 'carrier` c ON o.id_carrier = c.id_carrier
 		LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-		WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+		WHERE ' . self::getCountedBetweenSql($date_from, $date_to) . ' AND os.logable = 1
 		' . Shop::addSqlRestriction(false, 'o')
         );
         foreach ($orders as $order) {

--- a/tests/Integration/Classes/Stats/StatsWithoutInvoiceTest.php
+++ b/tests/Integration/Classes/Stats/StatsWithoutInvoiceTest.php
@@ -29,7 +29,7 @@ class StatsWithoutInvoiceTest extends TestCase
 
     protected function tearDown(): void
     {
-        DatabaseDump::restoreTables(['orders']);
+        DatabaseDump::restoreTables(['orders', 'order_detail']);
 
         parent::tearDown();
     }
@@ -47,6 +47,64 @@ class StatsWithoutInvoiceTest extends TestCase
         $this->insertOrder(self::DAY . ' 10:00:00', '2019-03-03 10:00:00');
 
         $this->assertSame(1, $this->countOrdersOnTheDay());
+    }
+
+    /**
+     * The category and average-cart figures were left on the raw column when the rest moved, so an
+     * order without an invoice date still counted for nothing there.
+     */
+    /**
+     * getBestCategory() joins the orders table alongside the product table, which carries a date_add
+     * of its own, so the date test has to name the alias. Left unqualified the query dies with
+     * "Column 'date_add' in where clause is ambiguous" - this pins that down.
+     */
+    public function testTheBestCategoryQueryRunsWithTheOrdersTableJoinedNextToProducts(): void
+    {
+        $productId = (int) Db::getInstance()->getValue(
+            'SELECT cp.id_product FROM ' . _DB_PREFIX_ . 'category_product cp ORDER BY cp.id_product'
+        );
+        $this->insertOrderWithAProduct('0000-00-00 00:00:00', $productId);
+
+        $this->assertNotNull(AdminStatsController::getBestCategory(self::DAY, self::DAY));
+    }
+
+    /**
+     * The defect this file is about is a query being left on the raw column while the rest moved, and
+     * the average-cart KPI is built inside displayAjaxGetKpi(), which echoes JSON and cannot be called
+     * from a test. Assert the property on the source instead: outside the two helpers that own the
+     * column, the controller must not mention it at all.
+     */
+    public function testNoQueryIsLeftOnTheRawInvoiceDateColumn(): void
+    {
+        $source = (string) file_get_contents(_PS_ROOT_DIR_ . '/controllers/admin/AdminStatsController.php');
+        $this->assertNotSame('', $source);
+
+        $helpers = [];
+        foreach (['getCountedAtSql', 'getCountedBetweenSql'] as $helper) {
+            $from = strpos($source, 'protected static function ' . $helper);
+            $this->assertNotFalse($from, $helper . '() is the seam this test relies on');
+            $helpers[] = substr($source, $from, strpos($source, "\n    }", $from) - $from);
+        }
+
+        $this->assertStringNotContainsString(
+            'invoice_date',
+            str_replace($helpers, '', $source),
+            'a statistics query still restricts itself to the invoice date, so an order whose status'
+            . ' issues no invoice is missing from it'
+        );
+    }
+
+    private function insertOrderWithAProduct(string $invoiceDate, int $productId): void
+    {
+        $this->insertOrder($invoiceDate);
+        $orderId = (int) Db::getInstance()->Insert_ID();
+
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'order_detail
+                (id_order, id_order_invoice, id_warehouse, id_shop, product_id, product_attribute_id, product_name, product_quantity,
+                 product_price, unit_price_tax_excl, unit_price_tax_incl, total_price_tax_excl, total_price_tax_incl)
+             VALUES (' . $orderId . ', 0, 0, 1, ' . $productId . ', 0, "QA", 1, 10, 10, 10, 10, 10)'
+        );
     }
 
     private function countOrdersOnTheDay(): int

--- a/tests/Integration/Classes/Stats/StatsWithoutInvoiceTest.php
+++ b/tests/Integration/Classes/Stats/StatsWithoutInvoiceTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Stats;
+
+use AdminStatsController;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * An order only gets an invoice date when its status issues invoices. Every statistic used to be
+ * restricted to that column, so turning invoices off for a status hid the order from all of them.
+ */
+class StatsWithoutInvoiceTest extends TestCase
+{
+    private const DAY = '2019-03-04';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        require_once _PS_ROOT_DIR_ . '/controllers/admin/AdminStatsController.php';
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(['orders']);
+
+        parent::tearDown();
+    }
+
+    public function testAnOrderWithoutAnInvoiceDateIsCountedOnItsCreationDay(): void
+    {
+        $this->insertOrder('0000-00-00 00:00:00');
+
+        $this->assertSame(1, $this->countOrdersOnTheDay());
+    }
+
+    public function testAnOrderWithAnInvoiceDateIsStillCountedOnTheInvoiceDay(): void
+    {
+        // Created the day before, invoiced on the day under test: it belongs to the invoice day.
+        $this->insertOrder(self::DAY . ' 10:00:00', '2019-03-03 10:00:00');
+
+        $this->assertSame(1, $this->countOrdersOnTheDay());
+    }
+
+    private function countOrdersOnTheDay(): int
+    {
+        return array_sum(array_map('intval', (array) AdminStatsController::getOrders(self::DAY, self::DAY, 'day')));
+    }
+
+    private function insertOrder(string $invoiceDate, ?string $dateAdd = null): void
+    {
+        $logableState = (int) Db::getInstance()->getValue('SELECT id_order_state FROM ' . _DB_PREFIX_ . 'order_state WHERE logable = 1');
+        $reference = 'QASTATS';
+
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'orders
+                (reference, id_shop_group, id_shop, id_customer, id_cart, id_currency, id_lang, id_address_delivery, id_address_invoice, current_state,
+                 payment, conversion_rate, total_paid, total_paid_real, total_paid_tax_excl, total_paid_tax_incl, total_products, total_products_wt,
+                 total_shipping, total_shipping_tax_excl, total_shipping_tax_incl, invoice_date, delivery_date, date_add, date_upd)
+             VALUES ("' . $reference . '", 1, 1, 1, 0, 1, 1, 1, 1, ' . $logableState . ',
+                 "QA", 1, 10, 10, 10, 10, 10, 10, 0, 0, 0,
+                 "' . pSQL($invoiceDate) . '", "0000-00-00 00:00:00", "' . pSQL($dateAdd ?? (self::DAY . ' 09:00:00')) . '", NOW())'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Every statistic in `AdminStatsController` restricts itself to `invoice_date`, but an order only receives one when its status has invoices enabled. With invoices turned off the column keeps the zero date, which is outside every range, so the order is counted by nothing - not by the order count, not by sales, not by the KPIs built on them. Such an order is now counted at its creation date instead.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Preferences > Statuses, turn invoices off for the statuses an order passes through, place an order, then look at Stats. Before, the order count stays at 0; after, the order appears on its creation day. `php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/Stats/StatsWithoutInvoiceTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36564, Fixes #15319
| Related PRs       | The same pattern exists in the `statsforecast` module, see below
| Sponsor company   |

### Measured

Taking one logable order on a 9.1 shop and clearing its `invoice_date`, which is what a status with invoices off leaves behind, then asking `AdminStatsController::getOrders()` for a range that covers every possible date:

```
with an invoice date      -> counted: 1
without an invoice date   -> counted: 0
```

and with this change, the same order is counted on its creation day.

### What changed

Two helpers, used by the twelve queries in the controller:

- `getCountedAtSql()` returns the date a statistic counts an order at - the invoice date when there is one, the creation date otherwise. It replaces `invoice_date` inside the `LEFT(..., 10)` and `LEFT(..., 7)` groupings, so an order without an invoice no longer groups under the zero date.
- `getCountedBetweenSql()` builds the range test as two comparisons rather than a condition on the expression above. `invoice_date` and `date_add` are both indexed and a `CASE` around them would not be, which matters on a shop with a large order table.

Shops that do issue invoices are unaffected: the fallback only applies to rows whose `invoice_date` was never set.

### Not covered here

`modules/statsforecast` runs its own queries against `o.invoice_date` (`statsforecast.php:142`, `:637`, `:659`) and needs the same treatment. That is a separate repository, so it cannot be fixed in this PR - happy to open the counterpart there once the shape here is agreed.

### Test

`StatsWithoutInvoiceTest` inserts a logable order without an invoice date and asserts the day's count, plus a second case with an invoice date that guards the existing behaviour. Reverting only the controller turns the first red and leaves the second green.


