### PR TITLE
Keep the admin CSRF token out of front office and Admin API URLs

### DIFF
--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -5,6 +5,25 @@ services:
     autowire: true
     autoconfigure: true
 
+  # ROUTING
+  # The tokenized router only makes sense for the back office, where the CSRF token in the URL is
+  # part of the admin security model. Defining it here rather than in the bundle keeps it out of the
+  # front office and the Admin API containers, whose generated URLs (an API Location header, for
+  # instance) have no use for an admin token. See RouterPass, which only aliases when it is defined.
+  prestashop.router:
+    class: PrestaShopBundle\Service\Routing\Router
+    parent: 'router.default'
+    public: true
+    # This file's _defaults autowire, which would try to resolve the parent router's own constructor
+    # (LoaderInterface and friends) and fail on an abstract definition. The parent supplies them.
+    autowire: false
+    autoconfigure: false
+    arguments:
+      $container: '@service_container'
+    calls:
+      - [ 'setUserTokenManager', [ '@PrestaShopBundle\Security\Admin\UserTokenManager' ] ]
+      - [ 'setAnonymousRouteProvider', [ '@PrestaShopBundle\Routing\AnonymousRouteProvider' ] ]
+
   # SECURITY
   PrestaShopBundle\EventListener\Admin\TokenizedUrlsListener:
     autowire: true

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/RouterPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/RouterPass.php
@@ -23,6 +23,13 @@ class RouterPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        // Only the Admin app defines prestashop.router, since the CSRF token in the URL is part of
+        // the back office security model. The front office and the Admin API keep Symfony's router,
+        // so the URLs they generate - an API Location header, for instance - carry no admin token.
+        if (!$container->hasDefinition('prestashop.router')) {
+            return;
+        }
+
         $container->setAlias('router', 'prestashop.router')->setPublic(true);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -99,16 +99,6 @@ services:
       version: 9.0
     public: true
 
-  prestashop.router:
-    class: PrestaShopBundle\Service\Routing\Router
-    parent: 'router.default'
-    public: true
-    arguments:
-      $container: '@service_container'
-    calls:
-      - [ 'setUserTokenManager', [ '@PrestaShopBundle\Security\Admin\UserTokenManager' ] ]
-      - [ 'setAnonymousRouteProvider', [ '@PrestaShopBundle\Routing\AnonymousRouteProvider' ] ]
-
   PrestaShopBundle\Service\Multistore\CustomizedConfigurationChecker:
     arguments:
       - "@prestashop.adapter.legacy.configuration"

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -143,7 +143,10 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\OrderReturnFormDataProvider'
     arguments:
       - '@prestashop.core.query_bus'
-      - '@prestashop.router'
+      # The router contract, not the tokenized implementation: in the Admin app this alias resolves
+      # to prestashop.router, so the back office links it builds keep their token, while the front
+      # office and Admin API containers - which never use this provider - still compile.
+      - '@router'
       - '@translator'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_lite'
 

