### PR TITLE
Give the not found and checkout pages a breadcrumb entry of their own

### DIFF
--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -98,6 +98,23 @@ class OrderControllerCore extends FrontController
     }
 
     /**
+     * Without an entry of its own the breadcrumb holds nothing but the home link, and a
+     * one-level breadcrumb is what themes hide as empty. The cart page it is reached from
+     * already carries one, so the checkout was the last step of that path with none.
+     */
+    public function getBreadcrumbLinks(): array
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+
+        $breadcrumb['links'][] = [
+            'title' => $this->getTranslator()->trans('Checkout', [], 'Shop.Theme.Actions'),
+            'url' => $this->context->link->getPageLink('order'),
+        ];
+
+        return $breadcrumb;
+    }
+
+    /**
      * @return CheckoutSession
      */
     public function getCheckoutSession(): CheckoutSession

--- a/controllers/front/PageNotFoundController.php
+++ b/controllers/front/PageNotFoundController.php
@@ -22,6 +22,23 @@ class PageNotFoundControllerCore extends FrontController
     }
 
     /**
+     * Without an entry of its own the breadcrumb holds nothing but the home link, and a
+     * one-level breadcrumb is what themes hide as empty. The wording matches the meta title
+     * this page is registered with.
+     */
+    public function getBreadcrumbLinks(): array
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+
+        $breadcrumb['links'][] = [
+            'title' => $this->getTranslator()->trans('404 error', [], 'Shop.Navigation'),
+            'url' => $this->context->link->getPageLink('pagenotfound'),
+        ];
+
+        return $breadcrumb;
+    }
+
+    /**
      * Assign template vars related to page content.
      *
      * @see FrontController::initContent()

--- a/tests/Integration/Classes/Controller/EmptyBreadcrumbPagesTest.php
+++ b/tests/Integration/Classes/Controller/EmptyBreadcrumbPagesTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use Context;
+use Controller;
+use FrontController;
+use OrderController;
+use PageNotFoundController;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * A page that adds no breadcrumb entry of its own is left with the bare home link. Themes treat a
+ * one-level breadcrumb as empty and hide it, so those pages show no breadcrumb at all while every
+ * neighbouring page shows one.
+ */
+class EmptyBreadcrumbPagesTest extends TestCase
+{
+    /**
+     * @dataProvider getControllersThatRenderAPage
+     */
+    public function testAPageCarriesAnEntryOfItsOwn(string $controllerClass, string $expectedTitle): void
+    {
+        $links = $this->getBreadcrumbLinks($controllerClass);
+
+        self::assertCount(2, $links, sprintf('%s left the breadcrumb with the home link alone', $controllerClass));
+        self::assertSame('Home', $links[0]['title']);
+        self::assertSame($expectedTitle, $links[1]['title']);
+        self::assertNotEmpty($links[1]['url'], 'the entry needs a link of its own');
+    }
+
+    public static function getControllersThatRenderAPage(): array
+    {
+        return [
+            'not found page' => [PageNotFoundController::class, '404 error'],
+            'checkout page' => [OrderController::class, 'Checkout'],
+        ];
+    }
+
+    /**
+     * @return array<int, array{title: string, url: string}>
+     */
+    private function getBreadcrumbLinks(string $controllerClass): array
+    {
+        // The constructor of a front controller boots a whole page context, which is far more than
+        // the breadcrumb needs - the method only reads the context and the translator.
+        $controller = $this->makeControllerWithoutBooting($controllerClass);
+
+        $context = Context::getContext();
+        $this->setProperty($controller, 'context', $context);
+        $this->setProperty($controller, 'translator', $context->getTranslator());
+
+        // Called through reflection so the test measures what the breadcrumb holds rather than
+        // the visibility the method happens to be declared with.
+        $method = new ReflectionMethod($controllerClass, 'getBreadcrumbLinks');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller)['links'];
+    }
+
+    private function makeControllerWithoutBooting(string $controllerClass): FrontController
+    {
+        return (new ReflectionClass($controllerClass))->newInstanceWithoutConstructor();
+    }
+
+    private function setProperty(Controller $controller, string $name, $value): void
+    {
+        $property = new ReflectionProperty(Controller::class, $name);
+        $property->setAccessible(true);
+        $property->setValue($controller, $value);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A front controller that adds no breadcrumb entry of its own is left with what `FrontController::getBreadcrumbLinks()` returns - the home link and nothing else. Themes treat a one-level breadcrumb as empty and hide it (Classic does it with `#wrapper .breadcrumb[data-depth="1"] { display: none; }`), so those pages show no breadcrumb while every neighbouring page shows one.<br><br>This follows the direction agreed in the issue: @Hlavtox listed the options, @tblivet picked adding the entry in the controller so the behaviour is the same everywhere. The cart page was fixed that way already; going through the front controllers, the two remaining pages that render HTML and add nothing are the not found page and the checkout. Measured on `9.1.x` before the change, reading the breadcrumb the page ships to the theme:<br><br>`/this-page-does-not-exist` -> `"breadcrumb":{"links":[{"title":"Home",...}],"count":1}`<br>`/cart?action=show`, `/contact-us`, `/login`, a category -> `"count":2`<br><br>After it, the not found page reports `Home / 404 error` and `"count":2`.<br><br>The wording is the meta title each page is already registered under, which is what the other controllers do - `cart` uses "Cart", `contact` uses "Contact us", and `pagenotfound` is stored as "404 error" (`Shop.Navigation`, from `MetaLang`). The checkout has no meta title stored at all, so it uses the existing "Checkout" wording from `Shop.Theme.Actions`. No new translation key is introduced.<br><br>The checkout renders the same layout as the not found page, so the render above covers both: `FrontController::getLayout()` keys on `php_self`, and neither `order` nor `pagenotfound` appears in the five entry `layouts:` map in `themes/classic/config/theme.yml` (category, best-sales, new-products, prices-drop, contact), so both fall through to the theme default - the layout that produced `Home / 404 error` above.<br><br>The home page is deliberately left alone: it reports `count` 1 and should, since an entry pointing at the page you are already on adds nothing. Of the remaining controllers without an override, only `IndexController` renders a page at all - the other eight (`Attachment`, `ChangeCurrency`, `GetFile`, `Statistics`, `Upload`, and the three `Pdf*`) never call `setTemplate()`; they serve a file or redirect.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a URL that does not exist. Before, the breadcrumb block is absent in Classic and shows a lone "Home" in Hummingbird; after, it reads `Home / 404 error`. Same for the checkout page. `tests/Integration/Classes/Controller/EmptyBreadcrumbPagesTest.php` asserts each page contributes an entry, and fails on `9.1.x` for whichever controller is reverted.
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/32699093884
| Fixed issue or discussion?     | Fixes #40369
| Related PRs       | #42186 touches the meta resolution of this same checkout page (it is registered under `php_self` `order`, and has no meta title stored). No file overlap with this one.
| Sponsor company   |

