### PR TITLE
Reject customer groups that belong to other shops

### DIFF
--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -7,15 +7,18 @@
 namespace PrestaShop\PrestaShop\Adapter\Customer\CommandHandler;
 
 use Customer;
+use Db;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\CommandHandler\EditCustomerHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\DuplicateCustomerEmailException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\RequiredField;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use Shop;
 
 /**
  * Handles commands which edits given customer with provided data.
@@ -63,6 +66,7 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
         }
 
         $this->assertCustomerCanAccessDefaultGroup($customer, $command);
+        $this->assertGroupsExistInCustomerShops($customer, $command);
 
         $this->updateCustomerWithCommandData($customer, $command);
 
@@ -239,5 +243,55 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
         if (!in_array($defaultGroupId, $groupIds)) {
             throw new CustomerDefaultGroupAccessException(sprintf('Customer default group with id "%s" must be in access groups', $command->getDefaultGroupId()));
         }
+    }
+
+    /**
+     * A group belongs to the shops it is associated with, and a customer to the shops that share
+     * customers with the one it was created in. Assigning a group from outside that set leaves the
+     * customer with a group its own shop cannot resolve.
+     *
+     * WHY the form can offer them at all: the choices come from Group::getGroups($langId, true),
+     * which restricts by the current shop context, so in the All shops context every group of every
+     * shop is listed.
+     *
+     * @throws CustomerConstraintException
+     */
+    private function assertGroupsExistInCustomerShops(Customer $customer, EditCustomerCommand $command): void
+    {
+        // If nothing is updated on groups, nothing to do here
+        if (null === $command->getDefaultGroupId() && null === $command->getGroupIds()) {
+            return;
+        }
+
+        $customerShopIds = Shop::getSharedShops((int) $customer->id_shop, Shop::SHARE_CUSTOMER);
+        if (empty($customerShopIds)) {
+            $customerShopIds = [(int) $customer->id_shop];
+        }
+
+        $groupIds = null === $command->getGroupIds() ? $customer->getGroups() : $command->getGroupIds();
+        if (null !== $command->getDefaultGroupId()) {
+            $groupIds[] = $command->getDefaultGroupId();
+        }
+
+        foreach (array_unique(array_map('intval', $groupIds)) as $groupId) {
+            if (!$this->isGroupAvailableInShops($groupId, $customerShopIds)) {
+                throw new CustomerConstraintException(
+                    sprintf('Customer group with id "%s" does not exist in the shops this customer belongs to', $groupId)
+                );
+            }
+        }
+    }
+
+    /**
+     * @param int[] $shopIds
+     */
+    private function isGroupAvailableInShops(int $groupId, array $shopIds): bool
+    {
+        $shopList = implode(',', array_map('intval', $shopIds));
+
+        return (bool) Db::getInstance()->getValue(
+            'SELECT 1 FROM `' . _DB_PREFIX_ . 'group_shop` WHERE `id_group` = ' . $groupId
+            . ' AND `id_shop` IN (' . $shopList . ')'
+        );
     }
 }

