### PR TITLE
Keep the back office order message while the order is being prepared

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/cart-editor.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/cart-editor.ts
@@ -53,6 +53,23 @@ export default class CartEditor {
   }
 
   /**
+   * Stores the order message typed while the order is still being prepared.
+   *
+   * The cart summary is deliberately not refreshed here: re-rendering it would replace the
+   * textarea the user is still typing in.
+   *
+   * @param {Number} cartId
+   * @param {String} orderMessage
+   */
+  changeOrderMessage(cartId: number, orderMessage: string): void {
+    $.post(this.router.generate('admin_carts_set_order_message', {cartId}), {
+      orderMessage,
+    })
+      .catch((response: Record<string, any>) => window.showErrorMessage(response.responseJSON.message),
+      );
+  }
+
+  /**
    * Modifies cart delivery option
    *
    * @param {Number} cartId

--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
@@ -309,6 +309,12 @@ export default class CreateOrderPage {
     this.$container.on('blur', createOrderMap.giftMessageField, () => this.cartEditor.updateDeliveryOptions(<number> this.cartId),
     );
 
+    this.$container.on('blur', createOrderMap.orderMessageField, (e: JQueryEventObject) => this.cartEditor.changeOrderMessage(
+      <number> this.cartId,
+      String($(e.currentTarget).val() ?? ''),
+    ),
+    );
+
     this.$container.on('click', createOrderMap.addToCartButton, () => this.productManager.addProductToCart(<number> this.cartId),
     );
 

--- a/src/Adapter/Cart/CommandHandler/UpdateCartOrderMessageHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartOrderMessageHandler.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
+
+use Cart;
+use Message;
+use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\UpdateCartOrderMessageHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
+use Validate;
+
+/**
+ * Stores the order message of a cart, so a draft written while preparing an order survives the page.
+ */
+#[AsCommandHandler]
+final class UpdateCartOrderMessageHandler extends AbstractCartHandler implements UpdateCartOrderMessageHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(UpdateCartOrderMessageCommand $command): void
+    {
+        $cart = $this->getCart($command->getCartId());
+        $orderMessage = $command->getOrderMessage();
+
+        if ('' !== $orderMessage && !Validate::isCleanHtml($orderMessage)) {
+            throw new CartConstraintException(
+                'The order message is invalid',
+                CartConstraintException::INVALID_ORDER_MESSAGE
+            );
+        }
+
+        $message = $this->findCartMessage($cart);
+
+        // An empty draft means the message was cleared, and an empty row is not worth keeping.
+        if ('' === $orderMessage) {
+            if (null !== $message) {
+                $message->delete();
+            }
+
+            return;
+        }
+
+        if (null === $message) {
+            $message = new Message();
+            $message->id_cart = (int) $cart->id;
+            $message->id_customer = (int) $cart->id_customer;
+            $message->private = true;
+        }
+
+        $message->message = $orderMessage;
+
+        if (!(null === $message->id ? $message->add() : $message->update())) {
+            throw new CartException('Failed to store the cart order message');
+        }
+    }
+
+    private function findCartMessage(Cart $cart): ?Message
+    {
+        $existing = Message::getMessageByCartId((int) $cart->id);
+
+        if (empty($existing['id_message'])) {
+            return null;
+        }
+
+        return new Message((int) $existing['id_message']);
+    }
+}

--- a/src/Core/Domain/Cart/Command/UpdateCartOrderMessageCommand.php
+++ b/src/Core/Domain/Cart/Command/UpdateCartOrderMessageCommand.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Cart\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
+
+/**
+ * Stores the order message of a cart that has no order yet, so that a draft written while an order
+ * is being prepared in the back office survives leaving the page.
+ */
+class UpdateCartOrderMessageCommand
+{
+    /**
+     * @var CartId
+     */
+    private $cartId;
+
+    /**
+     * @var string
+     */
+    private $orderMessage;
+
+    public function __construct(int $cartId, string $orderMessage)
+    {
+        $this->cartId = new CartId($cartId);
+        $this->orderMessage = $orderMessage;
+    }
+
+    public function getCartId(): CartId
+    {
+        return $this->cartId;
+    }
+
+    public function getOrderMessage(): string
+    {
+        return $this->orderMessage;
+    }
+}

