### PR TITLE
Cast tiny-int booleans when denormalizing a CQRS query result

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/QueryResultSerializerTrait.php
+++ b/src/PrestaShopBundle/ApiPlatform/QueryResultSerializerTrait.php
@@ -42,16 +42,25 @@ trait QueryResultSerializerTrait
         // Start by normalizing the QueryResult object into normalized array
         $normalizedQueryResult = $this->domainSerializer->normalize($CQRSQueryResult, null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getCQRSQueryMapping($operation)]);
 
+        // A CQRS query is free to return raw database rows instead of a QueryResult DTO (SearchCustomers
+        // does), and those carry booleans as tiny ints, so the cast is needed here for the same reason
+        // QueryListProvider needs it for grid rows. It only affects properties typed bool, a result that
+        // already carries real booleans is unchanged.
+        $denormalizationContext = [
+            NormalizationMapper::NORMALIZATION_MAPPING => $this->getApiResourceMapping($operation),
+            CQRSApiSerializer::CAST_BOOL => true,
+        ];
+
         if ($operation instanceof CollectionOperationInterface) {
             foreach ($normalizedQueryResult as $key => $result) {
-                $normalizedQueryResult[$key] = $this->domainSerializer->denormalize(array_merge($extraParameters, $result), $operation->getClass(), null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getApiResourceMapping($operation)]);
+                $normalizedQueryResult[$key] = $this->domainSerializer->denormalize(array_merge($extraParameters, $result), $operation->getClass(), null, $denormalizationContext);
             }
 
             return $normalizedQueryResult;
         } else {
             $normalizedQueryResult = array_merge($extraParameters, $normalizedQueryResult);
 
-            return $this->domainSerializer->denormalize($normalizedQueryResult, $operation->getClass(), null, [NormalizationMapper::NORMALIZATION_MAPPING => $this->getApiResourceMapping($operation)]);
+            return $this->domainSerializer->denormalize($normalizedQueryResult, $operation->getClass(), null, $denormalizationContext);
         }
     }
 