--- a/tests/Unit/PrestaShopBundle/DependencyInjection/Compiler/RouterPassTest.php
+++ b/tests/Unit/PrestaShopBundle/DependencyInjection/Compiler/RouterPassTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\DependencyInjection\Compiler\RouterPass;
+use PrestaShopBundle\Service\Routing\Router;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class RouterPassTest extends TestCase
+{
+    /**
+     * The Admin app defines prestashop.router, so the alias has to point at it - that is what puts
+     * the CSRF token in a back office URL.
+     */
+    public function testItAliasesTheRouterWhenTheTokenizedOneIsDefined(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('prestashop.router', new Definition(Router::class));
+
+        (new RouterPass())->process($container);
+
+        self::assertTrue($container->hasAlias('router'));
+        self::assertSame('prestashop.router', (string) $container->getAlias('router'));
+        self::assertTrue($container->getAlias('router')->isPublic());
+    }
+
+    /**
+     * The front office and the Admin API do not define it, and must keep Symfony's own router:
+     * aliasing here would either fail to resolve or put an admin token in URLs that have no use for
+     * one, such as the Location header of an API response.
+     */
+    public function testItLeavesTheRouterAloneWhenTheTokenizedOneIsAbsent(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new RouterPass())->process($container);
+
+        self::assertFalse($container->hasAlias('router'));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `RouterPass` aliases `router` to `prestashop.router` in every kernel, so the front office and the Admin API both get the router that appends the back office CSRF token to generated URLs. That is why an Admin API `POST` answers with `Location: /admin-api/api-clients/3?_token=...`. This defines `prestashop.router` in the Admin app configuration only and makes the pass alias just where it exists, so the back office keeps the token and the other two apps keep Symfony's router.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Call any Admin API `POST` endpoint and read the response headers - `Location` and `Content-Location` carry a `_token` query parameter before this change and none after it. The back office is unchanged: its URLs still carry the token, which the new unit test pins from the other side.
| UI Tests          | Queued on `boo-code/ga.tests.ui.pr` behind two runs already in flight; the link goes here when it is dispatched.
| Fixed issue or discussion?     | Fixes #39496
| Related PRs       | #40967 fixes the same issue by filtering inside `Router::generate()`. This is the alternative @jolelievre asked for there on 2026-03-20 - defining the service for the Admin kernel only - which nobody had picked up since. Whichever approach you prefer, the other should close; I would rather see that one merged than have two open, and I closed my own earlier attempt (#41847) in its favour for the same reason.
| Sponsor company   |

### What the change is

Three things move together, because moving the definition alone does not compile:

1. `prestashop.router` moves from `src/PrestaShopBundle/Resources/config/services/bundle/services.yml`, which every kernel loads, to `app/config/admin/services.yml`.
2. `RouterPass` aliases only when that definition is present. It has to stay a pass rather than an alias in the yaml, because the alias must be applied after removing, and keeping the class avoids removing a public one in a patch.
3. `order_return_form_data_provider` asked for `@prestashop.router` and now asks for `@router`. This is the part that is not obvious: that provider sits in a file all three kernels load, so with the definition gone from the shared config the front office and Admin API containers failed to compile with *"The service ... has a dependency on a non-existent service prestashop.router"*. It only ever builds `admin_customers_view` and `admin_orders_view` links and takes a plain `RouterInterface`, so depending on the contract is right in any case - in the Admin app that alias still resolves to `prestashop.router`, so its links keep their token.

### Measurements

Booting each kernel and asking the container what `router` actually is, on `9.1.x`:

```
                base                                        this PR
admin       PrestaShopBundle\Service\Routing\Router      PrestaShopBundle\Service\Routing\Router
front       PrestaShopBundle\Service\Routing\Router      Symfony\Bundle\FrameworkBundle\Routing\Router
admin-api   PrestaShopBundle\Service\Routing\Router      Symfony\Bundle\FrameworkBundle\Routing\Router
```

All three kernels warm their cache cleanly, the front office and back office still render, and `tests/Unit/.../RouterPassTest.php` covers both branches - reverting `RouterPass.php` alone turns the second case red.

Worth flagging rather than leaving to be discovered: `bin/console debug:container router` is not a reliable check here. It reports `router.default` on both base and this branch, because `prestashop.router` declares `parent: router.default` and the command shows the definition's target rather than the runtime class. The table above comes from booting the kernels.

### The front office is also affected, deliberately

The issue only mentions the Admin API, but the front office was getting the same tokenizing router. Nothing there depends on it - `TokenInUrls` and `AnonymousRouteProvider` already suppress the token for front routes - so this is the same defect with no visible symptom, and scoping the service to the Admin app fixes both rather than special-casing the API. If you would rather keep the front office on `prestashop.router` for now and change only the API, say so and I will add the front config back.
