### PR TITLE
Let modules add fields to multistore configuration forms

### DIFF
--- a/src/Core/Configuration/AbstractMultistoreConfiguration.php
+++ b/src/Core/Configuration/AbstractMultistoreConfiguration.php
@@ -86,10 +86,14 @@ abstract class AbstractMultistoreConfiguration implements DataConfigurationInter
 
     /**
      * This method checks that:
-     * - Only defined configuration fields exist
+     * - Defined configuration fields hold valid values
      * - In single or group shop context, multistore fields are added to the list of defined fields, so that no error
      * is triggered because of additional checkboxes
      * - In all shop context, all fields are required
+     *
+     * Fields that a module added to the form through the `action<Page>Form` hook are left out of the check:
+     * they are not core configuration, the module saves them itself in the matching `action<Page>Save` hook,
+     * and they reach this method in the same array as the core ones.
      *
      * @param array $configurationInputValues
      *
@@ -112,7 +116,7 @@ abstract class AbstractMultistoreConfiguration implements DataConfigurationInter
             $resolver->setRequired($definedOptions);
         }
 
-        $resolver->resolve($configurationInputValues);
+        $resolver->resolve(array_intersect_key($configurationInputValues, array_flip($fields)));
 
         return true;
     }

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -19,7 +19,7 @@ use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
 use Shop;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\Resources\DatabaseDump;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
@@ -109,23 +109,38 @@ class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
     }
 
     /**
+     * A field the configuration does not declare - typically one a module added to the form through
+     * its hook, which the module saves itself - is left out of the check rather than rejected.
+     *
      * @dataProvider provideShopConstraints
      *
      * @param ShopConstraint $shopConstraint
      */
