### PR TITLE
Keep the cart attribute pairs instead of parsing them back from text

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -187,7 +187,7 @@ class CartCore extends ObjectModel
     public const ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING = 8;
     public const ONLY_PRODUCTS_WITHOUT_GIFTS = 9;
 
-    private const DEFAULT_ATTRIBUTES_KEYS = ['attributes' => '', 'attributes_small' => ''];
+    private const DEFAULT_ATTRIBUTES_KEYS = ['attributes' => '', 'attributes_small' => '', 'attributes_array' => []];
 
     /**
      * CartCore constructor.
@@ -1318,6 +1318,10 @@ class CartCore extends ObjectModel
             $key = $row['id_product_attribute'] . '-' . $id_lang;
             self::$_attributesLists[$key]['attributes'] .= $row['public_group_name'] . $colon . $row['attribute_name'] . $separator . ' ';
             self::$_attributesLists[$key]['attributes_small'] .= $row['attribute_name'] . $separator . ' ';
+            // Keep the pair as it came out of the database. Flattening it into the string above and
+            // parsing it back is lossy: a group or attribute name may itself contain the colon or
+            // the separator, and then the pair cannot be recovered from the text.
+            self::$_attributesLists[$key]['attributes_array'][$row['public_group_name']] = $row['attribute_name'];
         }
 
         foreach ($pa_implode as $id_product_attribute) {

--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -519,7 +519,11 @@ class CartLazyArray extends AbstractLazyArray
     private function presentProduct(array $rawProduct)
     {
         if (isset($rawProduct['attributes']) && is_string($rawProduct['attributes'])) {
-            $rawProduct['attributes'] = $this->cartPresenter->getAttributesArrayFromString($rawProduct['attributes']);
+            // The cart carries the group/value pairs as they were read; parsing the flattened
+            // string is only a fallback for rows built by something other than Cart::getProducts().
+            $rawProduct['attributes'] = !empty($rawProduct['attributes_array'])
+                ? $rawProduct['attributes_array']
+                : $this->cartPresenter->getAttributesArrayFromString($rawProduct['attributes']);
         }
         $rawProduct['remove_from_cart_url'] = $this->link->getRemoveFromCartURL(
             $rawProduct['id_product'],

--- a/tests/Integration/Adapter/Presenter/Cart/CartAttributeNameWithColonTest.php
+++ b/tests/Integration/Adapter/Presenter/Cart/CartAttributeNameWithColonTest.php
@@ -111,7 +111,11 @@ class CartAttributeNameWithColonTest extends KernelTestCase
 
         // What the theme actually renders: the presented line must carry the same pair.
         $presented = (new CartPresenter())->present($cart);
-        $presentedLine = reset($presented['products']);
+        // reset() takes its argument by reference and the presented cart is a lazy array, so the
+        // element has to be read into a variable first or PHP raises "indirect modification of
+        // overloaded element ... has no effect".
+        $presentedProducts = $presented['products'];
+        $presentedLine = reset($presentedProducts);
         self::assertArrayHasKey(
             'Colour : shade',
             $presentedLine['attributes'],

--- a/tests/Integration/Adapter/Presenter/Cart/CartAttributeNameWithColonTest.php
+++ b/tests/Integration/Adapter/Presenter/Cart/CartAttributeNameWithColonTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Presenter\Cart;
+
+use Cart;
+use Context;
+use Currency;
+use Customer;
+use Db;
+use Language;
+use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The cart flattens each attribute into "group<colon>value" and used to parse that text back into
+ * pairs. A group or attribute name may itself contain the colon - the back office allows it - and
+ * then the pair cannot be recovered, so the attribute silently disappeared from the cart.
+ */
+class CartAttributeNameWithColonTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['attribute_group_lang'];
+    private const COMBINATION_ID = 1;
+
+    private static int $cartId;
+    private static int $groupId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        self::bootKernel();
+
+        $db = Db::getInstance();
+
+        // The group this combination belongs to, renamed so its public name carries a colon.
+        self::$groupId = (int) $db->getValue(
+            'SELECT a.id_attribute_group FROM ' . _DB_PREFIX_ . 'product_attribute_combination pac
+             INNER JOIN ' . _DB_PREFIX_ . 'attribute a ON a.id_attribute = pac.id_attribute
+             WHERE pac.id_product_attribute = ' . self::COMBINATION_ID
+        );
+        $db->execute(
+            'UPDATE ' . _DB_PREFIX_ . "attribute_group_lang SET public_name = 'Colour : shade'
+             WHERE id_attribute_group = " . self::$groupId
+        );
+
+        $productId = (int) $db->getValue(
+            'SELECT id_product FROM ' . _DB_PREFIX_ . 'product_attribute WHERE id_product_attribute = ' . self::COMBINATION_ID
+        );
+
+        $cart = new Cart();
+        $cart->id_customer = 1;
+        $cart->id_currency = 1;
+        $cart->id_lang = 1;
+        $cart->id_shop = 1;
+        $cart->id_shop_group = 1;
+        $cart->id_address_delivery = 0;
+        $cart->id_address_invoice = 0;
+        $cart->add();
+        self::$cartId = (int) $cart->id;
+        $cart->updateQty(1, $productId, self::COMBINATION_ID);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Db::getInstance()->delete('cart_product', 'id_cart = ' . self::$cartId);
+        Db::getInstance()->delete('cart', 'id_cart = ' . self::$cartId);
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        Cart::resetStaticCache();
+        parent::tearDownAfterClass();
+    }
+
+    public function testAGroupNameContainingAColonStillReachesTheCart(): void
+    {
+        self::bootKernel();
+        Cart::resetStaticCache();
+
+        $context = Context::getContext();
+        // Legacy presenters resolve services through the context rather than being injected.
+        $context->container = self::getContainer();
+        $context->currency = new Currency(1);
+        $context->language = new Language(1);
+        $context->shop = new Shop(1);
+        $context->customer = new Customer(1);
+        // The product presenter formats numbers through the context locale.
+        $context->currentLocale = self::getContainer()
+            ->get('prestashop.core.localization.locale.repository')
+            ->getLocale($context->language->getLocale());
+
+        $cart = new Cart(self::$cartId);
+        $context->cart = $cart;
+
+        $products = $cart->getProducts(true);
+        self::assertNotEmpty($products, 'the cart has no line to present');
+
+        $line = reset($products);
+        self::assertArrayHasKey('attributes_array', $line, 'the cart no longer carries the structured pairs');
+        self::assertArrayHasKey(
+            'Colour : shade',
+            $line['attributes_array'],
+            'the group name containing a colon was lost'
+        );
+        self::assertSame($this->expectedAttributeName(), $line['attributes_array']['Colour : shade']);
+
+        // What the theme actually renders: the presented line must carry the same pair.
+        $presented = (new CartPresenter())->present($cart);
+        $presentedLine = reset($presented['products']);
+        self::assertArrayHasKey(
+            'Colour : shade',
+            $presentedLine['attributes'],
+            'the presented cart line lost the group name containing a colon'
+        );
+
+        // The flattened text cannot express it, which is why the pairs are kept alongside it.
+        self::assertArrayNotHasKey(
+            'Colour : shade',
+            (new CartPresenter())->getAttributesArrayFromString($line['attributes']),
+            'if parsing the text recovered the name, keeping the pairs would be pointless'
+        );
+    }
+
+    private function expectedAttributeName(): string
+    {
+        return (string) Db::getInstance()->getValue(
+            'SELECT al.name FROM ' . _DB_PREFIX_ . 'product_attribute_combination pac
+             INNER JOIN ' . _DB_PREFIX_ . 'attribute a ON a.id_attribute = pac.id_attribute
+             INNER JOIN ' . _DB_PREFIX_ . 'attribute_lang al ON al.id_attribute = pac.id_attribute AND al.id_lang = 1
+             WHERE pac.id_product_attribute = ' . self::COMBINATION_ID . ' AND a.id_attribute_group = ' . self::$groupId
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | An attribute whose group public name contains a colon disappears from the cart line, because the pair is flattened into text and then parsed back out of it.<br><br>`Cart::cacheSomeAttributesLists()` reads `public_group_name` and `attribute_name` in one batched query and joins them into `"group<colon>value"`, separated by `PS_ATTRIBUTE_ANCHOR_SEPARATOR`. `CartPresenter::getAttributesArrayFromString()` then recovers the pairs with `/(?>(?P<attribute>[^:]+:[^:]+)…/` and `explode(':', …)`. Both steps assume exactly one colon in a pair, so `Colour : shade` matches nothing and the attribute is dropped. It is not a regex that can be tightened - once a name may contain the separator, the flattened text no longer determines the pairs, and a value containing one is equally unrecoverable.<br><br>So the pairs are simply kept. The query already has them and is already batched, so this costs no extra query: `Cart::getProducts()` now also carries `attributes_array`, and the cart presenter uses it, falling back to parsing the text only for rows built by something other than `Cart::getProducts()` - a module composing its own line still works exactly as before. `attributes` and `attributes_small` are untouched, so anything rendering the text is unaffected.<br><br>@matks listed three options in the issue back in 2020 - warn on the character, sanitise it away, or escape on the front office - and @colinegin preferred warning the merchant. This is none of those on purpose: the colon is a legitimate character that the back office accepts and that renders correctly on the product page, so the cart losing it is the defect rather than the merchant's input. Restricting what may be typed would still be a reasonable thing to do on top, but it would not repair the carts of shops already using such a name, and it is a separate change in the attributes screen.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Catalog > Attributes & Features > edit a group and put a colon in its public name, for example `Colour : shade`. Add a product using that group to the cart. Before, the attribute is missing from the cart line; after, it shows with the full group name. `tests/Integration/Adapter/Presenter/Cart/CartAttributeNameWithColonTest.php` covers it end to end and also asserts that parsing the text still cannot recover the name, which is why the pairs are kept; reverting either changed file on its own makes it fail.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #12237
| Related PRs       |
| Sponsor company   |