--- a/tests/Integration/Adapter/Customer/CommandHandler/EditCustomerGroupShopTest.php
+++ b/tests/Integration/Adapter/Customer/CommandHandler/EditCustomerGroupShopTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Customer\CommandHandler;
+
+use Customer;
+use Db;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * In the All shops context the customer form lists the groups of every shop, so a group belonging to
+ * another shop can be picked. Storing it leaves the customer with a group its own shop cannot
+ * resolve, which is what this refuses.
+ */
+class EditCustomerGroupShopTest extends KernelTestCase
+{
+    private const FOREIGN_SHOP_ID = 999;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(['group', 'group_lang', 'group_shop', 'customer', 'customer_group']);
+
+        parent::tearDown();
+    }
+
+    public function testAGroupFromAnotherShopIsRefused(): void
+    {
+        $customer = $this->getCustomer();
+        $foreignGroupId = $this->createGroupInShop(self::FOREIGN_SHOP_ID);
+
+        $this->expectException(CustomerConstraintException::class);
+
+        $this->handle($customer, array_merge($customer->getGroups(), [$foreignGroupId]));
+    }
+
+    public function testTheCustomerOwnGroupsAreStillAccepted(): void
+    {
+        $customer = $this->getCustomer();
+
+        $this->handle($customer, $customer->getGroups());
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @param int[] $groupIds
+     */
+    private function handle(Customer $customer, array $groupIds): void
+    {
+        $command = (new EditCustomerCommand((int) $customer->id))
+            ->setGroupIds($groupIds)
+            ->setDefaultGroupId((int) $customer->id_default_group);
+
+        self::getContainer()->get('prestashop.core.command_bus')->handle($command);
+    }
+
+    private function getCustomer(): Customer
+    {
+        $customerId = (int) Db::getInstance()->getValue(
+            'SELECT id_customer FROM ' . _DB_PREFIX_ . 'customer WHERE deleted = 0 AND is_guest = 0 ORDER BY id_customer ASC'
+        );
+        $this->assertGreaterThan(0, $customerId, 'the fixture has no registered customer');
+
+        $customer = new Customer($customerId);
+        // The guard is about the shops that share customers with the one the account lives in.
+        $this->assertNotContains(self::FOREIGN_SHOP_ID, Shop::getSharedShops((int) $customer->id_shop, Shop::SHARE_CUSTOMER) ?: []);
+
+        return $customer;
+    }
+
+    private function createGroupInShop(int $shopId): int
+    {
+        $prefix = _DB_PREFIX_;
+        Db::getInstance()->execute("INSERT INTO {$prefix}group (reduction, price_display_method, show_prices, date_add, date_upd) VALUES (0, 0, 1, NOW(), NOW())");
+        $groupId = (int) Db::getInstance()->Insert_ID();
+        Db::getInstance()->execute("INSERT INTO {$prefix}group_lang (id_group, id_lang, name) VALUES ($groupId, 1, 'Group of another shop')");
+        Db::getInstance()->execute("INSERT INTO {$prefix}group_shop (id_group, id_shop) VALUES ($groupId, $shopId)");
+
+        return $groupId;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | In multistore, the customer form offers groups the customer's shop does not have. `GroupByIdChoiceProvider` calls `Group::getGroups($langId, true)`, and that second parameter is a flag, not a shop id: it adds `Shop::addSqlAssociation('group', 'g')`, which joins `group_shop` on the current shop *context*. So the list is filtered by the employee's context, not by the shop the edited customer belongs to - in All shops context the join covers every shop in context and every group is offered, and in single shop context the axis is still wrong, since the employee's shop and the customer's shop need not be the same. A back office user editing a customer of shop B can therefore assign a group that only exists in shop A. The association is written to `customer_group` and is invisible to that shop afterwards: the customer view shows a group the shop does not have, price rules and group restrictions never match it, and removing it requires editing another shop's context. `EditCustomerHandler` already refuses a default group the customer cannot access, but nothing checks the shop the group belongs to. This adds that check: every group id in the command - the group list and the default group - must be associated with at least one of the shops the customer belongs to (`Shop::getSharedShops(..., Shop::SHARE_CUSTOMER)`, so a customer shared across a group of shops keeps access to that whole group's groups). A group from an unrelated shop is refused with `CustomerConstraintException`.<br><br>The guard is the save-side half. Restricting the choice list itself is the display half and is a form change (`GroupType` needs the customer's shops, which means a `ChoiceLoader` instead of the resolved `choices` array it uses now), and it must not touch the same type's second use as the Customers grid filter, where filtering by any shop's group is legitimate. I would rather land the guard first, since it is what actually protects the data, and follow with the form change; say so if you want them together.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Multistore on, two shops that do not share customers. Create a group in shop B only. Edit a customer of shop A and post that group id - before this change it is saved and then shows up as an unusable group on the customer view; after it, the save is refused. `tests/Integration/Adapter/Customer/CommandHandler/EditCustomerGroupShopTest.php` covers both directions: a group associated only with a foreign shop is refused, the customer's own groups still save.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23192
| Related PRs       | #42148 touches the same two places in `EditCustomerHandler` (the assertion call site and the private assertion block). Whichever lands first, the other needs a one line rebase. The checks are complementary: #42148 rejects a group id that resolves to nothing, this one rejects a group that exists but not in the customer's shops.
| Sponsor company   |


