### PR TITLE
Match the order line by its customization when applying cart updates

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -284,9 +284,13 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         foreach ($updatedProducts as $updatedProduct) {
             $updatedCombinationId = null !== $updatedProduct->getCombinationId() ? $updatedProduct->getCombinationId()->getValue() : 0;
             $affectedOrderDetail = null;
+            $updatedCustomizationId = $updatedProduct->getCustomizationId() !== null
+                ? $updatedProduct->getCustomizationId()->getValue()
+                : 0;
             foreach ($orderDetails as $orderDetailData) {
                 if ((int) $orderDetailData['product_id'] === $updatedProduct->getProductId()->getValue()
-                    && (int) $orderDetailData['product_attribute_id'] === $updatedCombinationId) {
+                    && (int) $orderDetailData['product_attribute_id'] === $updatedCombinationId
+                    && (int) $orderDetailData['id_customization'] === $updatedCustomizationId) {
                     $affectedOrderDetail = new OrderDetail($orderDetailData['id_order_detail']);
                     break;
                 }

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -218,9 +218,16 @@ class OrderAmountUpdater
         $combinationId = null === $productUpdate->getCombinationId()
             ? 0
             : $productUpdate->getCombinationId()->getValue();
+        // WHY the customization: CartProductUpdate::productMatches() counts it as part of a product's
+        // identity, so two order lines that differ only by it are different lines and matching on the
+        // product alone returns whichever comes first.
+        $customizationId = null === $productUpdate->getCustomizationId()
+            ? 0
+            : $productUpdate->getCustomizationId()->getValue();
         foreach ($order->getProducts() as $product) {
             if ((int) $product['product_id'] === $productUpdate->getProductId()->getValue()
-                && (int) $product['product_attribute_id'] === $combinationId) {
+                && (int) $product['product_attribute_id'] === $combinationId
+                && (int) $product['id_customization'] === $customizationId) {
                 return $product;
             }
         }

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -180,10 +180,14 @@ class OrderProductQuantityUpdater
             $updatedCombinationId = $updatedProduct->getCombinationId() !== null
                 ? $updatedProduct->getCombinationId()->getValue()
                 : 0;
+            $updatedCustomizationId = $updatedProduct->getCustomizationId() !== null
+                ? $updatedProduct->getCustomizationId()->getValue()
+                : 0;
             $updatedOrderDetail = null;
             foreach ($orderDetails as $orderDetailData) {
                 if ((int) $orderDetailData['product_id'] === $updatedProduct->getProductId()->getValue()
-                    && (int) $orderDetailData['product_attribute_id'] === $updatedCombinationId) {
+                    && (int) $orderDetailData['product_attribute_id'] === $updatedCombinationId
+                    && (int) $orderDetailData['id_customization'] === $updatedCustomizationId) {
                     $updatedOrderDetail = new OrderDetail($orderDetailData['id_order_detail']);
                     break;
                 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Three loops in `src/Adapter/Order` pick the order line to act on by product and combination only, and take the **first** row that matches. The value object they iterate, `CartProductUpdate`, counts the customization as part of a product's identity in its own `productMatches()`. With two order lines of the same product and combination differing only by their customization, those loops can therefore update the wrong line. They now compare the customization the same way.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On an order holding two lines of the same product and combination with different customizations, change the quantity of one of them from the back office and check the other line is untouched.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Part of #31898
| Related PRs       | #42183 fixes the duplicate-invoice half of the same issue
| Sponsor company   |

### Why these three

`CartProductUpdate::productMatches()` already defines what "the same product" means:

```php
return $combinationIdValue === $checkedCombinationIdValue && $customizationIdValue === $checkedCustomizationIdValue;
```

but the three loops that consume those objects stop at the combination:

- `OrderAmountUpdater::findProductInOrder()` returns the first matching row
- `OrderProductQuantityUpdater::applyOtherProductUpdates()` builds an `OrderDetail` from the first match and updates its quantity
- `AddProductToOrderHandler` does the same before recomputing the invoice

`OrderDetailUpdater` is not in the list: it already takes a `$customizationId` and compares it, which is what the fixed loops now do too.

### Risk

The added condition is a no-op wherever no customization is involved: `id_customization` is `0` on both sides and the comparison is `0 === 0`. It only changes which row is picked when several lines of the same product carry different customizations - the case that is broken today.

### Regression check

The full order Behat suite passes on this branch:

```
259 scenarios (259 passed)
7321 steps (7321 passed)
```

An earlier revision of this description said the suite would not start here. That turned out to be my environment rather than the suite: a previous failed run had left the fixture modules in `/tmp/ps_backup_test_modules` instead of `tests/Resources/modules/`, so `the module "dummy_payment" is installed` could not resolve the module and every later run failed the same way. With the fixtures restored the suite runs, and it is green with these three changes in place.

