### PR TITLE
Make the discount lines shown add up to the discount charged

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -520,6 +520,10 @@ class CartCore extends ObjectModel
         } else {
             $virtual_context->virtualTotalTaxIncluded = $virtual_context->cart->getOrderTotal(true, self::ONLY_PRODUCTS);
         }
+        // Keep what the running total started at: a rule reducing one product line needs to know how
+        // much of the cart earlier rules have already taken, and that is this minus the running total.
+        $virtual_context->virtualTotalBaseTaxExcluded = $virtual_context->virtualTotalTaxExcluded;
+        $virtual_context->virtualTotalBaseTaxIncluded = $virtual_context->virtualTotalTaxIncluded;
 
         foreach ($result as &$row) {
             $row['obj'] = new CartRule($row['id_cart_rule'], (int) $this->id_lang);

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1447,6 +1447,42 @@ class CartRuleCore extends ObjectModel
      *
      * @return float|int|string
      */
+    /**
+     * How much of the cart survives the rules already applied, as a fraction of what it started at.
+     * An amount taken off the order total is spread over the lines in proportion to their value, so
+     * a line that has been through it is worth this much of its original price.
+     *
+     * Returns 1 when there is no running total to compare against: getContextualValue() is also
+     * called outside the loop that maintains it, and then nothing has been applied yet to account for.
+     *
+     * @param Context $context
+     * @param bool $useTax
+     * @param float $cartAmountTaxIncluded
+     * @param float $cartAmountTaxExcluded
+     *
+     * @return float
+     */
+    private function getAlreadyReducedRatio(Context $context, $useTax, $cartAmountTaxIncluded, $cartAmountTaxExcluded)
+    {
+        $runningTotal = $useTax ? $context->virtualTotalTaxIncluded : $context->virtualTotalTaxExcluded;
+        // What the running total started at, recorded beside it. Deliberately not CartRule's static
+        // cart-amount cache: that is filled the first time a cart is priced in the request and never
+        // refreshed, so adding a product afterwards leaves it holding a smaller cart than the one
+        // being priced. It falls back to that cache only when no running total was set up at all.
+        $originalTotal = $useTax ? $context->virtualTotalBaseTaxIncluded : $context->virtualTotalBaseTaxExcluded;
+        if (empty($originalTotal)) {
+            $originalTotal = $useTax ? $cartAmountTaxIncluded : $cartAmountTaxExcluded;
+        }
+
+        if (empty($runningTotal) || $originalTotal <= 0) {
+            return 1.0;
+        }
+
+        // A rule can take the cart below zero on paper; a line is never worth less than nothing, and
+        // never more than it started at.
+        return max(0.0, min(1.0, $runningTotal / $originalTotal));
+    }
+
     public function getContextualValue($use_tax, ?Context $context = null, $filter = null, $package = null, $use_cache = true)
     {
         if (!CartRule::isFeatureActive()) {
@@ -1591,9 +1627,16 @@ class CartRuleCore extends ObjectModel
 
             // Discount (%) on a specific product
             if ((float) $this->reduction_percent && $this->reduction_product > 0) {
+                // Rules are applied one after another, so a percentage reaching a product line has to
+                // see what earlier rules already took off it - which is what the percentage on the
+                // order total does a few lines above by reading the running total. Without it the
+                // line printed under the cart is computed on the undiscounted price while the total
+                // charged is not, and the two stop adding up.
+                $alreadyReducedRatio = $this->getAlreadyReducedRatio($context, $use_tax, $cart_amount_ti, $cart_amount_te);
                 foreach ($package_products as $product) {
                     if ($product['id_product'] == $this->reduction_product && (($this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
-                        $reduction_value += ($use_tax ? $product['total_wt'] : $product['total']) * $this->reduction_percent / 100;
+                        $productTotal = ($use_tax ? $product['total_wt'] : $product['total']) * $alreadyReducedRatio;
+                        $reduction_value += $productTotal * $this->reduction_percent / 100;
                     }
                 }
             }

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -101,6 +101,12 @@ class ContextCore
     /** @var float */
     public $virtualTotalTaxIncluded = 0;
 
+    /** @var float what virtualTotalTaxExcluded started at, before any cart rule was applied */
+    public $virtualTotalBaseTaxExcluded = 0;
+
+    /** @var float what virtualTotalTaxIncluded started at, before any cart rule was applied */
+    public $virtualTotalBaseTaxIncluded = 0;
+
     /** @var Translator */
     protected $translator = null;
 

--- a/tests/Integration/Classes/CartRuleDisplayedValueTest.php
+++ b/tests/Integration/Classes/CartRuleDisplayedValueTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Cache;
+use Cart;
+use CartRule;
+use Configuration;
+use Context;
+use Country;
+use Currency;
+use Customer;
+use Db;
+use Language;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The discount lines printed under the cart have to add up to the discount the cart charges. The
+ * lines come from CartRule::getContextualValue() and the total from Cart::getOrderTotal(), and the
+ * two only agree if a percentage restricted to a product accounts for what earlier rules already
+ * took off that product.
+ */
+class CartRuleDisplayedValueTest extends KernelTestCase
+{
+    private const RESTRICTED_PRODUCT_ID = 2;
+    private const SECOND_PRODUCT_ID = 3;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        static::resetDatabase();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::resetDatabase();
+    }
+
+    protected static function resetDatabase(): void
+    {
+        DatabaseDump::restoreTables([
+            'cart',
+            'cart_product',
+            'cart_cart_rule',
+            'cart_rule',
+            'cart_rule_lang',
+            'cart_rule_shop',
+            'cart_rule_product_rule_group',
+            'cart_rule_product_rule',
+            'cart_rule_product_rule_value',
+        ]);
+    }
+
+    public function testTheLinesShownAddUpToTheDiscountCharged(): void
+    {
+        $cart = $this->buildCart(true);
+
+        self::assertEqualsWithDelta(
+            (float) $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS),
+            $this->sumOfShownLines($cart, 2),
+            0.01,
+            'the discount lines shown under the cart do not add up to the discount it charges'
+        );
+    }
+
+    /**
+     * With nothing applied before it, a percentage on a product is worth the whole percentage of
+     * that product - the reduction above must not change that.
+     */
+    public function testAPercentageOnItsOwnIsUntouched(): void
+    {
+        $cart = $this->buildCart(false);
+
+        self::assertEqualsWithDelta(
+            (float) $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS),
+            $this->sumOfShownLines($cart, 1),
+            0.01,
+            'a percentage applied on its own changed value'
+        );
+    }
+
+    private function sumOfShownLines(Cart $cart, int $expectedRules): float
+    {
+        // Building the cart warmed getContextualValue()'s cache. A customer opening the cart gets a
+        // fresh request instead, so drop it before reading what the page would print.
+        Cache::clean('getContextualValue_*');
+
+        $shownTotal = 0.0;
+        $seen = [];
+        foreach ($cart->getCartRules() as $cartRule) {
+            if (isset($seen[$cartRule['id_cart_rule']])) {
+                continue;
+            }
+            $seen[$cartRule['id_cart_rule']] = true;
+            $shownTotal += (float) $cartRule['value_real'];
+        }
+
+        self::assertCount($expectedRules, $seen, 'the expected rules did not all apply');
+
+        return $shownTotal;
+    }
+
+    private function buildCart(bool $withAmountOnTotal): Cart
+    {
+        self::bootKernel();
+        $context = Context::getContext();
+        $context->container = self::getContainer();
+        // The CLI context has no shop front, and pricing reaches for the currency's precision.
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->shop = new Shop(1);
+        $context->country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'));
+        $context->customer = new Customer(1);
+
+        $this->deleteExistingCartRules();
+        if ($withAmountOnTotal) {
+            $this->createRule('Amount off the order total', ['reduction_amount' => 10.0]);
+        }
+        $this->createPercentOnOneProductRule();
+
+        $cart = new Cart();
+        $cart->id_customer = 1;
+        $cart->id_lang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $cart->id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $cart->id_shop = 1;
+        $cart->id_guest = 1;
+        $cart->add();
+
+        $context->cart = $cart;
+        $cart->updateQty(1, self::RESTRICTED_PRODUCT_ID);
+        $cart->updateQty(1, self::SECOND_PRODUCT_ID);
+        CartRule::autoAddToCart($context, false);
+
+        return $cart;
+    }
+
+    private function deleteExistingCartRules(): void
+    {
+        $tables = [
+            'cart_cart_rule',
+            'cart_rule',
+            'cart_rule_lang',
+            'cart_rule_shop',
+            'cart_rule_product_rule_group',
+            'cart_rule_product_rule',
+            'cart_rule_product_rule_value',
+        ];
+        foreach ($tables as $table) {
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . $table);
+        }
+    }
+
+    private function createPercentOnOneProductRule(): void
+    {
+        $id = $this->createRule('Percentage on one product', [
+            'reduction_percent' => 10.0,
+            'reduction_product' => self::RESTRICTED_PRODUCT_ID,
+        ]);
+
+        $db = Db::getInstance();
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . 'cart_rule_product_rule_group (id_cart_rule, quantity) VALUES (' . $id . ', 1)');
+        $groupId = (int) $db->Insert_ID();
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . "cart_rule_product_rule (id_product_rule_group, type) VALUES ($groupId, 'products')");
+        $productRuleId = (int) $db->Insert_ID();
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . 'cart_rule_product_rule_value (id_product_rule, id_item) VALUES (' . $productRuleId . ', ' . self::RESTRICTED_PRODUCT_ID . ')');
+        $db->execute('UPDATE ' . _DB_PREFIX_ . 'cart_rule SET product_restriction = 1 WHERE id_cart_rule = ' . $id);
+    }
+
+    /**
+     * @param array<string, float|int> $reduction
+     */
+    private function createRule(string $name, array $reduction): int
+    {
+        $cartRule = new CartRule();
+        // No code, so it applies on its own and the cart prints a line for it.
+        $cartRule->name = [(int) Configuration::get('PS_LANG_DEFAULT') => $name];
+        $cartRule->quantity = 100;
+        $cartRule->quantity_per_user = 100;
+        $cartRule->date_from = date('Y-m-d H:i:s', strtotime('-1 day'));
+        $cartRule->date_to = date('Y-m-d H:i:s', strtotime('+1 year'));
+        $cartRule->active = true;
+        $cartRule->partial_use = true;
+        $cartRule->priority = 1;
+        $cartRule->reduction_tax = true;
+        $cartRule->reduction_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $cartRule->reduction_amount = $reduction['reduction_amount'] ?? 0;
+        $cartRule->reduction_percent = $reduction['reduction_percent'] ?? 0;
+        $cartRule->reduction_product = $reduction['reduction_product'] ?? 0;
+        $cartRule->add();
+
+        return (int) $cartRule->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The discount lines printed under the cart do not add up to the discount the cart charges when an amount off the order total is combined with a percentage restricted to one product. The total applies the rules one after another, so the percentage lands on what is left of that product line, while the line printed for it is computed on the undiscounted price. This makes the printed line use the same base the total does. The amount charged does not change.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create two automatic cart rules: one taking a fixed amount off the order total, one applying a percentage restricted to a single product. Put that product and one other in the cart. Before this change the "Discount" total and the sum of the individual discount lines differ; after, they match, and the total charged is the same as before. `tests/Integration/Classes/CartRuleDisplayedValueTest.php` covers it and fails on the base branch.
| UI Tests          | Queued on `boo-code/ga.tests.ui.pr` behind two runs already in flight; the link goes here when it is dispatched.
| Fixed issue or discussion?     | Fixes #38798
| Related PRs       |
| Sponsor company   |

### Measured

Two carts, on two different data sets, reading the lines a page would print and the discount the cart charges:

```
                          lines shown            charged     
base      9.1.x shop      10.00 + 3.45  = 13.45   12.95   off by 0.50
this PR                   10.00 + 2.95  = 12.95   12.95   matches

base      test fixtures   10.00 + 2.872 = 12.872  12.370  off by 0.502
this PR                   10.00 + 2.374 = 12.374  12.370  matches
```

The charged figure is identical in both columns: this changes what is printed, never what is taken. Reverting `classes/CartRule.php` alone brings the gap back and turns the test red.

### What was wrong

`Cart::getCartRules()` already keeps a running total for exactly this reason, and `getContextualValue()` reads it for a percentage on the order total. A percentage restricted to a product ignored it and used the product's full line, so the two calculations disagreed by the percentage of whatever earlier rules had taken off that product - the 0.50 above is 10% of that product's share of the 10 off the total.

### Why it does not read the existing cart-amount cache

The obvious base for the ratio is `CartRule::$cartAmountCache`, and it is wrong for this. It is filled the first time a cart is priced in a request and never refreshed, so a cart that gains a product afterwards leaves it holding the smaller total. Building the cart in the usual order - add first product, add second - is enough to do that: the cache ends up at one line's value while the cart holds two. So the base is recorded next to the running total when that total is set up, which is the only place it is guaranteed to describe the same cart.

That staleness is worth knowing about on its own; it is pre-existing and this PR does not otherwise touch it.

### Ordering

The lines and the total are still produced by two passes, and the priority order used for the total comes from `DiscountPriority::sortByPriority()` (type, then the priority field, then `date_add`). This change makes a percentage on a product agree with the total for the ordering the cart actually uses; it does not merge the two passes. If you would rather have the breakdown derived from the total's own pass so the two cannot drift again, that is a larger change and I am happy to do it that way instead - say so and I will rework it.
