### PR TITLE
Scope combination image associations to the shop they were made in

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -379,9 +379,18 @@ class CombinationCore extends ObjectModel
      */
     public function setImages($idsImage)
     {
+        // WHY: the association row has no shop of its own - an image is scoped by image_shop, so
+        // the rows belonging to the current context are the ones naming an image it can see.
+        // Deleting them all discards the selection every other shop made for this combination.
+        $shopIds = Shop::getContextListShopID();
+        $shopRestriction = empty($shopIds)
+            ? ''
+            : ' AND ims.`id_shop` IN (' . implode(',', array_map('intval', $shopIds)) . ')';
+
         if (Db::getInstance()->execute('
-			DELETE FROM `' . _DB_PREFIX_ . 'product_attribute_image`
-			WHERE `id_product_attribute` = ' . (int) $this->id) === false) {
+			DELETE pai FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai
+			INNER JOIN `' . _DB_PREFIX_ . 'image_shop` ims ON ims.`id_image` = pai.`id_image`' . $shopRestriction . '
+			WHERE pai.`id_product_attribute` = ' . (int) $this->id) === false) {
             return false;
         }
 

--- a/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
@@ -37,6 +37,9 @@ final class RemoveAllCombinationImagesHandler implements RemoveAllCombinationIma
      */
     public function handle(RemoveAllCombinationImagesCommand $command): void
     {
-        $this->combinationImagesUpdater->deleteAllImageAssociations($command->getCombinationId());
+        $this->combinationImagesUpdater->deleteAllImageAssociations(
+            $command->getCombinationId(),
+            $command->getShopConstraint()
+        );
     }
 }

--- a/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
@@ -37,6 +37,10 @@ final class SetCombinationImagesHandler implements SetCombinationImagesHandlerIn
      */
     public function handle(SetCombinationImagesCommand $command): void
     {
-        $this->combinationImagesUpdater->associateImages($command->getCombinationId(), $command->getImageIds());
+        $this->combinationImagesUpdater->associateImages(
+            $command->getCombinationId(),
+            $command->getImageIds(),
+            $command->getShopConstraint()
+        );
     }
 }

--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -147,7 +147,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
         $combination = $this->combinationRepository->getByShopConstraint($query->getCombinationId(), $shopConstraint);
         $productId = new ProductId((int) $combination->id_product);
         $product = $this->productRepository->getByShopConstraint($productId, $query->getShopConstraint());
