### PR TITLE
Offer the order level discount type in the back office again

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
@@ -43,8 +43,7 @@ class DiscountTypeSelectorType extends TranslatorAwareType
         $choiceAttr = [];
 
         foreach ($this->discountTypeRepository->getAllTypes() as $type) {
-            // Disabled temporarily, because of infinite loop issue with this kind of discount. See issue #39419
-            if (!$type['enabled'] || $type['discount_type'] === DiscountType::ORDER_LEVEL) {
+            if (!$type['enabled']) {
                 continue;
             }
             $discountTypeValue = $type['discount_type'];

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/FO/order_level_discount_with_free_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/FO/order_level_discount_with_free_shipping.feature
@@ -1,0 +1,35 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s discount --tags order-level-with-free-shipping
+@restore-all-tables-before-feature
+@order-level-with-free-shipping
+@clear-cache-before-feature
+@clear-cache-after-feature
+Feature: Order level discount combined with a free shipping discount
+  An order level discount caps itself against the shipping total, and a free shipping discount
+  changes that total, so the two evaluate against each other on the same cart
+
+  Background:
+    Given there is a customer named "testCustomer" whose email is "pub3@prestashop.com"
+    And language with iso code "en" is the default one
+    And shop "shop1" with name "test_shop" exists
+    And there is a currency named "usd" with iso code "USD" and exchange rate of 0.92
+
+  Scenario: Both discounts apply on the same cart
+    Given I create an empty cart "combined_cart" for customer "testCustomer"
+    And I enable feature flag "discount"
+    And there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    When I create a "free_shipping" discount "combined_free_shipping" with following properties:
+      | name[en-US] | Free shipping |
+      | active      | true          |
+      | code        | COMBINED_FS   |
+    And I create a "order_level" discount "combined_order_level" with following properties:
+      | name[en-US]            | Discount on total order |
+      | active                 | true                    |
+      | code                   | COMBINED_OL             |
+      | reduction_amount       | 5.0                     |
+      | reduction_currency     | usd                     |
+      | reduction_tax_included | true                    |
+    And I add 1 product "product1" to the cart "combined_cart"
+    And I use a voucher "combined_free_shipping" on the cart "combined_cart"
+    And I use a voucher "combined_order_level" on the cart "combined_cart"
+    Then my cart "combined_cart" should have the following details:
+      | total_products | $19.81 |

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorTypeTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Sell\Discount;
+
+use PrestaShop\PrestaShop\Adapter\Discount\Repository\DiscountTypeRepository;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountType;
+use PrestaShopBundle\Form\Admin\Sell\Discount\DiscountTypeSelectorType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class DiscountTypeSelectorTypeTest extends TypeTestCase
+{
+    private const LANG_ID = 1;
+
+    protected function getExtensions(): array
+    {
+        $discountTypeRepository = $this->createMock(DiscountTypeRepository::class);
+        $discountTypeRepository->method('getAllTypes')->willReturn([
+            1 => $this->type(1, DiscountType::FREE_SHIPPING, 'Free shipping', true),
+            2 => $this->type(2, DiscountType::CART_LEVEL, 'On cart amount', true),
+            3 => $this->type(3, DiscountType::ORDER_LEVEL, 'On total order', true),
+            4 => $this->type(4, DiscountType::PRODUCT_LEVEL, 'On catalog products', true),
+            5 => $this->type(5, DiscountType::FREE_GIFT, 'Free gift', false),
+        ]);
+
+        $languageContext = $this->createMock(LanguageContext::class);
+        $languageContext->method('getId')->willReturn(self::LANG_ID);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        return [
+            new PreloadedExtension(
+                [new DiscountTypeSelectorType($discountTypeRepository, $languageContext, $translator, [])],
+                []
+            ),
+        ];
+    }
+
+    /**
+     * Every type the shop declares enabled is offered. order_level used to be skipped by name on top
+     * of the enabled flag, which is what made it reachable through the CQRS command and the Admin API
+     * but not from the back office.
+     */
+    public function testItOffersEveryEnabledType(): void
+    {
+        $view = $this->factory->create(DiscountTypeSelectorType::class)->createView();
+
+        $this->assertSame(
+            [
+                DiscountType::FREE_SHIPPING,
+                DiscountType::CART_LEVEL,
+                DiscountType::ORDER_LEVEL,
+                DiscountType::PRODUCT_LEVEL,
+            ],
+            array_map(
+                static fn ($choiceView) => $choiceView->value,
+                $view['discount_type_selector']->vars['choices']
+            )
+        );
+    }
+
+    /**
+     * A type marked inactive in ps_cart_rule_type is the supported way to withdraw one.
+     */
+    public function testItSkipsADisabledType(): void
+    {
+        $view = $this->factory->create(DiscountTypeSelectorType::class)->createView();
+
+        $values = array_map(
+            static fn ($choiceView) => $choiceView->value,
+            $view['discount_type_selector']->vars['choices']
+        );
+
+        $this->assertNotContains(DiscountType::FREE_GIFT, $values);
+    }
+
+    private function type(int $id, string $discountType, string $name, bool $enabled): array
+    {
+        return [
+            'id_cart_rule_type' => $id,
+            'discount_type' => $discountType,
+            'is_core' => true,
+            'enabled' => $enabled,
+            'names' => [self::LANG_ID => $name],
+            'descriptions' => [self::LANG_ID => $name],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `DiscountTypeSelectorType` skips `order_level` by name on top of the `enabled` flag, so the back office is the only place that does not offer a type the rest of the shop supports: it is row 3 of `ps_cart_rule_type` with `is_core = 1, active = 1`, it is handled by `DiscountPriority`, `DiscountBuilder`, `DiscountValidator` and `CartRule::getContextualValue()`, and `POST /discounts` creates it - `ps_apiresources`' `DiscountEndpointTest` asserts that it does. This drops the by-name skip, leaving the `enabled` flag as the single way to withdraw a type.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Back office, Catalog > Discounts > Add new discount: "On total order" is offered again alongside the other four. `tests/Unit/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorTypeTest.php` asserts the selector offers every enabled type and still skips a disabled one; the first test fails on `9.1.x`. The whole discount Behat suite is green - `behat -s discount` gives 187 scenarios, 2981 steps, 0 failures, including the new `order_level_discount_with_free_shipping.feature`.
| UI Tests          | Run dispatched, result posted in a comment when it concludes
| Fixed issue or discussion?     | Fixes #42209
| Related PRs       | Reverts the form part of #39569
| Sponsor company   |

### Why the skip was there, and what I measured before removing it

#39569 added it, and #39419 - "Apply a discount on total amount crash my PC and the FO" - was closed by that PR. Its entire diff is the commented-out choice, so the `Cart::getOrderTotal()` recursion @boherm identified in that thread was never fixed; the option was taken out of the form instead. That makes "the type is dangerous" an assumption worth testing rather than a fact to inherit, so I tested what the harness can reach:

- `Discount/FO/full_user_experience_test_with_discount_order_level.feature` already creates an order level discount through the CQRS command, applies it as a voucher and asserts the totals, in four scenarios - including one where the discount exceeds the cart total and clamps to `$0.00`. Those totals include shipping (`$39.81` products + `$7.00` shipping = `$46.81`), so `Cart::ONLY_SHIPPING` is exercised, which is the call the ORDER_LEVEL branches of `CartRule::getContextualValue()` make. All four pass on `9.1.x`.
- The combination those scenarios did not cover is an order level discount together with a free shipping one, since the second changes the total the first caps itself against. `order_level_discount_with_free_shipping.feature` covers it now: both apply, no recursion, 4.3s.

I also went the other way first, and it is worth recording that it does not work: refusing the type in `AddDiscountHandler` to make the Admin API agree with the form takes the discount suite from 187 scenarios green to 8 failures, all of them order level ones. The type is not dead code that can be closed off - it is supported everywhere except the form.

### What is not proven

The exact route in #39419 is a discount code applied from the front office checkout form, then a page refresh. The Behat steps apply the voucher through the cart domain rather than that controller, so this PR does not prove that specific path. If QA reproduces the crash with the steps in #39419, the fix is to put the line back and reopen the recursion as its own issue rather than leave the type half-available - and I will do that rather than defend this change.
