### PR TITLE
Find the meta of a page registered under the controller php_self

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1821,7 +1821,7 @@ class FrontControllerCore extends Controller
         }
 
         $page_name = $this->getPageName();
-        $meta_tags = Meta::getMetaTags($this->context->language->id, $page_name);
+        $meta_tags = Meta::getMetaTags($this->context->language->id, $this->getMetaPageName($page_name));
 
         $my_account_controllers = [
             'address',
@@ -2063,6 +2063,32 @@ class FrontControllerCore extends Controller
     protected function getCurrentURL()
     {
         return Tools::getCurrentUrl();
+    }
+
+    /**
+     * The page a controller is configured under in SEO & URLs, which is not always the name it
+     * presents to the theme.
+     *
+     * WHY: getPageName() answers with $page_name when it is set, and that is what the theme uses for
+     * its body class and template. A controller can be registered in the meta table under its
+     * $php_self instead - the order page is "checkout" for the theme and "order" in the table - and
+     * looking only at the first one silently lost the title and description the merchant configured.
+     *
+     * @param string $pageName
+     *
+     * @return string
+     */
+    protected function getMetaPageName($pageName)
+    {
+        if (empty($this->php_self) || $this->php_self === $pageName) {
+            return $pageName;
+        }
+
+        if (Meta::getMetaByPage($pageName, $this->context->language->id)) {
+            return $pageName;
+        }
+
+        return $this->php_self;
     }
 
     public function getPageName()

--- a/tests/Integration/Classes/Controller/FrontControllerMetaPageTest.php
+++ b/tests/Integration/Classes/Controller/FrontControllerMetaPageTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use Configuration;
+use Context;
+use Controller;
+use Db;
+use FrontController;
+use Language;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * A controller tells the theme its page name and the meta table its php_self, and those two are not
+ * always the same word: the order page is "checkout" for the theme and "order" in the table. The
+ * meta lookup has to reach the row the merchant actually configured.
+ */
+class FrontControllerMetaPageTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(['meta', 'meta_lang']);
+
+        parent::tearDown();
+    }
+
+    public function testAControllerConfiguredUnderItsPhpSelfFindsThatPage(): void
+    {
+        $this->assertSame('order', $this->resolveMetaPage('checkout', 'order'));
+    }
+
+    public function testAPageThatHasItsOwnRowIsLeftAlone(): void
+    {
+        $this->assertSame('cart', $this->resolveMetaPage('cart', 'order'));
+    }
+
+    public function testAControllerWithoutAPhpSelfIsLeftAlone(): void
+    {
+        $this->assertSame('checkout', $this->resolveMetaPage('checkout', ''));
+    }
+
+    private function resolveMetaPage(string $pageName, string $phpSelf): string
+    {
+        $controller = new class() extends FrontController {
+            public function __construct()
+            {
+            }
+        };
+        $controller->php_self = $phpSelf;
+
+        $context = Context::getContext();
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $contextProperty = new ReflectionProperty(Controller::class, 'context');
+        $contextProperty->setAccessible(true);
+        $contextProperty->setValue($controller, $context);
+
+        $method = new ReflectionMethod(FrontController::class, 'getMetaPageName');
+        $method->setAccessible(true);
+
+        return (string) $method->invoke($controller, $pageName);
+    }
+
+    public function testTheOrderPageIsRegisteredUnderOrderAndNotCheckout(): void
+    {
+        $prefix = _DB_PREFIX_;
+
+        $this->assertSame('1', (string) Db::getInstance()->getValue("SELECT COUNT(*) FROM {$prefix}meta WHERE page = 'order'"));
+        $this->assertSame('0', (string) Db::getInstance()->getValue("SELECT COUNT(*) FROM {$prefix}meta WHERE page = 'checkout'"));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `OrderController` presents itself to the theme as `checkout` (`$page_name`) and is registered in the meta table as `order` (`$php_self`). `FrontController::getTemplateVarPage()` looked the meta up with the first one only, found no row and fell through to the shop name, so the title and description configured in SEO & URLs for the order page were ignored. The lookup now falls back to `$php_self` when the page name has no row of its own.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shop Parameters > Traffic & SEO > SEO & URLs, give the "Order" page a title, then open the checkout in the front office. Before, the tab shows the shop name; after, it shows the configured title. `php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/Controller/FrontControllerMetaPageTest.php`
| UI Tests          | Not run. The change is covered by the integration test added here, `FrontControllerMetaPageTest`, on the meta lookup; a campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #10653
| Related PRs       |
| Sponsor company   |

### Measured on 9.1.x

With a title set on the `order` meta row:

```
getMetaByPage('checkout') -> NOTHING
getMetaByPage('order')    -> title='QA Order Title'
getMetaTags('checkout')   -> meta_title='PrestaShop'      (the shop name)
getMetaTags('order')      -> meta_title='QA Order Title'
```

and `OrderController` declares both names:

```php
public $php_self = 'order';
public $page_name = 'checkout';
```

`getPageName()` prefers `$page_name`, so the lookup asked for `checkout`. That is also why the rewritten URL works while the title does not - the URL is resolved from the meta row itself, the title from the page name.

### The choice

Two ways to line them up. Renaming `$page_name` to `order` would fix the lookup but change the body class and the template the theme picks for the checkout, which is a real break for themes. Instead the meta lookup gets the fallback @jolelievre suggested in the issue: use the page name when it has a row, otherwise the controller's `$php_self`. Nothing changes for a controller whose two names agree, or for one that has its own row.

### What this does not do

@Hlavtox noted in the issue that the URL stays wrong even once the title works, and that a proper fix there probably means a small BC break. That part is untouched here - this PR only makes the configured title and description reach the page. Happy to look at the URL separately if you want them in one go.

### Test

`FrontControllerMetaPageTest` covers the three cases: a controller configured under its `php_self`, one whose page name has its own row, and one with no `php_self` at all. It also asserts the shipped data really registers the order page as `order` and not `checkout`, which is what makes the first case meaningful. Reverting the controller turns the three resolution cases red and leaves the data assertion green.

