### PR TITLE
Translate core discount type labels in the back office

### DIFF
--- a/src/Core/Domain/Discount/ValueObject/DiscountType.php
+++ b/src/Core/Domain/Discount/ValueObject/DiscountType.php
@@ -14,6 +14,22 @@ class DiscountType
     public const FREE_SHIPPING = 'free_shipping';
     public const ORDER_LEVEL = 'order_level';
 
+    /**
+     * Display label of each core type, in the Admin.Catalog.Feature domain.
+     *
+     * The name stored in cart_rule_type_lang cannot be used for these: installing a language copies
+     * the rows of the default one, and no per-language seed overwrites them, so a core type reads
+     * back in English whatever the employee's language is. Module-provided types are not listed here
+     * and keep their stored name, which is the only source there is for them.
+     */
+    public const CORE_LABELS = [
+        self::CART_LEVEL => 'On cart amount',
+        self::PRODUCT_LEVEL => 'On catalog products',
+        self::FREE_GIFT => 'On free gift',
+        self::FREE_SHIPPING => 'On free shipping',
+        self::ORDER_LEVEL => 'On total order',
+    ];
+
     public function __construct(private readonly string $value)
     {
     }

--- a/src/Core/Grid/Data/Factory/DiscountGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/DiscountGridDataFactoryDecorator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
+use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountType;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridDataInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
@@ -16,7 +17,8 @@ use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * Decorates discount grid data to display a fallback when expiration date is null
+ * Decorates discount grid data to display a fallback when expiration date is null,
+ * and to label core discount types from the translation catalogue.
  */
 final class DiscountGridDataFactoryDecorator implements GridDataFactoryInterface
 {
@@ -37,6 +39,17 @@ final class DiscountGridDataFactoryDecorator implements GridDataFactoryInterface
         foreach ($records as &$record) {
             if (DateTimeUtil::isNull($record['date_to'] ?? null)) {
                 $record['date_to'] = $this->translator->trans('No end date', [], 'Admin.Catalog.Feature');
+            }
+            // The query reads the label from cart_rule_type_lang, which holds the default language's
+            // text for every language because installing a language copies those rows and no
+            // per-language seed replaces them. Core types are therefore labelled from the catalogue;
+            // a type provided by a module keeps its stored name, the only source there is for it.
+            if (isset($record['discount_type'], DiscountType::CORE_LABELS[$record['discount_type']])) {
+                $record['discount_type_label'] = $this->translator->trans(
+                    DiscountType::CORE_LABELS[$record['discount_type']],
+                    [],
+                    'Admin.Catalog.Feature'
+                );
             }
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
@@ -49,7 +49,9 @@ class DiscountTypeSelectorType extends TranslatorAwareType
                 continue;
             }
             $discountTypeValue = $type['discount_type'];
-            $name = $type['names'][$currentLangId] ?? (reset($type['names']) ?: $discountTypeValue);
+            $name = isset(DiscountType::CORE_LABELS[$discountTypeValue])
+                ? $this->trans(DiscountType::CORE_LABELS[$discountTypeValue], 'Admin.Catalog.Feature')
+                : ($type['names'][$currentLangId] ?? (reset($type['names']) ?: $discountTypeValue));
             $iconData = self::ICON_MAP[$discountTypeValue] ?? [];
 
             $choices[$name] = $discountTypeValue;

--- a/tests/Unit/Core/Grid/Data/Factory/DiscountGridDataFactoryDecoratorTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/DiscountGridDataFactoryDecoratorTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Grid\Data\Factory;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountType;
+use PrestaShop\PrestaShop\Core\Grid\Data\Factory\DiscountGridDataFactoryDecorator;
+use PrestaShop\PrestaShop\Core\Grid\Data\Factory\GridDataFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class DiscountGridDataFactoryDecoratorTest extends TestCase
+{
+    /**
+     * The query labels the badge from cart_rule_type_lang, which holds the default language's text
+     * for every language, so a core type must be labelled from the catalogue instead.
+     */
+    public function testItTranslatesTheLabelOfACoreType(): void
+    {
+        $records = $this->getData([
+            ['discount_type' => DiscountType::FREE_SHIPPING, 'discount_type_label' => 'On free shipping'],
+            ['discount_type' => DiscountType::CART_LEVEL, 'discount_type_label' => 'On cart amount'],
+        ]);
+
+        $this->assertSame('translated:On free shipping', $records[0]['discount_type_label']);
+        $this->assertSame('translated:On cart amount', $records[1]['discount_type_label']);
+    }
+
+    /**
+     * A type provided by a module has no catalogue entry, so its stored name is all there is.
+     */
+    public function testItKeepsTheStoredLabelOfAModuleType(): void
+    {
+        $records = $this->getData([
+            ['discount_type' => 'some_module_type', 'discount_type_label' => 'Remise du module'],
+        ]);
+
+        $this->assertSame('Remise du module', $records[0]['discount_type_label']);
+    }
+
+    /**
+     * The expiration fallback this decorator already provided must keep working alongside it.
+     */
+    public function testItStillLabelsAnEmptyExpirationDate(): void
+    {
+        $records = $this->getData([
+            ['discount_type' => DiscountType::CART_LEVEL, 'discount_type_label' => 'On cart amount', 'date_to' => null],
+            ['discount_type' => DiscountType::CART_LEVEL, 'discount_type_label' => 'On cart amount', 'date_to' => '2026-01-01 00:00:00'],
+        ]);
+
+        $this->assertSame('translated:No end date', $records[0]['date_to']);
+        $this->assertSame('2026-01-01 00:00:00', $records[1]['date_to']);
+    }
+
+    private function getData(array $records): array
+    {
+        $decorated = $this->createMock(GridDataFactoryInterface::class);
+        $decorated->method('getData')->willReturn(new GridData(new RecordCollection($records), count($records), 'query'));
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => 'translated:' . $id
+        );
+
+        $decorator = new DiscountGridDataFactoryDecorator($decorated, $translator);
+
+        return $decorator->getData($this->createMock(SearchCriteriaInterface::class))->getRecords()->all();
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorTypeTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Sell\Discount;
+
+use PrestaShop\PrestaShop\Adapter\Discount\Repository\DiscountTypeRepository;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountType;
+use PrestaShopBundle\Form\Admin\Sell\Discount\DiscountTypeSelectorType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class DiscountTypeSelectorTypeTest extends TypeTestCase
+{
+    private const LANG_ID = 2;
+
+    protected function getExtensions(): array
+    {
+        // cart_rule_type_lang holds the default language's text for every language, which is what the
+        // selector used to display: the names below are deliberately the English ones a French shop
+        // gets after installing the language.
+        $discountTypeRepository = $this->createMock(DiscountTypeRepository::class);
+        $discountTypeRepository->method('getAllTypes')->willReturn([
+            1 => $this->type(1, DiscountType::FREE_SHIPPING, 'On free shipping'),
+            2 => $this->type(2, DiscountType::CART_LEVEL, 'On cart amount'),
+            3 => $this->type(3, 'some_module_type', 'Remise du module'),
+        ]);
+
+        $languageContext = $this->createMock(LanguageContext::class);
+        $languageContext->method('getId')->willReturn(self::LANG_ID);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => 'translated:' . $id
+        );
+
+        return [
+            new PreloadedExtension(
+                [new DiscountTypeSelectorType($discountTypeRepository, $languageContext, $translator, [])],
+                []
+            ),
+        ];
+    }
+
+    public function testACoreTypeIsLabelledFromTheCatalogue(): void
+    {
+        $labels = $this->getChoiceLabels();
+
+        $this->assertSame('translated:On free shipping', $labels[DiscountType::FREE_SHIPPING]);
+        $this->assertSame('translated:On cart amount', $labels[DiscountType::CART_LEVEL]);
+    }
+
+    /**
+     * A module-provided type has no catalogue entry, so its stored name is all there is.
+     */
+    public function testAModuleTypeKeepsItsStoredName(): void
+    {
+        $this->assertSame('Remise du module', $this->getChoiceLabels()['some_module_type']);
+    }
+
+    /**
+     * @return array<string, string> discount type => label
+     */
+    private function getChoiceLabels(): array
+    {
+        $view = $this->factory->create(DiscountTypeSelectorType::class)->createView();
+
+        $labels = [];
+        foreach ($view['discount_type_selector']->vars['choices'] as $choiceView) {
+            $labels[$choiceView->value] = $choiceView->label;
+        }
+
+        return $labels;
+    }
+
+    private function type(int $id, string $discountType, string $name): array
+    {
+        return [
+            'id_cart_rule_type' => $id,
+            'discount_type' => $discountType,
+            'is_core' => true,
+            'enabled' => true,
+            'names' => [self::LANG_ID => $name],
+            'descriptions' => [self::LANG_ID => $name],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The discount type is shown in English on a shop in any other language, in both the grid badge and the "Select discount type" modal, while everything around it is translated. The label comes from `cart_rule_type_lang.name`, and installing a language copies the default language's rows with no per-language seed to replace them - `install-dev/langs/en/data/cart_rule_type.xml` is the only one in the tree - so the row reads back in English whatever the employee's language is. A core type has a stable identifier, so its label is taken from the translation catalogue instead, where the five strings already exist. A type provided by a module keeps its stored name, which is the only source there is for it.<br><br>Retargeted from `9.1.x`. On `9.2.x` the grid already routes through `DiscountGridDataFactoryDecorator`, which has the translator injected and already walks the records, so the label translation goes in there rather than in a second decorator on the same service id - which drops the new factory class and both service YAML changes this carried on `9.1.x`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with a second language installed, switch the employee to it and open Catalog > Discounts: the `Type` badges and the types listed in the "Select discount type" modal are translated instead of reading "On free shipping", "On cart amount", "On catalog products", "On free gift". `tests/Unit/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorTypeTest.php` and `tests/Unit/Core/Grid/Data/Factory/DiscountGridDataFactoryDecoratorTest.php` cover both sites plus the module-provided type. 5 tests pass with the change; reverting the three source files leaves 2 failures, one per site. The decorator test also pins the `No end date` fallback that class already provided.
| UI Tests          | Queued behind two runs in flight on boo-code/ga.tests.ui.pr; the link goes here when it starts
| Fixed issue or discussion?     | Fixes #42096
| Related PRs       | Touches `DiscountTypeSelectorType` like #42214, on a different line - the two merge cleanly.
| Sponsor company   |

### Where it comes from

Until `69d1d6058c5` the selector listed its choices with the labels inline:

```php
'choices' => [
    $this->trans('On cart amount', 'Admin.Catalog.Feature') => DiscountType::CART_LEVEL,
    $this->trans('On catalog products', 'Admin.Catalog.Feature') => DiscountType::PRODUCT_LEVEL,
    …
```

That commit replaced the list with a loop over `DiscountTypeRepository::getAllTypes()` and took the label from the row instead. The strings are still in `translations/default/AdminCatalogFeature.xlf` - all five of them - they simply stopped being used. The grid badge has the same source through `COALESCE(crtl.name, crt.discount_type) AS discount_type_label` in `DiscountQueryBuilder`.

Measured on a shop with English and French installed, before this change:

```
id_lang 1   On free shipping | On cart amount | On total order | On catalog products | On free gift
id_lang 2   On free shipping | On cart amount | On total order | On catalog products | On free gift
```

### Shape of the fix

`DiscountType::CORE_LABELS` maps each core identifier to its catalogue string, next to the identifiers themselves. The form type reads it directly; the grid gets a `DiscountGridDataFactory` decorator that rewrites `discount_type_label` for those identifiers, following `CatalogPriceRuleGridDataFactory`, which already translates a label the same way. Nothing else in the query or the schema changes, and a module type never carries one of the five core identifiers so it falls through untouched.

The alternative is to fix the data - ship a per-language `cart_rule_type.xml` so the rows are translated at install time. That belongs to the language packs rather than to core, it would not help a shop whose language is already installed, and it leaves the label untranslatable for anyone who edits it. If you would rather go that way I will rework this.

