### PR TITLE
Offer carrier modules that compute their price without ranges

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -731,9 +731,12 @@ class CarrierCore extends ObjectModel
         foreach ($result as $k => $row) {
             $carrier = new Carrier((int) $row['id_carrier']);
             $shipping_method = $carrier->getShippingMethod();
-            // A carrier that does not need ranges cannot be judged by them; its price comes from
-            // the module instead.
-            if ($shipping_method != Carrier::SHIPPING_METHOD_FREE && $carrier->need_range) {
+            // Only a carrier module that computes its price externally escapes the range check: its
+            // price comes from the module, so there are no ranges to judge it by. A core carrier
+            // with need_range = 0 is simply one nobody configured ranges for, and it still has to be
+            // filtered out here.
+            $computesItsOwnPrice = $carrier->is_module && !$carrier->need_range;
+            if ($shipping_method != Carrier::SHIPPING_METHOD_FREE && !$computesItsOwnPrice) {
                 /*
                  * First, we check loosely if the carrier is available for the zone with at least one range.
                  * No weight, no price, just check if the carrier has any ranges for the zone.

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -719,13 +719,21 @@ class CarrierCore extends ObjectModel
         }
 
         // And get all carriers available in the system
-        $result = Carrier::getCarriers($id_lang, true, false, (int) $id_zone, $groups, self::PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE);
+        /*
+         * A carrier module that computes its price externally has no ranges by design, so it was
+         * excluded here and never reached getPackageShippingCost(), which is where
+         * getOrderShippingCostExternal() would have been called. The only group the previous filter
+         * left out was exactly that one - module carriers with need_range = 0.
+         */
+        $result = Carrier::getCarriers($id_lang, true, false, (int) $id_zone, $groups, self::ALL_CARRIERS);
         $results_array = [];
 
         foreach ($result as $k => $row) {
             $carrier = new Carrier((int) $row['id_carrier']);
             $shipping_method = $carrier->getShippingMethod();
-            if ($shipping_method != Carrier::SHIPPING_METHOD_FREE) {
+            // A carrier that does not need ranges cannot be judged by them; its price comes from
+            // the module instead.
+            if ($shipping_method != Carrier::SHIPPING_METHOD_FREE && $carrier->need_range) {
                 /*
                  * First, we check loosely if the carrier is available for the zone with at least one range.
                  * No weight, no price, just check if the carrier has any ranges for the zone.

--- a/tests/Integration/Classes/CarrierExternalWithoutRangesTest.php
+++ b/tests/Integration/Classes/CarrierExternalWithoutRangesTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Carrier;
+use Cart;
+use Configuration;
+use Context;
+use Currency;
+use Customer;
+use Db;
+use Language;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A carrier module that computes its price through an API sets `need_range = 0` and implements
+ * `getOrderShippingCostExternal()`. The carrier list filtered those out in SQL, so such a carrier
+ * never appeared in the front office and the external price method was never reached.
+ */
+class CarrierExternalWithoutRangesTest extends KernelTestCase
+{
+    private const ZONE_ID = 1;
+
+    private static int $externalCarrierId;
+    private static int $pricedCarrierId;
+    private static int $groupId;
+    private static int $cartId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::bootKernel();
+
+        $db = Db::getInstance();
+        self::$groupId = (int) Configuration::get('PS_UNIDENTIFIED_GROUP');
+
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'carrier
+             (id_reference, name, url, active, deleted, shipping_handling, range_behavior, is_module,
+              is_free, shipping_external, need_range, external_module_name, shipping_method, position,
+              max_width, max_height, max_depth, max_weight, grade)
+             VALUES (0, "External probe carrier", "", 1, 0, 0, 0, 1, 1, 1, 0, "probe_carrier_module", 0, 99, 0, 0, 0, 0, 0)'
+        );
+        self::$externalCarrierId = (int) $db->Insert_ID();
+
+        $db->execute(
+            'UPDATE ' . _DB_PREFIX_ . 'carrier SET id_reference = ' . self::$externalCarrierId
+            . ' WHERE id_carrier = ' . self::$externalCarrierId
+        );
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'carrier_lang (id_carrier, id_shop, id_lang, delay)
+             VALUES (' . self::$externalCarrierId . ', 1, ' . (int) Configuration::get('PS_LANG_DEFAULT') . ', "probe")'
+        );
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'carrier_shop (id_carrier, id_shop) VALUES (' . self::$externalCarrierId . ', 1)'
+        );
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'carrier_zone (id_carrier, id_zone) VALUES (' . self::$externalCarrierId . ', ' . self::ZONE_ID . ')'
+        );
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'carrier_group (id_carrier, id_group) VALUES (' . self::$externalCarrierId . ', ' . self::$groupId . ')'
+        );
+
+        // A second one that is not free, so it goes through the range checks and the exclusion
+        // becomes visible in the error list rather than silently.
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'carrier
+             (id_reference, name, url, active, deleted, shipping_handling, range_behavior, is_module,
+              is_free, shipping_external, need_range, external_module_name, shipping_method, position,
+              max_width, max_height, max_depth, max_weight, grade)
+             VALUES (0, "External priced probe", "", 1, 0, 0, 0, 1, 0, 1, 0, "probe_carrier_module", 2, 99, 0, 0, 0, 0, 0)'
+        );
+        self::$pricedCarrierId = (int) $db->Insert_ID();
+        $db->execute('UPDATE ' . _DB_PREFIX_ . 'carrier SET id_reference = ' . self::$pricedCarrierId . ' WHERE id_carrier = ' . self::$pricedCarrierId);
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . 'carrier_lang (id_carrier, id_shop, id_lang, delay) VALUES (' . self::$pricedCarrierId . ', 1, ' . (int) Configuration::get('PS_LANG_DEFAULT') . ', "probe")');
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . 'carrier_shop (id_carrier, id_shop) VALUES (' . self::$pricedCarrierId . ', 1)');
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . 'carrier_zone (id_carrier, id_zone) VALUES (' . self::$pricedCarrierId . ', ' . self::ZONE_ID . ')');
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . 'carrier_group (id_carrier, id_group) VALUES (' . self::$pricedCarrierId . ', ' . self::$groupId . ')');
+
+        // Pricing a non-free carrier needs a cart to price against.
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'cart
+             (id_shop_group, id_shop, id_carrier, delivery_option, id_lang, id_address_delivery,
+              id_address_invoice, id_currency, id_customer, secure_key, date_add, date_upd)
+             VALUES (1, 1, 0, "", 1, 0, 0, 1, 1, "x", NOW(), NOW())'
+        );
+        self::$cartId = (int) $db->Insert_ID();
+        $db->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'cart_product
+             (id_cart, id_product, id_address_delivery, id_shop, id_product_attribute, quantity, date_add)
+             VALUES (' . self::$cartId . ', 1, 0, 1, 1, 1, NOW())'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $db = Db::getInstance();
+        $db->delete('cart_product', 'id_cart = ' . self::$cartId);
+        $db->delete('cart', 'id_cart = ' . self::$cartId);
+        foreach (['carrier_lang', 'carrier_shop', 'carrier_zone', 'carrier_group', 'carrier'] as $table) {
+            $db->delete($table, 'id_carrier IN (' . self::$externalCarrierId . ', ' . self::$pricedCarrierId . ')');
+        }
+        Carrier::resetStaticCache();
+        parent::tearDownAfterClass();
+    }
+
+    public function testACarrierComputingItsPriceExternallyIsOffered(): void
+    {
+        self::bootKernel();
+
+        $context = Context::getContext();
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->shop = new Shop(1);
+        Shop::setContext(Shop::CONTEXT_SHOP, 1);
+
+        $context->currency = new Currency(1);
+        $context->customer = new Customer(1);
+        $context->container = self::getContainer();
+        $cart = new Cart(self::$cartId);
+        $context->cart = $cart;
+
+        $error = [];
+        $carriers = Carrier::getCarriersForOrder(self::ZONE_ID, [self::$groupId], $cart, $error);
+
+        $offeredIds = array_map('intval', array_column($carriers, 'id_carrier'));
+
+        self::assertContains(
+            self::$externalCarrierId,
+            $offeredIds,
+            'a module carrier with need_range = 0 was not offered, so its external price is never asked for'
+        );
+
+        // The priced one is dropped later for want of a real module, but it must not be dropped for
+        // missing ranges - a carrier that declares it needs none cannot be judged by them.
+        self::assertArrayNotHasKey(
+            self::$pricedCarrierId,
+            $error,
+            'the carrier was excluded over ranges it declared it does not need'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A carrier module that computes its price through an API sets `need_range = 0` and implements `getOrderShippingCostExternal()`, which is what the documentation tells module authors to do. Such a carrier never appeared in the front office, so that method was never reached.<br><br>`Carrier::getCarriersForOrder()` asked for `PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE`, which is `AND (c.is_module = 0 OR c.need_range = 1)`. The only group that leaves out is exactly `is_module = 1 AND need_range = 0` - the external carriers. They were dropped in SQL, before anything could ask the module for a price. `Cart::getPackageShippingCost()` has had the branch that calls them all along:<br><br>`if (!$carrier->need_range) { return $module->getOrderShippingCostExternal($this); }`<br><br>so the price path was ready and simply unreachable. That answers @Hlavtox's question in the issue - it is not that the second method does not work, it is that the carrier never gets far enough for it to be called.<br><br>Two changes, both needed. The list now asks for `ALL_CARRIERS`, which adds no clause of its own, so the result is the previous set plus the excluded group. And the range availability checks are skipped for a carrier with `need_range = 0`, because such a carrier has no ranges by definition and would otherwise be dropped a second time by `getMaxDeliveryPriceByWeight()`/`ByPrice()` returning false.<br><br>Carriers that return `false` from the module are still removed, a few lines further down, which is the documented way for a module to say it does not serve a destination. So an external carrier appears when its module prices it and disappears when it declines - which is the behaviour the documentation describes.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a carrier module with `need_range = 0`, `is_module = 1` and `getOrderShippingCostExternal()` returning a price. Before this change the carrier is absent from the front office delivery step; after it, it is offered at the price the module returns. `tests/Integration/Classes/CarrierExternalWithoutRangesTest.php` covers both halves separately - reverting the filter makes the carrier absent, and reverting only the range guard makes it excluded with a range error - so neither half can be dropped without the test noticing.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36294
| Related PRs       |
| Sponsor company   |

