### PR TITLE
Offer partial use of an amount discount on the discount form again

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
@@ -183,6 +183,8 @@ class DiscountFormDataHandler implements FormDataHandlerInterface
         } else {
             throw new RuntimeException('Unknown discount value type ' . $reduction['type']);
         }
+
+        $command->setAllowPartialUse((bool) ($data['value']['allow_partial_use'] ?? true));
     }
 
     private function updateDiscountConditions(AddDiscountCommand|UpdateDiscountCommand $command, array $data): void

--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -71,6 +71,11 @@ class DiscountFormDataProvider implements FormDataProviderInterface
             'information' => [
                 'highlight_in_cart' => false,
             ],
+            // Same default the cart rule itself carries, so a new discount behaves as one made
+            // before this option was on the form.
+            'value' => [
+                'allow_partial_use' => true,
+            ],
             'period' => [
                 'valid_date_range' => [
                     'from' => $startDate->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
@@ -181,6 +186,7 @@ class DiscountFormDataProvider implements FormDataProviderInterface
                     'type' => $isAmountDiscount ? DiscountSettings::AMOUNT : DiscountSettings::PERCENT,
                     'include_tax' => $discountForEditing->getReductionAmount()?->isTaxIncluded(),
                 ],
+                'allow_partial_use' => $discountForEditing->isAllowPartialUse(),
             ],
             'free_gift' => [
                 'product' => $this->getGiftDetails($discountForEditing),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountValueType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountValueType.php
@@ -7,6 +7,7 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Discount;
 
 use PrestaShopBundle\Form\Admin\Type\CardType;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -23,6 +24,13 @@ class DiscountValueType extends TranslatorAwareType
                 'row_attr' => [
                     'class' => 'discount-container',
                 ],
+            ])
+            // Only an amount discount can leave a remainder, so this has no effect on a percentage
+            // one - the same as in the previous discount form, which also stored it either way.
+            ->add('allow_partial_use', SwitchType::class, [
+                'label' => $this->trans('Partial use', 'Admin.Catalog.Feature'),
+                'label_help_box' => $this->trans('If you do not allow partial use, the voucher value will be lowered to the total order amount. If you allow partial use, however, a new voucher will be created with the remainder.', 'Admin.Catalog.Help'),
+                'required' => false,
             ])
         ;
     }

