### PR TITLE
Send a legacy back office URL to the form its own links resolve against

### DIFF
--- a/src/PrestaShopBundle/EventListener/Admin/LegacyUrlListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/LegacyUrlListener.php
@@ -42,9 +42,53 @@ class LegacyUrlListener
         try {
             $convertedUrl = $this->converter->convertByRequest($event->getRequest());
         } catch (CoreException) {
+            $this->redirectToCanonicalLegacyUrl($event);
+
             return;
         }
 
         $event->setResponse(new RedirectResponse($convertedUrl, Response::HTTP_PERMANENTLY_REDIRECT));
+    }
+
+    /**
+     * A page that has not been migrated builds its links relative to `index.php`, so they only
+     * resolve while the URL is `index.php` itself. Reached as `index.php/` the browser reads the
+     * trailing slash as a directory and resolves every one of those links one level deeper, which
+     * is where the second `index.php` in the reported 404 comes from. Both URLs serve the same
+     * page - `/` matches admin_homepage, which falls back to the legacy controller - so the fix is
+     * to send the request to the form whose links work rather than to let the page emit broken ones.
+     */
+    private function redirectToCanonicalLegacyUrl(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        // Without a legacy controller this is the back office homepage, which is a route of its own
+        // and must keep working at that URL.
+        if (!$request->query->has('controller')) {
+            return;
+        }
+
+        // Only a URL that carries the front controller in its path can hold the spurious slash.
+        // Reached as a directory instead - which is how the back office is normally served - the
+        // trailing slash is the directory's own and the web server answers the stripped form with a
+        // redirect back to it, so removing it here would loop until the browser gives up.
+        $baseUrl = $request->getBaseUrl();
+        if (!str_ends_with($baseUrl, '/' . basename($request->getScriptName()))) {
+            return;
+        }
+
+        // getPathInfo() answers "/" for index.php and for index.php/ alike, so it cannot tell the
+        // two apart and using it here redirects the canonical URL to itself. The raw path can:
+        // only the uncanonical form carries the trailing slash after the script name.
+        $path = parse_url($request->getRequestUri(), PHP_URL_PATH);
+        if ($baseUrl . '/' !== $path) {
+            return;
+        }
+
+        $queryString = $request->getQueryString();
+        $canonicalUrl = $baseUrl . (null !== $queryString ? '?' . $queryString : '');
+
+        // 308 rather than 301 so a form posted to the uncanonical URL keeps its method and body.
+        $event->setResponse(new RedirectResponse($canonicalUrl, Response::HTTP_PERMANENTLY_REDIRECT));
     }
 }

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/LegacyUrlListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/LegacyUrlListenerTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\EventListener\Admin;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagManager;
+use PrestaShopBundle\EventListener\Admin\LegacyUrlListener;
+use PrestaShopBundle\Routing\Converter\LegacyRouteFactory;
+use PrestaShopBundle\Routing\Converter\LegacyUrlConverter;
+use PrestaShopBundle\Routing\Converter\RouterProvider;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Router;
+
+class LegacyUrlListenerTest extends TestCase
+{
+    /**
+     * A controller that has not been migrated renders the legacy page, and that page builds its
+     * links relative to index.php. Served from index.php/ the browser reads the trailing slash as a
+     * directory and resolves them one level deeper, so each one gains a second index.php.
+     */
+    public function testItCanonicalisesALegacyUrlCarryingATrailingSlash(): void
+    {
+        $event = $this->createEvent('/admin-dev/index.php/?controller=AdminCartRules');
+
+        $this->createListener()->onKernelRequest($event);
+
+        $response = $event->getResponse();
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/admin-dev/index.php?controller=AdminCartRules', $response->getTargetUrl());
+        self::assertSame(308, $response->getStatusCode());
+    }
+
+    /**
+     * The canonical URL has to be left alone. Request::getPathInfo() answers "/" for it exactly as
+     * it does for the trailing-slash form, so a check written against it redirects this URL to
+     * itself and the browser stops after following the loop to its limit.
+     */
+    public function testItLeavesTheCanonicalLegacyUrlAlone(): void
+    {
+        $event = $this->createEvent('/admin-dev/index.php?controller=AdminCartRules');
+
+        $this->createListener()->onKernelRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    /**
+     * Without a legacy controller this is the back office homepage, a route in its own right.
+     */
+    public function testItLeavesTheHomepageAlone(): void
+    {
+        $event = $this->createEvent('/admin-dev/index.php/');
+
+        $this->createListener()->onKernelRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    /**
+     * Reached without the front controller in the path, the trailing slash belongs to the directory
+     * and not to index.php. Stripping it makes the web server send the request straight back here,
+     * which the browser reports as ERR_TOO_MANY_REDIRECTS. This is the form the back office is
+     * actually reached in, so every page load loops, starting with the login.
+     */
+    public function testItLeavesADirectoryTrailingSlashAlone(): void
+    {
+        $event = $this->createEvent('/admin-dev/?controller=AdminCartRules');
+
+        self::assertSame('/admin-dev', $event->getRequest()->getBaseUrl());
+
+        $this->createListener()->onKernelRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    /**
+     * A converter holding no route for the requested controller is what "not migrated" looks like,
+     * and it is the only case where the legacy page - and its relative links - is really rendered.
+     */
+    private function createListener(): LegacyUrlListener
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('admin_products_index', new Route('/products', ['_legacy_link' => 'AdminProducts']));
+
+        $router = $this->getMockBuilder(Router::class)->disableOriginalConstructor()->getMock();
+        $router->method('getRouteCollection')->willReturn($routeCollection);
+        $router->method('getContext')->willReturn(new RequestContext());
+
+        $converter = new LegacyUrlConverter(
+            $router,
+            new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagManager::class)))
+        );
+
+        return new LegacyUrlListener($converter);
+    }
+
+    private function createEvent(string $requestUri): RequestEvent
+    {
+        $request = Request::create($requestUri, 'GET', [], [], [], [
+            'SCRIPT_NAME' => '/admin-dev/index.php',
+            'SCRIPT_FILENAME' => '/admin-dev/index.php',
+            'PHP_SELF' => $requestUri,
+        ]);
+
+        return new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Reaching a back office page that has not been migrated as `index.php/?controller=X` - the URL in the report - renders it, but every link the page emits is relative to `index.php`, and the browser resolves them against `index.php/` as if it were a directory. So the toolbar's "Add new cart rule" becomes `index.php/index.php?...` and answers `No route found`. Both URLs serve the same page (`/` matches `admin_homepage`, which falls back to the legacy controller), so this redirects the uncanonical one to the form whose links resolve, instead of letting the page emit URLs that 404.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open `[shop]/[admin]/index.php/?controller=AdminCartRules`, click "I understand the risk", then "Add new cart rule". Before this change you land on `No route found for "GET .../index.php/index.php"`; after, the request is redirected once to `index.php?controller=AdminCartRules` and the button opens the form. Check the two URLs that must not move: `index.php?controller=AdminCartRules` still serves the page directly, and `index.php/` with no controller is still the dashboard.
| UI Tests          | Queued on `boo-code/ga.tests.ui.pr` behind two runs already in flight; the link goes here when it is dispatched.
| Fixed issue or discussion?     | Fixes #40534
| Related PRs       |
| Sponsor company   |

### Measured on 9.1.5

Following the report's steps with a real back office session, the toolbar emits a relative link and the browser resolves it one level too deep:

```
page            /admin-dev/index.php/?controller=AdminCartRules
CTA href        index.php?controller=AdminCartRules&addcart_rule&token=...
resolves to     /admin-dev/index.php/index.php?controller=...   ->  404 No route found
```

With this change the entry URL is redirected once and the same click resolves to `/admin-dev/index.php?controller=AdminCartRules&addcart_rule&token=...`, which answers 200 with the "Cart Rules > Add new" form.

### Why the redirect rather than absolute links

Every legacy link comes from one place - `self::$currentIndex`, built in `AdminController` as `'index.php' . '?controller=' . ...` - so making that absolute would fix them too. It is a public static that modules read and extend, though, and changing the shape of its value reaches further than this bug does. Canonicalising the entry URL fixes every relative link on every legacy page at once and leaves the contract alone.

The redirect only fires when the converter has already declined the URL, which is its way of saying the controller has not been migrated and the legacy page really is about to render. A migrated controller still gets the existing 308 to its Symfony route.

### One trap worth recording, since it is not visible in a single request

`Request::getPathInfo()` normalises to `"/"` for `index.php` and for `index.php/` alike, so the obvious condition matches the canonical URL as well and redirects it to itself. A one-shot check looks correct - the first hop returns a sensible 308 - and only following the chain shows it: the first version of this patch produced an endless `308 -> same URL` loop until curl gave up at 50 hops. The condition therefore compares the raw request path with the base URL, which is the only thing that distinguishes the two forms. `testItLeavesTheCanonicalLegacyUrlAlone` pins it.

308 rather than 301 so that a form posted to the uncanonical URL keeps its method and body.
