### PR TITLE
Export the product price the listing displays

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -822,6 +822,7 @@ class ProductController extends PrestaShopAdminController
             'price' => $this->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
             'price_final' => $this->trans('Price (tax incl.)', [], 'Admin.Catalog.Feature'),
             'sav_quantity' => $this->trans('Quantity', [], 'Admin.Global'),
+            'active' => $this->trans('Status', [], 'Admin.Global'),
         ];
 
         $data = [];
@@ -833,9 +834,12 @@ class ProductController extends PrestaShopAdminController
                 'name' => $record['name'],
                 'reference' => $record['reference'],
                 'name_category' => $record['category'],
-                'price' => $record['final_price_tax_excluded'],
+                // The listing shows ps.price in this column - final_price_tax_excluded adds the
+                // ecotax on top, so exporting it made the file disagree with the screen.
+                'price' => $record['price_tax_excluded'],
                 'price_final' => $record['price_tax_included'],
                 'sav_quantity' => $record['quantity'],
+                'active' => $record['active'],
             ];
         }
 

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -14,6 +14,8 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductGridDefinitionFactory;
+use Product;
 use Symfony\Component\DomCrawler\Crawler;
 use Tests\Integration\Core\Form\IdentifiableObject\Handler\FormHandlerChecker;
 use Tests\Integration\PrestaShopBundle\Controller\FormGridControllerTestCase;
@@ -268,6 +270,74 @@ class ProductControllerTest extends FormGridControllerTestCase
     /**
      * {@inheritDoc}
      */
+    /**
+     * The export writes its own rows instead of reusing the grid columns, so the price it writes has
+     * to be the one the listing shows: ps.price, not ps.price + ecotax.
+     */
+    public function testExportUsesTheDisplayedPrice(): void
+    {
+        $product = new Product(1);
+        $originalEcotax = $product->ecotax;
+        $product->ecotax = 3.5;
+        $product->save();
+
+        // The export follows whatever filter the grid currently holds, and that filter is stored per
+        // employee, so a test that ran before this one leaves its own filter behind - re-submitting
+        // the form does not clear it, since the form renders with those values already in it.
+        $this->client->request('POST', $this->router->generate(
+            'admin_common_reset_search_by_filter_id',
+            ['filterId' => ProductGridDefinitionFactory::GRID_ID]
+        ));
+
+        try {
+            $this->client->request('GET', $this->router->generate('admin_products_export'));
+            // The streamed body is already consumed by the test client, so it is read from there
+            // rather than by calling sendContent() again.
+            $csv = (string) $this->client->getInternalResponse()->getContent();
+        } finally {
+            $product->ecotax = $originalEcotax;
+            $product->save();
+        }
+
+        $rows = array_map(
+            static fn (string $line): array => str_getcsv($line, ';'),
+            array_filter(explode("\n", trim($csv)))
+        );
+        $headers = array_shift($rows);
+        $priceColumn = array_search('Price (tax excl.)', $headers, true);
+        $this->assertNotFalse($priceColumn, 'The tax excluded price column is missing from the export');
+
+        $exportedRow = null;
+        foreach ($rows as $row) {
+            if ((int) $row[0] === 1) {
+                $exportedRow = $row;
+
+                break;
+            }
+        }
+
+        $this->assertNotNull($exportedRow, 'Product 1 is missing from the export');
+        // The cell carries the formatted price, so only its digits are compared.
+        $this->assertSame(
+            number_format((float) $product->price, 2, '.', ''),
+            preg_replace('/[^0-9.]/', '', $exportedRow[$priceColumn]),
+            'The exported price must be the one the listing shows, without the ecotax added on top'
+        );
+    }
+
+    /**
+     * The listing has a status column and the export writes its own header list, so it used to drop it.
+     */
+    public function testExportIncludesTheStatusColumn(): void
+    {
+        $this->client->request('GET', $this->router->generate('admin_products_export'));
+        $csv = (string) $this->client->getInternalResponse()->getContent();
+
+        $headers = str_getcsv(strtok(trim($csv), "\n"), ';');
+
+        $this->assertNotFalse(array_search('Status', $headers, true), 'The status column is missing from the export');
+    }
+
     protected function getFilterSearchButtonSelector(): string
     {
         return 'product[actions][search]';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The product listing's export writes its rows by hand instead of reusing the grid columns, and the two drifted apart. The column headed "Price (tax excl.)" exports `final_price_tax_excluded`, which the query defines as `ps.price + ps.ecotax`, while the listing column with that meaning displays `price_tax_excluded`, i.e. `ps.price`. Any product carrying an ecotax therefore exports a price the merchant never saw on screen. The hand-written header list also drops the `Status` column, although `ps.active` is already selected by the query. This exports the field the column displays and carries the status through.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set an ecotax on a product, then Catalog > Products > Export. Before this change the "Price (tax excl.)" cell is the price plus the ecotax while the listing shows the price alone; after it, the two match, and a `Status` column is present. `ProductControllerTest::testExportUsesTheDisplayedPrice` and `::testExportIncludesTheStatusColumn` cover both; both fail on `9.1.x`.
| UI Tests          | Queued behind two runs in flight on boo-code/ga.tests.ui.pr; the link goes here when it starts
| Fixed issue or discussion?     | Fixes #41313
| Related PRs       |
| Sponsor company   |

### Measured

With an ecotax of 3.50 on product 1, on a 9.1.x install:

```
price_tax_excluded         23.90     the value the Base price column displays
final_price_tax_excluded   27.40     the value the CSV wrote under "Price (tax excl.)"
```

### What this does not do

The report also asks for descriptions, every image and combination data. Those are not part of the product listing at any point - this button exports the grid, and the grid does not carry them - so adding them would not be a fix to this export but a separate catalogue exporter, which is what the Import/Export tooling covers. Worth tracking separately if that is the real need, because it will not be solved here.

### Noticed while checking

`ProductQueryBuilder` has an ecotax branch whose two bodies are identical:

```php
if ($this->configuration->getBoolean('PS_USE_ECOTAX')) {
    $qb->addSelect('(ps.`price` + ps.`ecotax`) AS `final_price_tax_excluded`');
} else {
    $qb->addSelect('(ps.`price` + ps.`ecotax`) AS `final_price_tax_excluded`');
}
```

Left alone here since it changes nothing today and belongs in its own change, but one of the two branches is presumably meant to leave the ecotax out.
