### PR TITLE
Order the category filter list by the merchant's arrangement

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/CategoryRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/CategoryRepository.php
@@ -96,7 +96,7 @@ class CategoryRepository
             FROM {table_prefix}category c
             INNER JOIN {table_prefix}category_lang cl ON (cl.id_category = c.id_category AND cl.id_lang = :language_id AND cl.id_shop = :shop_id)
             INNER JOIN {table_prefix}category_shop cs ON (cs.id_category = c.id_category AND cs.id_shop = :shop_id)
-            ORDER BY c.id_parent ASC
+            ORDER BY c.id_parent ASC, c.position ASC, c.id_category ASC
         '
         );
 

--- a/tests/Integration/PrestaShopBundle/Entity/Repository/CategoryRepositoryOrderTest.php
+++ b/tests/Integration/PrestaShopBundle/Entity/Repository/CategoryRepositoryOrderTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Entity\Repository;
+
+use Context;
+use Db;
+use Employee;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The category list behind the stock filter was ordered by parent alone, so siblings came back in
+ * whatever order the storage engine happened to return - usually by id, which is not the order the
+ * merchant arranged them in.
+ */
+class CategoryRepositoryOrderTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['category'];
+    private const PARENT_ID = 2;
+
+    public static function tearDownAfterClass(): void
+    {
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        parent::tearDownAfterClass();
+    }
+
+    public function testSiblingsComeBackInTheOrderTheMerchantArrangedThem(): void
+    {
+        self::bootKernel();
+
+        // The repository reads the language and shop from the context when it is built.
+        $context = Context::getContext();
+        $context->employee = new Employee(1);
+        $context->shop = new Shop(1);
+        Shop::setContext(Shop::CONTEXT_SHOP, 1);
+
+        $db = Db::getInstance();
+
+        $siblingIds = array_map(
+            'intval',
+            array_column(
+                $db->executeS(
+                    'SELECT id_category FROM ' . _DB_PREFIX_ . 'category
+                     WHERE id_parent = ' . self::PARENT_ID . ' ORDER BY id_category ASC'
+                ) ?: [],
+                'id_category'
+            )
+        );
+        self::assertGreaterThanOrEqual(2, count($siblingIds), 'the fixture needs at least two sibling categories');
+
+        // Arrange them against their id order, so that ordering by id cannot pass by accident.
+        $expected = array_reverse($siblingIds);
+        foreach ($expected as $position => $categoryId) {
+            $db->execute(
+                'UPDATE ' . _DB_PREFIX_ . 'category SET position = ' . (int) $position
+                . ' WHERE id_category = ' . $categoryId
+            );
+        }
+
+        $categories = self::getContainer()->get('prestashop.core.api.category.repository')->getCategories();
+
+        $returned = [];
+        foreach ($categories as $category) {
+            if ((int) $category['id_parent'] === self::PARENT_ID) {
+                $returned[] = (int) $category['id_category'];
+            }
+        }
+
+        self::assertSame($expected, $returned, 'the siblings did not come back in their configured order');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The category list behind the stock page filter was ordered by parent alone (`ORDER BY c.id_parent ASC`), so siblings came back in whatever order the storage engine happened to return - in practice by id, which is not the order the merchant arranged them in. `position` was already selected and simply not used.<br><br>Measured on `9.1.x` after giving three siblings positions that disagree with their ids:<br><br>current: `Clothes(2), Accessories(1), Art(0)`<br>with position: `Art(0), Accessories(1), Clothes(2)`<br><br>`id_category` is added as a final tie-break so the result is deterministic when two siblings share a position, which the database allows.<br><br>This is the second half of the report. The first half - the filter matching by name so a category whose name also exists under another parent matched both - is already fixed: `QueryParamsCollection::appendSqlCategoryFilter()` matches `cp.id_category` and `appendSqlCategoryFilterParam()` binds `array_map('intval', ...)`, so it filters by id. Only the ordering was left.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Reorder some sibling categories in Catalog > Categories so their order differs from their ids, then open Catalog > Stocks and the category filter. Before, they are listed by id; after, in the order you arranged. `tests/Integration/PrestaShopBundle/Entity/Repository/CategoryRepositoryOrderTest.php` arranges the fixture's siblings against their id order, so ordering by id cannot pass by accident, and fails on `9.1.x`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #12899
| Related PRs       |
| Sponsor company   |

