### PR TITLE
Add a status action to the prestashop:module CLI command

### DIFF
--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -11,10 +11,15 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
+use PrestaShop\PrestaShop\Core\Domain\Module\Exception\ModuleNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Module\Query\GetModuleInfos;
+use PrestaShop\PrestaShop\Core\Domain\Module\QueryResult\ModuleInfos;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -32,6 +37,7 @@ class ModuleCommand extends Command
         'upgrade',
         'configure',
         'delete',
+        'status',
     ];
 
     /**
@@ -51,6 +57,7 @@ class ModuleCommand extends Command
         protected readonly ModuleManager $moduleManager,
         protected readonly ContextBuilderPreparer $contextBuilderPreparer,
         protected readonly Configuration $configuration,
+        protected readonly CommandBusInterface $queryBus,
     ) {
         parent::__construct();
     }
@@ -63,7 +70,8 @@ class ModuleCommand extends Command
             ->addArgument('action', InputArgument::REQUIRED, sprintf('Action to execute (Allowed actions: %s).', implode(' / ', $this->allowedActions)))
             ->addArgument('module name', InputArgument::REQUIRED, 'Module on which the action will be executed')
             ->addArgument('file path', InputArgument::OPTIONAL, 'YML file path for configuration')
-            ->addOption('skip-overrides', null, InputOption::VALUE_NONE, 'Skip installing/uninstalling module overrides');
+            ->addOption('skip-overrides', null, InputOption::VALUE_NONE, 'Skip installing/uninstalling module overrides')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'For the "status" action, output the status as a JSON object instead of a table.');
     }
 
     protected function init(InputInterface $input, OutputInterface $output)
@@ -112,6 +120,8 @@ class ModuleCommand extends Command
         try {
             if ($action === 'configure') {
                 $this->executeConfigureModuleAction($moduleName, $file);
+            } elseif ($action === 'status') {
+                return $this->executeStatusModuleAction($moduleName, (bool) $input->getOption('json'));
             } else {
                 $this->executeGenericModuleAction($action, $moduleName);
             }
@@ -153,6 +163,54 @@ class ModuleCommand extends Command
             $this->translator->trans('Configuration successfully applied.', [], 'Admin.Modules.Notification'),
             'info'
         );
+    }
+
+    /**
+     * Read-only action: reports whether the module is installed and enabled, along with its versions.
+     */
+    protected function executeStatusModuleAction(string $moduleName, bool $asJson): int
+    {
+        try {
+            /** @var ModuleInfos $moduleInfos */
+            $moduleInfos = $this->queryBus->handle(new GetModuleInfos($moduleName));
+        } catch (ModuleNotFoundException) {
+            $this->displayMessage(
+                $this->translator->trans(
+                    'Module %module% was not found on disk.',
+                    ['%module%' => $moduleName],
+                    'Admin.Modules.Notification'
+                ),
+                'error'
+            );
+
+            return 1;
+        }
+
+        if ($asJson) {
+            $this->output->writeln((string) json_encode([
+                'technical_name' => $moduleInfos->getTechnicalName(),
+                'module_id' => $moduleInfos->getModuleId(),
+                'installed' => $moduleInfos->isInstalled(),
+                'enabled' => $moduleInfos->isEnabled(),
+                'version' => $moduleInfos->getModuleVersion(),
+                'installed_version' => $moduleInfos->getInstalledVersion(),
+            ]));
+
+            return 0;
+        }
+
+        $table = new Table($this->output);
+        $table->setRows([
+            ['Technical name', $moduleInfos->getTechnicalName()],
+            ['Module ID', null === $moduleInfos->getModuleId() ? '-' : (string) $moduleInfos->getModuleId()],
+            ['Installed', $moduleInfos->isInstalled() ? 'yes' : 'no'],
+            ['Enabled', $moduleInfos->isEnabled() ? 'yes' : 'no'],
+            ['Version (disk)', $moduleInfos->getModuleVersion()],
+            ['Version (installed)', $moduleInfos->getInstalledVersion() ?? '-'],
+        ]);
+        $table->render();
+
+        return 0;
     }
 
     protected function executeGenericModuleAction($action, $moduleName)

--- a/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
@@ -45,6 +45,8 @@ services:
 
   PrestaShopBundle\Command\ModuleCommand:
     autowire: true
+    arguments:
+      $queryBus: '@prestashop.core.query_bus'
     tags:
       - 'console.command'
 

