### PR TITLE
Stop deleting index.php from module entity folders

### DIFF
--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -14,6 +14,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -61,6 +62,48 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('prestashop.admin_cookie_lifetime', $this->getAdminCookieLifetime());
         $this->preprendApiConfig($container);
         $this->preprendSessionConfig($container);
+    }
+
+    /**
+     * ApiPlatform reads a mapping path with ReflectionClassRecursiveIterator, which requires a
+     * directory and does a require_once on every PHP file it finds there. A module index.php holds
+     * an `exit` statement, so including it stops the whole build - and it cannot be caught, since
+     * the iterator only guards against Throwable.
+     *
+     * Rather than delete files from a directory the shop does not own, which is what used to happen
+     * here and what made those files show up as missing during an update, we point ApiPlatform at a
+     * directory of our own holding one link per entity file. Symlinks resolve back to the module
+     * file, so a class is still loaded from its own path; copying is the fallback where linking is
+     * not available.
+     *
+     * @return string the directory to hand to ApiPlatform
+     */
+    private function mirrorModuleEntities(ContainerBuilder $container, string $moduleName, string $entitiesPath): string
+    {
+        $mirrorPath = sprintf('%s/api_platform/module_entities/%s', $container->getParameter('kernel.cache_dir'), $moduleName);
+
+        $filesystem = new Filesystem();
+        $filesystem->remove($mirrorPath);
+        $filesystem->mkdir($mirrorPath);
+
+        $entityFiles = Finder::create()
+            ->files()
+            ->in($entitiesPath)
+            ->name('*.php')
+            ->notName('index.php');
+
+        foreach ($entityFiles as $entityFile) {
+            $target = $mirrorPath . DIRECTORY_SEPARATOR . $entityFile->getRelativePathname();
+            $filesystem->mkdir(dirname($target));
+
+            try {
+                $filesystem->symlink($entityFile->getRealPath(), $target);
+            } catch (IOException $e) {
+                $filesystem->copy($entityFile->getRealPath(), $target);
+            }
+        }
+
+        return $mirrorPath;
     }
 
     protected function preprendSessionConfig(ContainerBuilder $container)
@@ -126,16 +169,7 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
             // Load Doctrine entities that could be used as ApiPlatform DTO resources as well in the src/Entity folder
             $entitiesRessourcesPath = sprintf('%s/src/Entity', $modulePath);
             if (file_exists($entitiesRessourcesPath)) {
-                // APIPlatform is looping on included resources and doing a require_once on those resources in ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories.
-                // This means that everything in those files is interpreted including the exit statement in some of those files ( especially in some index.php files used as an old way to make the directory read only ).
-                // Since we cannot override or decorate the reflection class itself we have no other choice but to delete those files.
-                (new Filesystem())->remove(
-                    Finder::create()
-                        ->files()
-                        ->in($entitiesRessourcesPath)
-                        ->name('index.php')
-                );
-                $paths[] = $entitiesRessourcesPath;
+                $paths[] = $this->mirrorModuleEntities($container, $moduleName, $entitiesRessourcesPath);
             }
 
             // Load ApiPlatform DTOs from the src/ApiPlatform/Resources folder

