### PR TITLE
Keep non writable fields when a webservice update omits them

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -171,6 +171,9 @@ class CarrierCore extends ObjectModel
         'fields' => [
             'deleted' => [],
             'is_module' => [],
+            // Internal versioning key, assigned by Carrier::add() and read by getCarrierByReference().
+            // It is not part of the carrier's editable data, so it must not be writable through the API.
+            'id_reference' => ['setter' => false],
             'id_tax_rules_group' => [
                 'getter' => 'getIdTaxRulesGroup',
                 'setter' => 'setTaxRulesGroup',

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1596,7 +1596,14 @@ class WebserviceRequestCore
                     $this->setError(400, 'parameter "' . $fieldName . '" required', 41);
 
                     return false;
-                } elseif ((!isset($fieldProperties['required']) || !$fieldProperties['required']) && property_exists($object, $sqlId)) {
+                } elseif (
+                    (!isset($fieldProperties['required']) || !$fieldProperties['required'])
+                    // A field the client is not allowed to write must survive its own absence: sending it is
+                    // rejected by the setter check above, so nulling it here leaves no request shape that
+                    // updates the resource and keeps the stored value.
+                    && (!isset($fieldProperties['setter']) || false !== $fieldProperties['setter'])
+                    && property_exists($object, $sqlId)
+                ) {
                     $object->$sqlId = null;
                 }
                 if (isset($fieldProperties['i18n']) && $fieldProperties['i18n']) {

--- a/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
@@ -183,6 +183,18 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
 
             $postFields = '<prestashop xmlns:xlink="http://www.w3.org/1999/xlink"><' . $itemNode . '>';
             foreach ($rows as $hash) {
+                // A multilang field is only accepted wrapped in a language node, so the table can carry
+                // an optional "language" column holding the language id to wrap the value with.
+                if (!empty($hash['language'])) {
+                    $postFields .= sprintf('<%s><language id="%d"><![CDATA[%s]]></language></%s>',
+                        $hash['key'],
+                        (int) $hash['language'],
+                        $hash['value'],
+                        $hash['key']
+                    );
+
+                    continue;
+                }
                 $postFields .= sprintf('<%s><![CDATA[%s]]></%s>',
                     $hash['key'],
                     $hash['value'],

--- a/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
@@ -111,6 +111,33 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Then /^using Webservice with key "(.*)" to view "(.+)" for reference "(.+)", I should get following non empty properties\:$/
+     */
+    public function assertLastRequestHasNonEmptyValues(string $webserviceKey, string $endpoint, string $reference, TableNode $rows): void
+    {
+        $id = (int) SharedStorage::getStorage()->get($reference);
+        $output = $this->whenRequest($webserviceKey, 'GET', $endpoint . '/' . $id);
+
+        foreach ($rows->getHash() as $hash) {
+            Assert::assertEquals(
+                1,
+                $output->filter('prestashop ' . $hash['key'])->count(),
+                sprintf(
+                    'The key %s has not been found',
+                    $hash['key']
+                )
+            );
+            Assert::assertNotEmpty(
+                $output->filter('prestashop ' . $hash['key'])->getNode(0)->nodeValue,
+                sprintf(
+                    'The key %s is empty',
+                    $hash['key']
+                )
+            );
+        }
+    }
+
+    /**
      * @Then /^I should get (\d+) errors?$/
      */
     public function assertWebserviceErrorCount(int $numErrors): void

--- a/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/carriers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/carriers.feature
@@ -1,0 +1,44 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s webservice --tags webservice-endpoints-carriers
+@restore-all-tables-before-feature
+@webservice-endpoints-carriers
+Feature: Webservice carriers endpoint
+  PrestaShop allows API users to manage carriers through the Webservice
+  As an API user
+  I must be able to update a carrier without destroying its reference
+
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    And I restore tables "webservice_account,webservice_account_shop,webservice_permission"
+    And shop configuration for "PS_WEBSERVICE" is set to 1
+    And I add a new webservice key with specified properties:
+      | key              | CARRIERSCARRIERSCARRIERSCARRIERS |
+      | description      | Carriers key                     |
+      | is_enabled       | 1                                |
+      | shop_association | shop1                            |
+      | permission_GET   | carriers                         |
+      | permission_POST  | carriers                         |
+      | permission_PUT   | carriers                         |
+
+  Scenario: The carrier reference survives an update that omits it
+    When I use Webservice with key "CARRIERSCARRIERSCARRIERSCARRIERS" to add "carriers" for reference "carrier1"
+      | key    | value      | language |
+      | name   | WS carrier |          |
+      | active | 1          |          |
+      | delay  | 3 days     | 1        |
+    Then using Webservice with key "CARRIERSCARRIERSCARRIERSCARRIERS" to view "carriers" for reference "carrier1", I should get following non empty properties:
+      | key          |
+      | id_reference |
+
+    # id_reference is an internal versioning key, set by Carrier::add() and read by getCarrierByReference().
+    # It is not writable through the Webservice, so omitting it must preserve it rather than reset it to 0.
+    When I use Webservice with key "CARRIERSCARRIERSCARRIERSCARRIERS" to update "carriers" for reference "carrier1"
+      | key    | value              | language |
+      | name   | WS carrier renamed |          |
+      | active | 1                  |          |
+      | delay  | 3 days             | 1        |
+    Then using Webservice with key "CARRIERSCARRIERSCARRIERSCARRIERS" to view "carriers" for reference "carrier1", I should get following properties:
+      | key  | value              |
+      | name | WS carrier renamed |
+    And using Webservice with key "CARRIERSCARRIERSCARRIERSCARRIERS" to view "carriers" for reference "carrier1", I should get following non empty properties:
+      | key          |
+      | id_reference |

--- a/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/customers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/customers.feature
@@ -1,0 +1,46 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s webservice --tags webservice-endpoints-customers
+@restore-all-tables-before-feature
+@webservice-endpoints-customers
+Feature: Webservice customers endpoint
+  PrestaShop allows API users to manage customers through the Webservice
+  As an API user
+  I must be able to update a customer without destroying the fields I am not allowed to write
+
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    And I restore tables "webservice_account,webservice_account_shop,webservice_permission"
+    And shop configuration for "PS_WEBSERVICE" is set to 1
+    And I add a new webservice key with specified properties:
+      | key              | CUSTOMERSCUSTOMERSCUSTOMERSCUSTO |
+      | description      | Customers key                    |
+      | is_enabled       | 1                                |
+      | shop_association | shop1                            |
+      | permission_GET   | customers                        |
+      | permission_POST  | customers                        |
+      | permission_PUT   | customers                        |
+
+  Scenario: A non writable field survives an update that omits it
+    When I use Webservice with key "CUSTOMERSCUSTOMERSCUSTOMERSCUSTO" to add "customers" for reference "customer1"
+      | key       | value                   |
+      | firstname | Web                     |
+      | lastname  | Service                 |
+      | email     | ws.customer@example.com |
+      | passwd    | Pr3st4Sh0P              |
+    Then using Webservice with key "CUSTOMERSCUSTOMERSCUSTOMERSCUSTO" to view "customers" for reference "customer1", I should get following non empty properties:
+      | key        |
+      | secure_key |
+
+    # secure_key is declared with "setter => false", so it cannot be part of the payload: sending it is
+    # rejected with error 93. Omitting it must therefore preserve it rather than wipe it.
+    When I use Webservice with key "CUSTOMERSCUSTOMERSCUSTOMERSCUSTO" to update "customers" for reference "customer1"
+      | key       | value                   |
+      | firstname | Updated                 |
+      | lastname  | Service                 |
+      | email     | ws.customer@example.com |
+      | passwd    | Pr3st4Sh0P              |
+    Then using Webservice with key "CUSTOMERSCUSTOMERSCUSTOMERSCUSTO" to view "customers" for reference "customer1", I should get following properties:
+      | key       | value   |
+      | firstname | Updated |
+    And using Webservice with key "CUSTOMERSCUSTOMERSCUSTOMERSCUSTO" to view "customers" for reference "customer1", I should get following non empty properties:
+      | key        |
+      | secure_key |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A Webservice `PUT` nulls every field the client is *not allowed* to send. `WebserviceRequest::saveEntityFromXml()` walks the resource schema and, for a field absent from the payload and not required, does `$object->$sqlId = null` before saving. A field declared `'setter' => false` can never be in the payload - including it is rejected with error 93, "parameter not writable" - so there is no request shape that updates the resource and keeps that field's stored value. On `customers` that wipes `secure_key`, and since order validation compares the cart's secure key with the customer's, the customer can no longer place or have an order validated, from the storefront or the back office. The request returns success, so nothing signals it. This skips the null-out for non-writable fields, and marks the carrier reference as non-writable so it stops being reset by an update.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31335399464 - 46 of 46 jobs green
| Fixed issue or discussion?     | Fixes #42206, Fixes #39147
| Related PRs       |
| Sponsor company   |

### How to test

Two scenarios under `tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/`, run with `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s webservice` (13 scenarios, 125 steps, green):

- `customers.feature` creates a customer over the Webservice, changes `firstname` with a `PUT` that omits `secure_key`, and asserts the customer still has one. Without the change it fails with `The key secure_key is empty`.
- `carriers.feature` creates a carrier, changes `name` with a `PUT` that omits `id_reference`, and asserts the reference survives. Without the `Carrier` change it fails with `The key id_reference is empty`.

`whenRequest()` gained an optional `language` column so a table can express a multilang field, which the carrier's required `delay` needs.

### Not only customers, and not only secure_key

`'setter' => false` appears 28 times across 11 core classes, and every one of them is nulled by any `PUT` that touches the resource:

| class | fields |
|---|---|
| `Order` | 9 |
| `Employee` | 5 |
| `Product` | 3 |
| `Customer` | 2 (`secure_key`, `last_passwd_gen`) |
| `Category`, `Manufacturer` | 2 each |
| `Customization`, `OrderDetail`, `OrderSlip`, `Stock`, `Warehouse` | 1 each |

So the reported symptom is one instance of a general rule being wrong, which is why the fix is at the rule rather than on the Customer resource.

### The carrier half of #39147

`Carrier::$id_reference` is an internal versioning key: `Carrier::add()` assigns it, `getCarrierByReference()` reads it, `module_carrier` rows are keyed on it, and the back office never exposes it. It was declared in `Carrier::$definition` as an ordinary `TYPE_INT` field and absent from `$webserviceParameters`, so the Webservice treated it as writable, and a `PUT` that did not carry it stored `0` - the reported symptom. Declaring it `'setter' => false` is what matches the field's role, and it only holds together with the change above, because a non-writable field was nulled by the very same line.

Observable change for API clients: a payload that carries `id_reference` now returns error 93 instead of writing it. Writing that key was never part of the carrier's editable data and doing so corrupts `getCarrierByReference()` and the `module_carrier` links, so the rejection replaces silent corruption rather than a supported behaviour.

The delete half of #39147 is a separate matter and is not addressed here: `Carrier::delete()` soft deletes a carrier that is in use and hard deletes one that is not, through the back office and the Webservice alike, so the two routes already behave the same. Details in https://github.com/PrestaShop/PrestaShop/issues/39147#issuecomment-5233282051.

### Why here and not a required flag

Marking `secure_key` required would swap silent data loss for a hard failure: the client still cannot send it, so every `PUT` would be rejected with error 41 instead. Adding a getter-based restore in `Customer` would fix one field of twenty-eight. The condition that is actually wrong is the one that treats "absent from the payload" as "the client wants it cleared" for a field the client is forbidden to send.

`PATCH` is unaffected - it already `continue`s on absent fields - and `POST` only changes in that a non-writable property keeps its constructor default instead of being set to `null` before `add()`, which is the same or better for every class listed above.

### Note

The reporter worked around this with an `actionObjectCustomerUpdateBefore` hook restoring the key before save. That workaround becomes unnecessary with this change, and it can stay in place harmlessly.
