### PR TITLE
Carry the shop on combination image associations

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -379,9 +379,18 @@ class CombinationCore extends ObjectModel
      */
     public function setImages($idsImage)
     {
+        // WHY: the selection belongs to the shops it was made in. Clearing every shop's rows is what
+        // made a save in one shop discard what the others had chosen for the same combination.
+        $shopIds = array_map('intval', Shop::getContextListShopID());
+        if (empty($shopIds)) {
+            $shopIds = [(int) Context::getContext()->shop->id];
+        }
+        $shopList = implode(',', $shopIds);
+
         if (Db::getInstance()->execute('
 			DELETE FROM `' . _DB_PREFIX_ . 'product_attribute_image`
-			WHERE `id_product_attribute` = ' . (int) $this->id) === false) {
+			WHERE `id_product_attribute` = ' . (int) $this->id . '
+			AND `id_shop` IN (' . $shopList . ')') === false) {
             return false;
         }
 
@@ -389,11 +398,13 @@ class CombinationCore extends ObjectModel
             $sqlValues = [];
 
             foreach ($idsImage as $value) {
-                $sqlValues[] = '(' . (int) $this->id . ', ' . (int) $value . ')';
+                foreach ($shopIds as $shopId) {
+                    $sqlValues[] = '(' . (int) $this->id . ', ' . (int) $value . ', ' . $shopId . ')';
+                }
             }
 
             Db::getInstance()->execute(
-                'INSERT INTO `' . _DB_PREFIX_ . 'product_attribute_image` (`id_product_attribute`, `id_image`)
+                'INSERT INTO `' . _DB_PREFIX_ . 'product_attribute_image` (`id_product_attribute`, `id_image`, `id_shop`)
 					VALUES ' . implode(',', $sqlValues)
             );
         }

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -483,15 +483,24 @@ class ImageCore extends ObjectModel
         if (!isset($combinationImages['new']) || !is_array($combinationImages['new'])) {
             return true;
         }
-        $query = 'INSERT INTO `' . _DB_PREFIX_ . 'product_attribute_image` (`id_product_attribute`, `id_image`) VALUES ';
+        // WHY: the association carries its shop, and the duplicated image was just associated to the
+        // shops of the one it was copied from, so the new rows follow the new image's own shops.
+        $selects = [];
         foreach ($combinationImages['new'] as $idProductAttribute => $imageIds) {
             foreach ($imageIds as $imageId) {
-                $query .= '(' . (int) $idProductAttribute . ', ' . (int) $imageId . '), ';
+                $selects[] = 'SELECT ' . (int) $idProductAttribute . ', `id_image`, `id_shop`
+                    FROM `' . _DB_PREFIX_ . 'image_shop` WHERE `id_image` = ' . (int) $imageId;
             }
         }
-        $query = rtrim($query, ', ');
 
-        return Db::getInstance()->execute($query);
+        if (empty($selects)) {
+            return true;
+        }
+
+        return Db::getInstance()->execute(
+            'INSERT IGNORE INTO `' . _DB_PREFIX_ . 'product_attribute_image` (`id_product_attribute`, `id_image`, `id_shop`) '
+            . implode(' UNION ALL ', $selects)
+        );
     }
 
     /**

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -214,7 +214,8 @@ class ImageCore extends ObjectModel
 					INNER JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
 						ON (i.id_image = image_shop.id_image AND image_shop.id_shop = ' . (int) $idShop . ')
 						INNER JOIN `' . _DB_PREFIX_ . 'product_attribute_image` pai
-						ON (pai.`id_image` = i.`id_image` AND pai.`id_product_attribute` = ' . (int) $idProductAttribute . ')
+						ON (pai.`id_image` = i.`id_image` AND pai.`id_product_attribute` = ' . (int) $idProductAttribute . '
+							AND pai.`id_shop` = ' . (int) $idShop . ')
 					LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il
 						ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $idLang . ')
 					WHERE i.`id_product` = ' . (int) $idProduct . ' ORDER BY i.`position` ASC');

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -379,7 +379,8 @@ class PackCore extends Product
 				LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag ON ag.`id_attribute_group` = a.`id_attribute_group`
 				LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = ' . (int) Context::getContext()->language->id . ')
 				LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int) Context::getContext()->language->id . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_image` pai ON (' . $line['id_product_attribute_item'] . ' = pai.`id_product_attribute`)
+				LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_image` pai ON (' . $line['id_product_attribute_item'] . ' = pai.`id_product_attribute`
+					AND pai.`id_shop` IN (' . implode(',', array_map('intval', Shop::getContextListShopID())) . '))
 				WHERE pa.`id_product` = ' . (int) $line['id_product'] . ' AND pa.`id_product_attribute` = ' . $line['id_product_attribute_item'] . '
 				GROUP BY pa.`id_product_attribute`, ag.`id_attribute_group`
 				ORDER BY ag.`position`, a.`position`';

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2678,7 +2678,8 @@ class ProductCore extends ObjectModel
             FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai
             LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (il.`id_image` = pai.`id_image`)
             INNER JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
-            WHERE i.`id_product` = ' . (int) $this->id . ' AND il.`id_lang` = ' . (int) $id_lang . ' ORDER by i.`position`'
+            WHERE i.`id_product` = ' . (int) $this->id . ' AND il.`id_lang` = ' . (int) $id_lang . '
+            AND pai.`id_shop` IN (' . implode(',', array_map('intval', Shop::getContextListShopID())) . ') ORDER by i.`position`'
         );
 
         if (!$result) {
@@ -2712,7 +2713,8 @@ class ProductCore extends ObjectModel
             FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai
             LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (il.`id_image` = pai.`id_image`)
             LEFT JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
-            WHERE pai.`id_product_attribute` = ' . (int) $id_product_attribute . ' AND il.`id_lang` = ' . (int) $id_lang . ' ORDER by i.`position` LIMIT 1'
+            WHERE pai.`id_product_attribute` = ' . (int) $id_product_attribute . ' AND il.`id_lang` = ' . (int) $id_lang . '
+            AND pai.`id_shop` IN (' . implode(',', array_map('intval', Shop::getContextListShopID())) . ') ORDER by i.`position` LIMIT 1'
         );
 
         if (!$result) {
@@ -4926,9 +4928,10 @@ class ProductCore extends ObjectModel
     {
         $combination_images = [];
         $data = Db::getInstance()->executeS('
-            SELECT `id_image`
+            SELECT DISTINCT `id_image`
             FROM `' . _DB_PREFIX_ . 'product_attribute_image`
-            WHERE `id_product_attribute` = ' . (int) $id_product_attribute);
+            WHERE `id_product_attribute` = ' . (int) $id_product_attribute . '
+            AND `id_shop` IN (' . implode(',', array_map('intval', Shop::getContextListShopID())) . ')');
         foreach ($data as $row) {
             $combination_images[] = (int) $row['id_image'];
         }

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -760,7 +760,9 @@ class OrderCore extends ObjectModel
                 FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai' .
                 Shop::addSqlAssociation('image', 'pai', true) . '
                 LEFT JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
-                WHERE id_product_attribute = ' . (int) $product['product_attribute_id'] . ' ORDER by i.position ASC');
+                WHERE id_product_attribute = ' . (int) $product['product_attribute_id'] . '
+                AND pai.id_shop IN (' . implode(',', array_map('intval', Shop::getContextListShopID())) . ')
+                ORDER by i.position ASC');
         }
 
         if (!isset($id_image) || !$id_image) {

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -282,7 +282,8 @@ class OrderInvoiceCore extends ObjectModel
                 SELECT image_shop.id_image
                 FROM ' . _DB_PREFIX_ . 'product_attribute_image pai' .
                 Shop::addSqlAssociation('image', 'pai', true) . '
-                WHERE id_product_attribute = ' . (int) $product['product_attribute_id']);
+                WHERE id_product_attribute = ' . (int) $product['product_attribute_id'] . '
+                AND pai.id_shop IN (' . implode(',', array_map('intval', Shop::getContextListShopID())) . ')');
         }
 
         if (!isset($id_image) || !$id_image) {

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1851,8 +1851,10 @@ CREATE TABLE `PREFIX_product_attribute_combination` (
 CREATE TABLE `PREFIX_product_attribute_image` (
   `id_product_attribute` int(10) unsigned NOT NULL,
   `id_image` int(10) unsigned NOT NULL,
+  `id_shop` int(10) unsigned NOT NULL,
   PRIMARY KEY (
-    `id_product_attribute`, `id_image`
+    `id_product_attribute`, `id_image`,
+    `id_shop`
   ),
   KEY `id_image` (`id_image`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;

--- a/src/Adapter/Attribute/AttributeDataProvider.php
+++ b/src/Adapter/Attribute/AttributeDataProvider.php
@@ -102,10 +102,11 @@ class AttributeDataProvider
     public function getImages($idAttribute)
     {
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-			SELECT a.`id_image` as id
+			SELECT DISTINCT a.`id_image` as id
 			FROM `' . _DB_PREFIX_ . 'product_attribute_image` a
 			' . Shop::addSqlAssociation('product_attribute', 'a') . '
 			WHERE a.`id_product_attribute` = ' . (int) $idAttribute . '
+			AND a.`id_shop` IN (' . implode(',', array_map('intval', Shop::getContextListShopID())) . ')
 		');
     }
 }

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -271,7 +271,8 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 SELECT `image_shop`.id_image
                 FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai' .
                 Shop::addSqlAssociation('image', 'pai', true) . '
-                WHERE id_product_attribute = ' . (int) $pack_item['id_product_attribute']);
+                WHERE id_product_attribute = ' . (int) $pack_item['id_product_attribute'] . '
+                AND pai.id_shop IN (' . implode(',', array_map('intval', Shop::getContextListShopID())) . ')');
         }
 
         if (!isset($id_image) || !$id_image) {

--- a/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
@@ -37,6 +37,9 @@ final class RemoveAllCombinationImagesHandler implements RemoveAllCombinationIma
      */
     public function handle(RemoveAllCombinationImagesCommand $command): void
     {
-        $this->combinationImagesUpdater->deleteAllImageAssociations($command->getCombinationId());
+        $this->combinationImagesUpdater->deleteAllImageAssociations(
+            $command->getCombinationId(),
+            $command->getShopConstraint()
+        );
     }
 }

