### PR TITLE
Clarify Group::getGroups() second parameter (flag, not shop id)

### DIFF
--- a/classes/Group.php
+++ b/classes/Group.php
@@ -80,10 +80,18 @@ class GroupCore extends ObjectModel
         self::$ps_customer_group = null;
     }
 
-    public static function getGroups($id_lang, $id_shop = false)
+    /**
+     * Returns all customer groups, ordered by id.
+     *
+     * @param int $id_lang
+     * @param bool $filterByShop When true, restricts the result to the groups associated with the
+     *                           **current shop context** (via Shop::addSqlAssociation). The value is
+     *                           used as a flag, not as a shop id: pass true/false, not a shop id.
+     */
+    public static function getGroups($id_lang, $filterByShop = false)
     {
         $shop_criteria = '';
-        if ($id_shop) {
+        if ($filterByShop) {
             $shop_criteria = Shop::addSqlAssociation('group', 'g');
         }
 

--- a/src/Adapter/Group/GroupDataProvider.php
+++ b/src/Adapter/Group/GroupDataProvider.php
@@ -18,13 +18,14 @@ class GroupDataProvider
      * Return available groups.
      *
      * @param int $id_lang
-     * @param bool $id_shop
+     * @param bool $filterByShop When true, restricts the result to the groups of the current shop
+     *                           context. The value is a flag, not a shop id.
      *
      * @return array Groups
      */
-    public function getGroups($id_lang, $id_shop = false)
+    public function getGroups($id_lang, $filterByShop = false)
     {
-        return Group::getGroups($id_lang, $id_shop);
+        return Group::getGroups($id_lang, $filterByShop);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------- |
| Branch?           | develop |
| Description?      | `Group::getGroups($id_lang, $id_shop = false)` names its second parameter after a shop id, but the implementation only ever tests it as a boolean (`if ($id_shop) { $shop_criteria = Shop::addSqlAssociation('group', 'g'); }`). The filtering is done against the **current shop context**, not against the value passed in — a caller passing an actual shop id would silently be treated as truthy and get the exact same result as passing `true`. The name invites the wrong reading and has already caused confusion (see the discussion on #41606, which added a `bool $filterByShop` flag on the payment choice provider that flows through to this method). <br><br>This PR renames the parameter to `$filterByShop` and documents the flag semantics on both `Group::getGroups()` and `GroupDataProvider::getGroups()` (which is a straight pass-through). The parameter stays untyped so the historical truthy/falsy coercion is preserved — notably `Shop::getContextShopID()`, which callers who misread the old name may already be passing, can still return `null`. No behaviour change. |
| Type?             | improvement |
| Category?         | CO |
| BC breaks?        | no |
| Deprecations?     | no |
| How to test?      | No functional change. Existing callers (`Install`, `GetOrderForViewingHandler`, `SearchCustomersHandler`, the two `GroupByIdChoiceProvider` classes and `GroupDataProvider`) all pass the argument positionally with a truthy/falsy value, so the rename is invisible to them. Unit tests on `Group` / `GroupDataProvider` should stay green. |
| Possible impacts? | The parameter is renamed from `$id_shop` to `$filterByShop`. A third-party caller using PHP 8 named arguments (`Group::getGroups(id_lang: 1, id_shop: true)`) would break; a grep of the core finds zero such caller. |
| Related PRs       | Follow-up to #41606 (adds `bool $filterByShop` on the Core payment choice provider). Related to #9858. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)