### PR TITLE
Compare the offered module version against the files on disk

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -215,7 +215,7 @@ class AdminModuleDataProvider implements ModuleInterface
 
                 if (!$module->canBeUpgraded()) {
                     unset($urls['upgrade']);
-                } elseif ($moduleAttributes->get('download_url') !== null) {
+                } elseif ($module->hasNewVersionAvailable() && $moduleAttributes->get('download_url') !== null) {
                     // If the module can be upgraded and has a download URL,
                     // we also generate an upload URL to be used for uploading the archive during the module upgrade process.
                     $upload_url = $this->router->generate('admin_module_manage_action', [

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -445,8 +445,17 @@ class Module implements ModuleInterface
      */
     public function hasNewVersionAvailable(): bool
     {
-        return $this->attributes->get('version_available') !== 0
-            && version_compare($this->database->get('version'), $this->attributes->get('version_available'), '<');
+        if ($this->attributes->get('version_available') === 0) {
+            return false;
+        }
+
+        /*
+         * Compared against the version on disk rather than the one recorded in database, because the
+         * files are what a download would replace. A module updated by hand - a git clone, an upload
+         * over FTP - is ahead on disk while the database still holds the old version, and comparing
+         * against the database made an older package from the API look like an update.
+         */
+        return version_compare($this->disk->get('version'), $this->attributes->get('version_available'), '<');
     }
 
     /**

--- a/tests/Unit/Adapter/Module/ModuleNewVersionAvailableTest.php
+++ b/tests/Unit/Adapter/Module/ModuleNewVersionAvailableTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Module;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Module\Module;
+
+/**
+ * A module updated by hand - a git clone, an upload over FTP - is ahead on disk while the database
+ * still holds the version of the last upgrade that ran. Asking whether the API has something newer
+ * has to compare against the files, because the files are what a download would replace. Comparing
+ * against the database made an older package from the API look like an update, and clicking it
+ * reverted the manual work.
+ */
+class ModuleNewVersionAvailableTest extends TestCase
+{
+    /**
+     * @dataProvider getVersions
+     */
+    public function testTheApiIsOnlyNewerThanWhatIsOnDisk(
+        string $databaseVersion,
+        string $diskVersion,
+        $apiVersion,
+        bool $expected,
+        string $because
+    ): void {
+        $module = new Module(
+            ['version' => $apiVersion],
+            ['version' => $diskVersion],
+            ['version' => $databaseVersion, 'installed' => 1]
+        );
+        $module->attributes->set('version_available', $apiVersion);
+
+        self::assertSame($expected, $module->hasNewVersionAvailable(), $because);
+    }
+
+    public static function getVersions(): array
+    {
+        return [
+            'manually updated past what the API offers' => [
+                '1.0.0', '2.0.0', '1.5.0', false,
+                'downloading 1.5.0 over the 2.0.0 on disk would undo the manual update',
+            ],
+            'the API genuinely has a newer package' => [
+                '1.0.0', '1.0.0', '1.5.0', true,
+                'nothing local is newer, so the API package is an update',
+            ],
+            'files updated by hand, API not ahead of them' => [
+                '1.0.0', '1.5.0', '1.5.0', false,
+                'the API has nothing the files do not already have',
+            ],
+            'no package offered at all' => [
+                '1.0.0', '1.0.0', 0, false,
+                'there is nothing to download',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Updating a module that was updated by hand - a git clone, an upload over FTP - downloaded the package from the API over it, so the files went backwards to whatever version the API had.<br><br>Two things combined. `Module::hasNewVersionAvailable()` compared the offered version against the version recorded in **database**, not the one on **disk**; and `AdminModuleDataProvider` attached the remote `download_url` to the update action whenever `canBeUpgraded()` was true. A module updated by hand is ahead on disk while the database still holds the version of the last upgrade that ran, so with database 1.0.0, disk 2.0.0 and an API offering 1.5.0, `1.0.0 < 1.5.0` said "newer available" and the update replaced 2.0.0 with 1.5.0.<br><br>The comparison now runs against the version on disk, because the files are what a download would replace, and the remote source is only attached when the API really is ahead of them. What is left when it is not - the case where the files are newer than the database - is still offered as an update, and now does what it should: run the upgrade scripts against the files that are there, without downloading anything. That is `ModuleManager::upgrade()` with no `$source`, which is already what `UpgradeModuleHandler` passes.<br><br>@Quetzacoalt91 this is the rule you described in the issue - "The API could download a package ONLY IF the version it can provide is newer than the manually uploaded version" - with the version taken from the files rather than the database, since the database version says what last ran, not what is installed.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a module, then replace its folder with a newer version by hand and bump the version in its main file, without running the upgrade. The Module Manager offers an update: before this change it downloads the API package and your files are reverted; after it, the upgrade scripts run against your files and nothing is downloaded. A module that is genuinely behind the API still downloads and updates as before. `tests/Unit/Adapter/Module/ModuleNewVersionAvailableTest.php` covers the four combinations, and the two manual-update ones fail on `9.1.x`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39980
| Related PRs       |
| Sponsor company   |