--- a/tests/Unit/PrestaShopBundle/Command/ModuleCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/Command/ModuleCommandTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Command;
+
+use Context;
+use Employee;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
+use PrestaShop\PrestaShop\Core\Domain\Module\Exception\ModuleNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Module\Query\GetModuleInfos;
+use PrestaShop\PrestaShop\Core\Domain\Module\QueryResult\ModuleInfos;
+use PrestaShop\PrestaShop\Core\Module\ModuleManager;
+use PrestaShopBundle\Command\ModuleCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ModuleCommandTest extends TestCase
+{
+    private CommandBusInterface&MockObject $queryBus;
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        $this->queryBus = $this->createMock(CommandBusInterface::class);
+
+        $legacyContext = $this->createMock(LegacyContext::class);
+        $context = $this->createMock(Context::class);
+        // Set an employee so the command does not try to build a legacy one.
+        $context->employee = $this->createMock(Employee::class);
+        $legacyContext->method('getContext')->willReturn($context);
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('get')->with('PS_LANG_DEFAULT')->willReturn(1);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $parameters = []) => strtr($id, $parameters)
+        );
+
+        $command = new ModuleCommand(
+            $translator,
+            $legacyContext,
+            $this->createMock(ModuleSelfConfigurator::class),
+            $this->createMock(ModuleManager::class),
+            $this->createMock(ContextBuilderPreparer::class),
+            $configuration,
+            $this->queryBus,
+        );
+        // The command relies on the "formatter" helper provided by the default helper set.
+        $command->setApplication(new Application());
+
+        $this->tester = new CommandTester($command);
+    }
+
+    public function testStatusDisplaysAnInstalledAndEnabledModule(): void
+    {
+        $this->expectQueryFor('ps_facetedsearch', new ModuleInfos(42, 'ps_facetedsearch', '3.16.1', '3.16.0', true, true));
+
+        $exitCode = $this->tester->execute(['action' => 'status', 'module name' => 'ps_facetedsearch']);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $display = $this->tester->getDisplay();
+        $this->assertStringContainsString('ps_facetedsearch', $display);
+        $this->assertMatchesRegularExpression('/Installed\s+\|\s+yes/', $display);
+        $this->assertMatchesRegularExpression('/Enabled\s+\|\s+yes/', $display);
+        $this->assertMatchesRegularExpression('/Version \(disk\)\s+\|\s+3\.16\.1/', $display);
+        $this->assertMatchesRegularExpression('/Version \(installed\)\s+\|\s+3\.16\.0/', $display);
+    }
+
+    public function testStatusDisplaysDashesForAModuleOnDiskButNotInstalled(): void
+    {
+        $this->expectQueryFor('ps_checkout', new ModuleInfos(null, 'ps_checkout', '2.0.0', null, false, false));
+
+        $exitCode = $this->tester->execute(['action' => 'status', 'module name' => 'ps_checkout']);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $display = $this->tester->getDisplay();
+        $this->assertMatchesRegularExpression('/Module ID\s+\|\s+-/', $display);
+        $this->assertMatchesRegularExpression('/Installed\s+\|\s+no/', $display);
+        $this->assertMatchesRegularExpression('/Enabled\s+\|\s+no/', $display);
+        $this->assertMatchesRegularExpression('/Version \(installed\)\s+\|\s+-/', $display);
+    }
+
+    public function testStatusOutputsJsonWhenTheJsonOptionIsPassed(): void
+    {
+        $this->expectQueryFor('ps_facetedsearch', new ModuleInfos(42, 'ps_facetedsearch', '3.16.1', '3.16.0', false, true));
+
+        $exitCode = $this->tester->execute(['action' => 'status', 'module name' => 'ps_facetedsearch', '--json' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertSame(
+            [
+                'technical_name' => 'ps_facetedsearch',
+                'module_id' => 42,
+                'installed' => true,
+                'enabled' => false,
+                'version' => '3.16.1',
+                'installed_version' => '3.16.0',
+            ],
+            json_decode(trim($this->tester->getDisplay()), true)
+        );
+    }
+
+    public function testStatusFailsWhenTheModuleIsNotFoundOnDisk(): void
+    {
+        $this->queryBus
+            ->expects($this->once())
+            ->method('handle')
+            ->willThrowException(new ModuleNotFoundException());
+
+        $exitCode = $this->tester->execute(['action' => 'status', 'module name' => 'unknown_module']);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+        $this->assertStringContainsString('Module unknown_module was not found on disk.', $this->tester->getDisplay());
+    }
+
+    public function testItRejectsAnUnknownAction(): void
+    {
+        $this->queryBus->expects($this->never())->method('handle');
+
+        $exitCode = $this->tester->execute(['action' => 'explode', 'module name' => 'ps_facetedsearch']);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+        $this->assertStringContainsString('Unknown module action', $this->tester->getDisplay());
+    }
+
+    private function expectQueryFor(string $technicalName, ModuleInfos $moduleInfos): void
+    {
+        $this->queryBus
+            ->expects($this->once())
+            ->method('handle')
+            ->with($this->callback(
+                static fn (GetModuleInfos $query) => $query->getTechnicalName()->getValue() === $technicalName
+            ))
+            ->willReturn($moduleInfos);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds a read-only `status` action to the `prestashop:module` console command, so a script can ask about **one** module instead of rendering and parsing the whole `prestashop:module:list` table. It reports whether the module is installed and enabled, plus its module ID and its disk / installed versions. A `--json` option outputs the same data as a JSON object, and the command exits `1` when the module is not present on disk so it can be used directly in shell conditionals. Implemented as a thin CLI presenter over the existing `GetModuleInfos` CQRS query — no new domain code.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On any 9.2 dev install: <br> 1. `php bin/console prestashop:module status ps_facetedsearch` → table showing `Installed: yes` / `Enabled: yes` and both versions; `echo $?` returns `0`. <br> 2. `php bin/console prestashop:module disable ps_facetedsearch`, re-run step 1 → `Enabled` flips to `no`, `Installed` stays `yes`. Re-enable afterwards. <br> 3. `php bin/console prestashop:module status demooverrideobjectmodel` (on disk, not installed) → `Installed: no` and `Module ID` / `Version (installed)` show `-`. <br> 4. `php bin/console prestashop:module status ps_facetedsearch --json` → single-line JSON object. <br> 5. `php bin/console prestashop:module status not_a_module` → "Module not_a_module was not found on disk."; `echo $?` returns `1`. <br> 6. `php bin/console prestashop:module --help` → `status` is listed among the allowed actions. <br> 7. `php vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter ModuleCommandTest` → 5 tests pass. <br> See the expected outputs below this table.
| UI Tests          | Not applicable — CLI-only change, no back-office or front-office UI involved. Covered by the new unit test.
| Fixed issue or discussion?     | [Fixes #42231](https://github.com/PrestaShop/PrestaShop/discussions/42231)
| Related PRs       | None. Follows up on #41446 (`prestashop:module:list`).
| Sponsor company   | creabilis.com

## Why

`prestashop:module` only exposes write actions (`install`, `uninstall`, `enable`, `disable`, `reset`, `upgrade`, `configure`, `delete`), and `prestashop:module:list` lists *all* modules. Deploy and CI scripts typically need the opposite: *"is `ps_facetedsearch` installed? is it enabled?"* before deciding whether to run `install` or `enable`. Until now that meant parsing the list output or querying `ps_module` / `ps_module_shop` in raw SQL, which bypasses the shop context.

## What changed

- `PrestaShopBundle\Command\ModuleCommand`: new `status` action + `--json` option.
- The action dispatches the existing `Core\Domain\Module\Query\GetModuleInfos` query and renders the resulting `ModuleInfos` DTO. The query bus is injected via an explicit `$queryBus: '@prestashop.core.query_bus'` binding in `command.yml`.
- `ModuleNotFoundException` (thrown by the handler when the module is absent from disk) is caught and reported, returning exit code `1`.
- New unit test `tests/Unit/PrestaShopBundle/Command/ModuleCommandTest.php` — the command previously had none.

## Expected output

Installed and enabled module:

```
$ php bin/console prestashop:module status ps_facetedsearch
+---------------------+------------------+
| Technical name      | ps_facetedsearch |
| Module ID           | 32               |
| Installed           | yes              |
| Enabled             | yes              |
| Version (disk)      | 4.0.1            |
| Version (installed) | 4.0.1            |
+---------------------+------------------+
$ echo $?
0
```

Module present on disk but not installed:

```
$ php bin/console prestashop:module status demooverrideobjectmodel
+---------------------+-------------------------+
| Technical name      | demooverrideobjectmodel |
| Module ID           | -                       |
| Installed           | no                      |
| Enabled             | no                      |
| Version (disk)      | 1.0.0                   |
| Version (installed) | -                       |
+---------------------+-------------------------+
```

JSON output for scripting:

```
$ php bin/console prestashop:module status ps_facetedsearch --json
{"technical_name":"ps_facetedsearch","module_id":32,"installed":true,"enabled":true,"version":"4.0.1","installed_version":"4.0.1"}
```

Unknown module — message plus exit code `1`:

```
$ php bin/console prestashop:module status not_a_module
  Module not_a_module was not found on disk.
$ echo $?
1
```

Action list:

```
$ php bin/console prestashop:module --help
  action   Action to execute (Allowed actions: install / uninstall / enable / disable / reset / upgrade / configure / delete / status).
```
