### PR TITLE
Number carrier positions over the carriers the grid shows

### DIFF
--- a/src/Core/Grid/Position/PositionDefinition.php
+++ b/src/Core/Grid/Position/PositionDefinition.php
@@ -38,24 +38,44 @@ final class PositionDefinition implements PositionDefinitionInterface
     private $firstPosition;
 
     /**
+     * @var array<string, scalar> column => value the rows taking part in the sequence must match
+     */
+    private $filters;
+
+    /**
      * @param string $table
      * @param string $idField
      * @param string $positionField
      * @param string|null $parentIdField
      * @param int $firstPosition
+     * @param array<string, scalar> $filters restricts the sequence to the rows the grid displays,
+     *                                       for a table whose grid hides some of its rows
      */
     public function __construct(
         $table,
         $idField,
         $positionField,
         $parentIdField = null,
-        int $firstPosition = 0
+        int $firstPosition = 0,
+        array $filters = []
     ) {
         $this->table = $table;
         $this->idField = $idField;
         $this->positionField = $positionField;
         $this->parentIdField = $parentIdField;
         $this->firstPosition = $firstPosition;
+        $this->filters = $filters;
+    }
+
+    /**
+     * Not on PositionDefinitionInterface on purpose: adding a method there would break any module
+     * implementing it. The update handler asks for these only when the definition is this class.
+     *
+     * @return array<string, scalar>
+     */
+    public function getFilters(): array
+    {
+        return $this->filters;
     }
 
     /**

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionUpdateHandler.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
 use Exception;
 use PrestaShop\PrestaShop\Core\Grid\Position\Exception\PositionUpdateException;
+use PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition;
 use PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinitionInterface;
 
 /**
@@ -57,6 +58,12 @@ final class DoctrinePositionUpdateHandler implements PositionUpdateHandlerInterf
                 ->setParameter('parentId', $parentId);
         }
 
+        foreach ($this->getFilters($positionDefinition) as $column => $value) {
+            $qb
+                ->andWhere('t.`' . $column . '` = :filter_' . $column)
+                ->setParameter('filter_' . $column, $value);
+        }
+
         $positions = $qb->executeQuery()->fetchAllAssociative();
         $currentPositions = [];
         foreach ($positions as $position) {
@@ -90,6 +97,12 @@ final class DoctrinePositionUpdateHandler implements PositionUpdateHandlerInterf
                         ->setParameter('parentId', $parentId);
                 }
 
+                foreach ($this->getFilters($positionDefinition) as $column => $value) {
+                    $qb
+                        ->andWhere('`' . $column . '` = :filter_' . $column)
+                        ->setParameter('filter_' . $column, $value);
+                }
+
                 try {
                     $qb->executeStatement();
                 } catch (Exception) {
@@ -103,5 +116,18 @@ final class DoctrinePositionUpdateHandler implements PositionUpdateHandlerInterf
 
             throw new PositionUpdateException('Could not update.', 'Admin.Catalog.Notification');
         }
+    }
+
+    /**
+     * A grid that hides part of its table - carriers keep their superseded rows as `deleted` - must
+     * not have those rows numbered, or they consume positions and the visible ones come out with
+     * gaps. The filters live on PositionDefinition rather than on its interface so that a module
+     * implementing that interface keeps working.
+     *
+     * @return array<string, scalar>
+     */
+    private function getFilters(PositionDefinitionInterface $positionDefinition): array
+    {
+        return $positionDefinition instanceof PositionDefinition ? $positionDefinition->getFilters() : [];
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
@@ -46,6 +46,10 @@ services:
       $table: 'carrier'
       $idField: 'id_carrier'
       $positionField: 'position'
+      # The carriers grid selects `deleted = 0`, and editing a carrier keeps the old row as deleted.
+      # Without the same restriction here those rows are numbered too and eat positions out of the
+      # visible sequence, which is what leaves gaps in the list after a drag.
+      $filters: { deleted: 0 }
 
   prestashop.core.grid.image.position_definition:
     class: 'PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition'

--- a/tests/Integration/Core/Grid/Position/CarrierPositionUpdateTest.php
+++ b/tests/Integration/Core/Grid/Position/CarrierPositionUpdateTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Grid\Position;
+
+use Db;
+use PrestaShop\PrestaShop\Core\Grid\Position\GridPositionUpdaterInterface;
+use PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition;
+use PrestaShop\PrestaShop\Core\Grid\Position\PositionUpdateFactoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * Editing a carrier keeps the superseded row and marks it deleted, and the carriers grid selects
+ * `deleted = 0`. The positions the grid writes back therefore have to be numbered over the visible
+ * rows only, or a deleted row eats a position and the list comes out with gaps.
+ */
+class CarrierPositionUpdateTest extends KernelTestCase
+{
+    private const DELETED_CARRIER_ID = 9501;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        static::resetDatabase();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::resetDatabase();
+    }
+
+    protected static function resetDatabase(): void
+    {
+        DatabaseDump::restoreTables(['carrier']);
+    }
+
+    public function testVisibleCarriersKeepAContiguousSequenceWhenADeletedOneSitsAmongThem(): void
+    {
+        self::bootKernel();
+
+        $visibleIds = $this->reindexCarriersLeavingRoomForADeletedOne();
+
+        /** @var PositionUpdateFactoryInterface $factory */
+        $factory = self::getContainer()->get(PositionUpdateFactoryInterface::class);
+        /** @var GridPositionUpdaterInterface $updater */
+        $updater = self::getContainer()->get(GridPositionUpdaterInterface::class);
+        /** @var PositionDefinition $positionDefinition */
+        $positionDefinition = self::getContainer()->get('prestashop.core.grid.carrier.position_definition');
+
+        // The grid numbers the rows it shows, so the last visible carrier dragged to second place
+        // reports its position among the visible ones, not among all the table's rows.
+        $lastVisibleId = end($visibleIds);
+        $update = $factory->buildPositionUpdate(
+            ['positions' => [[
+                'rowId' => $lastVisibleId,
+                'oldPosition' => count($visibleIds) - 1,
+                'newPosition' => 1,
+            ]]],
+            $positionDefinition
+        );
+
+        $updater->update($update);
+
+        $positions = $this->getVisibleCarrierPositions();
+        self::assertSame(
+            range(0, count($visibleIds) - 1),
+            array_values($positions),
+            'the carriers the grid shows must be numbered without a gap'
+        );
+        self::assertSame(1, $positions[$lastVisibleId], 'the dragged carrier must land where it was dropped');
+    }
+
+    /**
+     * @return int[] the ids of the visible carriers, in position order
+     */
+    private function reindexCarriersLeavingRoomForADeletedOne(): array
+    {
+        $db = Db::getInstance();
+        $carriers = $db->executeS(
+            'SELECT id_carrier FROM ' . _DB_PREFIX_ . 'carrier WHERE deleted = 0 ORDER BY position ASC'
+        );
+        $visibleIds = array_map('intval', array_column($carriers, 'id_carrier'));
+        self::assertGreaterThan(2, count($visibleIds), 'the fixture needs a few carriers to reorder');
+
+        // Position 1 is taken by a deleted row, so the visible ones start out at 0, 2, 3, 4...
+        $db->execute(sprintf(
+            'INSERT INTO `%scarrier` (`id_carrier`, `id_reference`, `name`, `url`, `active`, `deleted`, `position`)
+             VALUES (%d, %d, \'Superseded carrier\', \'\', 0, 1, 1)',
+            _DB_PREFIX_,
+            self::DELETED_CARRIER_ID,
+            self::DELETED_CARRIER_ID
+        ));
+
+        $position = 0;
+        foreach ($visibleIds as $id) {
+            if (1 === $position) {
+                ++$position;
+            }
+            $db->execute(sprintf(
+                'UPDATE `%scarrier` SET `position` = %d WHERE `id_carrier` = %d',
+                _DB_PREFIX_,
+                $position,
+                $id
+            ));
+            ++$position;
+        }
+
+        return $visibleIds;
+    }
+
+    /**
+     * @return array<int, int> carrier id => position, in position order
+     */
+    private function getVisibleCarrierPositions(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_carrier, position FROM ' . _DB_PREFIX_ . 'carrier WHERE deleted = 0 ORDER BY position ASC'
+        );
+
+        $positions = [];
+        foreach ($rows as $row) {
+            $positions[(int) $row['id_carrier']] = (int) $row['position'];
+        }
+
+        return $positions;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Reordering on the migrated carriers page writes positions with gaps instead of 1..n. The carriers grid selects `deleted = 0`, but the position machinery numbers every row of `ps_carrier`, and editing a carrier keeps the superseded row with `deleted = 1`. Those rows consume positions out of the sequence, so what the merchant sees after a drag is 1, 2, 4, 5. `PositionDefinition` can now carry the same restriction the grid applies, and the carrier definition declares `deleted = 0`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop where a carrier has been edited at least once - which is what leaves a `deleted = 1` row behind - open Shipping > Carriers and drag a carrier. Before this change the position column comes back with holes; after it, the visible carriers are numbered consecutively and the dragged one lands where it was dropped. `tests/Integration/Core/Grid/Position/CarrierPositionUpdateTest.php` sets up exactly that row and fails on the base branch.
| UI Tests          | Queued on `boo-code/ga.tests.ui.pr` behind two runs already in flight; the link goes here when it is dispatched.
| Fixed issue or discussion?     | Fixes #39286
| Related PRs       | #39320 reached the same diagnosis - @smilesrg's "it may be related to soft-deleted items" on the issue is what this confirms - but its branch carried four unrelated files and it was closed the same day.
| Sponsor company   |

### Measured on 9.1.5

With one superseded carrier sitting at position 1, dragging the last visible carrier to second place:

```
before the drag   id=1 pos=0 | id=50 pos=1 DELETED | id=2 pos=2 | id=3 pos=3 | id=4 pos=4

base              visible positions 0, 1, 3, 4     <- the deleted row keeps position 2
this PR           visible positions 0, 1, 2, 3
```

Reverting only `DoctrinePositionUpdateHandler.php` brings the gap straight back, so the change is doing the work rather than the fixture.

### The shape of the fix

`PositionDefinition` takes an optional `$filters` map, and `DoctrinePositionUpdateHandler` applies it both when it reads the current sequence and when it writes the new one. The carrier definition is the only one that needs it today - of the tables with a position definition, `carrier` is the only one with a `deleted` column - but the mechanism is not carrier-specific, since the real rule is "number the rows the grid shows".

`getFilters()` is deliberately **not** on `PositionDefinitionInterface`. Adding a method there would break any module implementing that interface, so the handler asks for the filters only when the definition is the concrete `PositionDefinition`, which is core's only implementation. If you would rather have it on the interface and take that in a major, say so and I will move it.

Deleted rows keep whatever position they had, which can now repeat a visible one. That is deliberate: their position has no meaning while `deleted = 1`, nothing reads it, and preserving it keeps the change to the sequence the merchant actually sees. The alternative - renumbering deleted rows after the visible ones - costs a second write per drag for no observable benefit.
