### PR TITLE
Keep the reserved quantity subtraction from underflowing on refunded lines

### DIFF
--- a/src/Adapter/Product/Stock/Repository/StockAvailableRepository.php
+++ b/src/Adapter/Product/Stock/Repository/StockAvailableRepository.php
@@ -332,7 +332,12 @@ class StockAvailableRepository extends AbstractMultiShopObjectModelRepository
     {
         $qb = $this->connection->createQueryBuilder();
         $qb
-            ->addSelect('SUM(od.product_quantity - od.product_quantity_refunded) AS reserved_quantity')
+            ->addSelect(
+                // Both columns are UNSIGNED, so a line refunded beyond its ordered quantity makes the
+                // subtraction underflow and MySQL raises "BIGINT UNSIGNED value is out of range"
+                // instead of returning a reserved quantity. Such a line reserves nothing.
+                'SUM(GREATEST(CAST(od.product_quantity AS SIGNED) - CAST(od.product_quantity_refunded AS SIGNED), 0)) AS reserved_quantity'
+            )
             ->from($this->dbPrefix . 'orders', 'o')
             ->innerJoin('o', $this->dbPrefix . 'order_detail', 'od', 'od.id_order = o.id_order')
             ->innerJoin('o', $this->dbPrefix . 'order_state', 'os', 'os.id_order_state = o.current_state')

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -151,7 +151,10 @@ class StockManager
 
         $updateReservedQuantityQuery .= '
             SET sa.reserved_quantity = (
-                SELECT SUM(od.product_quantity - od.product_quantity_refunded)
+                -- Both columns are UNSIGNED, so a line refunded beyond its ordered quantity would make
+                -- the subtraction underflow and raise "BIGINT UNSIGNED value is out of range"
+                -- instead of returning a quantity. Such a line reserves nothing.
+                SELECT SUM(GREATEST(CAST(od.product_quantity AS SIGNED) - CAST(od.product_quantity_refunded AS SIGNED), 0))
                 FROM {table_prefix}orders o
                 INNER JOIN {table_prefix}order_detail od ON od.id_order = o.id_order
                 INNER JOIN {table_prefix}order_state os ON os.id_order_state = o.current_state

--- a/tests/Integration/Adapter/StockManagerReservedQuantityTest.php
+++ b/tests/Integration/Adapter/StockManagerReservedQuantityTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter;
+
+use Configuration;
+use Db;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
+use PrestaShop\PrestaShop\Adapter\StockManager;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockId;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * `product_quantity` and `product_quantity_refunded` are both UNSIGNED, so an order line whose
+ * refunded quantity exceeds the quantity still on the line makes the reserved-quantity subtraction
+ * underflow. MySQL then aborts the whole statement with "BIGINT UNSIGNED value is out of range",
+ * which takes down changing an order status and the stock pages rather than that one line.
+ *
+ * A back office user can produce that state: editing the quantity of a partially refunded line is
+ * not validated against what was already refunded.
+ */
+class StockManagerReservedQuantityTest extends KernelTestCase
+{
+    private const PRODUCT_ID = 1;
+    private const PRODUCT_ATTRIBUTE_ID = 0;
+
+    private static int $orderId;
+    private static int $orderDetailId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::bootKernel();
+
+        $db = Db::getInstance();
+        // A valid order in a state that has not shipped, so it counts towards reserved quantity.
+        $notShippedState = (int) $db->getValue(
+            'SELECT id_order_state FROM ' . _DB_PREFIX_ . 'order_state WHERE shipped = 0 AND deleted = 0 ORDER BY id_order_state ASC'
+        );
+
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'orders
+             (id_address_delivery, id_address_invoice, id_cart, id_currency, id_lang, id_customer, id_carrier,
+              current_state, payment, conversion_rate, total_paid, total_paid_real, total_products,
+              total_products_wt, valid, id_shop, id_shop_group, date_add, date_upd)
+             VALUES (1, 1, 0, 1, 1, 1, 1, ' . $notShippedState . ", 'Test', 1, 0, 0, 0, 0, 1, 1, 1, NOW(), NOW())"
+        );
+        self::$orderId = (int) $db->Insert_ID();
+
+        // The inconsistent line: one unit left on the line, nine already refunded.
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'order_detail
+             (id_order, id_order_invoice, id_warehouse, id_shop, product_id, product_attribute_id,
+              product_name, product_quantity, product_quantity_refunded, product_price, id_tax_rules_group)
+             VALUES (' . self::$orderId . ', 0, 0, 1, ' . self::PRODUCT_ID . ', ' . self::PRODUCT_ATTRIBUTE_ID
+             . ", 'Underflow probe', 1, 9, 10.0, 0)"
+        );
+        self::$orderDetailId = (int) $db->Insert_ID();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Db::getInstance()->delete('order_detail', 'id_order_detail = ' . self::$orderDetailId);
+        Db::getInstance()->delete('orders', 'id_order = ' . self::$orderId);
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * The same subtraction exists in the repository behind the product page stock tab, reached
+     * through its own public entry point.
+     */
+    public function testTheRepositoryPathSurvivesTheSameLine(): void
+    {
+        self::bootKernel();
+        $repository = self::getContainer()->get(StockAvailableRepository::class);
+
+        $stockId = Db::getInstance()->getValue(
+            'SELECT id_stock_available FROM ' . _DB_PREFIX_ . 'stock_available
+             WHERE id_product = ' . self::PRODUCT_ID . ' AND id_product_attribute = ' . self::PRODUCT_ATTRIBUTE_ID
+             . ' AND id_shop = 1'
+        );
+        self::assertNotFalse($stockId, 'no stock row to exercise the repository with');
+
+        $repository->updatePhysicalProductQuantity(
+            new StockId((int) $stockId),
+            new OrderStateId((int) Configuration::get('PS_OS_ERROR')),
+            new OrderStateId((int) Configuration::get('PS_OS_CANCELED'))
+        );
+
+        $reserved = (int) Db::getInstance()->getValue(
+            'SELECT reserved_quantity FROM ' . _DB_PREFIX_ . 'stock_available WHERE id_stock_available = ' . (int) $stockId
+        );
+        self::assertGreaterThanOrEqual(0, $reserved, 'the repository path returned a negative reserved quantity');
+    }
+
+    public function testALineRefundedBeyondItsQuantityDoesNotBreakTheStockUpdate(): void
+    {
+        self::bootKernel();
+        $stockManager = new StockManager();
+
+        $stockManager->updatePhysicalProductQuantity(
+            1,
+            (int) Configuration::get('PS_OS_ERROR'),
+            (int) Configuration::get('PS_OS_CANCELED'),
+            self::PRODUCT_ID
+        );
+
+        $reserved = Db::getInstance()->getValue(
+            'SELECT reserved_quantity FROM ' . _DB_PREFIX_ . 'stock_available
+             WHERE id_product = ' . self::PRODUCT_ID . ' AND id_product_attribute = ' . self::PRODUCT_ATTRIBUTE_ID
+             . ' AND id_shop = 1'
+        );
+
+        self::assertNotFalse($reserved, 'the stock row was not reachable after the update');
+        self::assertGreaterThanOrEqual(
+            0,
+            (int) $reserved,
+            'an over-refunded line must reserve nothing rather than a negative quantity'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `order_detail.product_quantity` and `product_quantity_refunded` are both `int unsigned`, and the reserved-quantity update subtracts one from the other inside a `SUM()`. When a line has been refunded beyond the quantity still on it, that subtraction underflows and MySQL aborts the whole statement:<br><br>`SQLSTATE[22003]: Numeric value out of range: 1690 BIGINT UNSIGNED value is out of range in 'od.product_quantity - od.product_quantity_refunded'`<br><br>It is the whole statement rather than that one line, which is why the symptom is that changing an order status stops working, other orders containing the same product fail, and the stock pages break - none of which look related to the refunded line that caused it.<br><br>A back office user reaches that state without doing anything unusual: editing the quantity of a partially refunded line is not validated against what was already refunded, and the report describes doing exactly that so the line reflects what was actually shipped.<br><br>Both places that run the subtraction now compute it as signed and floor it at zero per line, so a line refunded beyond its quantity reserves nothing instead of taking the statement down. `GREATEST()` is already used this way in `OrderReturn`, so the shape is not new here.<br><br>This deliberately fixes the crash and not the wider request in the issue. The reporter also asks that `product_quantity` reflect the post-refund quantity, and that manual edits be validated - both change what the field means to every reader, including the webservice payload they mention, so they are not something to slip into a patch release. Say so if you want either, and I will open it separately.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Place an order with quantity 10, refund 9 of it, then edit the line quantity down to 1 so the refunded quantity exceeds it. Before this change, changing the order status raises `BIGINT UNSIGNED value is out of range` and the stock pages fail; after it, the update runs and the line reserves nothing. `tests/Integration/Adapter/StockManagerReservedQuantityTest.php` builds that line and drives both code paths; reverting either file on its own makes it fail with the error above.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39391
| Related PRs       |
| Sponsor company   |