-    public function testUndefinedOptionsException(ShopConstraint $shopConstraint): void
+    public function testUndeclaredFieldsAreIgnored(ShopConstraint $shopConstraint): void
     {
         $isAllShopContext = ($shopConstraint->getShopGroupId() === null && $shopConstraint->getShopId() === null);
         $testedObject = $this->getDummyMultistoreConfiguration($shopConstraint);
-        $this->expectException(UndefinedOptionsException::class);
 
+        $values = ['a_field_added_by_a_module' => true];
         if ($isAllShopContext) {
-            // in all shop context, multistore field are not expected
-            $testedObject->updateConfiguration(['test_conf_1' => true, MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . 'test_conf_1' => true]);
-        } else {
-            // test in other shop contexts with an undefined field
-            $testedObject->updateConfiguration(['undefined_element' => true]);
+            // every declared field is required in all shop context, so they have to be present for
+            // this to be about the undeclared one
+            $values += ['test_conf_1' => true, 'test_conf_2' => 'value'];
         }
+
+        // updateConfiguration() returns the list of errors, so an empty array means it went through
+        $this->assertSame([], $testedObject->updateConfiguration($values));
+    }
+
+    /**
+     * Dropping the undeclared fields must not weaken the requirement on the declared ones.
+     */
+    public function testDeclaredFieldsAreStillRequiredInAllShopContext(): void
+    {
+        $testedObject = $this->getDummyMultistoreConfiguration(ShopConstraint::allShops());
+        $this->expectException(MissingOptionsException::class);
+
+        $testedObject->updateConfiguration(['test_conf_1' => true, 'a_field_added_by_a_module' => true]);
     }
 
     /**

--- a/tests/Unit/Adapter/Carrier/CarrierOptionsConfigurationTest.php
+++ b/tests/Unit/Adapter/Carrier/CarrierOptionsConfigurationTest.php
@@ -12,7 +12,6 @@ use Carrier;
 use PrestaShop\PrestaShop\Adapter\Carrier\CarrierOptionsConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class CarrierOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -73,7 +72,6 @@ class CarrierOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['default_carrier' => true, 'carrier_default_order_by' => Carrier::SORT_BY_POSITION, 'carrier_default_order_way' => Carrier::SORT_BY_DESC]],
             [InvalidOptionsException::class, ['default_carrier' => 25, 'carrier_default_order_by' => true, 'carrier_default_order_way' => Carrier::SORT_BY_DESC]],
             [InvalidOptionsException::class, ['default_carrier' => 25, 'carrier_default_order_by' => Carrier::SORT_BY_POSITION, 'carrier_default_order_way' => true]],

--- a/tests/Unit/Adapter/Carrier/HandlingConfigurationTest.php
+++ b/tests/Unit/Adapter/Carrier/HandlingConfigurationTest.php
@@ -11,7 +11,6 @@ namespace Tests\Unit\Adapter\Carrier;
 use PrestaShop\PrestaShop\Adapter\Carrier\HandlingConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class HandlingConfigurationTest extends AbstractConfigurationTestCase
@@ -72,7 +71,6 @@ class HandlingConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['shipping_handling_charges' => 'wrong_value', 'free_shipping_price' => 10.5, 'free_shipping_weight' => 10.5]],
             [InvalidOptionsException::class, ['shipping_handling_charges' => 10.5, 'free_shipping_price' => 'wrong_value', 'free_shipping_weight' => 10.5]],
             [InvalidOptionsException::class, ['shipping_handling_charges' => 10.5, 'free_shipping_price' => 10.5, 'free_shipping_weight' => 'wrong_value']],

--- a/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
+++ b/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
@@ -11,7 +11,6 @@ namespace Tests\Unit\Adapter\Customer;
 use PrestaShop\PrestaShop\Adapter\Customer\CustomerConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class CustomerConfigurationTest extends AbstractConfigurationTestCase
@@ -85,7 +84,6 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['redisplay_cart_at_login' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['send_email_after_registration' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['password_reset_delay' => 'wrong_type'])],

--- a/tests/Unit/Adapter/Invoice/InvoiceOptionsConfigurationTest.php
+++ b/tests/Unit/Adapter/Invoice/InvoiceOptionsConfigurationTest.php
@@ -13,7 +13,6 @@ use PrestaShop\PrestaShop\Adapter\Invoice\InvoiceOptionsConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class InvoiceOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -86,7 +85,6 @@ class InvoiceOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_invoices' => 'invalid_value_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_tax_breakdown' => 'invalid_value_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_product_images' => 'invalid_value_type'])],

--- a/tests/Unit/Adapter/Meta/SEOOptionsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SEOOptionsDataConfigurationTest.php
@@ -11,7 +11,6 @@ namespace Tests\Unit\Adapter\Preferences;
 use PrestaShop\PrestaShop\Adapter\Meta\SEOOptionsDataConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class SEOOptionsDataConfigurationTest extends AbstractConfigurationTestCase
@@ -68,7 +67,6 @@ class SEOOptionsDataConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['product_attributes_in_title' => 'wrong_type']],
         ];
     }

--- a/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
@@ -12,7 +12,6 @@ use PrestaShop\PrestaShop\Adapter\File\HtaccessFileGenerator;
 use PrestaShop\PrestaShop\Adapter\Meta\SetUpUrlsDataConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
@@ -135,7 +134,6 @@ class SetUpUrlsDataConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['friendly_url' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['default_language_url_prefix' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['accented_url' => 'wrong_type'])],

--- a/tests/Unit/Adapter/Meta/UrlSchemaDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/UrlSchemaDataConfigurationTest.php
@@ -12,7 +12,6 @@ use PrestaShop\PrestaShop\Adapter\Meta\UrlSchemaDataConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
@@ -273,7 +272,6 @@ class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['category_rule' => false])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['supplier_rule' => false])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['manufacturer_rule' => false])],

--- a/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
+++ b/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
@@ -11,7 +11,6 @@ namespace Tests\Unit\Adapter\Order;
 use PrestaShop\PrestaShop\Adapter\Order\GeneralConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class GeneralConfigurationTest extends AbstractConfigurationTestCase
@@ -91,7 +90,6 @@ class GeneralConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_final_summary' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_guest_checkout' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['disable_reordering_option' => 'wrong_type'])],

--- a/tests/Unit/Adapter/Order/GiftOptionsConfigurationTest.php
+++ b/tests/Unit/Adapter/Order/GiftOptionsConfigurationTest.php
@@ -11,7 +11,6 @@ namespace Tests\Unit\Adapter\Order;
 use PrestaShop\PrestaShop\Adapter\Order\GiftOptionsConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -81,7 +80,6 @@ class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_gift_wrapping' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['gift_wrapping_price' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['gift_wrapping_tax_rules_group' => 'wrong_type'])],

--- a/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
+++ b/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
@@ -11,7 +11,6 @@ namespace Tests\Unit\Adapter\Shop;
 use PrestaShop\PrestaShop\Adapter\Shop\MaintenanceConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
@@ -74,7 +73,6 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['enable_shop' => 'wrong_type', 'maintenance_allow_admins' => true, 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
             [InvalidOptionsException::class, ['enable_shop' => true, 'maintenance_allow_admins' => 'wrong_type', 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
             [InvalidOptionsException::class, ['enable_shop' => true, 'maintenance_allow_admins' => true, 'maintenance_ip' => ['wrong_type'], 'maintenance_text' => ['fr' => 'test string']]],

--- a/tests/Unit/Adapter/Webservice/WebserviceConfigurationTest.php
+++ b/tests/Unit/Adapter/Webservice/WebserviceConfigurationTest.php
@@ -11,7 +11,6 @@ namespace Tests\Unit\Adapter\Webservice;
 use PrestaShop\PrestaShop\Adapter\Webservice\WebserviceConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class WebserviceConfigurationTest extends AbstractConfigurationTestCase
@@ -71,7 +70,6 @@ class WebserviceConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['enable_webservice' => 'wrong_type', 'enable_cgi' => true]],
             [InvalidOptionsException::class, ['enable_webservice' => true, 'enable_cgi' => 'wrong_type']],
         ];

--- a/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -12,6 +12,8 @@ use PrestaShop\PrestaShop\Adapter\Shop\Context as ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\Resources\DummyMultistoreConfiguration;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
@@ -85,6 +87,49 @@ class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
             ['toto', ['toto' => 'value', $multistorePrefix . 'toto' => true], true, 'set'], // multistore checkbox is there, method 'set' must be called
             ['toto', ['toto' => 'value'], true, 'deleteFromContext'], // multistore checkbox absent, method 'deleteFromContext' must be called
             ['toto', [], true, null], // do not make any update if the field is not in the input array
+        ];
+    }
+
+    /**
+     * @dataProvider provideForValidateConfiguration
+     *
+     * @param array $inputValues
+     * @param bool $isAllShopContext
+     * @param bool $isMultistoreUsed
+     * @param string|null $expectedException
+     */
+    public function testValidateConfiguration(array $inputValues, bool $isAllShopContext, bool $isMultistoreUsed, ?string $expectedException): void
+    {
+        $abstractMultistoreConfiguration = $this->getTestableClass($isAllShopContext, null, $isMultistoreUsed);
+
+        if (null !== $expectedException) {
+            $this->expectException($expectedException);
+        }
+
+        $this->assertTrue($abstractMultistoreConfiguration->validateConfiguration($inputValues));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideForValidateConfiguration(): array
+    {
+        $multistorePrefix = MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX;
+        $coreFields = ['test_conf_1' => true, 'test_conf_2' => 'value'];
+
+        return [
+            'core fields only' => [$coreFields, true, false, null],
+            // A module adding a field through the form hook puts it in the submitted data; it is not core
+            // configuration, so it must not make the whole form fail to save.
+            'field added by a module' => [$coreFields + ['module_field' => 'value'], true, false, null],
+            'field added by a module, single shop context' => [
+                $coreFields + [$multistorePrefix . 'test_conf_1' => true, 'module_field' => 'value'],
+                false,
+                true,
+                null,
+            ],
+            'core field missing' => [['test_conf_1' => true], true, false, MissingOptionsException::class],
+            'core field of the wrong type' => [['test_conf_1' => 'not a bool', 'test_conf_2' => 'value'], true, false, InvalidOptionsException::class],
         ];
     }
 

--- a/tests/Unit/Core/OrderReturn/Configuration/OrderReturnOptionsConfigurationTest.php
+++ b/tests/Unit/Core/OrderReturn/Configuration/OrderReturnOptionsConfigurationTest.php
@@ -12,7 +12,6 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\OrderReturn\Configuration\OrderReturnOptionsConfiguration;
 use PrestaShopBundle\Form\Admin\Sell\CustomerService\OrderReturn\OrderReturnOptionsType;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class OrderReturnOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -98,10 +97,6 @@ class OrderReturnOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [
-                UndefinedOptionsException::class,
-                ['does_not_exist' => 'does_not_exist'],
-            ],
             [
                 InvalidOptionsException::class,
                 array_merge(

--- a/tests/Unit/Core/Tax/TaxOptionsConfigurationTest.php
+++ b/tests/Unit/Core/Tax/TaxOptionsConfigurationTest.php
@@ -12,7 +12,6 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Tax\Ecotax\ProductEcotaxResetterInterface;
 use PrestaShop\PrestaShop\Core\Tax\TaxOptionsConfiguration;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class TaxOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -103,7 +102,6 @@ class TaxOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, [
                 'enable_tax' => 'wrong_type',
                 'display_tax_in_cart' => true,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `AbstractMultistoreConfiguration::validateConfiguration()` resolves the submitted array against an `OptionsResolver` that only defines core's own fields, so a field a module adds through the `action<Page>Form` hook makes the whole form fail to save with `UndefinedOptionsException`. The resolver now sees only the fields it defines; anything else is left for the module to save in the matching `action<Page>Save` hook, which already receives it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Register a module on `actionShippingPreferencesPageHandlingForm` and add a field to `$params['form_builder']` normally, with no `mapped => false` and no `allow_extra_fields`. Save **Improve > Shipping > Preferences**. Before this change the page fails with `The options "<your field>" do not exist. Defined options are: "free_shipping_price", "free_shipping_weight", "shipping_handling_charges".` After it, the core fields save and `actionShippingPreferencesPageHandlingSave` receives your field in `form_data`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #41696
| Related PRs       | #41409 converts five more configuration classes to `AbstractMultistoreConfiguration`; no overlap in files, but it widens what this fixes.
| Sponsor company   |

`validateConfiguration()` no longer throws `UndefinedOptionsException` for an unknown key. Type and required-field validation of core's own fields is unchanged; the reasoning and the thirteen affected tests are in the last two sections.

### What happens

`validateConfiguration()` ends with

```php
$resolver->resolve($configurationInputValues);
```

on a resolver built from the subclass's own `CONFIGURATION_FIELDS`. The array it receives is `$form->getData()`, which contains every child of the form - including the ones a module added through the form hook. `OptionsResolver::resolve()` rejects any key it does not know, so one module field fails the whole save.

Reproduced on `9.1.x` through the real service rather than from reading, calling `prestashop.admin.shipping_preferences.handling.form_handler::save()` with the three core fields plus one module field:

```
THREW Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException:
The option "tox_trendo_delivery_deadline" does not exist.
Defined options are: "free_shipping_price", "free_shipping_weight", "shipping_handling_charges".
```

which is the message in the report, verbatim. With this change, the same call:

```
SAVE OK, errors=[]
form_data passed to the Save hook: ["shipping_handling_charges","free_shipping_price","free_shipping_weight","tox_trendo_delivery_deadline"]
stored PS_SHIPPING_HANDLING = 2
```

so both halves of the report are covered: the form saves, and the module's value arrives in the Save hook without needing `mapped => false`, which was the workaround that lost it.

This is not specific to Shipping Preferences. Thirteen classes extend `AbstractMultistoreConfiguration` and none of them override `validateConfiguration()`, so every one of their forms rejects module fields the same way. The two forms named in the issue as working, Administration > General and Performance > Debug mode, are `GeneralConfiguration` and `DebugModeConfiguration`, which are not multistore configurations and implement `validateConfiguration()` themselves with an `isset()` check that ignores extra keys. The inconsistency between those two shapes is what the report is describing.

### Why the filter is safe

`array_intersect_key($configurationInputValues, array_flip($fields))` feeds `resolve()` only. `$fields` is the defined options plus, in single or group shop context, the `multistore_*` checkbox names, so both survive. The filtered array is discarded: `updateConfigurationValue()` still reads from the unfiltered `$configurationInputValues`, so nothing downstream sees a different input.

I enumerated the callers before changing shared behaviour. Every caller of this method is an `updateConfiguration()` in one of the thirteen subclasses, and every caller of those is a form data provider's `setData()`, where the keys come from the form definition. The one non-form caller of any `updateConfiguration()` is `EditImageSettingsHandler`, which passes a hardcoded key set to `ImageConfiguration` - a class that does not extend `AbstractMultistoreConfiguration` and has its own `validateConfiguration()`. So no path exists where a client's typo'd key reaches this filter and is silently accepted.

### About the BC line

Thirteen unit tests asserted `UndefinedOptionsException` for `['does_not_exist' => 'does_not_exist']`. That row is the defect, so it is removed in each, and the new behaviour is asserted once in `AbstractMultistoreConfigurationTest` where it belongs, together with two guards that the rest of the validation still bites: a missing core field still raises `MissingOptionsException`, and a core field of the wrong type still raises `InvalidOptionsException`.

The alternative I considered was keeping the rejection and giving subclasses an explicit allow-list for module fields. I did not take it because the module cannot know at form-build time which configuration class it will end up in, so the allow-list would have to be maintained by core for fields it does not own. If you would rather have that, or want the rejection kept behind an opt-out, say so and I will rework it.

### Verification

- The new test fails on `9.1.x` with the source reverted and the test kept: 2 errors, both `UndefinedOptionsException`.
- `tests/Unit/Core` and `tests/Unit/Adapter`: 3275 tests, the only failures are `RouteValidatorTest` (8) and `ModuleRepositoryTest::testGetList` (1), all of which fail identically on a clean `9.1.x` with this branch stashed.
- `php -l`, `php-cs-fixer` and `phpstan` clean on all 15 touched files.