--- a/tests/Unit/PrestaShopBundle/DependencyInjection/PrestaShopExtensionModuleEntitiesTest.php
+++ b/tests/Unit/PrestaShopBundle/DependencyInjection/PrestaShopExtensionModuleEntitiesTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\DependencyInjection\PrestaShopExtension;
+use ReflectionMethod;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * ApiPlatform reads a mapping path by requiring every PHP file it finds there, and a module
+ * index.php holds an `exit` statement. That used to be handled by deleting those files from the
+ * module, which left a shop quietly modifying files it does not own - they then show up as missing
+ * when updating. The mapping is built against a directory of links instead.
+ */
+class PrestaShopExtensionModuleEntitiesTest extends TestCase
+{
+    private string $workDir;
+    private string $moduleDir;
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->workDir = sys_get_temp_dir() . '/ps_extension_test_' . uniqid();
+        $this->moduleDir = $this->workDir . '/modules/';
+        $this->cacheDir = $this->workDir . '/cache';
+
+        $entityDir = $this->moduleDir . 'probemodule/src/Entity';
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($entityDir);
+        $filesystem->mkdir($this->cacheDir);
+
+        file_put_contents($entityDir . '/ProbeEntity.php', "<?php\nnamespace Probe\\Entity;\nclass ProbeEntity {}\n");
+        // The file the module ships to keep the folder from being listed, holding an exit statement.
+        file_put_contents($entityDir . '/index.php', "<?php\nexit;\n");
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->workDir);
+        parent::tearDown();
+    }
+
+    public function testTheModuleKeepsItsIndexFile(): void
+    {
+        $this->prependApiConfig();
+
+        self::assertFileExists(
+            $this->moduleDir . 'probemodule/src/Entity/index.php',
+            'the shop removed a file from a module directory it does not own'
+        );
+    }
+
+    public function testTheMappingPointsAtLinksWithoutTheIndexFile(): void
+    {
+        $container = $this->prependApiConfig();
+
+        $paths = $container->getExtensionConfig('api_platform')[0]['mapping']['paths'] ?? [];
+        self::assertNotEmpty($paths, 'no mapping path was registered for the module entities');
+
+        $mirror = null;
+        foreach ($paths as $path) {
+            if (str_contains($path, 'probemodule')) {
+                $mirror = $path;
+            }
+        }
+        self::assertNotNull($mirror, 'the module entities were not mapped at all');
+        self::assertStringStartsWith($this->cacheDir, $mirror, 'the module folder itself is still mapped');
+
+        self::assertFileExists($mirror . '/ProbeEntity.php', 'the entity is not reachable through the mapping');
+        self::assertFileDoesNotExist($mirror . '/index.php', 'index.php would be required and would stop the build');
+        self::assertSame(
+            realpath($this->moduleDir . 'probemodule/src/Entity/ProbeEntity.php'),
+            realpath($mirror . '/ProbeEntity.php'),
+            'the entity must still resolve to its own file in the module'
+        );
+    }
+
+    private function prependApiConfig(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('prestashop.active_modules', ['probemodule']);
+        $container->setParameter('prestashop.module_dir', $this->moduleDir);
+        $container->setParameter('kernel.cache_dir', $this->cacheDir);
+
+        $method = new ReflectionMethod(PrestaShopExtension::class, 'preprendApiConfig');
+        $method->setAccessible(true);
+        $method->invoke(new PrestaShopExtension(), $container);
+
+        return $container;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PrestaShopExtension::preprendApiConfig()` deleted every `index.php` found in an active module's `src/Entity` folder, on each container build. The shop was modifying files it does not own, and the update assistant then correctly reported them as missing.<br><br>The reason it did that is real, and the comment in the code says it: ApiPlatform reads a mapping path through `ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories()`, which does `require_once` on every PHP file it finds. A module `index.php` holds an `exit` statement, so including it ends the build - and it cannot be caught, because the iterator only guards with `catch (\Throwable)`, which an `exit` does not trigger. Passing the entity files individually is not an option either: that method builds a `RecursiveDirectoryIterator`, so it needs a directory.<br><br>So the mapping is pointed at a directory of our own instead, under `kernel.cache_dir`, holding one symlink per entity file and no `index.php`. ApiPlatform still gets a real directory to walk, and `realpath()` resolves each link back to the module file, so a class is loaded from its own path exactly as before - not from a copy that could later collide with the autoloader. Copying is the fallback where symlinking is not available. The directory is rebuilt with the container, so it cannot go stale.<br><br>Verified on a shop: with `modules/productcomments/src/Entity/index.php` in place, `bin/console cache:clear` used to remove it and now leaves it, and the mapping directory comes out holding the six entity files with `index.php` absent, each one resolving back to `modules/productcomments/src/Entity/`.<br><br>The alternative would be to stop `PrestaShop/autoupgrade` reporting these files, as was done for the admin-api ones in PrestaShop/autoupgrade#1534. I did not go that way on purpose: that report is telling the truth, and silencing it would leave a shop still deleting module files.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Put an `index.php` containing `exit;` into an active module's `src/Entity` folder - `productcomments` has such a folder - and run `bin/console cache:clear`. Before this change the file is gone afterwards; after it, it is still there and the shop still boots. The generated mapping folder is `var/cache/<env>/<app>/api_platform/module_entities/<module>`. `tests/Unit/PrestaShopBundle/DependencyInjection/PrestaShopExtensionModuleEntitiesTest.php` covers both halves - the module keeps its file, and the mapped directory holds the entity but not `index.php` - and both fail on `9.1.x`.
| UI Tests          | Run dispatched: https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30447287888 - result posted in a comment when it concludes
| Fixed issue or discussion?     | Fixes #40078
| Related PRs       |
| Sponsor company   |
