### PR TITLE
Price a cart whose address no longer exists instead of failing the page

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -540,15 +540,20 @@ class AddressCore extends ObjectModel
         $cache_id = 'Address::initialize_' . $context_hash;
 
         if (!Cache::isStored($cache_id)) {
-            /*
-             * Case 1 - Specific address ID is provided. We just load it.
-             */
-            if ($id_address) {
-                $address = new Address((int) $id_address);
+            $requestedAddress = $id_address ? new Address((int) $id_address) : null;
 
-                if (!Validate::isLoadedObject($address)) {
-                    throw new PrestaShopException('Invalid address #' . (int) $id_address);
-                }
+            /*
+             * Case 1 - Specific address ID is provided and the address still exists. We just load it.
+             *
+             * A cart or an order keeps the id of the address it was placed with, and that row can be
+             * gone - deleted directly, or by something that did not clean up after itself. We fall
+             * through to the cases below rather than refusing, because the address is wanted for tax
+             * and geolocation data and no caller is better off with the whole page failing over one
+             * unpriceable line. Cart::getOrderTotal() already caught the exception and did exactly
+             * this, so this makes the behaviour consistent rather than new.
+             */
+            if (null !== $requestedAddress && Validate::isLoadedObject($requestedAddress)) {
+                $address = $requestedAddress;
             /*
              * Case 2 - We try to use geolocation information if allowed. However, geoloc_id_country
              * is not set to the customer anywhere in the current codebase. Most geolocation logic either

--- a/tests/Integration/Classes/ProductPriceWithDeletedAddressTest.php
+++ b/tests/Integration/Classes/ProductPriceWithDeletedAddressTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Cart;
+use Context;
+use Currency;
+use Customer;
+use Db;
+use Employee;
+use Language;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A cart keeps the id of the address it was placed with, and that row can disappear - deleted
+ * directly, or by something that did not clean up after itself. Pricing then asked for an address
+ * that no longer exists and `Address::initialize()` threw, so the whole customer page in the back
+ * office answered with a 500 rather than the one line that could not be priced.
+ */
+class ProductPriceWithDeletedAddressTest extends KernelTestCase
+{
+    private const MISSING_ADDRESS_ID = 999999;
+
+    private static int $cartId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::bootKernel();
+
+        $db = Db::getInstance();
+        self::assertEmpty(
+            $db->getValue('SELECT id_address FROM ' . _DB_PREFIX_ . 'address WHERE id_address = ' . self::MISSING_ADDRESS_ID),
+            'the fixture needs an address id that does not exist'
+        );
+
+        // Written directly: the point is a cart pointing at an address row that is not there, which
+        // the model would refuse to create.
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'cart
+             (id_shop_group, id_shop, id_carrier, delivery_option, id_lang, id_address_delivery,
+              id_address_invoice, id_currency, id_customer, secure_key, date_add, date_upd)
+             VALUES (1, 1, 1, "", 1, ' . self::MISSING_ADDRESS_ID . ', ' . self::MISSING_ADDRESS_ID . ', 1, 1, "x", NOW(), NOW())'
+        );
+        self::$cartId = (int) $db->Insert_ID();
+
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'cart_product
+             (id_cart, id_product, id_address_delivery, id_shop, id_product_attribute, quantity, date_add)
+             VALUES (' . self::$cartId . ', 1, ' . self::MISSING_ADDRESS_ID . ', 1, 1, 1, NOW())'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Db::getInstance()->delete('cart_product', 'id_cart = ' . self::$cartId);
+        Db::getInstance()->delete('cart', 'id_cart = ' . self::$cartId);
+        Cart::resetStaticCache();
+        parent::tearDownAfterClass();
+    }
+
+    public function testACartPointingAtARemovedAddressCanStillBePriced(): void
+    {
+        self::bootKernel();
+        Cart::resetStaticCache();
+
+        $context = Context::getContext();
+        // Legacy cart code resolves services through the context rather than being injected.
+        $context->container = self::getContainer();
+        $context->currency = new Currency(1);
+        $context->language = new Language(1);
+        $context->shop = new Shop(1);
+        $context->customer = new Customer(1);
+        // The back office reaches this with an employee, which is what decides whether the cart id
+        // has to be passed down to the price computation.
+        $context->employee = new Employee(1);
+
+        $cart = new Cart(self::$cartId);
+        $context->cart = $cart;
+
+        $total = $cart->getOrderTotal(true, Cart::BOTH);
+
+        self::assertIsNumeric($total, 'the cart total could not be computed at all');
+        self::assertGreaterThan(0, (float) $total, 'the line should still be priced, using the contextual address');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A cart or an order keeps the id of the address it was placed with, and that row can be gone - deleted directly, or by something that did not clean up after itself. `Address::initialize()` then threw `Invalid address #N`, and because the customer page in the back office prices every cart the customer ever had, one such record answered the whole page with a 500.<br><br>The fix is in `Address::initialize()` rather than at the call sites, because there is no single call site. Reproducing it walked through two different ones - `Product::getPriceStatic()` and `Tax::getProductTaxRate()` via `Product::getProductTaxRate()` - and there are around ten callers in total, all wanting the address for tax and geolocation data rather than proof that it exists. Guarding them one by one would be a race with the next one.<br><br>So the specific-id case now falls through to the same handling as when no id is given: the contextual address, which is what the comment above the call in `Product::getPriceStatic()` already describes as the expected behaviour. This is not new behaviour either - `Cart::getOrderTotal()` has been catching that exception and doing precisely this for a while, with a comment saying it should not normally be needed. The change makes the rest of the code behave the way that one call site already assumed.<br><br>Nothing that currently catches the exception breaks; the catch simply stops firing. A line priced this way uses the shop's contextual country rather than a deleted address, which is the only defined answer available and is what the customer page needs in order to render at all.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Point a cart at an address id that does not exist - `UPDATE ps_cart SET id_address_delivery = 999999, id_address_invoice = 999999 WHERE id_cart = <id>` - and open that customer in Sell > Customers. Before, the page answers 500 with `Invalid address #999999`; after, it renders and the cart is priced against the contextual address. `tests/Integration/Classes/ProductPriceWithDeletedAddressTest.php` builds that cart and prices it; reverting `classes/Address.php` makes it fail with the same exception.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #12617
| Related PRs       |
| Sponsor company   |

