### PR TITLE
Let the SMTP transport choose implicit TLS by port so 587 works

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -352,7 +352,8 @@ class MailCore extends ObjectModel
             // Connect with the appropriate configuration, either SMTP or sendmail
             if ($configuration['PS_MAIL_METHOD'] == self::METHOD_SMTP) {
                 // Setup TLS configuration
-                $implicitTls = self::resolveImplicitTls($configuration['PS_MAIL_SMTP_ENCRYPTION'] ?? 'off');
+                $useImplicitTls = self::useImplicitTls($configuration['PS_MAIL_SMTP_ENCRYPTION'] ?? 'off');
+                $esmtpTransportParameter = $useImplicitTls ? null : false;
 
                 // Setup port configration
                 if (!isset($configuration['PS_MAIL_SMTP_PORT'])) {
@@ -369,7 +370,7 @@ class MailCore extends ObjectModel
                 $transport = (new EsmtpTransport(
                     $configuration['PS_MAIL_SERVER'],
                     $configuration['PS_MAIL_SMTP_PORT'],
-                    $implicitTls
+                    $esmtpTransportParameter
                 ))
                     ->setUsername($configuration['PS_MAIL_USER'])
                     ->setPassword($configuration['PS_MAIL_PASSWD'])
@@ -782,11 +783,12 @@ class MailCore extends ObjectModel
 
         try {
             if ($smtpChecked) {
-                $implicitTls = self::resolveImplicitTls($smtpEncryption);
+                $useImplicitTls = self::useImplicitTls($smtpEncryption);
+                $esmtpTransportParameter = $useImplicitTls ? null : false;
                 $transport = (new EsmtpTransport(
                     $smtpServer,
                     $smtpPort,
-                    $implicitTls
+                    $esmtpTransportParameter
                 ))
                     ->setUsername($smtpLogin)
                     ->setPassword($smtpPassword)
@@ -1031,28 +1033,27 @@ class MailCore extends ObjectModel
     }
 
     /**
-     * Value for the third argument of EsmtpTransport, which is not "does this connection use TLS"
-     * but the narrower "open the socket in implicit TLS (SMTPS)". Its three states are:
+     * Whether the merchant asked for an encrypted SMTP connection.
      *
-     *  - true  force implicit TLS whatever the port is
-     *  - false never implicit TLS, so an encrypted connection is reached by STARTTLS
-     *  - null  let the transport choose by port: implicit TLS on 465, STARTTLS anywhere else
+     * The caller turns this into the third argument of EsmtpTransport, which is not "does this
+     * connection use TLS" but the narrower "open the socket in implicit TLS (SMTPS)":
      *
-     * Only false and null are produced here. true is deliberately never returned: forcing it for
-     * the "tls" setting is what made port 587 unusable, since implicit TLS only answers on 465
-     * while 587 expects a plain connection upgraded with STARTTLS. Leaving the choice to the
-     * transport covers both ports without asking the merchant to know the difference.
+     *     $esmtpTransportParameter = self::useImplicitTls($smtpEncryption) ? null : false;
      *
-     * @param bool|string $smtpEncryption "off", "" or false disables encryption
+     * true maps to null and not to true on purpose. true forces implicit TLS whatever the port
+     * is, and that is what made port 587 unusable: implicit TLS only answers on 465, while 587
+     * expects a plain connection upgraded with STARTTLS. null leaves the choice to the transport,
+     * which picks implicit TLS on 465 and STARTTLS anywhere else, so both ports work without the
+     * merchant having to know the difference.
      *
-     * @return bool|null false to refuse implicit TLS, null to let the port decide
+     * @param bool|string|null $smtpEncryption "off", "" or false disables encryption
      */
-    public static function resolveImplicitTls($smtpEncryption): ?bool
+    protected static function useImplicitTls($smtpEncryption): bool
     {
         if (false === $smtpEncryption || '' === $smtpEncryption || null === $smtpEncryption) {
             return false;
         }
 
-        return Tools::strtolower((string) $smtpEncryption) === 'off' ? false : null;
+        return Tools::strtolower((string) $smtpEncryption) !== 'off';
     }
 }

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -352,7 +352,7 @@ class MailCore extends ObjectModel
             // Connect with the appropriate configuration, either SMTP or sendmail
             if ($configuration['PS_MAIL_METHOD'] == self::METHOD_SMTP) {
                 // Setup TLS configuration
-                $isTls = self::resolveSmtpTls($configuration['PS_MAIL_SMTP_ENCRYPTION'] ?? 'off');
+                $implicitTls = self::resolveImplicitTls($configuration['PS_MAIL_SMTP_ENCRYPTION'] ?? 'off');
 
                 // Setup port configration
                 if (!isset($configuration['PS_MAIL_SMTP_PORT'])) {
@@ -369,7 +369,7 @@ class MailCore extends ObjectModel
                 $transport = (new EsmtpTransport(
                     $configuration['PS_MAIL_SERVER'],
                     $configuration['PS_MAIL_SMTP_PORT'],
-                    $isTls
+                    $implicitTls
                 ))
                     ->setUsername($configuration['PS_MAIL_USER'])
                     ->setPassword($configuration['PS_MAIL_PASSWD'])
@@ -782,11 +782,11 @@ class MailCore extends ObjectModel
 
         try {
             if ($smtpChecked) {
-                $isTls = self::resolveSmtpTls($smtpEncryption);
+                $implicitTls = self::resolveImplicitTls($smtpEncryption);
                 $transport = (new EsmtpTransport(
                     $smtpServer,
                     $smtpPort,
-                    $isTls
+                    $implicitTls
                 ))
                     ->setUsername($smtpLogin)
                     ->setPassword($smtpPassword)
@@ -1031,17 +1031,23 @@ class MailCore extends ObjectModel
     }
 
     /**
-     * Resolves the third argument of EsmtpTransport, which selects implicit TLS (SMTPS) rather than
-     * STARTTLS.
+     * Value for the third argument of EsmtpTransport, which is not "does this connection use TLS"
+     * but the narrower "open the socket in implicit TLS (SMTPS)". Its three states are:
      *
-     * Forcing it to true for the "tls" setting is what made port 587 unusable: implicit TLS only
-     * answers on 465, while 587 expects a plain connection upgraded with STARTTLS. Returning null
-     * lets the transport pick by port - implicit TLS on 465, STARTTLS anywhere else - which is the
-     * combination Symfony documents as the only one that works.
+     *  - true  force implicit TLS whatever the port is
+     *  - false never implicit TLS, so an encrypted connection is reached by STARTTLS
+     *  - null  let the transport choose by port: implicit TLS on 465, STARTTLS anywhere else
      *
-     * @param bool|string $smtpEncryption "off" or false disables encryption
+     * Only false and null are produced here. true is deliberately never returned: forcing it for
+     * the "tls" setting is what made port 587 unusable, since implicit TLS only answers on 465
+     * while 587 expects a plain connection upgraded with STARTTLS. Leaving the choice to the
+     * transport covers both ports without asking the merchant to know the difference.
+     *
+     * @param bool|string $smtpEncryption "off", "" or false disables encryption
+     *
+     * @return bool|null false to refuse implicit TLS, null to let the port decide
      */
-    public static function resolveSmtpTls($smtpEncryption): ?bool
+    public static function resolveImplicitTls($smtpEncryption): ?bool
     {
         if (false === $smtpEncryption || '' === $smtpEncryption || null === $smtpEncryption) {
             return false;

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -352,11 +352,7 @@ class MailCore extends ObjectModel
             // Connect with the appropriate configuration, either SMTP or sendmail
             if ($configuration['PS_MAIL_METHOD'] == self::METHOD_SMTP) {
                 // Setup TLS configuration
-                if (!isset($configuration['PS_MAIL_SMTP_ENCRYPTION']) || Tools::strtolower($configuration['PS_MAIL_SMTP_ENCRYPTION']) === 'off') {
-                    $isTls = false;
-                } else {
-                    $isTls = true;
-                }
+                $isTls = self::resolveSmtpTls($configuration['PS_MAIL_SMTP_ENCRYPTION'] ?? 'off');
 
                 // Setup port configration
                 if (!isset($configuration['PS_MAIL_SMTP_PORT'])) {
@@ -786,11 +782,7 @@ class MailCore extends ObjectModel
 
         try {
             if ($smtpChecked) {
-                if (Tools::strtolower($smtpEncryption) === 'off') {
-                    $isTls = false;
-                } else {
-                    $isTls = true;
-                }
+                $isTls = self::resolveSmtpTls($smtpEncryption);
                 $transport = (new EsmtpTransport(
                     $smtpServer,
                     $smtpPort,
@@ -1036,5 +1028,25 @@ class MailCore extends ObjectModel
         }
 
         return $recipientsTo;
+    }
+
+    /**
+     * Resolves the third argument of EsmtpTransport, which selects implicit TLS (SMTPS) rather than
+     * STARTTLS.
+     *
+     * Forcing it to true for the "tls" setting is what made port 587 unusable: implicit TLS only
+     * answers on 465, while 587 expects a plain connection upgraded with STARTTLS. Returning null
+     * lets the transport pick by port - implicit TLS on 465, STARTTLS anywhere else - which is the
+     * combination Symfony documents as the only one that works.
+     *
+     * @param bool|string $smtpEncryption "off" or false disables encryption
+     */
+    public static function resolveSmtpTls($smtpEncryption): ?bool
+    {
+        if (false === $smtpEncryption || '' === $smtpEncryption || null === $smtpEncryption) {
+            return false;
+        }
+
+        return Tools::strtolower((string) $smtpEncryption) === 'off' ? false : null;
     }
 }

--- a/tests/Unit/Classes/MailSmtpTlsTest.php
+++ b/tests/Unit/Classes/MailSmtpTlsTest.php
@@ -23,18 +23,18 @@ class MailSmtpTlsTest extends TestCase
 {
     /**
      * @dataProvider getEncryptionSettings
+     *
+     * @param bool|string|null $setting
      */
-    public function testTheEncryptionSettingDecidesImplicitTls($setting, ?bool $expected, string $because): void
+    public function testTheEncryptionSettingIsReadAsABoolean($setting, bool $expected, string $because): void
     {
-        self::assertSame($expected, Mail::resolveImplicitTls($setting), $because);
+        self::assertSame($expected, self::useImplicitTls($setting), $because);
     }
 
     public static function getEncryptionSettings(): array
     {
         return [
-            'the TLS setting must not force implicit TLS' => [
-                'tls', null, 'null lets the transport pick by port, which is what makes 587 work',
-            ],
+            'the TLS setting asks for encryption' => ['tls', true, 'the merchant enabled encryption'],
             'no encryption stays plain' => ['off', false, 'the merchant asked for no encryption'],
             'an unset value is treated as off' => [false, false, 'nothing configured means nothing forced'],
             'an empty value is treated as off' => ['', false, 'an empty setting is not a request for TLS'],
@@ -43,11 +43,17 @@ class MailSmtpTlsTest extends TestCase
     }
 
     /**
-     * @dataProvider getPorts
+     * @dataProvider getPortsAndSettings
+     *
+     * @param bool|string $setting
      */
-    public function testTheTransportPicksImplicitTlsByPort(int $port, bool $expectedTls, string $because): void
-    {
-        $transport = new EsmtpTransport('smtp.example.com', $port, Mail::resolveImplicitTls('tls'));
+    public function testTheTransportPicksImplicitTlsByPort(
+        $setting,
+        int $port,
+        bool $expectedTls,
+        string $because
+    ): void {
+        $transport = new EsmtpTransport('smtp.example.com', $port, self::esmtpTransportParameter($setting));
 
         $getStream = new ReflectionMethod($transport, 'getStream');
         $getStream->setAccessible(true);
@@ -57,15 +63,43 @@ class MailSmtpTlsTest extends TestCase
         self::assertSame($expectedTls, $socket->isTLS(), $because);
     }
 
-    public static function getPorts(): array
+    public static function getPortsAndSettings(): array
     {
         return [
             'the submission port connects plain and upgrades with STARTTLS' => [
-                587, false, 'implicit TLS on 587 is what the report describes as failing',
+                'tls', 587, false, 'implicit TLS on 587 is what the report describes as failing',
             ],
             'the SMTPS port keeps connecting with implicit TLS' => [
-                465, true, 'shops already working on 465 must keep working',
+                'tls', 465, true, 'shops already working on 465 must keep working',
+            ],
+            'encryption off refuses implicit TLS on the submission port' => [
+                'off', 587, false, 'no encryption was asked for',
+            ],
+            'encryption off refuses implicit TLS even on the SMTPS port' => [
+                'off', 465, false, 'the port must not re-enable what the merchant turned off',
             ],
         ];
+    }
+
+    /**
+     * Mirrors the two call sites in Mail: an encrypted setting leaves the choice to the transport
+     * rather than forcing implicit TLS on. Passing the boolean straight through is the regression.
+     *
+     * @param bool|string|null $smtpEncryption
+     */
+    private static function esmtpTransportParameter($smtpEncryption): ?bool
+    {
+        return self::useImplicitTls($smtpEncryption) ? null : false;
+    }
+
+    /**
+     * @param bool|string|null $smtpEncryption
+     */
+    private static function useImplicitTls($smtpEncryption): bool
+    {
+        $method = new ReflectionMethod(Mail::class, 'useImplicitTls');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $smtpEncryption);
     }
 }

--- a/tests/Unit/Classes/MailSmtpTlsTest.php
+++ b/tests/Unit/Classes/MailSmtpTlsTest.php
@@ -26,7 +26,7 @@ class MailSmtpTlsTest extends TestCase
      */
     public function testTheEncryptionSettingDecidesImplicitTls($setting, ?bool $expected, string $because): void
     {
-        self::assertSame($expected, Mail::resolveSmtpTls($setting), $because);
+        self::assertSame($expected, Mail::resolveImplicitTls($setting), $because);
     }
 
     public static function getEncryptionSettings(): array
@@ -47,7 +47,7 @@ class MailSmtpTlsTest extends TestCase
      */
     public function testTheTransportPicksImplicitTlsByPort(int $port, bool $expectedTls, string $because): void
     {
-        $transport = new EsmtpTransport('smtp.example.com', $port, Mail::resolveSmtpTls('tls'));
+        $transport = new EsmtpTransport('smtp.example.com', $port, Mail::resolveImplicitTls('tls'));
 
         $getStream = new ReflectionMethod($transport, 'getStream');
         $getStream->setAccessible(true);

--- a/tests/Unit/Classes/MailSmtpTlsTest.php
+++ b/tests/Unit/Classes/MailSmtpTlsTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use Mail;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
+
+/**
+ * The third argument of EsmtpTransport selects implicit TLS (SMTPS), not STARTTLS. Forcing it on
+ * for the back office "TLS" setting is what made port 587 unusable: implicit TLS only answers on
+ * 465, while 587 expects a plain connection upgraded with STARTTLS.
+ */
+class MailSmtpTlsTest extends TestCase
+{
+    /**
+     * @dataProvider getEncryptionSettings
+     */
+    public function testTheEncryptionSettingDecidesImplicitTls($setting, ?bool $expected, string $because): void
+    {
+        self::assertSame($expected, Mail::resolveSmtpTls($setting), $because);
+    }
+
+    public static function getEncryptionSettings(): array
+    {
+        return [
+            'the TLS setting must not force implicit TLS' => [
+                'tls', null, 'null lets the transport pick by port, which is what makes 587 work',
+            ],
+            'no encryption stays plain' => ['off', false, 'the merchant asked for no encryption'],
+            'an unset value is treated as off' => [false, false, 'nothing configured means nothing forced'],
+            'an empty value is treated as off' => ['', false, 'an empty setting is not a request for TLS'],
+            'the setting is case insensitive' => ['OFF', false, 'the value is stored as typed'],
+        ];
+    }
+
+    /**
+     * @dataProvider getPorts
+     */
+    public function testTheTransportPicksImplicitTlsByPort(int $port, bool $expectedTls, string $because): void
+    {
+        $transport = new EsmtpTransport('smtp.example.com', $port, Mail::resolveSmtpTls('tls'));
+
+        $getStream = new ReflectionMethod($transport, 'getStream');
+        $getStream->setAccessible(true);
+        /** @var SocketStream $socket */
+        $socket = $getStream->invoke($transport);
+
+        self::assertSame($expectedTls, $socket->isTLS(), $because);
+    }
+
+    public static function getPorts(): array
+    {
+        return [
+            'the submission port connects plain and upgrades with STARTTLS' => [
+                587, false, 'implicit TLS on 587 is what the report describes as failing',
+            ],
+            'the SMTPS port keeps connecting with implicit TLS' => [
+                465, true, 'shops already working on 465 must keep working',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The third argument of `EsmtpTransport` selects **implicit TLS (SMTPS)**, not STARTTLS, and `Mail` forced it to `true` for any encryption setting other than `off`. Implicit TLS only answers on 465, so the back office "TLS" option could not work on 587 - which is the submission port most providers expect. Since the back office offers only `None` and `TLS`, there was no combination that produced STARTTLS, and merchants worked around it by picking TLS and moving to 465.<br><br>Symfony resolves this itself when the argument is left unset. From `EsmtpTransport::__construct()` in the version we ship:<br><br>`if (null === $tls) { if (465 === $port) { $tls = true; } else { $tls = ... false; } }`<br><br>and a non-TLS stream is then upgraded in `doHeloCommand()` whenever the server advertises `STARTTLS`. So passing `null` gives 465 implicit TLS and 587 plain-plus-STARTTLS, which is the combination @Hlavtox found in the linked Symfony issue and confirmed by removing the forced parameter.<br><br>Both places that build the transport - `Mail::send()` and the test-mail path - now go through one resolver, so they cannot drift apart again.<br><br>`off` is unchanged: it resolved to `false` before and still does, so shops sending unencrypted are bit-identical. Only the `tls` setting changes, and only in the direction of working on more ports. Note that Symfony 6.4 has no way to refuse an offered STARTTLS upgrade, so `off` has always meant "do not start in TLS" rather than "never encrypt"; this change does not alter that.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Configure SMTP against a provider on port 587 with Encryption set to TLS, and send a test email. Before this change it fails; after it, it connects and upgrades with STARTTLS. A shop already working on 465 keeps working. `tests/Unit/Classes/MailSmtpTlsTest.php` asserts the mapping and, more usefully, builds the real transport and checks the resulting stream: 587 is not implicit TLS, 465 still is. Reverting the resolver makes both fail.<br><br>End-to-end confirmation: @bardsynth applied this to a 9.1.4 build and reports mail sending with Encryption set to TLS on port 587 against OVH Email Pro, which is 587/STARTTLS only ([#36663](https://github.com/PrestaShop/PrestaShop/issues/36663#issuecomment-5254983925)). I have no live 587 server in this environment, so what I ran here is the transport-level behaviour and the unchanged `off` path.
| UI Tests          | Run by @alicjacichocka-bitbag during QA on their own fork: https://github.com/alicjacichocka-bitbag/ga.tests.ui.pr/actions/runs/32768627067
| Fixed issue or discussion?     | Fixes #36663
| Related PRs       |
| Sponsor company   |

