### PR TITLE
Derive the locale from the IETF tag when the ISO code is not a known one

### DIFF
--- a/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
@@ -106,9 +106,11 @@ final class AddLanguageHandler extends AbstractLanguageHandler implements AddLan
         $language = new Language();
         $language->name = $command->getName();
         $language->iso_code = $command->getIsoCode()->getValue();
-        if (false !== ($languageDetails = Language::getLangDetails($command->getIsoCode()->getValue()))) {
-            $language->locale = $languageDetails['locale'];
-        }
+        // PrestaShop only knows the locale of the ISO codes it ships with. For any other one the
+        // language used to be stored with an empty locale, so derive it from the IETF tag the
+        // merchant supplied instead.
+        $languageDetails = Language::getLangDetails($command->getIsoCode()->getValue());
+        $language->locale = false !== $languageDetails ? $languageDetails['locale'] : $command->getTagIETF()->toLocale();
         $language->language_code = $command->getTagIETF()->getValue();
         $language->date_format_lite = $command->getShortDateFormat();
         $language->date_format_full = $command->getFullDateFormat();

--- a/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
@@ -17,6 +17,7 @@ use PrestaShop\PrestaShop\Core\Domain\Language\Exception\CannotDisableDefaultLan
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\TagIETF;
 
 /**
  * Handles command which edits language using legacy object model
@@ -77,15 +78,19 @@ final class EditLanguageHandler extends AbstractLanguageHandler implements EditL
             $language->name = $command->getName();
         }
 
-        if (null !== $command->getIsoCode()) {
-            $language->iso_code = $command->getIsoCode()->getValue();
-            if (false !== ($languageDetails = Language::getLangDetails($command->getIsoCode()->getValue()))) {
-                $language->locale = $languageDetails['locale'];
-            }
-        }
-
         if (null !== $command->getTagIETF()) {
             $language->language_code = $command->getTagIETF()->getValue();
+        }
+
+        if (null !== $command->getIsoCode()) {
+            $language->iso_code = $command->getIsoCode()->getValue();
+            // Same as when adding: an ISO code PrestaShop does not ship has no locale to look up,
+            // so fall back to the IETF tag. Read from the language rather than the command, since
+            // the tag is only present when it is being changed too.
+            $languageDetails = Language::getLangDetails($command->getIsoCode()->getValue());
+            $language->locale = false !== $languageDetails
+                ? $languageDetails['locale']
+                : (new TagIETF($language->language_code))->toLocale();
         }
 
         if (null !== $command->getShortDateFormat()) {

--- a/src/Core/Domain/Language/ValueObject/TagIETF.php
+++ b/src/Core/Domain/Language/ValueObject/TagIETF.php
@@ -45,6 +45,23 @@ class TagIETF
     }
 
     /**
+     * The locale this tag stands for, in the `language-REGION` shape `Validate::isLocale()` accepts.
+     *
+     * A tag carrying a region gives it directly - `de-ch` is `de-CH`. A tag without one has no
+     * region to offer, so the language is repeated as the region: `de` becomes `de-DE`. That is the
+     * same shape PrestaShop's own list uses for such languages - `fr` is stored as `fr-FR` - and it
+     * is a defined answer rather than a guess at the country the merchant meant.
+     *
+     * @return string
+     */
+    public function toLocale(): string
+    {
+        [$language, $region] = array_pad(explode('-', $this->tagIETF, 2), 2, null);
+
+        return strtolower($language) . '-' . strtoupper($region ?? $language);
+    }
+
+    /**
      * @param string $tagIETF
      *
      * @throws LanguageConstraintException

--- a/tests/Unit/Core/Domain/Language/ValueObject/TagIETFTest.php
+++ b/tests/Unit/Core/Domain/Language/ValueObject/TagIETFTest.php
@@ -32,6 +32,29 @@ class TagIETFTest extends TestCase
         new TagIETF($invalidTagIETFValue);
     }
 
+    /**
+     * A language whose ISO code PrestaShop does not ship has no locale to look up, and the tag is
+     * the only thing left that says which one the merchant meant.
+     *
+     * @dataProvider getTagIETFAndExpectedLocale
+     */
+    public function testItDerivesTheLocaleFromTheTag(string $tagIETF, string $expectedLocale)
+    {
+        $this->assertSame($expectedLocale, (new TagIETF($tagIETF))->toLocale());
+    }
+
+    public function getTagIETFAndExpectedLocale()
+    {
+        // A tag carrying a region simply gets the casing Validate::isLocale() asks for.
+        yield 'the reported case' => ['de-ch', 'de-CH'];
+        yield 'already cased' => ['lt-LT', 'lt-LT'];
+        yield 'upper language' => ['EN-gb', 'en-GB'];
+        // Without a region there is none to take, so the language stands in for it - which is the
+        // shape PrestaShop's own list already stores for such a language (fr is fr-FR).
+        yield 'no region' => ['fr', 'fr-FR'];
+        yield 'no region, upper' => ['DE', 'de-DE'];
+    }
+
     public function getValidTagIETFValues()
     {
         yield ['fr'];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Adding a language whose ISO code PrestaShop does not ship with stores it with an empty locale. `AddLanguageHandler` fills that column from `Language::getLangDetails($isoCode)`, which returns `false` for any code outside the bundled list, and nothing fills it in afterwards - the form has no locale field, so the merchant cannot supply one either. The IETF tag they did enter says which locale is meant, so it is derived from that when the lookup finds nothing.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | International > Localization > Languages > Add new language, ISO code `ch`, language code `de-ch`, save. Before this change the Locale column of the new row is empty; after, it is `de-CH`. A language whose ISO code is in the bundled list is unaffected - `fr` still takes `fr-FR` from that list, not from the tag.
| UI Tests          | Queued on `boo-code/ga.tests.ui.pr` behind two runs already in flight; the link goes here when it is dispatched.
| Fixed issue or discussion?     | Fixes #38808
| Related PRs       | #39689 attacked the same issue by adding a locale field to the form, with a new value object and a validator; it was closed by its author. This is the other reading, and the one the reporter asked for - "since the locale cannot be entered, I expect it to be auto generated".
| Sponsor company   |

### Measured on 9.1.5

Dispatching the real `AddLanguageCommand` with the reported input, and reading the row back:

```
base      id=6  iso_code=ch  language_code=de-ch  locale=''
this PR   id=4  iso_code=ch  language_code=de-ch  locale='de-CH'
```

Reverting only `AddLanguageHandler.php` puts the empty locale straight back.

### The rule the derivation uses

`TagIETF` accepts `xx` or `xx-yy`, and `Validate::isLocale()` accepts exactly `^[a-z]{2}-[A-Z]{2}$`, so:

- a tag with a region gives it directly - `de-ch` becomes `de-CH`;
- a tag without one has no region to offer, so the language stands in for it - `de` becomes `de-DE`.

The second half is a defined answer rather than a guess at the country: it is the shape PrestaShop's own list already stores for such a language, `fr` being kept as `fr-FR` on a stock install. Neither rule is reached for a language PrestaShop knows, since the lookup still wins there.

`EditLanguageHandler` carried the same lookup and the same gap, so it gets the same fallback. Its ISO-code branch had to move below the tag branch to read the tag that is being saved in the same command; the tag is optional on edit, so the fallback reads `$language->language_code`, which is by then either the new tag or the stored one.

### What I deliberately did not change

Passing a null "No picture" image to `AddLanguageCommand` throws a `TypeError` out of `copyNoPictureImage()`, which the edit handler guards against and the add handler does not. It is not reachable from the back office - the field is `required` on the add form and optional only when editing - so guarding it would be a change with no caller behind it, and I left it alone. Worth knowing if this handler is ever called directly.
