### PR TITLE
Let a grid status menu show past the scrolling table

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/choice-extension.ts
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/choice-extension.ts
@@ -28,6 +28,8 @@ export default class ChoiceExtension {
       .getContainer()
       .find(GridMap.bulks.choiceOptions);
 
+    this.letOpenMenusEscapeTheScrollingTable(grid);
+
     $choiceOptionsContainer.find(GridMap.dropdownItem).on('click', (e) => {
       e.preventDefault();
       const $button = $(e.currentTarget);
@@ -35,6 +37,37 @@ export default class ChoiceExtension {
       const url = $parent.data('url');
 
       this.submitForm(url, $button);
+    });
+  }
+
+  /**
+   * The grid sits inside a `.table-responsive`, which sets `overflow-x: auto`. Once either axis is
+   * not `visible` the other one clips too, so a status menu taller than the table is cut off - which
+   * is what happens on a short list, where the table is only a few rows high.
+   *
+   * The horizontal scrolling is still wanted for wide grids, so rather than dropping it the
+   * container is allowed to overflow only while a menu is open.
+   *
+   * @param {Grid} grid
+   * @private
+   */
+  private letOpenMenusEscapeTheScrollingTable(grid: Grid): void {
+    const $container = grid.getContainer();
+
+    $container.on('show.bs.dropdown', (e: JQuery.TriggeredEvent) => {
+      if ($(e.target).find(GridMap.bulks.choiceOptions).length === 0) {
+        return;
+      }
+
+      $(e.target).closest('.table-responsive').css('overflow', 'visible');
+    });
+
+    $container.on('hide.bs.dropdown', (e: JQuery.TriggeredEvent) => {
+      if ($(e.target).find(GridMap.bulks.choiceOptions).length === 0) {
+        return;
+      }
+
+      $(e.target).closest('.table-responsive').css('overflow', '');
     });
   }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | The order status menu in the Orders list is cut off when the list is short. The grid is wrapped in a `.table-responsive` (`Grid/Blocks/table.html.twig`), which Bootstrap defines as:<br><br>`.table-responsive { display: block; width: 100%; overflow-x: auto; }`<br><br>Once one axis is not `visible`, CSS makes the other one clip as well, so the container clips vertically even though only horizontal scrolling was asked for. With a few orders the table is only a couple of rows high, the status menu is taller than that, and the part that does not fit is cut - which is what the screenshot in the report shows.<br><br>The horizontal scrolling is still wanted for wide grids, so instead of dropping it the container is allowed to overflow only while a menu is open, and put back when it closes. It is scoped to the grid's own choice menus, so no other dropdown behaviour changes.<br><br>`data-boundary` was not the answer here: it changes where Popper positions the menu, not whether an ancestor clips it, so the menu would still have been cut.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Sell > Orders with only a few orders in the list, so the table is short. Open the status menu on a row: before this change the entries that do not fit inside the table are cut off; after it, the whole menu is visible and the table still scrolls horizontally when it is too wide.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30427815710
| Fixed issue or discussion?     | Fixes #28519
| Related PRs       |
| Sponsor company   |
