### PR TITLE
Redirect module front controllers to their friendly URL

### DIFF
--- a/classes/controller/ModuleFrontController.php
+++ b/classes/controller/ModuleFrontController.php
@@ -25,6 +25,64 @@ class ModuleFrontControllerCore extends FrontController
     }
 
     /**
+     * Front controllers redirect to their friendly URL when reached through the parameter form, but
+     * that is driven by `php_self`, which a module controller does not have - so module pages were
+     * reachable under both URLs with neither pointing at the other.
+     *
+     * The redirect is limited to requests carrying nothing but the routing parameters. Module
+     * controllers are also the payment and callback endpoints, and those arrive with parameters
+     * that must not be dropped by a redirect; leaving them alone costs only the canonical URL of
+     * pages that were never indexable anyway.
+     */
+    public function init()
+    {
+        parent::init();
+
+        if (!$this->shouldRedirectToCanonicalModuleUrl()) {
+            return;
+        }
+
+        $this->canonicalRedirection($this->context->link->getModuleLink(
+            $this->module->name,
+            Dispatcher::getInstance()->getController(),
+            [],
+            $this->ssl,
+            $this->context->language->id
+        ));
+    }
+
+    /**
+     * A module controller is also a payment or callback endpoint, and those arrive carrying
+     * parameters that a redirect would drop. Only a request that carries nothing but the routing
+     * parameters is safe to send to the friendly URL.
+     */
+    protected function shouldRedirectToCanonicalModuleUrl(): bool
+    {
+        if (Tools::getValue('ajax') || Tools::isPHPCLI()) {
+            return false;
+        }
+
+        if ('GET' !== strtoupper($_SERVER['REQUEST_METHOD'] ?? '')) {
+            return false;
+        }
+
+        return $this->carriesOnlyRoutingParameters($_GET);
+    }
+
+    /**
+     * True when the query holds nothing but what routed the request, so nothing is lost by sending
+     * it to the friendly URL.
+     *
+     * @param array $query
+     */
+    protected function carriesOnlyRoutingParameters(array $query): bool
+    {
+        $routingParameters = ['controller', 'fc', 'module', 'id_lang', 'isolang'];
+
+        return empty(array_diff_key($query, array_flip($routingParameters)));
+    }
+
+    /**
      * Assigns module template for page content.
      *
      * @param string $template Template filename

--- a/tests/Unit/Classes/Controller/ModuleFrontControllerCanonicalTest.php
+++ b/tests/Unit/Classes/Controller/ModuleFrontControllerCanonicalTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Controller;
+
+use ModuleFrontController;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * A module front controller now redirects to its friendly URL, which core controllers have always
+ * done. Module controllers are also the payment and callback endpoints though, so the decision has
+ * to leave anything carrying real parameters alone - a redirect would drop them.
+ */
+class ModuleFrontControllerCanonicalTest extends TestCase
+{
+    private array $originalGet;
+    private array $originalServer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalGet = $_GET;
+        $this->originalServer = $_SERVER;
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = $this->originalGet;
+        $_SERVER = $this->originalServer;
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getRequests
+     */
+    public function testOnlyARequestWithoutItsOwnParametersIsRedirected(array $query, bool $expected, string $because): void
+    {
+        $_GET = $query;
+
+        self::assertSame($expected, $this->decide(), $because);
+    }
+
+    public static function getRequests(): array
+    {
+        return [
+            'the plain parameter form of a module page' => [
+                ['controller' => 'gdpr', 'fc' => 'module', 'module' => 'psgdpr'],
+                true,
+                'a module page reached through the parameter form has a friendly URL to point at',
+            ],
+            'a language parameter still belongs to the routing' => [
+                ['controller' => 'gdpr', 'fc' => 'module', 'module' => 'psgdpr', 'id_lang' => '1'],
+                true,
+                'the language is part of the route, not of the page',
+            ],
+            'a payment callback carrying a cart' => [
+                ['controller' => 'validation', 'fc' => 'module', 'module' => 'ps_wirepayment', 'id_cart' => '7'],
+                false,
+                'redirecting would drop the cart the callback is about',
+            ],
+            'a callback carrying a token' => [
+                ['controller' => 'validation', 'fc' => 'module', 'module' => 'ps_wirepayment', 'token' => 'abc'],
+                false,
+                'redirecting would drop the token the callback is authenticated with',
+            ],
+        ];
+    }
+
+    private function decide(): bool
+    {
+        $controller = (new ReflectionClass(ModuleFrontController::class))->newInstanceWithoutConstructor();
+        $method = new ReflectionMethod(ModuleFrontController::class, 'carriesOnlyRoutingParameters');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $_GET);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A module page is reachable under both `/module/psgdpr/gdpr` and `/index.php?controller=gdpr&fc=module&module=psgdpr`, with neither pointing at the other. Core controllers have always redirected the parameter form to the friendly one.<br><br>The reason is narrow: `FrontController::init()` guards the canonical redirect with `!empty($this->php_self)`, and a module controller has no `php_self` - `ModuleFrontController` sets `page_name` instead. So the redirect was skipped for every module controller, and the URL it would need is `getModuleLink()` rather than `getPageLink()` anyway.<br><br>Measured on `9.1.x` with debug mode on, which prints the canonical target instead of redirecting:<br><br>`/index.php?controller=contact` -> `[Debug] This page has moved ... /contact-us`<br>`/index.php?controller=gdpr&fc=module&module=psgdpr` -> nothing at all<br><br>After the change the module URL reports `... /module/psgdpr/gdpr`, and the core one is unchanged.<br><br>The redirect is deliberately limited to requests carrying nothing beyond the routing parameters. Module front controllers are also the payment and callback endpoints - `ps_wirepayment/validation` is one - and those arrive with a cart id or a token that a redirect to the bare friendly URL would drop. Sending them is not worth the canonical URL of a page nobody indexes, so a request with its own parameters is left alone. If you would rather carry the parameters across instead, that is a small change and I will do it - it just needs the generated URL to reproduce them exactly, or the request bounces between the two forms.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Friendly URLs on. Open `/index.php?controller=gdpr&fc=module&module=psgdpr` on a shop with psgdpr installed: before, it renders the page under the parameter URL; after, it redirects to `/module/psgdpr/gdpr`. Check that the friendly URL itself does not redirect, and that adding a parameter (`&id_cart=7`) still renders without redirecting. `tests/Unit/Classes/Controller/ModuleFrontControllerCanonicalTest.php` covers the decision, including the two callback shapes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #13418
| Related PRs       |
| Sponsor company   |

