### PR TITLE
Accept a blank translation of a wording that takes parameters

### DIFF
--- a/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
+++ b/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
@@ -25,6 +25,14 @@ class PassVsprintfValidator extends ConstraintValidator
             throw new UnexpectedTypeException($translation, 'PrestaShopBundle\Entity\Translation');
         }
 
+        // WHY: a blank translation removes the wording altogether, so there is nothing left for
+        // vsprintf to format and the placeholders it no longer carries cannot break anything.
+        // Refusing it is what stopped a merchant from hiding a sentence that happens to take
+        // parameters, which is the documented way of removing an unwanted text.
+        if ('' === trim((string) $translation->getTranslation())) {
+            return;
+        }
+
         if ($this->countArgumentsOfTranslation($translation->getKey()) != $this->countArgumentsOfTranslation($translation->getTranslation())) {
             $this->context->buildViolation($constraint->message)
                 ->addViolation();

--- a/tests/Unit/PrestaShopBundle/PassVsprintfContraintTest.php
+++ b/tests/Unit/PrestaShopBundle/PassVsprintfContraintTest.php
@@ -51,4 +51,43 @@ class PassVsprintfContraintTest extends ConstraintValidatorTestCase
 
         $this->buildViolation($constraint->message)->assertRaised();
     }
+
+    /**
+     * Translating a string to a blank removes it, which is the documented way of hiding an unwanted
+     * wording. There is nothing left for vsprintf to format, so the placeholders the blank no longer
+     * carries must not be counted against it.
+     *
+     * @dataProvider getBlankTranslations
+     */
+    public function testABlankTranslationOfAStringWithParametersIsAccepted(string $blank): void
+    {
+        $translation = (new Translation())
+            ->setKey('Your order with the reference %order_name% has been shipped.')
+            ->setTranslation($blank);
+
+        $this->validator->validate($translation, new PassVsprintf());
+
+        $this->assertNoViolation();
+    }
+
+    public function getBlankTranslations(): array
+    {
+        return [
+            'a single space' => [' '],
+            'several spaces' => ['   '],
+            'empty' => [''],
+        ];
+    }
+
+    public function testAWordingThatSimplyDropsAParameterIsStillRefused(): void
+    {
+        $translation = (new Translation())
+            ->setKey('Your order with the reference %order_name% has been shipped.')
+            ->setTranslation('Your order has been shipped.');
+        $constraint = new PassVsprintf();
+
+        $this->validator->validate($translation, $constraint);
+
+        $this->buildViolation($constraint->message)->assertRaised();
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Translating a wording to a blank is the documented way of removing an unwanted text, but `PassVsprintfValidator` compares the number of placeholders in the key with the number in the translation, and a blank has none. The save was therefore rejected and the field reverted, which is what the report describes for wordings that take parameters. A blank removes the wording altogether, so there is nothing left for `vsprintf` to format and the count no longer means anything - it is skipped in that case.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | International > Translations, edit an email wording that takes a parameter, for example `Your order with the reference %order_name% has been shipped.`, put a single space in the field and save. Before, the field comes back with the original text; after, the blank is kept. `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/PrestaShopBundle/PassVsprintfContraintTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23932
| Related PRs       |
| Sponsor company   |

### Measured

Saving a blank through `TranslationService::saveTranslationMessage()`, which is what the back office form does, on `9.1.x`:

```
before   save returned false | stored = false
after    save returned true  | stored = '[ ]'
```

The `false` came from the validation block in that method, and the violation from `PassVsprintfValidator::validate()`:

```php
if ($this->countArgumentsOfTranslation($translation->getKey()) != $this->countArgumentsOfTranslation($translation->getTranslation())) {
```

with 1 placeholder on the key and 0 on the blank.

### What stays refused

Only a blank is exempt. A translation that keeps wording while dropping a placeholder - the case the constraint exists for, since `vsprintf` would then be handed an argument it cannot place - still raises the violation, and there is a test for that alongside the new ones.

### Test

Four cases appended to `PassVsprintfContraintTest`: a single space, several spaces, an empty string, and the still-refused case of a wording that drops a parameter. Reverting only the validator turns the three blanks red and leaves the refused case green, so the control is inside the set.

