### PR TITLE
Recognise the left to right mark in a currency pattern

### DIFF
--- a/src/Core/Localization/Currency/PatternTransformer.php
+++ b/src/Core/Localization/Currency/PatternTransformer.php
@@ -16,6 +16,7 @@ class PatternTransformer
 {
     public const NO_BREAK_SPACE = "\u{00A0}";
     public const RTL_CHARACTER = "\u{200F}";
+    public const LTR_CHARACTER = "\u{200E}";
     public const REGULAR_SPACE = ' ';
     public const CURRENCY_SYMBOL = '¤';
 
@@ -35,6 +36,7 @@ class PatternTransformer
         self::CURRENCY_SYMBOL .
         self::NO_BREAK_SPACE .
         self::REGULAR_SPACE .
+        self::LTR_CHARACTER .
         self::RTL_CHARACTER
     ;
 
@@ -76,7 +78,7 @@ class PatternTransformer
     public function getTransformationType(string $currencyPattern)
     {
         $patterns = explode(';', $currencyPattern);
-        $pattern = str_replace(self::RTL_CHARACTER, '', $patterns[0]);
+        $pattern = str_replace([self::RTL_CHARACTER, self::LTR_CHARACTER], '', $patterns[0]);
 
         $regexpList = [
             self::TYPE_LEFT_SYMBOL_WITH_SPACE => '/^¤[ ' . self::NO_BREAK_SPACE . ']+.+/',
@@ -122,6 +124,15 @@ class PatternTransformer
      */
     private function getRtlCharacter(string $currencyPattern): string
     {
-        return (str_contains($currencyPattern, self::RTL_CHARACTER)) ? self::RTL_CHARACTER : '';
+        // WHY both: CLDR marks the direction of a currency pattern with U+200F for locales such as
+        // Hebrew and with U+200E for Persian. Handling only the first left the Persian pattern
+        // unrecognised, so the back office could not tell where its symbol sits.
+        foreach ([self::RTL_CHARACTER, self::LTR_CHARACTER] as $character) {
+            if (str_contains($currencyPattern, $character)) {
+                return $character;
+            }
+        }
+
+        return '';
     }
 }

--- a/tests/Unit/Core/Localization/Currency/PatternTransformerTest.php
+++ b/tests/Unit/Core/Localization/Currency/PatternTransformerTest.php
@@ -168,4 +168,49 @@ class PatternTransformerTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * CLDR marks the direction of a currency pattern with U+200F for locales such as Hebrew and with
+     * U+200E for Persian. Only the first used to be recognised, so the Persian pattern was reported
+     * as having no transformation type at all and the back office could not tell where its symbol sits.
+     *
+     * @dataProvider getDirectionalPatterns
+     */
+    public function testADirectionalMarkDoesNotHideTheTransformationType(string $expectedType, string $pattern): void
+    {
+        $transformer = new PatternTransformer();
+
+        $this->assertSame($expectedType, $transformer->getTransformationType($pattern));
+    }
+
+    public function getDirectionalPatterns(): array
+    {
+        return [
+            'persian, left to right mark' => [
+                PatternTransformer::TYPE_LEFT_SYMBOL_WITHOUT_SPACE,
+                "\u{200E}\u{00A4}#,##0.00",
+            ],
+            'hebrew, right to left mark' => [
+                PatternTransformer::TYPE_RIGHT_SYMBOL_WITH_SPACE,
+                "\u{200F}#,##0.00\u{00A0}\u{00A4}",
+            ],
+            'no mark at all' => [
+                PatternTransformer::TYPE_LEFT_SYMBOL_WITHOUT_SPACE,
+                "\u{00A4}#,##0.00",
+            ],
+        ];
+    }
+
+    /**
+     * A transformed pattern has to keep the directional mark it came with.
+     */
+    public function testTheLeftToRightMarkSurvivesATransformation(): void
+    {
+        $transformer = new PatternTransformer();
+
+        $this->assertSame(
+            "\u{200E}#,##0.00\u{00A0}\u{00A4}",
+            $transformer->transform("\u{200E}\u{00A4}#,##0.00", PatternTransformer::TYPE_RIGHT_SYMBOL_WITH_SPACE)
+        );
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PatternTransformer` strips U+200F before matching a currency pattern against the four symbol positions, but CLDR marks the Persian pattern with U+200E instead. That pattern therefore matched none of them, `getTransformationType()` returned an empty string, and the currency form had no position to show as selected. Both marks are now recognised, and a transformed pattern keeps the one it came with.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | International > Localization, import the Iran pack, then International > Currencies and edit any currency: the symbol and format customization now shows a selected position for Persian as it does for the other languages. `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/Localization/Currency/PatternTransformerTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36604
| Related PRs       |
| Sponsor company   |

### Measured

Asking `getTransformationType()` for the CLDR currency pattern of four locales, on `9.1.x`:

```
en-US   pattern "¤#,##0.00"                      -> leftWithoutSpace
ar-EG   pattern "#,##0.00 ¤"                     -> rightWithSpace
he-IL   pattern "<U+200F>#,##0.00 ¤;…"           -> rightWithSpace
fa-IR   pattern "<U+200E>¤#,##0.00"              -> ''
```

The Hebrew pattern is recognised because U+200F is stripped first; the Persian one is not, because U+200E is not. With this change `fa-IR` answers `leftWithoutSpace` and the other three are unchanged.

### What changed

- a `LTR_CHARACTER` constant next to the existing `RTL_CHARACTER`;
- `getTransformationType()` strips either mark before matching;
- `getRtlCharacter()` returns whichever mark the pattern carried, so a transformation does not silently drop it;
- the mark is added to `CHARACTERS_TO_TRIM`, so it is not left stranded in the middle of a rebuilt pattern.

### Test

Four cases appended to the existing `PatternTransformerTest`: the Persian pattern, the Hebrew one, a pattern with no mark, and a transformation that has to preserve the mark. Reverting only the transformer turns the two Persian ones red and leaves the Hebrew and unmarked ones green, so the new cases are pinned to this change rather than to the detection in general.