--- a/src/Core/Domain/Cart/CommandHandler/UpdateCartOrderMessageHandlerInterface.php
+++ b/src/Core/Domain/Cart/CommandHandler/UpdateCartOrderMessageHandlerInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartOrderMessageCommand;
+
+/**
+ * Interface for service that stores the order message of a cart.
+ */
+interface UpdateCartOrderMessageHandlerInterface
+{
+    public function handle(UpdateCartOrderMessageCommand $command): void;
+}

--- a/src/Core/Domain/Cart/Exception/CartConstraintException.php
+++ b/src/Core/Domain/Cart/Exception/CartConstraintException.php
@@ -25,4 +25,9 @@ class CartConstraintException extends CartException
      * When carrier is not found or inactive
      */
     public const INVALID_CARRIER = 3;
+
+    /**
+     * When the order message contains markup that is not allowed
+     */
+    public const INVALID_ORDER_MESSAGE = 4;
 }

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -53,6 +53,7 @@ class LegacyLinkLinterCommand extends Command
         'admin_carts_edit_product_quantity',
         'admin_carts_info',
         'admin_carts_set_delivery_settings',
+        'admin_carts_set_order_message',
         'admin_catalog_price_rules_list_for_product',
         'admin_categories_get_ajax_categories',
         'admin_categories_delete_thumbnail_image',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -22,6 +22,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartCarrierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartCurrencyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartDeliverySettingsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartLanguageCommand;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartOrderMessageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductPriceInCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductQuantityInCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CannotDeleteCartException;
@@ -418,6 +419,31 @@ class CartController extends PrestaShopAdminController
                 $giftSettingsEnabled ? $request->request->getBoolean('isAGift') : null,
                 $recycledPackagingEnabled ? $request->request->getBoolean('useRecycledPackaging', false) : null,
                 $request->request->get('giftMessage')
