### PR TITLE
Offer disabled currencies when configuring payment restrictions

### DIFF
--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -45,7 +45,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
      */
     public function getCurrencies($object = false, $active = true, $group_by = false)
     {
-        return Currency::getCurrencies($object = false, $active = true, $group_by = false);
+        return Currency::getCurrencies($object, $active, $group_by);
     }
 
     /**

--- a/src/Core/Form/ChoiceProvider/CurrencyByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CurrencyByIdChoiceProvider.php
@@ -23,9 +23,15 @@ final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface, F
     /**
      * @param CurrencyDataProviderInterface $currencyDataProvider
      */
-    public function __construct(CurrencyDataProviderInterface $currencyDataProvider)
+    /**
+     * @var bool whether currencies that are not enabled are offered as well
+     */
+    private $includeDisabled;
+
+    public function __construct(CurrencyDataProviderInterface $currencyDataProvider, bool $includeDisabled = false)
     {
         $this->currencyDataProvider = $currencyDataProvider;
+        $this->includeDisabled = $includeDisabled;
     }
 
     /**
@@ -61,6 +67,8 @@ final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface, F
 
     private function getCurrencies(): array
     {
-        return $this->currencyDataProvider->getCurrencies(false, true, true);
+        // Grouping by id_currency matters in multistore, where the shop association join returns the
+        // same currency once per shop it belongs to and the list would otherwise repeat it.
+        return $this->currencyDataProvider->getCurrencies(false, !$this->includeDisabled, true);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -151,6 +151,9 @@ services:
       $groupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
       $carrierChoices: '@=service("prestashop.core.form.choice_provider.carrier_by_reference_id").getChoices()'
       $countryDataProvider: '@prestashop.adapter.data_provider.country'
+      # Restrictions are set up before a currency is switched on, so this screen lists the disabled
+      # ones too - unlike everywhere else, where a currency is being picked for immediate use.
+      $currencyChoicesProvider: '@prestashop.core.form.choice_provider.currency_by_id_including_disabled'
 
   PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email\EmailConfigurationType:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -20,6 +20,14 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider:
     public: true
 
+  # Same provider, offering currencies that are not enabled yet. Used where the merchant configures a
+  # currency ahead of turning it on - payment restrictions - rather than picking one to be used now.
+  prestashop.core.form.choice_provider.currency_by_id_including_disabled:
+    class: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider
+    arguments:
+      $currencyDataProvider: '@prestashop.adapter.data_provider.currency'
+      $includeDisabled: true
+
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider:
     arguments:
       $languages: '@=service("prestashop.adapter.data_provider.language").getLanguages(false)'

--- a/tests/Unit/Core/Form/ChoiceProvider/CurrencyByIdChoiceProviderTest.php
+++ b/tests/Unit/Core/Form/ChoiceProvider/CurrencyByIdChoiceProviderTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\ChoiceProvider;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider;
+
+class CurrencyByIdChoiceProviderTest extends TestCase
+{
+    /**
+     * Everywhere a currency is picked for immediate use - an order, a product price - only the
+     * enabled ones belong in the list.
+     */
+    public function testItAsksForEnabledCurrenciesByDefault(): void
+    {
+        $provider = new CurrencyByIdChoiceProvider($this->createDataProviderExpecting(true));
+
+        self::assertSame(['Euro (EUR)' => 1], $provider->getChoices());
+    }
+
+    /**
+     * Payment restrictions are configured before a currency is switched on, so that screen has to
+     * offer the disabled ones too.
+     */
+    public function testItAsksForEveryCurrencyWhenDisabledOnesAreIncluded(): void
+    {
+        $provider = new CurrencyByIdChoiceProvider($this->createDataProviderExpecting(false), true);
+
+        self::assertSame(['Euro (EUR)' => 1, 'US Dollar (USD)' => 99], $provider->getChoices());
+    }
+
+    /**
+     * The grouping argument is not decoration: in multistore the shop association join returns a
+     * currency once per shop, and without it the same currency is offered several times.
+     */
+    public function testItAlwaysGroupsByCurrency(): void
+    {
+        $dataProvider = $this->createMock(CurrencyDataProviderInterface::class);
+        $dataProvider
+            ->expects(self::once())
+            ->method('getCurrencies')
+            ->with(false, self::anything(), true)
+            ->willReturn([]);
+
+        (new CurrencyByIdChoiceProvider($dataProvider))->getChoices();
+    }
+
+    /**
+     * @param bool $expectedActiveOnly the value the provider must pass as the "active only" argument
+     */
+    private function createDataProviderExpecting(bool $expectedActiveOnly): CurrencyDataProviderInterface
+    {
+        $currencies = [
+            ['id_currency' => 1, 'name' => 'Euro', 'iso_code' => 'EUR', 'symbol' => '€'],
+        ];
+
+        if (!$expectedActiveOnly) {
+            $currencies[] = ['id_currency' => 99, 'name' => 'US Dollar', 'iso_code' => 'USD', 'symbol' => '$'];
+        }
+
+        $dataProvider = $this->createMock(CurrencyDataProviderInterface::class);
+        $dataProvider
+            ->expects(self::once())
+            ->method('getCurrencies')
+            ->with(false, $expectedActiveOnly, true)
+            ->willReturn($currencies);
+
+        return $dataProvider;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Payment > Preferences only lists enabled currencies, so a merchant cannot set up restrictions for a currency before switching it on - the case in the report is adding EUR to a running shop and configuring modules and rates while it is still disabled. The cause is one line below the form: `CurrencyDataProvider::getCurrencies()` assigns its parameters inside the call instead of passing them, so it always asks for enabled currencies whatever the caller wants. This forwards them, and gives the payment screen a provider that includes the disabled ones, leaving every other currency list unchanged.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add a second currency and leave it disabled, then open Improve > Payment > Preferences. Before this change the currency restrictions table does not list it and there is no way to configure it; after, it is listed alongside the enabled ones. Check that nothing else changed: the currency selectors on a product's price, a supplier, a discount, a catalog price rule and Localization still offer enabled currencies only, and so does the currency field when creating an order.
| UI Tests          | Queued on `boo-code/ga.tests.ui.pr` behind two runs already in flight; the link goes here when it is dispatched.
| Fixed issue or discussion?     | Fixes #40586
| Related PRs       | #40988 attacked the same issue from the form side and was closed by its author on 2026-07-17 without review. This one starts from the data provider, which is where the argument is actually lost.
| Sponsor company   |

### The line

```php
public function getCurrencies($object = false, $active = true, $group_by = false)
{
    return Currency::getCurrencies($object = false, $active = true, $group_by = false);
}
```

Those are assignments in the argument list, not arguments. Whatever a caller passes is overwritten, so the method is a constant `(false, true, false)` and there is no way to reach a disabled currency through `CurrencyDataProviderInterface`. Measured on `9.1.x` with one enabled currency and one disabled:

```
adapter->getCurrencies(false, false, true)   ->  EUR
Currency::getCurrencies(false, false, true)  ->  EUR, USD
```

Reverting only this file with the rest of the change in place puts the flag below back to returning `EUR` alone, so the fix is load-bearing rather than cosmetic.

### Why the payment screen gets its own provider instead of a wider default

`CurrencyByIdChoiceProvider` has three consumers: `PaymentModulePreferencesType`, `CurrencyChoiceType` - which feeds product pricing, product suppliers, discounts, catalog price rules, price reductions and the Localization default currency - and the order currency field in `OrderController`. Offering a disabled currency is right for the first and wrong for the rest: you should not be able to create an order in a currency the shop has switched off. So the class takes an optional `$includeDisabled`, and a second service definition of the same class is wired into the payment form only. No other list changes, and the constructor argument is optional so existing instantiations are untouched.

### One thing that comes along with it

The single caller of the broken method asks for `group_by = true`, and until now silently got `false`. `Currency::findAll()` turns that into `GROUP BY c.id_currency`, which matters in multistore: `Shop::addSqlAssociation` returns a currency once per shop it is associated with, so without the grouping the same currency appears several times in the list. Forwarding the argument fixes that too, and `testItAlwaysGroupsByCurrency` pins it so it cannot be dropped again.

If you would rather split this - the parameter forwarding as a fix on its own, the payment screen behaviour separately - say so and I will break it in two.
