### PR TITLE
Tell the customer a product is unbuyable instead of asking for an impossible quantity

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -431,7 +431,7 @@ class CartControllerCore extends FrontController
             $availableProductQuantity = Product::getQuantity($this->id_product, $this->id_product_attribute);
             $productName = Product::getProductName($this->id_product, $this->id_product_attribute);
 
-            if ($availableProductQuantity > 0) {
+            if ($availableProductQuantity > 0 && $this->isMinimalQuantityReachable($product, $availableProductQuantity)) {
                 $this->errors[] = $this->trans(
                     'You can only buy %quantity% "%product%". Please adjust the quantity in your cart to continue.',
                     [
@@ -452,27 +452,34 @@ class CartControllerCore extends FrontController
         }
 
         // Check minimal_quantity
-        if (!$this->id_product_attribute) {
-            if ($qty_to_check < $product->minimal_quantity) {
+        $minimalQuantity = $this->id_product_attribute
+            ? (int) (new Combination($this->id_product_attribute))->minimal_quantity
+            : (int) $product->minimal_quantity;
+
+        if ($qty_to_check < $minimalQuantity) {
+            /*
+             * Stock can drop below the minimum the product may be bought in, and then no quantity is
+             * accepted at all - a larger one is refused for lack of stock, a smaller one for being
+             * under the minimum, and the customer is bounced between the two messages with no way
+             * out. In that case the product simply cannot be bought, so say that once instead.
+             */
+            if (!$this->isMinimalQuantityReachable($product, Product::getQuantity($this->id_product, $this->id_product_attribute))) {
                 $this->errors[] = $this->trans(
-                    'The minimum purchase order quantity for the product %product% is %quantity%.',
-                    ['%product%' => $product->name, '%quantity%' => $product->minimal_quantity],
+                    'This product (%product%) is no longer available.',
+                    ['%product%' => $product->name],
                     'Shop.Notifications.Error'
                 );
 
                 return;
             }
-        } else {
-            $combination = new Combination($this->id_product_attribute);
-            if ($qty_to_check < $combination->minimal_quantity) {
-                $this->errors[] = $this->trans(
-                    'The minimum purchase order quantity for the product %product% is %quantity%.',
-                    ['%product%' => $product->name, '%quantity%' => $combination->minimal_quantity],
-                    'Shop.Notifications.Error'
-                );
 
-                return;
-            }
+            $this->errors[] = $this->trans(
+                'The minimum purchase order quantity for the product %product% is %quantity%.',
+                ['%product%' => $product->name, '%quantity%' => $minimalQuantity],
+                'Shop.Notifications.Error'
+            );
+
+            return;
         }
 
         // If no errors, process product addition
@@ -609,6 +616,26 @@ class CartControllerCore extends FrontController
      *
      * @return bool
      */
+    /**
+     * Whether the product can still be bought at all, given that it may only be bought from a
+     * certain quantity upwards. Once stock falls below that minimum, no quantity is acceptable, and
+     * telling the customer to buy more or fewer is advice that cannot be followed.
+     *
+     * Ordering out of stock keeps it reachable, since stock is then not the limit.
+     */
+    protected function isMinimalQuantityReachable(Product $product, int $availableQuantity): bool
+    {
+        if (Product::isAvailableWhenOutOfStock($product->out_of_stock)) {
+            return true;
+        }
+
+        $minimalQuantity = $this->id_product_attribute
+            ? (int) (new Combination($this->id_product_attribute))->minimal_quantity
+            : (int) $product->minimal_quantity;
+
+        return $availableQuantity >= $minimalQuantity;
+    }
+
     protected function shouldAvailabilityErrorBeRaised(Product $product, int $qtyToCheck)
     {
         if ($this->id_product_attribute) {

--- a/tests/Integration/Classes/Controller/CartMinimalQuantityReachableTest.php
+++ b/tests/Integration/Classes/Controller/CartMinimalQuantityReachableTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use CartController;
+use Product;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Stock can fall below the quantity a product may only be bought from upwards. Every quantity is
+ * then refused - a larger one for lack of stock, a smaller one for being under the minimum - and the
+ * customer is bounced between the two messages with no way out. Such a product cannot be bought at
+ * all, and the cart has to say that rather than ask for a quantity that does not exist.
+ */
+class CartMinimalQuantityReachableTest extends KernelTestCase
+{
+    /**
+     * @dataProvider getStockSituations
+     */
+    public function testAProductIsOnlyBuyableWhenStockReachesItsMinimum(
+        int $minimalQuantity,
+        int $availableQuantity,
+        int $outOfStock,
+        bool $expected,
+        string $because
+    ): void {
+        self::bootKernel();
+
+        $product = new Product();
+        $product->minimal_quantity = $minimalQuantity;
+        $product->out_of_stock = $outOfStock;
+
+        self::assertSame($expected, $this->isReachable($product, $availableQuantity), $because);
+    }
+
+    public static function getStockSituations(): array
+    {
+        // 0 denies ordering out of stock, 1 allows it.
+        return [
+            'stock fell below the minimum' => [
+                3, 2, 0, false,
+                'no quantity is acceptable, so the product cannot be bought at all',
+            ],
+            'stock exactly meets the minimum' => [
+                3, 3, 0, true,
+                'the minimum can still be bought',
+            ],
+            'stock is above the minimum' => [
+                3, 10, 0, true,
+                'nothing stands in the way',
+            ],
+            'out of stock orders are allowed' => [
+                3, 0, 1, true,
+                'stock is not the limit when the shop sells beyond it',
+            ],
+            'no minimum set' => [
+                1, 0, 0, false,
+                'nothing is left to sell',
+            ],
+        ];
+    }
+
+    private function isReachable(Product $product, int $availableQuantity): bool
+    {
+        $controller = (new ReflectionClass(CartController::class))->newInstanceWithoutConstructor();
+
+        $attribute = new ReflectionProperty(CartController::class, 'id_product_attribute');
+        $attribute->setAccessible(true);
+        $attribute->setValue($controller, 0);
+
+        $method = new ReflectionMethod(CartController::class, 'isMinimalQuantityReachable');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $product, $availableQuantity);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A product that may only be bought from a certain quantity upwards becomes impossible to deal with once stock falls below that minimum. In `CartController`, a quantity above what is left is refused by the availability check, and a quantity below the minimum is refused by the minimum check, so **no quantity is accepted at all** - the customer is bounced between "You can only buy 2" and "The minimum purchase order quantity is 3" with no way to resolve either.<br><br>Both messages are also wrong in that situation. Telling someone they can buy 2 is not true when 2 is below the minimum, and asking for 3 is not true when only 2 exist. What is true is that the product cannot be bought at present, which is what the cart now says - once - reusing the existing "This product is no longer available." wording, so the customer knows to remove it rather than keep trying.<br><br>The decision is in one place, `isMinimalQuantityReachable()`, used by both branches so they cannot disagree again. Shops that allow ordering out of stock are unaffected: stock is not the limit there, so the minimum stays reachable and the existing messages are untouched.<br><br>@paulnoelcholot on not being able to reproduce - the two settings that have to be together are a minimum quantity above 1 **and** "deny orders when out of stock"; with out-of-stock orders allowed there is no conflict and nothing to see. The reproduction then only needs stock to drop below the minimum while the product sits in a cart.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Product with minimum quantity 3, stock 3, orders denied when out of stock. Add it to the cart in the front office, then set stock to 2 in the back office and return to the cart. Before this change the two messages contradict each other and no quantity is accepted; after it, the cart says the product is no longer available so it can be removed. With "allow orders out of stock" the behaviour is unchanged. `tests/Integration/Classes/Controller/CartMinimalQuantityReachableTest.php` covers the five combinations and fails on `9.1.x`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #40549
| Related PRs       |
| Sponsor company   |

