### PR TITLE
Apply price rules once per webservice feature update

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2299,8 +2299,9 @@ class ProductCore extends ObjectModel
      */
     public function deleteProductFeatures()
     {
-        SpecificPriceRule::applyAllRules([(int) $this->id]);
-
+        // No price rule recalculation here: it used to run before deleteFeatures(), so it could only
+        // ever see the state being removed, and the sole caller is delete(), after which the product
+        // has no prices left to recalculate.
         return $this->deleteFeatures();
     }
 
@@ -4619,7 +4620,9 @@ class ProductCore extends ObjectModel
         }
         $row = ['id_feature' => (int) $id_feature, 'id_product' => (int) $this->id, 'id_feature_value' => (int) $id_value];
         Db::getInstance()->insert('feature_product', $row);
-        SpecificPriceRule::applyAllRules([(int) $this->id]);
+        // Price rules are not re-applied here: this method adds one feature value, and a caller
+        // adding a whole set would pay for a full recalculation on every one of them. Callers apply
+        // them once when they are done, see setWsProductFeatures().
         if ($id_value) {
             return $id_value;
         }
@@ -6691,6 +6694,9 @@ class ProductCore extends ObjectModel
         foreach ($product_features as $product_feature) {
             $this->addFeaturesToDB($product_feature['id'], $product_feature['id_feature_value']);
         }
+        // Once for the whole set rather than once per feature value: a product carrying a hundred
+        // features used to trigger a hundred full recalculations for a single webservice call.
+        SpecificPriceRule::applyAllRules([(int) $this->id]);
 
         return true;
     }

--- a/tests/Integration/Classes/ProductWebserviceFeaturesTest.php
+++ b/tests/Integration/Classes/ProductWebserviceFeaturesTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+use Tests\Resources\DatabaseDump;
+
+class ProductWebserviceFeaturesTest extends TestCase
+{
+    /**
+     * @var int
+     */
+    private static $productId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['product', 'product_shop', 'product_lang', 'feature', 'feature_lang', 'feature_value', 'feature_value_lang', 'feature_product', 'specific_price']);
+
+        $product = new Product();
+        $product->name = [1 => 'Features perf probe'];
+        $product->link_rewrite = [1 => 'features-perf-probe'];
+        $product->price = 10.0;
+        $product->add();
+        self::$productId = (int) $product->id;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['product', 'product_shop', 'product_lang', 'feature', 'feature_lang', 'feature_value', 'feature_value_lang', 'feature_product', 'specific_price']);
+    }
+
+    /**
+     * setWsProductFeatures() used to call SpecificPriceRule::applyAllRules() from addFeaturesToDB(),
+     * so one webservice call carrying N features paid for N full price recalculations. The cost of
+     * the call must depend on the number of features only through the inserts, not through a
+     * recalculation per value, so the difference between a small and a large set has to stay close
+     * to the number of extra inserts.
+     */
+    public function testTheCostDoesNotGrowWithAFullRecalculationPerFeature(): void
+    {
+        $smallSet = $this->countQueriesForFeatures(2);
+        $largeSet = $this->countQueriesForFeatures(20);
+
+        $extraFeatures = 18;
+        // One insert per extra feature, plus a small constant margin for the surrounding statements.
+        $this->assertLessThanOrEqual(
+            $extraFeatures + 10,
+            $largeSet - $smallSet,
+            sprintf(
+                'Adding %d more features cost %d extra queries (2 features: %d, 20 features: %d), which means the price rules are still recalculated per feature.',
+                $extraFeatures,
+                $largeSet - $smallSet,
+                $smallSet,
+                $largeSet
+            )
+        );
+    }
+
+    private function countQueriesForFeatures(int $featureCount): int
+    {
+        $product = new Product(self::$productId);
+        $features = [];
+        for ($i = 1; $i <= $featureCount; ++$i) {
+            $features[] = ['id' => $i, 'id_feature_value' => $i];
+        }
+
+        $before = $this->getExecutedStatements();
+        $product->setWsProductFeatures($features);
+
+        return $this->getExecutedStatements() - $before;
+    }
+
+    private function getExecutedStatements(): int
+    {
+        $status = Db::getInstance()->executeS("SHOW SESSION STATUS LIKE 'Questions'");
+
+        return (int) $status[0]['Value'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Product::setWsProductFeatures()` adds the features one at a time through `addFeaturesToDB()`, and that method ends with `SpecificPriceRule::applyAllRules([$this->id])`. One webservice call carrying N features therefore triggers N full price-rule recalculations for the same product. This moves the call to the end of `setWsProductFeatures()`, so it runs once for the whole set. It also drops the call from `deleteProductFeatures()`, where it ran *before* `deleteFeatures()` and so could only ever see the state being removed.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `tests/Integration/Classes/ProductWebserviceFeaturesTest.php` calls `setWsProductFeatures()` with 2 features and then with 20, and asserts the extra cost tracks the extra inserts rather than growing by a recalculation each. On `9.1.x` it fails with `Adding 18 more features cost 36 extra queries`; with this change the same run costs 18.
| UI Tests          | Queued behind two runs in flight on boo-code/ga.tests.ui.pr; the link goes here when it starts
| Fixed issue or discussion?     | Fixes #39825
| Related PRs       |
| Sponsor company   |

### Measured

Statement count for one `setWsProductFeatures()` call, on a shop with no specific price rules defined:

```
                2 features   20 features   difference
9.1.x                    6            42           36     2 per feature
this branch              5            23           18     1 per feature, the insert
```

The remaining per-feature query is the `feature_product` insert, which is the work being asked for. The one that disappears is `applyAllRules()`, and this fixture is the cheap case for it: with no rules configured it costs a single query. On the shop in the report - many features and several `SpecificPriceRule` rows - each of those calls does the full recalculation, which is what makes the endpoint unusable there.

### On not removing it altogether

The report suggested dropping the call, on the grounds that specific prices do not depend on features. @Eolia pointed out in the thread that they can, through `SpecificPriceRule` conditions, so removing it would change which prices a product ends up with. Calling it once per request keeps that behaviour and only stops repeating it: the rules are applied after the whole feature set is in place, which is also the only point at which the product's features are in their final state.

`deleteProductFeatures()` is a separate case. It called `applyAllRules()` and then `deleteFeatures()`, so the recalculation ran against the features that were about to disappear, and its only caller is `Product::delete()`, after which the product has no prices left to recalculate. Both core callers are single (`addFeaturesToDB()` from `setWsProductFeatures()`, `deleteProductFeatures()` from `delete()`), so nothing else in core relied on the removed calls.

If you would rather keep `addFeaturesToDB()` self-contained for third-party callers and only fix the webservice path, say so and I will reduce it to that.