--- a/tests/Integration/ApiPlatform/Provider/QueryProviderBooleanCastTest.php
+++ b/tests/Integration/ApiPlatform/Provider/QueryProviderBooleanCastTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ApiPlatform\Provider;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetRequiredFieldsForCustomer;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShopBundle\ApiPlatform\ContextParametersProvider;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
+use PrestaShopBundle\ApiPlatform\Serializer\CQRSApiSerializer;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\ApiPlatform\Resources\ApiTest;
+
+class QueryProviderBooleanCastTest extends KernelTestCase
+{
+    private CQRSApiSerializer $serializer;
+
+    /**
+     * @var ContextParametersProvider&MockObject
+     */
+    private ContextParametersProvider $contextParametersProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serializer = self::getContainer()->get(CQRSApiSerializer::class);
+
+        // The serializer reads the PrestaShop contexts while (de)normalizing, so they must be
+        // initialized even though their values are irrelevant to the casting under test.
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+        $shopContextBuilder->setShopId(1);
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+        $languageContextBuilder->setDefaultLanguageId(1);
+        /** @var CurrencyContextBuilder $currencyContextBuilder */
+        $currencyContextBuilder = self::getContainer()->get('test_currency_context_builder');
+        $currencyContextBuilder->setCurrencyId(1);
+
+        $this->contextParametersProvider = $this->createMock(ContextParametersProvider::class);
+        $this->contextParametersProvider->method('getContextParameters')->willReturn([]);
+    }
+
+    /**
+     * @dataProvider getTinyIntBooleans
+     */
+    public function testTinyIntIsCastForASingleResource(int $tinyInt, bool $expected): void
+    {
+        $provider = $this->createQueryProvider(['productId' => 1, 'type' => 'standard', 'active' => $tinyInt]);
+
+        $result = $provider->provide(new CQRSGet(
+            uriTemplate: '/test/cqrs/bool_cast',
+            class: ApiTest::class,
+            CQRSQuery: GetRequiredFieldsForCustomer::class,
+            scopes: [],
+        ));
+
+        // provide() is typed array|object, and the analyser has no PHPUnit extension to narrow it
+        // from the assertion alone.
+        self::assertInstanceOf(ApiTest::class, $result);
+        /* @var ApiTest $result */
+        $this->assertSame($expected, $result->active);
+    }
+
+    /**
+     * @dataProvider getTinyIntBooleans
+     */
+    public function testTinyIntIsCastForACollection(int $tinyInt, bool $expected): void
+    {
+        $provider = $this->createQueryProvider([['productId' => 1, 'type' => 'standard', 'active' => $tinyInt]]);
+
+        $result = $provider->provide(new CQRSGetCollection(
+            uriTemplate: '/test/cqrs/bool_cast_collection',
+            class: ApiTest::class,
+            CQRSQuery: GetRequiredFieldsForCustomer::class,
+            scopes: [],
+        ));
+
+        $this->assertSame($expected, $result[0]->active);
+    }
+
+    /**
+     * A result that already carries a real boolean keeps its value (regression guard).
+     */
+    public function testRealBooleanIsUnchanged(): void
+    {
+        $provider = $this->createQueryProvider(['productId' => 1, 'type' => 'standard', 'active' => false]);
+
+        $result = $provider->provide(new CQRSGet(
+            uriTemplate: '/test/cqrs/bool_cast_real',
+            class: ApiTest::class,
+            CQRSQuery: GetRequiredFieldsForCustomer::class,
+            scopes: [],
+        ));
+
+        self::assertInstanceOf(ApiTest::class, $result);
+        /* @var ApiTest $result */
+        $this->assertFalse($result->active);
+    }
+
+    public function getTinyIntBooleans(): iterable
+    {
+        yield 'enabled' => [1, true];
+        yield 'disabled' => [0, false];
+    }
+
+    private function createQueryProvider(array $queryResult): QueryProvider
+    {
+        // The query bus is mocked so no handler runs: the query class only has to be instantiable,
+        // and the returned value stands in for a CQRS query result made of raw database rows.
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        $queryBus->method('handle')->willReturn($queryResult);
+
+        return new QueryProvider($queryBus, $this->serializer, $this->contextParametersProvider);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | An Admin API resource property typed `bool` is a hard 500 whenever the CQRS query behind it returns raw database rows rather than a QueryResult DTO, because MySQL hands booleans back as tiny ints: `The type of the "enabled" attribute must be "bool", "integer" given`. `CQRSApiSerializer` already knows how to cast them, but only when `CAST_BOOL` is in the denormalization context, and the single place that sets it is `QueryListProvider::paginationByGridDataFactory()` - the grid path. `QueryResultSerializerTrait`, which serves every `CQRSGet` and `CQRSGetCollection`, never sets it, so the same row shape works through a grid-backed resource and fails through a query-backed one. This sets it there too.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `tests/Integration/ApiPlatform/Provider/QueryProviderBooleanCastTest.php` denormalizes a query result carrying `active => 1` and `active => 0` onto the `bool $active` property of the `ApiTest` resource, through both a `CQRSGet` and a `CQRSGetCollection`, plus a guard that a result already carrying a real boolean is untouched. On `9.1.x` the four tiny-int cases raise `NotNormalizableValueException`; with this change all five pass.
| UI Tests          | Queued behind two runs in flight on boo-code/ga.tests.ui.pr; the link goes here when it starts
| Fixed issue or discussion?     | Refs #42131
| Related PRs       | PrestaShop/ps_apiresources#402 renames the customer search keys onto the ones the write endpoints use; its remaining field, `active` -> `enabled`, is blocked on this change. PrestaShop/PrestaShop#42210 fixes the response container of the same endpoint.
| Sponsor company   |

### Why the trait rather than the caller

The flag belongs wherever a CQRS result is denormalized into a resource, and that is this trait: `QueryProvider` and `CommandProcessor` both go through it, and neither can know whether the handler behind the operation returns a DTO or rows. Setting it per resource would push a serialization detail into the module that declares the endpoint.

`QueryListProvider::paginationByCQRSQuery()` is the one remaining site without the flag. It is untouched here because no resource uses it today - every `PaginatedList` in `ps_apiresources` declares a `gridDataFactory`, not a `CQRSQuery`.

### Blast radius

`addBooleanCastCallbacks()` registers a callback only for properties whose reflection type is exactly `bool`, so nothing else in a payload is affected, and `filter_var(true, FILTER_VALIDATE_BOOLEAN)` returns `true` unchanged - a result that already carries real booleans, which is every `*ForEditing` DTO, serializes exactly as before. The regression guard in the test covers that.

What does change beyond the fix: a `bool` property fed an uninterpretable value now becomes `false` instead of raising. That is the trade-off `FILTER_VALIDATE_BOOLEAN` carries and it is already what the grid path does, so this makes the two paths agree rather than introducing a new behaviour.

Measured on the full `tests/Integration/ApiPlatform` suite, same environment either way:

```
9.1.x          48 tests   25 errors   0 failures
with change    48 tests   21 errors   0 failures
```

The 21 are pre-existing in this local environment (the API resources module is not mounted); the 4 that disappear are the new tests.
