### PR TITLE
Mask session and client secrets in SQL manager results

### DIFF
--- a/classes/RequestSql.php
+++ b/classes/RequestSql.php
@@ -51,9 +51,18 @@ class RequestSqlCore extends ObjectModel
         ],
     ];
 
+    /**
+     * Columns whose value is replaced by the placeholder in an execution result. Matching is by
+     * column name, so a name has to be unambiguous across the schema: `token` only ever names a
+     * session or thread secret, while `key` also names ordinary data (translation keys) and is
+     * deliberately left out.
+     */
     public $attributes = [
         'passwd' => '*******************',
         'secure_key' => '*******************',
+        'reset_password_token' => '*******************',
+        'token' => '*******************',
+        'client_secret' => '*******************',
     ];
 
     /** @var array : list of errors */

--- a/tests/Integration/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandlerTest.php
+++ b/tests/Integration/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandlerTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Adapter\SqlManager\QueryHandler;
 
+use Db;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\AddSqlRequestCommand;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestConstraintException;
@@ -44,6 +45,7 @@ class GetSqlRequestExecutionResultHandlerTest extends KernelTestCase
     {
         DatabaseDump::restoreTables([
             'request_sql',
+            'employee',
         ]);
     }
 
@@ -84,6 +86,48 @@ class GetSqlRequestExecutionResultHandlerTest extends KernelTestCase
         /** @var SqlRequestExecutionResult $sqlRequestExecutionResult */
         $sqlRequestExecutionResult = $this->queryBus->handle($query);
         self::assertEquals('*******************', $sqlRequestExecutionResult->getRows()[0]['MyStrongPassword']);
+    }
+
+    /**
+     * The list used to be passwd and secure_key only, so every other credential the schema carries
+     * came back in clear text - which matters more now the same handler answers an API endpoint.
+     *
+     * @dataProvider getSecretColumns
+     */
+    public function testEveryKnownSecretColumnIsHidden(string $column, string $sql, string $selected): void
+    {
+        // hideSensitiveData() skips a null value, so the column has to hold something to be a test
+        Db::getInstance()->execute(sprintf(
+            'UPDATE `%semployee` SET `%s` = \'a-real-secret\' WHERE `id_employee` = 1',
+            _DB_PREFIX_,
+            $column
+        ));
+
+        /** @var SqlRequestId $sqlRequestId */
+        $sqlRequestId = $this->commandBus->handle(new AddSqlRequestCommand('secret_request', $sql));
+        /** @var SqlRequestExecutionResult $result */
+        $result = $this->queryBus->handle(new GetSqlRequestExecutionResult($sqlRequestId->getValue()));
+
+        self::assertEquals(
+            '*******************',
+            $result->getRows()[0][$selected],
+            sprintf('%s was returned in clear text', $selected)
+        );
+    }
+
+    public function getSecretColumns(): iterable
+    {
+        yield 'reset token' => [
+            'reset_password_token',
+            'SELECT e.id_employee, e.reset_password_token FROM ps_employee e WHERE e.id_employee = 1;',
+            'reset_password_token',
+        ];
+        // the alias path has to keep working for the names added alongside passwd
+        yield 'reset token behind an alias' => [
+            'reset_password_token',
+            'SELECT e.id_employee, e.reset_password_token AS session_token FROM ps_employee e WHERE e.id_employee = 1;',
+            'session_token',
+        ];
     }
 
     public function testUnauthorizedFunctionInSelect(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `GetSqlRequestExecutionResultHandler::hideSensitiveData()` replaces the value of every column whose name is a key of `RequestSql::$attributes`, and that list is two entries - `passwd` and `secure_key`. Every other credential the schema carries comes back as it is stored: `ps_api_client.client_secret`, the `token` of `ps_customer_session`, `ps_employee_session`, `ps_customer_thread` and `ps_wishlist`, and the `reset_password_token` of both customers and employees. This adds `reset_password_token`, `token` and `client_secret` to the list.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In the back office, Advanced Parameters > Database > SQL Manager, add a request such as `SELECT id_employee, reset_password_token FROM ps_employee` (or `SELECT id_api_client, client_secret FROM ps_api_client`) and view its result. Before this change the stored value is printed as it is; after it, the placeholder is shown. Aliases are covered too - `SELECT e.reset_password_token AS whatever FROM ps_employee e` masks `whatever`, since the handler resolves aliases through the SQL parser. The automated cover is `tests/Integration/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandlerTest::testEveryKnownSecretColumnIsHidden`, which fails on the base branch for both of its data sets and passes with this commit.
| UI Tests          | Queued behind two runs already in flight on the fork runner; the link goes here once it is dispatched.
| Fixed issue or discussion?     | Fixes #42220
| Related PRs       | https://github.com/PrestaShop/ps_apiresources/pull/396 exposes this same handler as an Admin API endpoint, which is what made the narrow list worth widening.
| Sponsor company   |

### Why the masking is load-bearing rather than cosmetic

Read as "someone who can already query the database can query the database", this looks like decoration. The permission split is what makes it more than that. `viewAction` and `exportAction` are guarded by `is_granted('read', ...)`, while `createAction` and `editAction` require `create` / `update`. So a profile with read-only access to the SQL Manager can execute a stored request and download its export, but cannot write SQL of its own - for that profile the placeholder is the only thing standing between them and the stored secret. It stays a narrow problem because someone holding `create` has to have saved such a request in the first place, which is why #42220 is filed as hardening and not as a vulnerability.

Both surfaces are covered by the one change: `viewAction` renders the result and `exportAction` streams it to CSV, but both dispatch the same `GetSqlRequestExecutionResult`, so neither builds its own result set.

### On the choice of names

Matching is by column name, so which names go in matters. Checked against `information_schema` on a stock 9.1.5 and a stock 9.2.0 install: every column named `token` is a secret (`customer_session`, `employee_session`, `customer_thread`, `wishlist`), and so are `client_secret` and `reset_password_token`. `key` is not, which is why it is left out - `ps_webservice_account.key` is a credential but `ps_translation.key` is ordinary data, and masking it would hide values an employee legitimately queries.

The cost of name-based matching is that a third-party table using one of these names for something ordinary would be masked as well. That is the same cost the existing `passwd` and `secure_key` entries already carry, and it seemed the better side to err on for these three; if you disagree for `token` specifically, it is the one of the three I would drop first.

On the BC question: the property stays public and keeps its shape, so nothing about the contract moves, but a saved request selecting one of the three new names now shows the placeholder where it used to show the value. That is the point of the change rather than a side effect. If you would rather stage it - `client_secret` now and the two token names in 9.2 - say so and I will split it.
