### PR TITLE
Always re-index sibling categories after a position update

### DIFF
--- a/src/Adapter/Category/CommandHandler/UpdateCategoryPositionHandler.php
+++ b/src/Adapter/Category/CommandHandler/UpdateCategoryPositionHandler.php
@@ -50,10 +50,11 @@ final class UpdateCategoryPositionHandler implements UpdateCategoryPositionHandl
         }
 
         if ($category->updatePosition((bool) $command->getWay(), $position)) {
-            /* Position '0' was not found in given positions so try to reorder parent category */
-            if (!$command->isFoundFirst()) {
-                Category::cleanPositions((int) $category->id_parent);
-            }
+            // Re-index unconditionally. updatePosition() shifts a range of siblings and can leave a
+            // duplicate or a gap when the requested way and position do not match the stored order,
+            // which the back office never produces but any other caller can. cleanPositions() is the
+            // only normalizer that also rewrites category_shop.position, so it has to run every time.
+            Category::cleanPositions((int) $category->id_parent);
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -9,6 +9,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 use Behat\Gherkin\Node\TableNode;
 use Category;
 use Configuration;
+use Db;
 use Language;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\AddCategoryCommand;
@@ -208,7 +209,7 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
      *
      * @param string $categoryReference
      */
-    public function updatePosition(string $categoryReference, string $way, int $newPosition)
+    public function updatePosition(string $categoryReference, string $way, int $newPosition, bool $foundFirst = false)
     {
         $categoryId = SharedStorage::getStorage()->get($categoryReference);
         $parentCategoryId = $this->getEditableCategory($categoryReference)->getParentId();
@@ -251,8 +252,49 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
             $parentCategoryId,
             self::CATEGORY_POSITION_WAYS_MAP[$way],
             $generatedPositions,
-            false
+            $foundFirst
         ));
+    }
+
+    /**
+     * Same move, but with the "found first" flag the back office sets when position 0 is part of the
+     * moved range. It is the flag that used to skip the re-index, so it is the case worth pinning.
+     *
+     * @When /^I move category "(.*)" (up|down) to a position "(.*)" with the found first flag$/
+     */
+    public function updatePositionFoundFirst(string $categoryReference, string $way, int $newPosition): void
+    {
+        $this->updatePosition($categoryReference, $way, $newPosition, true);
+    }
+
+    /**
+     * @Then categories sharing the parent of ":categoryReference" should have contiguous positions
+     */
+    public function assertContiguousPositions(string $categoryReference): void
+    {
+        $parentCategoryId = (int) $this->getCategory($this->getSharedStorage()->get($categoryReference))->id_parent;
+
+        $rows = Db::getInstance()->executeS(sprintf(
+            'SELECT c.`id_category`, c.`position`, cs.`position` AS shop_position
+             FROM `%1$scategory` c
+             INNER JOIN `%1$scategory_shop` cs ON cs.`id_category` = c.`id_category`
+             WHERE c.`id_parent` = %2$d
+             ORDER BY cs.`position`',
+            _DB_PREFIX_,
+            $parentCategoryId
+        ));
+
+        $expected = range(0, count($rows) - 1);
+        Assert::assertSame(
+            $expected,
+            array_map(static fn (array $row): int => (int) $row['position'], $rows),
+            'category.position must stay a contiguous sequence without duplicates'
+        );
+        Assert::assertSame(
+            $expected,
+            array_map(static fn (array $row): int => (int) $row['shop_position'], $rows),
+            'category_shop.position must stay a contiguous sequence without duplicates'
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -575,6 +575,36 @@ Feature: Category Management
     Then category "category16" position should be "2"
     Then category "category14" position should be "3"
 
+  Scenario: Update category position with the found first flag
+    Given I add new category "category-700" with following details:
+      | name[en-US]         | not important  |
+      | name[fr-FR]         | not important  |
+      | active              | true           |
+      | parent category     | home           |
+      | link rewrite[en-US] | not-important7 |
+    Given I add new category "category21" with following details:
+      | name[en-US]         | PC parts 21    |
+      | name[fr-FR]         | PC parts 21 fr |
+      | active              | true           |
+      | parent category     | category-700   |
+      | link rewrite[en-US] | pc-parts21     |
+    And I add new category "category22" with following details:
+      | name[en-US]         | PC parts 22    |
+      | name[fr-FR]         | PC parts 22 fr |
+      | active              | true           |
+      | parent category     | category-700   |
+      | link rewrite[en-US] | pc-parts22     |
+    And I add new category "category23" with following details:
+      | name[en-US]         | PC parts 23    |
+      | name[fr-FR]         | PC parts 23 fr |
+      | active              | true           |
+      | parent category     | category-700   |
+      | link rewrite[en-US] | pc-parts23     |
+    # "up" with a target below the current position is a combination the back office never produces,
+    # but nothing stops an API client from sending it together with the found first flag.
+    When I move category "category21" up to a position "2" with the found first flag
+    Then categories sharing the parent of "category21" should have contiguous positions
+
   Scenario: Edit home category
     When I edit home category "home" with following details:
       | name[en-US]                   | PC parts                       |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `UpdateCategoryPositionHandler` re-indexes the siblings only when the command's `foundFirst` flag is false. `Category::updatePosition()` shifts a range of siblings, and when the requested `way` and position do not match the stored order it leaves a duplicate and a gap - which the back office never produces, because it derives both from the drag and drop payload, but any other caller can. With the flag set, nothing repairs it. This re-indexes unconditionally.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The scenario added to `category_management.feature` creates three sibling categories, moves the first one "up" to position 2 with the found first flag, and asserts the siblings are still a contiguous `0..n-1` in both `category` and `category_shop`. On `9.1.x` the positions come back as `[1, 2, 2]`; with this change they are `[0, 1, 2]`.
| UI Tests          | Queued behind two runs in flight on boo-code/ga.tests.ui.pr; the link goes here when it starts
| Fixed issue or discussion?     | Refs #42104
| Related PRs       | Unblocks the core half of the `PUT /categories/{categoryId}/positions` endpoint described in #42104.
| Sponsor company   |

### Measured

Full `behat -s category` run, same environment each time:

```
9.1.x, with the new scenario      20 scenarios   3 failed
this branch, same scenario        20 scenarios   2 failed
9.1.x, without the new scenario   19 scenarios   2 failed
```

The two that fail throughout are `Assert and delete category cover image` and `Assert category thumbnail image`; they fail on a clean `9.1.x` too, on the `@reset-img-after-feature` hook looking for `/tmp/ps_backup_test_img`, and have nothing to do with positions.

### Why not the position component

The obvious route is to register a `PositionDefinition` for categories next to `cms_page_category`, `attribute` and the rest, and let `DoctrinePositionUpdateHandler` re-index. That does not work here: `PositionDefinition` is single-table (`$table`, `$idField`, `$positionField`, `$parentIdField`), while a category's position lives in both `category` and `category_shop`, and `Category::cleanPositions()` sorts by `category_shop.position` before writing both columns. Categories are the only entity in that list with a per-shop position table, so the legacy normalizer is the one that has to run.

### On the flag

`foundFirst` becomes inert rather than dangerous. It is derived from the drag and drop payload in the back office and was never meant as a caller-supplied input, so removing its effect is what lets #42104 expose a position endpoint without a client being able to corrupt sibling positions. `way` and the `tr_{rowId}_{parentId}_{categoryId}` format are untouched here; if you would rather also add an `UpdateCategoriesPositionCommand(parentCategoryId, orderedCategoryIds)` so the API never sees them at all, say so and I will put it on top - it would call the same `cleanPositions()` underneath.