--- a/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
@@ -37,6 +37,10 @@ final class SetCombinationImagesHandler implements SetCombinationImagesHandlerIn
      */
     public function handle(SetCombinationImagesCommand $command): void
     {
-        $this->combinationImagesUpdater->associateImages($command->getCombinationId(), $command->getImageIds());
+        $this->combinationImagesUpdater->associateImages(
+            $command->getCombinationId(),
+            $command->getImageIds(),
+            $command->getShopConstraint()
+        );
     }
 }

--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -147,7 +147,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
         $combination = $this->combinationRepository->getByShopConstraint($query->getCombinationId(), $shopConstraint);
         $productId = new ProductId((int) $combination->id_product);
         $product = $this->productRepository->getByShopConstraint($productId, $query->getShopConstraint());
-        $images = $this->getImages($combination);
+        $images = $this->getImages($combination, $shopConstraint);
 
         return new CombinationForEditing(
             $query->getCombinationId()->getValue(),
@@ -282,11 +282,11 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
      *
      * @return int[]
      */
-    private function getImages(Combination $combination): array
+    private function getImages(Combination $combination, ShopConstraint $shopConstraint): array
     {
         $combinationIdValue = (int) $combination->id;
         $combinationId = new CombinationId($combinationIdValue);
-        $combinationImageIds = $this->productImageRepository->getImageIdsForCombinations([$combinationId]);
+        $combinationImageIds = $this->productImageRepository->getImageIdsForCombinations([$combinationId], $shopConstraint);
 
         if (empty($combinationImageIds[$combinationIdValue])) {
             return [];

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -118,7 +118,10 @@ final class GetEditableCombinationsListHandler implements GetEditableCombination
         );
 
         $productImageIds = $this->productImageRepository->getImageIds($query->getProductId(), $query->getShopConstraint());
-        $imageIdsByCombinationIds = $this->productImageRepository->getImageIdsForCombinations($combinationIds);
+        $imageIdsByCombinationIds = $this->productImageRepository->getImageIdsForCombinations(
+            $combinationIds,
+            $query->getShopConstraint()
+        );
 
         return $this->formatEditableCombinationsForListing(
             $combinations,

--- a/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
@@ -8,11 +8,14 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Update;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
+use PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Updates images associated to combination
@@ -29,47 +32,79 @@ class CombinationImagesUpdater
      */
     private $dbPrefix;
 
+    /**
+     * @var ShopRepository
+     */
+    private $shopRepository;
+
     public function __construct(
         Connection $connection,
-        string $dbPrefix
+        string $dbPrefix,
+        ShopRepository $shopRepository
     ) {
         $this->connection = $connection;
         $this->dbPrefix = $dbPrefix;
+        $this->shopRepository = $shopRepository;
     }
 
     /**
      * @param CombinationId $combinationId
+     * @param ShopConstraint|null $shopConstraint Null clears every shop, which is what callers with
+     *                                            no shop context have always done
      *
      * @throws DBALException
      * @throws InvalidArgumentException
      */
-    public function deleteAllImageAssociations(CombinationId $combinationId): void
+    public function deleteAllImageAssociations(CombinationId $combinationId, ?ShopConstraint $shopConstraint = null): void
     {
-        $this->connection->delete(
-            $this->dbPrefix . 'product_attribute_image',
-            ['id_product_attribute' => $combinationId->getValue()]
+        if (null === $shopConstraint || $shopConstraint->forAllShops()) {
+            $this->connection->delete(
+                $this->dbPrefix . 'product_attribute_image',
+                ['id_product_attribute' => $combinationId->getValue()]
+            );
+
+            return;
+        }
+
+        // WHY: the selection belongs to the shop it was made in. Clearing every shop's rows is what
+        // made a save in one shop discard what the others had chosen for the same combination.
+        $this->connection->executeStatement(
+            'DELETE FROM ' . $this->dbPrefix . 'product_attribute_image
+             WHERE id_product_attribute = :combinationId AND id_shop IN (:shopIds)',
+            [
+                'combinationId' => $combinationId->getValue(),
+                'shopIds' => $this->shopRepository->getAssociatedShopIds($shopConstraint),
+            ],
+            ['shopIds' => ArrayParameterType::INTEGER]
         );
     }
 
     /**
      * @param CombinationId $combinationId
      * @param ImageId[] $imageIds
+     * @param ShopConstraint|null $shopConstraint
      *
      * @throws DBALException
      * @throws InvalidArgumentException
      */
-    public function associateImages(CombinationId $combinationId, array $imageIds): void
+    public function associateImages(CombinationId $combinationId, array $imageIds, ?ShopConstraint $shopConstraint = null): void
     {
-        // First delete all images
-        $this->deleteAllImageAssociations($combinationId);
+        // First delete the images this shop is responsible for
+        $this->deleteAllImageAssociations($combinationId, $shopConstraint);
 
-        // Then create all new ones
+        $shopIds = null === $shopConstraint || $shopConstraint->forAllShops()
+            ? $this->shopRepository->getAllShopIds()
+            : $this->shopRepository->getAssociatedShopIds($shopConstraint);
+
+        // Then create all new ones, once per shop the selection was made for
         foreach ($imageIds as $imageId) {
-            $insertedValues = [
-                'id_product_attribute' => $combinationId->getValue(),
-                'id_image' => $imageId->getValue(),
-            ];
-            $this->connection->insert($this->dbPrefix . 'product_attribute_image', $insertedValues);
+            foreach ($shopIds as $shopId) {
+                $this->connection->insert($this->dbPrefix . 'product_attribute_image', [
+                    'id_product_attribute' => $combinationId->getValue(),
+                    'id_image' => $imageId->getValue(),
+                    'id_shop' => $shopId,
+                ]);
+            }
         }
     }
 }

--- a/src/Adapter/Product/Image/ProductImageProvider.php
+++ b/src/Adapter/Product/Image/ProductImageProvider.php
@@ -12,6 +12,7 @@ use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepositor
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Provider\ProductImageProviderInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 class ProductImageProvider implements ProductImageProviderInterface
@@ -53,7 +54,10 @@ class ProductImageProvider implements ProductImageProviderInterface
 
     public function getCombinationCoverUrl(CombinationId $combinationId, ShopId $shopId): string
     {
-        $imageId = $this->productImageRepository->getPreviewCombinationProduct($combinationId);
+        $imageId = $this->productImageRepository->getPreviewCombinationProduct(
+            $combinationId,
+            ShopConstraint::shop($shopId->getValue())
+        );
 
         if ($imageId) {
             return $this->productImagePathFactory->getPathByType($imageId, ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);

--- a/src/Adapter/Product/Image/Repository/ProductImageRepository.php
+++ b/src/Adapter/Product/Image/Repository/ProductImageRepository.php
@@ -11,6 +11,7 @@ namespace PrestaShop\PrestaShop\Adapter\Product\Image\Repository;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Generator;
 use Image;
 use ImageType;
@@ -255,7 +256,11 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
      *
      * @return array<int, ImageId[]> [(int) id_combination => [ImageId]]
      */
-    public function getImageIdsForCombinations(array $combinationIds): array
+    /**
+     * @param CombinationId[] $combinationIds
+     * @param ShopConstraint|null $shopConstraint Null returns the associations of every shop
+     */
+    public function getImageIdsForCombinations(array $combinationIds, ?ShopConstraint $shopConstraint = null): array
     {
         if (empty($combinationIds)) {
             return [];
@@ -278,6 +283,10 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('combinationIds', $combinationIds, Connection::PARAM_INT_ARRAY)
             ->orderBy('i.position', 'asc')
         ;
+
+        // WHY: the selection is per shop, so a shop must be shown its own rows only - otherwise it
+        // lists what another shop chose and then re-saves it as its own.
+        $this->restrictToShops($qb, $shopConstraint);
 
         $results = $qb->executeQuery()->fetchAllAssociative();
 
@@ -745,7 +754,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
         return $imageTypes;
     }
 
-    public function getPreviewCombinationProduct(CombinationId $combinationId): ?ImageId
+    public function getPreviewCombinationProduct(CombinationId $combinationId, ?ShopConstraint $shopConstraint = null): ?ImageId
     {
         $qb = $this->connection->createQueryBuilder();
         $qb->select('pai.id_image')
@@ -755,11 +764,63 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->orderBy('i.cover', 'DESC')
             ->setMaxResults(1)
             ->setParameter('productAttribute', $combinationId->getValue());
+
+        $this->restrictToShops($qb, $shopConstraint);
+
         $data = $qb->executeQuery()->fetchOne();
         if ($data > 0) {
             return new ImageId((int) $data);
         }
 
         return null;
+    }
+
+    /**
+     * Restricts a query over product_attribute_image (aliased pai) to the constrained shops.
+     * A null or all-shops constraint leaves the query untouched.
+     */
+    private function restrictToShops(QueryBuilder $qb, ?ShopConstraint $shopConstraint): void
+    {
+        if (null === $shopConstraint || $shopConstraint->forAllShops()) {
+            return;
+        }
+
+        if ($shopConstraint->getShopGroupId()) {
+            $qb
+                ->innerJoin(
+                    'pai',
+                    $this->dbPrefix . 'shop',
+                    'pai_shop',
+                    'pai_shop.id_shop = pai.id_shop AND pai_shop.id_shop_group = :paiShopGroupId'
+                )
+                ->setParameter('paiShopGroupId', $shopConstraint->getShopGroupId()->getValue())
+            ;
+
+            return;
+        }
+
+        if ($shopConstraint instanceof ShopCollection && $shopConstraint->hasShopIds()) {
+            $qb
+                ->andWhere('pai.id_shop IN (:paiShopIds)')
+                ->setParameter(
+                    'paiShopIds',
+                    array_map(fn (ShopId $shopId) => $shopId->getValue(), $shopConstraint->getShopIds()),
+                    ArrayParameterType::INTEGER
+                )
+            ;
+
+            return;
+        }
+
+        if ($shopConstraint->getShopId()) {
+            $qb
+                ->andWhere('pai.id_shop = :paiShopId')
+                ->setParameter('paiShopId', $shopConstraint->getShopId()->getValue())
+            ;
+
+            return;
+        }
+
+        throw new InvalidShopConstraintException('Cannot handle this kind of ShopConstraint');
     }
 }

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -817,7 +817,13 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->addSelect('p.reference as product_reference')
             ->addSelect('pa.reference as combination_reference')
             ->addSelect('ai.id_image as combination_image_id')
-            ->leftJoin('p', $this->dbPrefix . 'product_attribute_image', 'ai', 'ai.id_product_attribute = pa.id_product_attribute')
+            ->leftJoin(
+                'p',
+                $this->dbPrefix . 'product_attribute_image',
+                'ai',
+                'ai.id_product_attribute = pa.id_product_attribute AND ai.id_shop = :combinationImageShopId'
+            )
+            ->setParameter('combinationImageShopId', $shopId->getValue())
             ->addGroupBy('p.id_product, pa.id_product_attribute')
             ->addOrderBy('pl.name', 'ASC')
             ->addOrderBy('p.id_product', 'ASC')

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -784,6 +784,8 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
             $newCombinationImages[] = [
                 'id_image' => $imagesMapping[(int) $oldCombinationImage['id_image']],
                 'id_product_attribute' => $combinationMatching[(int) $oldCombinationImage['id_product_attribute']],
+                // The copy keeps the shop the original association was made for
+                'id_shop' => (int) $oldCombinationImage['id_shop'],
             ];
         }
         $this->bulkInsert('product_attribute_image', $newCombinationImages, CannotDuplicateProductException::FAILED_DUPLICATE_IMAGES);

--- a/src/Core/Domain/Product/Combination/Command/RemoveAllCombinationImagesCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/RemoveAllCombinationImagesCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 class RemoveAllCombinationImagesCommand
 {
@@ -20,9 +21,20 @@ class RemoveAllCombinationImagesCommand
     /**
      * @param int $combinationId
      */
-    public function __construct(int $combinationId)
+    /**
+     * @var ShopConstraint|null
+     */
+    private $shopConstraint;
+
+    public function __construct(int $combinationId, ?ShopConstraint $shopConstraint = null)
     {
         $this->combinationId = new CombinationId($combinationId);
+        $this->shopConstraint = $shopConstraint;
+    }
+
+    public function getShopConstraint(): ?ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 
     /**

--- a/src/Core/Domain/Product/Combination/Command/SetCombinationImagesCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/SetCombinationImagesCommand.php
@@ -10,6 +10,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 class SetCombinationImagesCommand
 {
@@ -27,8 +28,14 @@ class SetCombinationImagesCommand
      * @param int $combinationId
      * @param array $imageIds
      */
-    public function __construct(int $combinationId, array $imageIds)
+    /**
+     * @var ShopConstraint|null
+     */
+    private $shopConstraint;
+
+    public function __construct(int $combinationId, array $imageIds, ?ShopConstraint $shopConstraint = null)
     {
+        $this->shopConstraint = $shopConstraint;
         $this->combinationId = new CombinationId($combinationId);
         $this->imageIds = array_map(function (int $imageId) { return new ImageId($imageId); }, $imageIds);
     }
@@ -47,5 +54,10 @@ class SetCombinationImagesCommand
     public function getImageIds(): array
     {
         return $this->imageIds;
+    }
+
+    public function getShopConstraint(): ?ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationImagesCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationImagesCommandsBuilder.php
@@ -28,11 +28,11 @@ class CombinationImagesCommandsBuilder implements CombinationCommandsBuilderInte
         }
 
         if (empty($formData['images'])) {
-            return [new RemoveAllCombinationImagesCommand($combinationId->getValue())];
+            return [new RemoveAllCombinationImagesCommand($combinationId->getValue(), $singleShopConstraint)];
         }
 
         $imageIds = array_map('intval', $formData['images']);
-        $command = new SetCombinationImagesCommand($combinationId->getValue(), $imageIds);
+        $command = new SetCombinationImagesCommand($combinationId->getValue(), $imageIds, $singleShopConstraint);
 
         return [$command];
     }

--- a/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
@@ -560,9 +560,11 @@ abstract class StockManagementRepository
         $query = 'SELECT id_image
                   FROM ' . $this->tablePrefix . 'product_attribute_image pai
                   WHERE id_product_attribute=:id_product_attribute
+                  AND id_shop=:id_shop
                   LIMIT 1';
         $statement = $this->connection->prepare($query);
         $statement->bindValue('id_product_attribute', (int) $row['combination_id'], PDO::PARAM_INT);
+        $statement->bindValue('id_shop', $this->getContextualShopId(), PDO::PARAM_INT);
         $result = $statement->executeQuery();
         $combinationCoverId = (int) $result->fetchOne();
         $result->free();

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -69,6 +69,7 @@ services:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
+      - '@PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository'
 
   PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\UpdateCombinationSuppliersHandler:
     autoconfigure: true

--- a/tests/Integration/Adapter/Product/Combination/CombinationImagesShopScopeTest.php
+++ b/tests/Integration/Adapter/Product/Combination/CombinationImagesShopScopeTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Product\Combination;
+
+use Configuration as LegacyConfiguration;
+use Db;
+use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\RemoveAllCombinationImagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\SetCombinationImagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Shop as LegacyShop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The combination image selection is per shop, and `product_attribute_image` carries the shop it was
+ * made for. Saving in one shop must leave every other shop's selection alone, including when the two
+ * shops picked the very same image - which a rule derived from `image_shop` alone cannot express.
+ */
+class CombinationImagesShopScopeTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['shop', 'shop_group', 'image_shop', 'product_attribute_image', 'configuration'];
+
+    private const COMBINATION_ID = 1;
+    private const SHARED_IMAGE_ID = 1;
+    private const SHOP_2_IMAGE_ID = 2;
+
+    private static int $secondShopId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration')
+            ->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        $db = Db::getInstance();
+        $db->insert('shop_group', [
+            'name' => 'test_group_combination_img', 'color' => '', 'share_customer' => 0,
+            'share_order' => 0, 'share_stock' => 0, 'active' => 1, 'deleted' => 0,
+        ]);
+        $secondGroupId = (int) $db->Insert_ID();
+        $db->insert('shop', [
+            'id_shop_group' => $secondGroupId, 'name' => 'test_shop_combination_img', 'color' => '',
+            'id_category' => 2, 'theme_name' => 'classic', 'active' => 1, 'deleted' => 0,
+        ]);
+        self::$secondShopId = (int) $db->Insert_ID();
+        LegacyShop::resetStaticCache();
+
+        // Image 1 belongs to BOTH shops - the case the shop of the image cannot distinguish.
+        // Image 2 belongs to the second shop only.
+        $db->insert('image_shop', [
+            'id_product' => 1, 'id_image' => self::SHARED_IMAGE_ID,
+            'id_shop' => self::$secondShopId, 'cover' => 0,
+        ]);
+        $db->delete('image_shop', 'id_image = ' . self::SHOP_2_IMAGE_ID);
+        $db->insert('image_shop', [
+            'id_product' => 1, 'id_image' => self::SHOP_2_IMAGE_ID,
+            'id_shop' => self::$secondShopId, 'cover' => 1,
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Db::getInstance()->delete('product_attribute_image', 'id_product_attribute = ' . self::COMBINATION_ID);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    /**
+     * The case a rule based on the image's own shops cannot express: both shops can see the image,
+     * so only the association itself can say which shop chose it.
+     */
+    public function testAShopKeepsItsSharedImageWhenAnotherShopChangesItsOwn(): void
+    {
+        self::bootKernel();
+        $commandBus = self::getContainer()->get('prestashop.core.command_bus');
+
+        $commandBus->handle(new SetCombinationImagesCommand(
+            self::COMBINATION_ID,
+            [self::SHARED_IMAGE_ID],
+            ShopConstraint::shop(1)
+        ));
+        $commandBus->handle(new SetCombinationImagesCommand(
+            self::COMBINATION_ID,
+            [self::SHOP_2_IMAGE_ID],
+            ShopConstraint::shop(self::$secondShopId)
+        ));
+
+        self::assertSame(
+            [self::SHARED_IMAGE_ID],
+            $this->getImageIdsForShop(1),
+            'the second shop discarded the first shop selection of the shared image'
+        );
+        self::assertSame([self::SHOP_2_IMAGE_ID], $this->getImageIdsForShop(self::$secondShopId));
+    }
+
+    /**
+     * Both shops may select the same image, and each holds it independently.
+     */
+    public function testTwoShopsCanSelectTheSameImageIndependently(): void
+    {
+        self::bootKernel();
+        $commandBus = self::getContainer()->get('prestashop.core.command_bus');
+
+        $commandBus->handle(new SetCombinationImagesCommand(
+            self::COMBINATION_ID,
+            [self::SHARED_IMAGE_ID],
+            ShopConstraint::shop(1)
+        ));
+        $commandBus->handle(new SetCombinationImagesCommand(
+            self::COMBINATION_ID,
+            [self::SHARED_IMAGE_ID],
+            ShopConstraint::shop(self::$secondShopId)
+        ));
+
+        self::assertSame([self::SHARED_IMAGE_ID], $this->getImageIdsForShop(1));
+        self::assertSame([self::SHARED_IMAGE_ID], $this->getImageIdsForShop(self::$secondShopId));
+
+        // Clearing it in the second shop leaves the first shop holding it.
+        $commandBus->handle(new RemoveAllCombinationImagesCommand(
+            self::COMBINATION_ID,
+            ShopConstraint::shop(self::$secondShopId)
+        ));
+
+        self::assertSame([self::SHARED_IMAGE_ID], $this->getImageIdsForShop(1), 'the first shop lost the shared image');
+        self::assertSame([], $this->getImageIdsForShop(self::$secondShopId));
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getImageIdsForShop(int $shopId): array
+    {
+        $repository = self::getContainer()->get(ProductImageRepository::class);
+        $imageIds = $repository->getImageIdsForCombinations(
+            [new CombinationId(self::COMBINATION_ID)],
+            ShopConstraint::shop($shopId)
+        );
+
+        $ids = array_map(
+            static fn (ImageId $imageId): int => $imageId->getValue(),
+            $imageIds[self::COMBINATION_ID] ?? []
+        );
+        sort($ids);
+
+        return $ids;
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationImagesCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationImagesCommandsBuilderTest.php
@@ -42,7 +42,8 @@ class CombinationImagesCommandsBuilderTest extends AbstractCombinationCommandBui
 
         $command = new SetCombinationImagesCommand(
             $this->getCombinationId()->getValue(),
-            [42, 51]
+            [42, 51],
+            $this->getSingleShopConstraint()
         );
         yield [
             [
@@ -54,7 +55,10 @@ class CombinationImagesCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new RemoveAllCombinationImagesCommand($this->getCombinationId()->getValue());
+        $command = new RemoveAllCombinationImagesCommand(
+            $this->getCombinationId()->getValue(),
+            $this->getSingleShopConstraint()
+        );
         yield [
             [
                 'images' => [],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | In multistore, choosing images for a combination in one shop discarded what another shop had chosen. `product_attribute_image` was `(id_product_attribute, id_image)` with no shop, so both write paths deleted every row for the combination before inserting - and every reader saw one global selection.<br><br>This gives the association its shop. `product_carrier` is the same kind of table and already does exactly this, so the shape follows it rather than inventing a `_shop` companion (a `*_shop` companion is for an entity with per shop attributes, like `image_shop` carrying `cover`; this table holds no entity, and what is per shop is the association itself):<br><br>`PRIMARY KEY (id_product_attribute, id_image, id_shop)`<br><br>Writers now write one row per shop the selection was made for, and readers filter on it. The four writers all had to change, because with the column `NOT NULL` an insert that omits it fails outright under `STRICT_TRANS_TABLES` (`ERROR 1364: Field 'id_shop' doesn't have a default value`) - `CombinationImagesUpdater`, `Combination::setImages()`, `Image::duplicateAttributeImageAssociations()` (rewritten as `INSERT ... SELECT` over `image_shop`, so it needs no new argument) and `ProductDuplicator` (carries the shop of the row it copies).<br><br>On the read side the sites that collapse to a single row are the ones that mattered: several restricted `image_shop` to the context shop but not the association, so a shop could surface an image another shop had picked. Those now filter the association too - `Image::getBestImageAttribute()`, `Order`, `OrderInvoice`, `GetOrderProductsForViewingHandler`, `StockManagementRepository`, `Pack`, `Product`, `AttributeDataProvider`, `ProductRepository`, and both `ProductImageRepository` readers behind the product page.<br><br>Relationship to #42188, which is the same bug on `9.1.x`: that one takes the shop from `image_shop`, since a patch branch cannot change the schema. It fixes the ordinary setup where each shop has its own images and cannot fix a shared one - measured, with image 1 in both shops and image 2 in the second only, shop 1 selecting image 1 and shop 2 selecting image 2 left `[2]` and shop 1 lost its selection. This PR replaces that derived scoping with the column and covers the shared case. If you would rather take only one of the two, this is the one that closes the report fully.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Multistore on, two shops sharing a product and an image. Pick images for a combination in shop A, switch to shop B and pick different ones, return to shop A - each shop keeps its own, including when both picked the same image. `tests/Integration/Adapter/Product/Combination/CombinationImagesShopScopeTest.php` covers both, and fails if the delete is unscoped. Existing suites: 155 green over Combination, ProductImage, Pack, Duplicate, Order and Stock.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #12638, Fixes #39226
| Related PRs       | PrestaShop/autoupgrade#1889 migrates existing installs. #42188 is the `9.1.x` fix this supersedes.
| Sponsor company   |