+            ));
+
+            return $this->json($this->getCartInfo($cartId));
+        } catch (Exception $e) {
+            return $this->json(
+                ['message' => $this->getErrorMessageForException($e, $this->getErrorMessages($e, $iniConfiguration))],
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+    }
+
+    /**
+     * Stores the order message of a cart that has no order yet, so a draft written while preparing
+     * an order in the back office is not lost when the page is left.
+     */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))")]
+    public function updateOrderMessageAction(
+        Request $request,
+        int $cartId,
+        IniConfiguration $iniConfiguration
+    ): JsonResponse {
+        try {
+            $this->dispatchCommand(new UpdateCartOrderMessageCommand(
+                $cartId,
+                (string) $request->request->get('orderMessage', '')
             ));
 
             return $this->json($this->getCartInfo($cartId));

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/carts.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/carts.yml
@@ -121,6 +121,17 @@ admin_carts_edit_language:
   options:
     expose: true
 
+admin_carts_set_order_message:
+  path: /{cartId}/order-message
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Order\CartController::updateOrderMessageAction
+    _legacy_controller: AdminCarts
+  requirements:
+    cartId: \d+
+  options:
+    expose: true
+
 admin_carts_set_delivery_settings:
   path: /{cartId}/rules/delivery-settings
   methods: [ POST ]

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
@@ -20,6 +20,10 @@ services:
     arguments:
       - '@prestashop.adapter.command_handler.update_cart_carrier_handler'
 
+  prestashop.adapter.cart.command_handler.update_cart_order_message_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\Cart\CommandHandler\UpdateCartOrderMessageHandler'
+    autoconfigure: true
+
   prestashop.adapter.cart.command_handler.update_delivery_options_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Cart\CommandHandler\UpdateCartDeliverySettingsHandler'
     autoconfigure: true

--- a/tests/Integration/Adapter/Cart/CommandHandler/UpdateCartOrderMessageHandlerTest.php
+++ b/tests/Integration/Adapter/Cart/CommandHandler/UpdateCartOrderMessageHandlerTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Cart\CommandHandler;
+
+use Cart;
+use Db;
+use Message;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartOrderMessageCommand;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A back office order is prepared on a cart that has no order yet, so the order message typed while
+ * preparing it has nowhere to live until the order is created. It belongs to the cart in the
+ * meantime - `Message` already reads it from there, nothing ever wrote it.
+ */
+class UpdateCartOrderMessageHandlerTest extends KernelTestCase
+{
+    private static int $cartId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::bootKernel();
+
+        $cart = new Cart();
+        $cart->id_customer = 1;
+        $cart->id_currency = 1;
+        $cart->id_lang = 1;
+        $cart->id_shop = 1;
+        $cart->id_shop_group = 1;
+        $cart->add();
+        self::$cartId = (int) $cart->id;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Db::getInstance()->delete('message', 'id_cart = ' . self::$cartId);
+        Db::getInstance()->delete('cart', 'id_cart = ' . self::$cartId);
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Db::getInstance()->delete('message', 'id_cart = ' . self::$cartId);
+    }
+
+    public function testTheMessageIsStoredOnACartThatHasNoOrderYet(): void
+    {
+        $this->dispatch('Call the customer before shipping');
+
+        $stored = Message::getMessageByCartId(self::$cartId);
+
+        self::assertNotEmpty($stored, 'nothing was stored for the cart');
+        self::assertSame('Call the customer before shipping', $stored['message']);
+    }
+
+    public function testWritingAgainReplacesTheDraftInsteadOfAddingAnother(): void
+    {
+        $this->dispatch('First draft');
+        $this->dispatch('Second draft');
+
+        self::assertSame(1, $this->countMessages(), 'a second row was created for the same cart');
+        self::assertSame('Second draft', Message::getMessageByCartId(self::$cartId)['message']);
+    }
+
+    public function testClearingTheDraftRemovesIt(): void
+    {
+        $this->dispatch('Something');
+        $this->dispatch('');
+
+        self::assertSame(0, $this->countMessages(), 'the emptied draft was left behind');
+    }
+
+    private function dispatch(string $orderMessage): void
+    {
+        self::getContainer()->get('prestashop.core.command_bus')->handle(
+            new UpdateCartOrderMessageCommand(self::$cartId, $orderMessage)
+        );
+    }
+
+    private function countMessages(): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'message WHERE id_cart = ' . self::$cartId
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | An order prepared in the back office is built on a cart that has no order yet, and the Order message typed in the Summary was only written when Create order was clicked. Leaving the page lost it, which is what the report describes: the message is often filled in before a payment link is sent to the customer.<br><br>The read side already expects it to be there. `GetCartForOrderCreationHandler` fills the summary from `Message::getMessageByCartId()`, and `summary-renderer.ts` puts that value into the textarea - so a message attached to the cart is displayed correctly. Nothing ever wrote one, so the field was always empty on return.<br><br>This adds the missing write: an `UpdateCartOrderMessageCommand` handled in the Cart domain, exposed on the cart ajax route the create-order page already uses for its other fields, and posted on blur exactly like the gift message next to it. The message is stored against the cart in `ps_message`, which is where the reader looks and where it already lives once the order exists.<br><br>Two deliberate choices, both easy to change if you would rather have it otherwise. Emptying the field deletes the row instead of storing an empty message, so an abandoned draft leaves nothing behind - this is the point @kpodemski raised in the issue, and it keeps the table free of rows for orders that were never created. And the summary is not re-rendered after the save, because re-rendering would replace the textarea while it is still being edited.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Sell > Orders > Add new order, pick a customer and a cart, type into Order message in the Summary, then reload the page - the message is still there, and it is carried onto the order when you create it. Clear the field and reload to confirm it is gone. `tests/Integration/Adapter/Cart/CommandHandler/UpdateCartOrderMessageHandlerTest.php` covers storing on a cart with no order, replacing an existing draft rather than adding a second row, and clearing.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39389
| Related PRs       |
| Sponsor company   |

