### PR TITLE
Return Admin API collections as a list, not an object keyed by the query result

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/QueryResultSerializerTrait.php
+++ b/src/PrestaShopBundle/ApiPlatform/QueryResultSerializerTrait.php
@@ -43,11 +43,16 @@ trait QueryResultSerializerTrait
         $normalizedQueryResult = $this->domainSerializer->normalize($CQRSQueryResult, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSQueryMapping($operation)]);
 
         if ($operation instanceof CollectionOperationInterface) {
-            foreach ($normalizedQueryResult as $key => $result) {
-                $normalizedQueryResult[$key] = $this->domainSerializer->denormalize(array_merge($extraParameters, $result), $operation->getClass(), null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getApiResourceMapping($operation)]);
+            // The keys of the query result must not survive into the collection: a CQRS query is free to
+            // index its result by entity id (SearchCustomers does), and keeping those keys makes the
+            // endpoint answer with a JSON object keyed by id instead of the JSON array every other
+            // collection returns.
+            $denormalizedItems = [];
+            foreach ($normalizedQueryResult as $result) {
+                $denormalizedItems[] = $this->domainSerializer->denormalize(array_merge($extraParameters, $result), $operation->getClass(), null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getApiResourceMapping($operation)]);
             }
 
-            return $normalizedQueryResult;
+            return $denormalizedItems;
         } else {
             $normalizedQueryResult = array_merge($extraParameters, $normalizedQueryResult);
 

--- a/tests/Integration/ApiPlatform/Provider/QueryProviderCollectionTest.php
+++ b/tests/Integration/ApiPlatform/Provider/QueryProviderCollectionTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ApiPlatform\Provider;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetRequiredFieldsForCustomer;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShopBundle\ApiPlatform\ContextParametersProvider;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
+use PrestaShopBundle\ApiPlatform\Serializer\CQRSApiSerializer;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\ApiPlatform\Resources\ApiTest;
+
+class QueryProviderCollectionTest extends KernelTestCase
+{
+    private CQRSApiSerializer $serializer;
+
+    /**
+     * @var ContextParametersProvider&MockObject
+     */
+    private ContextParametersProvider $contextParametersProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serializer = self::getContainer()->get(CQRSApiSerializer::class);
+
+        // The serializer reads the PrestaShop contexts while (de)normalizing, so they must be
+        // initialized even though their values are irrelevant to the shape under test.
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+        $shopContextBuilder->setShopId(1);
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+        $languageContextBuilder->setDefaultLanguageId(1);
+        /** @var CurrencyContextBuilder $currencyContextBuilder */
+        $currencyContextBuilder = self::getContainer()->get('test_currency_context_builder');
+        $currencyContextBuilder->setCurrencyId(1);
+
+        $this->contextParametersProvider = $this->createMock(ContextParametersProvider::class);
+        $this->contextParametersProvider->method('getContextParameters')->willReturn([]);
+    }
+
+    /**
+     * A CQRS query is free to index its result by entity id - SearchCustomers does, to deduplicate
+     * matches across search phrases. Those keys must not reach the response: a collection operation
+     * is serialized as a JSON list, and preserved keys turn it into a JSON object keyed by id.
+     */
+    public function testCollectionKeyedByEntityIdIsReturnedAsAList(): void
+    {
+        $provider = $this->createQueryProvider([
+            12 => ['productId' => 12, 'type' => 'standard'],
+            7 => ['productId' => 7, 'type' => 'combinations'],
+        ]);
+
+        $result = $provider->provide($this->createCollectionOperation());
+
+        $this->assertIsArray($result);
+        $this->assertSame([0, 1], array_keys($result));
+        $this->assertContainsOnlyInstancesOf(ApiTest::class, $result);
+        $this->assertSame(12, $result[0]->productId);
+        $this->assertSame(7, $result[1]->productId);
+    }
+
+    /**
+     * A query result that is already a list keeps its order and indexes (regression guard).
+     */
+    public function testCollectionAlreadyAListIsUnchanged(): void
+    {
+        $provider = $this->createQueryProvider([
+            ['productId' => 3, 'type' => 'standard'],
+            ['productId' => 5, 'type' => 'pack'],
+        ]);
+
+        $result = $provider->provide($this->createCollectionOperation());
+
+        $this->assertSame([0, 1], array_keys($result));
+        $this->assertSame(3, $result[0]->productId);
+        $this->assertSame('pack', $result[1]->type);
+    }
+
+    private function createCollectionOperation(): CQRSGetCollection
+    {
+        return new CQRSGetCollection(
+            uriTemplate: '/test/cqrs/collection',
+            class: ApiTest::class,
+            CQRSQuery: GetRequiredFieldsForCustomer::class,
+            scopes: [],
+        );
+    }
+
+    private function createQueryProvider(array $queryResult): QueryProvider
+    {
+        // The query bus is mocked so no handler runs: the query class only has to be instantiable,
+        // and the returned value stands in for the CQRS query result under test.
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        $queryBus->method('handle')->willReturn($queryResult);
+
+        return new QueryProvider($queryBus, $this->serializer, $this->contextParametersProvider);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `GET /admin-api/customers/search` answers with a JSON **object keyed by customer id** instead of a JSON array, so a client cannot iterate it the way it iterates every other Admin API collection. The cause is not in the endpoint: `QueryResultSerializerTrait::denormalizeQueryResult()` writes the denormalized resources back under the query result's own keys (`$normalizedQueryResult[$key] = …`), and `SearchCustomersHandler` indexes its result by `id_customer` to deduplicate matches across search phrases. A collection operation is rendered as a list, so the query result's keys must not survive into it. This drops them.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `tests/Integration/ApiPlatform/Provider/QueryProviderCollectionTest.php` covers both shapes: a query result keyed by entity id must come back as a list, and one that is already a list must be unchanged. It fails on `9.1.x` and passes with this change. End to end, with an Admin API client holding `customer_read`: `curl "…/admin-api/customers/search?phrases[]=john"` returns `{"2":{"idCustomer":2,…}}` before and `[{"idCustomer":2,…}]` after.
| UI Tests          | Run dispatched: https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30445638272 - result posted in a comment when it concludes
| Fixed issue or discussion?     | Fixes #42131
| Related PRs       | PrestaShop/ps_apiresources#402 fixes the other half of #42131 (the `firstname` / `lastname` key casing on the same endpoint). The two are independent.
| Sponsor company   |

### Scope of the change

Five resources use `CQRSGetCollection` today, and only one of them is affected, because only one CQRS query returns a keyed array:

| resource | CQRS query | result shape |
|---|---|---|
| `FoundCustomer` | `SearchCustomers` | keyed by `id_customer` |
| `FoundProduct` | `SearchProducts` | list |
| `FoundCartRule` | `SearchCartRules` | list |
| `ProductImageList` | `GetProductImages` | list |
| `DiscountTypeList` | `GetDiscountTypes` | list (`array_values()` applied in the handler) |

For the four already returning a list, dropping the keys is a no-op - the second test asserts that. `GetDiscountTypesHandler` already calls `array_values()` on its own result, which is the same correction made one layer lower; doing it in the trait means a query does not have to know how the API renders it.

### Alternative considered

The keys could instead be dropped in `SearchCustomersHandler`. That was rejected because the CQRS query is also consumed by `CustomerController::searchCustomers()` and by two Behat contexts, where the id keys are part of the contract, and because it leaves the next keyed query result free to reintroduce the same response shape. If you would rather keep the trait untouched and fix the handler, say so and I will rework it.

`SearchCustomers` responses do change shape for API consumers, which is the point of the issue; the resources inside the list are byte-identical, only the enclosing container changes from an object to an array.