--- a/tests/Integration/Core/Form/IdentifiableObject/DiscountPartialUseTest.php
+++ b/tests/Integration/Core/Form/IdentifiableObject/DiscountPartialUseTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Form\IdentifiableObject;
+
+use CartRule;
+use Configuration;
+use Context;
+use Currency;
+use Db;
+use Language;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\DiscountFormDataHandler;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\DiscountFormDataProvider;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The previous discount form let a merchant allow partial use of an amount discount, and the cart
+ * rule has always stored it. The rewritten form has to carry it in both directions or the setting
+ * is invisible and silently reset on the next save.
+ */
+class DiscountPartialUseTest extends KernelTestCase
+{
+    private const CART_LEVEL_DISCOUNT_TYPE_ID = 2;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        static::resetDatabase();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::resetDatabase();
+    }
+
+    protected static function resetDatabase(): void
+    {
+        DatabaseDump::restoreTables(['cart_rule', 'cart_rule_lang', 'cart_rule_shop']);
+    }
+
+    /**
+     * @dataProvider getStoredAndExpectedFlag
+     */
+    public function testTheStoredFlagReachesTheForm(int $stored, bool $expected): void
+    {
+        $discountId = $this->createAmountDiscount($stored);
+
+        $data = $this->getProvider()->getData($discountId);
+
+        self::assertSame($expected, $data['value']['allow_partial_use']);
+    }
+
+    public function getStoredAndExpectedFlag(): iterable
+    {
+        yield 'not allowed' => [0, false];
+        yield 'allowed' => [1, true];
+    }
+
+    /**
+     * @dataProvider getSubmittedAndExpectedFlag
+     */
+    public function testWhatTheFormSubmitsIsStored(int $stored, bool $submitted, int $expected): void
+    {
+        $discountId = $this->createAmountDiscount($stored);
+
+        $data = $this->getProvider()->getData($discountId);
+        $data['value']['allow_partial_use'] = $submitted;
+        $this->getHandler()->update($discountId, $data);
+
+        self::assertSame(
+            $expected,
+            (int) Db::getInstance()->getValue(
+                'SELECT partial_use FROM ' . _DB_PREFIX_ . 'cart_rule WHERE id_cart_rule = ' . $discountId
+            )
+        );
+    }
+
+    public function getSubmittedAndExpectedFlag(): iterable
+    {
+        yield 'turning it on' => [0, true, 1];
+        yield 'turning it off' => [1, false, 0];
+    }
+
+    /**
+     * A discount made before the option existed on the form allowed partial use, so a new one has to
+     * start the same way rather than silently taking it away.
+     */
+    public function testANewDiscountStartsAllowingIt(): void
+    {
+        self::assertTrue($this->getProvider()->getDefaultData()['value']['allow_partial_use']);
+    }
+
+    private function getProvider(): DiscountFormDataProvider
+    {
+        $this->bootWithShopContext();
+
+        return self::getContainer()->get(DiscountFormDataProvider::class);
+    }
+
+    private function getHandler(): DiscountFormDataHandler
+    {
+        $this->bootWithShopContext();
+
+        return self::getContainer()->get(DiscountFormDataHandler::class);
+    }
+
+    private function bootWithShopContext(): void
+    {
+        if (null === self::$kernel) {
+            self::bootKernel();
+        }
+
+        $context = Context::getContext();
+        $context->container = self::getContainer();
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->shop = new Shop(1);
+    }
+
+    private function createAmountDiscount(int $partialUse): int
+    {
+        $this->bootWithShopContext();
+
+        $cartRule = new CartRule();
+        $cartRule->name = [(int) Configuration::get('PS_LANG_DEFAULT') => 'Amount discount'];
+        $cartRule->quantity = 10;
+        $cartRule->quantity_per_user = 1;
+        $cartRule->date_from = date('Y-m-d H:i:s', strtotime('-1 day'));
+        $cartRule->date_to = date('Y-m-d H:i:s', strtotime('+1 year'));
+        $cartRule->active = true;
+        $cartRule->priority = 1;
+        $cartRule->reduction_amount = 20.0;
+        $cartRule->reduction_tax = true;
+        $cartRule->reduction_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        // The parameter carries the stored tinyint, which is what the UPDATE below writes; the
+        // property itself is declared bool.
+        $cartRule->partial_use = (bool) $partialUse;
+        $cartRule->add();
+
+        // The rewritten form only reads discounts that carry one of its types.
+        Db::getInstance()->execute(sprintf(
+            'UPDATE `%scart_rule` SET `id_cart_rule_type` = %d, `partial_use` = %d WHERE `id_cart_rule` = %d',
+            _DB_PREFIX_,
+            self::CART_LEVEL_DISCOUNT_TYPE_ID,
+            $partialUse,
+            (int) $cartRule->id
+        ));
+
+        return (int) $cartRule->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The rewritten discount form has no partial use option, so a merchant cannot allow a customer to spend part of an amount discount and keep the remainder, as the previous form allowed. Everything below the form already carries it - the command, the query result, the filler and the validator all handle `partial_use` - only the form itself was missing, which also means the stored value was reset on every save from that screen. This adds the field and maps it in both directions.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With the discount feature enabled, create or edit a discount set as an amount: the value card now carries a "Partial use" switch. Turn it off, save, reopen - it stays off, and the `partial_use` column of the cart rule follows. A discount created before this change keeps whatever it had rather than being reset by the first save.
| UI Tests          | Queued on `boo-code/ga.tests.ui.pr` behind two runs already in flight; the link goes here when it is dispatched.
| Fixed issue or discussion?     | Fixes #41198
| Related PRs       |
| Sponsor company   |

### What was already there

`UpdateDiscountCommand::setAllowPartialUse()`, `AddDiscountCommand::$allowPartialUse`, `DiscountForEditing::isAllowPartialUse()`, `DiscountFiller` writing `partial_use` and `DiscountValidator` validating it. So this is three lines of wiring plus the field, not a new feature:

```
DiscountValueType             the switch
DiscountFormDataProvider      getData()        reads it back onto the form
                              getDefaultData() a new discount starts allowing it
DiscountFormDataHandler       setDiscountValue() sends it to the command
```

Measured through the real services, each read in its own process so nothing is served from the request cache:

```
stored partial_use=0  ->  form shows allow_partial_use = false
stored partial_use=1  ->  form shows allow_partial_use = true
submitted true        ->  stored partial_use = 1
submitted false       ->  stored partial_use = 0
new discount default  ->  true
```

Reverting the three files turns all five cases red.

### Two choices worth naming

**Where the field lives.** I put it on the value card, next to the amount, because that is where the previous form had it and where a merchant coming from it will look. The alternative is the usability card, which holds the other consumption settings - quantity, priority, compatibility - and is arguably the better home semantically. Say which you prefer and I will move it.

**The default.** A new discount starts with partial use allowed, matching `CartRule::$partial_use` and `AddDiscountCommand::$allowPartialUse`, both of which already default to true. The database column defaults to 0, so a row inserted outside the domain differs, but nothing in the discount flow does that.

Only an amount discount can leave a remainder, so the switch has no effect on a percentage one. The previous form stored it either way as well, and hiding it by discount type is front-end behaviour I would rather add deliberately than guess at - happy to wire that up if you want it conditional.