-        $images = $this->getImages($combination);
+        $images = $this->getImages($combination, $shopConstraint);
 
         return new CombinationForEditing(
             $query->getCombinationId()->getValue(),
@@ -279,14 +279,18 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
 
     /**
      * @param Combination $combination
+     * @param ShopConstraint $shopConstraint
      *
      * @return int[]
      */
-    private function getImages(Combination $combination): array
+    private function getImages(Combination $combination, ShopConstraint $shopConstraint): array
     {
         $combinationIdValue = (int) $combination->id;
         $combinationId = new CombinationId($combinationIdValue);
-        $combinationImageIds = $this->productImageRepository->getImageIdsForCombinations([$combinationId]);
+        $combinationImageIds = $this->productImageRepository->getImageIdsForCombinations(
+            [$combinationId],
+            $shopConstraint
+        );
 
         if (empty($combinationImageIds[$combinationIdValue])) {
             return [];

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -118,7 +118,10 @@ final class GetEditableCombinationsListHandler implements GetEditableCombination
         );
 
         $productImageIds = $this->productImageRepository->getImageIds($query->getProductId(), $query->getShopConstraint());
-        $imageIdsByCombinationIds = $this->productImageRepository->getImageIdsForCombinations($combinationIds);
+        $imageIdsByCombinationIds = $this->productImageRepository->getImageIdsForCombinations(
+            $combinationIds,
+            $query->getShopConstraint()
+        );
 
         return $this->formatEditableCombinationsForListing(
             $combinations,

--- a/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
@@ -8,11 +8,14 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Update;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
+use PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Updates images associated to combination
@@ -29,39 +32,68 @@ class CombinationImagesUpdater
      */
     private $dbPrefix;
 
+    /**
+     * @var ShopRepository
+     */
+    private $shopRepository;
+
     public function __construct(
         Connection $connection,
-        string $dbPrefix
+        string $dbPrefix,
+        ShopRepository $shopRepository
     ) {
         $this->connection = $connection;
         $this->dbPrefix = $dbPrefix;
+        $this->shopRepository = $shopRepository;
     }
 
     /**
      * @param CombinationId $combinationId
+     * @param ShopConstraint|null $shopConstraint Null clears every shop, which is what callers
+     *                                            that have no shop context have always done
      *
      * @throws DBALException
      * @throws InvalidArgumentException
      */
-    public function deleteAllImageAssociations(CombinationId $combinationId): void
+    public function deleteAllImageAssociations(CombinationId $combinationId, ?ShopConstraint $shopConstraint = null): void
     {
-        $this->connection->delete(
-            $this->dbPrefix . 'product_attribute_image',
-            ['id_product_attribute' => $combinationId->getValue()]
+        if (null === $shopConstraint || $shopConstraint->forAllShops()) {
+            $this->connection->delete(
+                $this->dbPrefix . 'product_attribute_image',
+                ['id_product_attribute' => $combinationId->getValue()]
+            );
+
+            return;
+        }
+
+        // WHY: the association row carries no shop of its own - an image is scoped by image_shop,
+        // so the rows belonging to a shop are the ones naming an image that shop has. Deleting
+        // without this join wipes the selections every other shop made for the same combination.
+        $this->connection->executeStatement(
+            'DELETE pai FROM ' . $this->dbPrefix . 'product_attribute_image pai
+             INNER JOIN ' . $this->dbPrefix . 'image_shop ims
+                ON ims.id_image = pai.id_image AND ims.id_shop IN (:shopIds)
+             WHERE pai.id_product_attribute = :combinationId',
+            [
+                'combinationId' => $combinationId->getValue(),
+                'shopIds' => $this->shopRepository->getAssociatedShopIds($shopConstraint),
+            ],
+            ['shopIds' => ArrayParameterType::INTEGER]
         );
     }
 
     /**
      * @param CombinationId $combinationId
      * @param ImageId[] $imageIds
+     * @param ShopConstraint|null $shopConstraint
      *
      * @throws DBALException
      * @throws InvalidArgumentException
      */
-    public function associateImages(CombinationId $combinationId, array $imageIds): void
+    public function associateImages(CombinationId $combinationId, array $imageIds, ?ShopConstraint $shopConstraint = null): void
     {
-        // First delete all images
-        $this->deleteAllImageAssociations($combinationId);
+        // First delete the images this shop is responsible for
+        $this->deleteAllImageAssociations($combinationId, $shopConstraint);
 
         // Then create all new ones
         foreach ($imageIds as $imageId) {

--- a/src/Adapter/Product/Image/Repository/ProductImageRepository.php
+++ b/src/Adapter/Product/Image/Repository/ProductImageRepository.php
@@ -11,6 +11,7 @@ namespace PrestaShop\PrestaShop\Adapter\Product\Image\Repository;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Generator;
 use Image;
 use ImageType;
@@ -255,7 +256,12 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
      *
      * @return array<int, ImageId[]> [(int) id_combination => [ImageId]]
      */
-    public function getImageIdsForCombinations(array $combinationIds): array
+    /**
+     * @param CombinationId[] $combinationIds
+     * @param ShopConstraint|null $shopConstraint Null returns the associations of every shop, which
+     *                                            is what callers without a shop context expect
+     */
+    public function getImageIdsForCombinations(array $combinationIds, ?ShopConstraint $shopConstraint = null): array
     {
         if (empty($combinationIds)) {
             return [];
@@ -278,6 +284,11 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('combinationIds', $combinationIds, Connection::PARAM_INT_ARRAY)
             ->orderBy('i.position', 'asc')
         ;
+
+        // WHY: an association names an image, and images are scoped by image_shop. Without this a
+        // shop lists the images another shop picked for the same combination, and the form would
+        // then offer them as its own selection.
+        $this->restrictToShopImages($qb, $shopConstraint);
 
         $results = $qb->executeQuery()->fetchAllAssociative();
 
@@ -755,11 +766,68 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->orderBy('i.cover', 'DESC')
             ->setMaxResults(1)
             ->setParameter('productAttribute', $combinationId->getValue());
+
         $data = $qb->executeQuery()->fetchOne();
         if ($data > 0) {
             return new ImageId((int) $data);
         }
 
         return null;
+    }
+
+    /**
+     * Restricts a query over product_attribute_image (aliased pai) to the images the constrained
+     * shops actually hold. A null or all-shops constraint leaves the query untouched.
+     */
+    private function restrictToShopImages(QueryBuilder $qb, ?ShopConstraint $shopConstraint): void
+    {
+        if (null === $shopConstraint || $shopConstraint->forAllShops()) {
+            return;
+        }
+
+        $qb->innerJoin(
+            'pai',
+            $this->dbPrefix . 'image_shop',
+            'pai_img_shop',
+            'pai_img_shop.id_image = pai.id_image'
+        );
+
+        if ($shopConstraint->getShopGroupId()) {
+            $qb
+                ->innerJoin(
+                    'pai_img_shop',
+                    $this->dbPrefix . 'shop',
+                    'pai_shop',
+                    'pai_shop.id_shop = pai_img_shop.id_shop AND pai_shop.id_shop_group = :paiShopGroupId'
+                )
+                ->setParameter('paiShopGroupId', $shopConstraint->getShopGroupId()->getValue())
+            ;
+
+            return;
+        }
+
+        if ($shopConstraint instanceof ShopCollection && $shopConstraint->hasShopIds()) {
+            $qb
+                ->andWhere('pai_img_shop.id_shop IN (:paiShopIds)')
+                ->setParameter(
+                    'paiShopIds',
+                    array_map(fn (ShopId $shopId) => $shopId->getValue(), $shopConstraint->getShopIds()),
+                    ArrayParameterType::INTEGER
+                )
+            ;
+
+            return;
+        }
+
+        if ($shopConstraint->getShopId()) {
+            $qb
+                ->andWhere('pai_img_shop.id_shop = :paiShopId')
+                ->setParameter('paiShopId', $shopConstraint->getShopId()->getValue())
+            ;
+
+            return;
+        }
+
+        throw new InvalidShopConstraintException('Cannot handle this kind of ShopConstraint');
     }
 }

--- a/src/Core/Domain/Product/Combination/Command/RemoveAllCombinationImagesCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/RemoveAllCombinationImagesCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 class RemoveAllCombinationImagesCommand
 {
@@ -18,11 +19,25 @@ class RemoveAllCombinationImagesCommand
     private $combinationId;
 
     /**
+     * @var ShopConstraint|null
+     */
+    private $shopConstraint;
+
+    /**
      * @param int $combinationId
      */
-    public function __construct(int $combinationId)
+    public function __construct(int $combinationId, ?ShopConstraint $shopConstraint = null)
     {
         $this->combinationId = new CombinationId($combinationId);
+        $this->shopConstraint = $shopConstraint;
+    }
+
+    /**
+     * @return ShopConstraint|null
+     */
+    public function getShopConstraint(): ?ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 
     /**

--- a/src/Core/Domain/Product/Combination/Command/SetCombinationImagesCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/SetCombinationImagesCommand.php
@@ -10,6 +10,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 class SetCombinationImagesCommand
 {
@@ -27,8 +28,14 @@ class SetCombinationImagesCommand
      * @param int $combinationId
      * @param array $imageIds
      */
-    public function __construct(int $combinationId, array $imageIds)
+    /**
+     * @var ShopConstraint|null
+     */
+    private $shopConstraint;
+
+    public function __construct(int $combinationId, array $imageIds, ?ShopConstraint $shopConstraint = null)
     {
+        $this->shopConstraint = $shopConstraint;
         $this->combinationId = new CombinationId($combinationId);
         $this->imageIds = array_map(function (int $imageId) { return new ImageId($imageId); }, $imageIds);
     }
@@ -47,5 +54,14 @@ class SetCombinationImagesCommand
     public function getImageIds(): array
     {
         return $this->imageIds;
+    }
+
+    /**
+     * @return ShopConstraint|null Null when the caller has no shop context, which keeps the
+     *                             historical behaviour of writing across every shop
+     */
+    public function getShopConstraint(): ?ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationImagesCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationImagesCommandsBuilder.php
@@ -28,11 +28,11 @@ class CombinationImagesCommandsBuilder implements CombinationCommandsBuilderInte
         }
 
         if (empty($formData['images'])) {
-            return [new RemoveAllCombinationImagesCommand($combinationId->getValue())];
+            return [new RemoveAllCombinationImagesCommand($combinationId->getValue(), $singleShopConstraint)];
         }
 
         $imageIds = array_map('intval', $formData['images']);
-        $command = new SetCombinationImagesCommand($combinationId->getValue(), $imageIds);
+        $command = new SetCombinationImagesCommand($combinationId->getValue(), $imageIds, $singleShopConstraint);
 
         return [$command];
     }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -69,6 +69,7 @@ services:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
+      - '@PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository'
 
   PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\UpdateCombinationSuppliersHandler:
     autoconfigure: true

--- a/tests/Integration/Adapter/Product/Combination/CombinationImagesShopScopeTest.php
+++ b/tests/Integration/Adapter/Product/Combination/CombinationImagesShopScopeTest.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Product\Combination;
+
+use Combination;
+use Configuration as LegacyConfiguration;
+use Db;
+use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\RemoveAllCombinationImagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\SetCombinationImagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Shop as LegacyShop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * A combination image selection belongs to the shop it was made in. Saving the combination in one
+ * shop must not discard the images another shop had associated with it.
+ */
+class CombinationImagesShopScopeTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['shop', 'shop_group', 'image_shop', 'product_attribute_image', 'configuration'];
+
+    private const COMBINATION_ID = 1;
+    private const SHOP_1_IMAGE_ID = 1;
+    private const SHOP_2_IMAGE_ID = 2;
+
+    private static int $secondShopId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        $configuration = self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        $db = Db::getInstance();
+        $db->insert('shop_group', [
+            'name' => 'test_group_combination_img', 'color' => '', 'share_customer' => 0,
+            'share_order' => 0, 'share_stock' => 0, 'active' => 1, 'deleted' => 0,
+        ]);
+        $secondGroupId = (int) $db->Insert_ID();
+        $db->insert('shop', [
+            'id_shop_group' => $secondGroupId, 'name' => 'test_shop_combination_img', 'color' => '',
+            'id_category' => 2, 'theme_name' => 'classic', 'active' => 1, 'deleted' => 0,
+        ]);
+        self::$secondShopId = (int) $db->Insert_ID();
+        LegacyShop::resetStaticCache();
+
+        // Each shop owns exactly one of the two images: image 1 stays in shop 1, image 2 moves to
+        // the second shop. This is the ordinary multistore setup - an image belongs to the shops it
+        // was associated with, and the combination selection can only ever name a visible image.
+        $db->delete('image_shop', 'id_image = ' . self::SHOP_2_IMAGE_ID);
+        $db->insert('image_shop', [
+            'id_product' => 1, 'id_image' => self::SHOP_2_IMAGE_ID,
+            'id_shop' => self::$secondShopId, 'cover' => 1,
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Each case builds its own associations, so start from none for this combination.
+        Db::getInstance()->delete('product_attribute_image', 'id_product_attribute = ' . self::COMBINATION_ID);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    /**
+     * Reproduces the reported journey: pick an image for the combination in one shop, switch the
+     * shop context, pick that shop's own image, and the first shop's choice must still be there.
+     */
+    public function testSavingInOneShopKeepsAnotherShopsSelection(): void
+    {
+        self::bootKernel();
+        $commandBus = self::getContainer()->get('prestashop.core.command_bus');
+
+        $commandBus->handle(new SetCombinationImagesCommand(
+            self::COMBINATION_ID,
+            [self::SHOP_1_IMAGE_ID],
+            ShopConstraint::shop(1)
+        ));
+        $commandBus->handle(new SetCombinationImagesCommand(
+            self::COMBINATION_ID,
+            [self::SHOP_2_IMAGE_ID],
+            ShopConstraint::shop(self::$secondShopId)
+        ));
+
+        $associatedImageIds = $this->getAssociatedImageIds();
+
+        self::assertContains(
+            self::SHOP_1_IMAGE_ID,
+            $associatedImageIds,
+            'saving the combination in the second shop discarded the first shop selection'
+        );
+        self::assertContains(self::SHOP_2_IMAGE_ID, $associatedImageIds, 'the second shop selection was stored');
+    }
+
+    /**
+     * The mirror of the above: a shop must not be able to drop an image it cannot even see, so
+     * removing every image in one shop only clears the ones belonging to that shop.
+     */
+    public function testClearingInOneShopKeepsAnotherShopsSelection(): void
+    {
+        self::bootKernel();
+        $commandBus = self::getContainer()->get('prestashop.core.command_bus');
+        $this->associateOneImagePerShop($commandBus);
+
+        $commandBus->handle(new RemoveAllCombinationImagesCommand(
+            self::COMBINATION_ID,
+            ShopConstraint::shop(self::$secondShopId)
+        ));
+
+        $associatedImageIds = $this->getAssociatedImageIds();
+
+        self::assertContains(
+            self::SHOP_1_IMAGE_ID,
+            $associatedImageIds,
+            'clearing the images in the second shop discarded the first shop selection'
+        );
+        self::assertNotContains(
+            self::SHOP_2_IMAGE_ID,
+            $associatedImageIds,
+            'the second shop images were not cleared'
+        );
+    }
+
+    /**
+     * The form and the combination list read through this repository, so each shop must be shown
+     * its own associations only - otherwise a shop lists, and then re-saves, another shop images.
+     */
+    public function testEachShopReadsOnlyItsOwnAssociations(): void
+    {
+        self::bootKernel();
+        $this->associateOneImagePerShop(self::getContainer()->get('prestashop.core.command_bus'));
+        $repository = self::getContainer()->get(ProductImageRepository::class);
+        $combinationId = new CombinationId(self::COMBINATION_ID);
+
+        $shop1ImageIds = $this->flattenImageIds(
+            $repository->getImageIdsForCombinations([$combinationId], ShopConstraint::shop(1))
+        );
+        $shop2ImageIds = $this->flattenImageIds(
+            $repository->getImageIdsForCombinations([$combinationId], ShopConstraint::shop(self::$secondShopId))
+        );
+
+        self::assertSame([self::SHOP_1_IMAGE_ID], $shop1ImageIds, 'the first shop sees only its own image');
+        self::assertSame([self::SHOP_2_IMAGE_ID], $shop2ImageIds, 'the second shop sees only its own image');
+    }
+
+    /**
+     * Scoping the delete must not make a row unreachable. An association naming an image of the
+     * first shop is the first shop's to remove, whichever shop happened to write it.
+     */
+    public function testAnAssociationWrittenFromAnotherShopStaysRemovable(): void
+    {
+        self::bootKernel();
+        $commandBus = self::getContainer()->get('prestashop.core.command_bus');
+
+        // The webservice and the import can write an association naming an image the writing shop
+        // does not hold; the form cannot, because its choices are already shop scoped.
+        $commandBus->handle(new SetCombinationImagesCommand(
+            self::COMBINATION_ID,
+            [self::SHOP_1_IMAGE_ID],
+            ShopConstraint::shop(self::$secondShopId)
+        ));
+        self::assertContains(self::SHOP_1_IMAGE_ID, $this->getAssociatedImageIds());
+
+        $commandBus->handle(new RemoveAllCombinationImagesCommand(
+            self::COMBINATION_ID,
+            ShopConstraint::shop(1)
+        ));
+
+        self::assertNotContains(
+            self::SHOP_1_IMAGE_ID,
+            $this->getAssociatedImageIds(),
+            'the shop owning the image cannot remove an association another shop wrote'
+        );
+    }
+
+    /**
+     * The webservice and the import go through the legacy ObjectModel rather than the command bus,
+     * and they discarded other shops' selections the same way.
+     */
+    public function testLegacySetImagesKeepsAnotherShopsSelection(): void
+    {
+        self::bootKernel();
+        $this->associateOneImagePerShop(self::getContainer()->get('prestashop.core.command_bus'));
+
+        $previousContext = LegacyShop::getContext();
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, self::$secondShopId);
+
+        try {
+            $combination = new Combination(self::COMBINATION_ID);
+            $combination->setImages([self::SHOP_2_IMAGE_ID]);
+        } finally {
+            LegacyShop::setContext($previousContext, 1);
+        }
+
+        self::assertContains(
+            self::SHOP_1_IMAGE_ID,
+            $this->getAssociatedImageIds(),
+            'the legacy setter discarded the first shop selection'
+        );
+    }
+
+    private function associateOneImagePerShop(object $commandBus): void
+    {
+        $commandBus->handle(new SetCombinationImagesCommand(
+            self::COMBINATION_ID,
+            [self::SHOP_1_IMAGE_ID],
+            ShopConstraint::shop(1)
+        ));
+        $commandBus->handle(new SetCombinationImagesCommand(
+            self::COMBINATION_ID,
+            [self::SHOP_2_IMAGE_ID],
+            ShopConstraint::shop(self::$secondShopId)
+        ));
+    }
+
+    /**
+     * @param array<int, ImageId[]> $imageIdsByCombinationId
+     *
+     * @return int[]
+     */
+    private function flattenImageIds(array $imageIdsByCombinationId): array
+    {
+        $imageIds = array_map(
+            static fn (ImageId $imageId): int => $imageId->getValue(),
+            $imageIdsByCombinationId[self::COMBINATION_ID] ?? []
+        );
+        sort($imageIds);
+
+        return $imageIds;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getAssociatedImageIds(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_image FROM ' . _DB_PREFIX_ . 'product_attribute_image
+             WHERE id_product_attribute = ' . self::COMBINATION_ID
+        );
+
+        return array_map('intval', array_column($rows ?: [], 'id_image'));
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationImagesCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationImagesCommandsBuilderTest.php
@@ -42,7 +42,8 @@ class CombinationImagesCommandsBuilderTest extends AbstractCombinationCommandBui
 
         $command = new SetCombinationImagesCommand(
             $this->getCombinationId()->getValue(),
-            [42, 51]
+            [42, 51],
+            $this->getSingleShopConstraint()
         );
         yield [
             [
@@ -54,7 +55,10 @@ class CombinationImagesCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new RemoveAllCombinationImagesCommand($this->getCombinationId()->getValue());
+        $command = new RemoveAllCombinationImagesCommand(
+            $this->getCombinationId()->getValue(),
+            $this->getSingleShopConstraint()
+        );
         yield [
             [
                 'images' => [],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Picking combination images in one shop wiped the choice another shop had made. Both write paths delete every association row for the combination before inserting the new ones - `CombinationImagesUpdater::deleteAllImageAssociations()` for the product page, and `Combination::setImages()` for the webservice and import - and neither has any shop condition. So saving the combination in shop B removed shop A's rows, which is the "it will lost own combination image select" in the report.<br><br>`product_attribute_image` has no shop column, but it does not need one: it names an image, and images are already scoped by `image_shop`. The rows that belong to a shop are the ones naming an image that shop has. Both deletes now join `image_shop` and only remove those, and the two readers behind the combination form (`getImageIdsForCombinations()`, `getPreviewCombinationProduct()`) take the same constraint so a shop no longer lists images that belong to another one. The `ShopConstraint` was already being built and passed down to `CombinationImagesCommandsBuilder`, which simply dropped it - the two image commands were the only ones in this domain not carrying it, which is why they were the shop-blind pair.<br><br>Scope worth stating: this makes each shop's selection independent as long as the shops have their own images, which is the ordinary multistore setup and the reported case. One case stays out of reach - an image associated with two shops cannot be on the combination in one of them only, because the association row cannot distinguish them. Expressing that needs a `product_attribute_image_shop` companion table plus a migration, and I would rather not put a schema change in a patch branch to cover a case nobody has reported. If you want it, say so and I will do it on `develop` as a follow-up.<br><br>The new `ShopConstraint` arguments are all optional and default to the previous all-shops behaviour, so no command bus or repository caller changes meaning unless it opts in. `Combination::setImages()` is the exception and deliberately so: it gained no argument and reads the context itself, so the webservice and the import do change behaviour - they stop clearing other shops' rows, which is the fix. With multistore off the context is the single shop and the outcome is identical.<br><br>One consequence of joining `image_shop` on the delete: an association naming an image that has no `image_shop` row at all would no longer be removed, where the unscoped delete always removed it. `image` is a multishop `ObjectModel`, so its shop rows are written with it and I measured none of these locally, but it is a real difference rather than a pure restriction.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Multistore on, two shops, each with its own image on the same product. Pick an image for a combination in shop A, switch the context to shop B, pick shop B's image, then go back to shop A - the selection is still there, and each shop's form only lists its own images. `tests/Integration/Adapter/Product/Combination/CombinationImagesShopScopeTest.php` automates the journey and fails on `9.1.x` without the change.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #12638
| Related PRs       |
| Sponsor company   |


