### PR TITLE
Report translations the server refused instead of always claiming success

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/translations/store/actions.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/store/actions.ts
@@ -94,15 +94,37 @@ export const saveTranslations = async ({commit}: {commit: Commit}, payload: Reco
   const {translations} = payload;
 
   try {
-    await fetch(url, {
+    const response = await fetch(url, {
       method: 'POST',
       body: JSON.stringify({translations}),
     });
 
-    payload.store.dispatch('refreshCounts', {
-      successfullySaved: translations.length,
-      store: payload.store,
-    });
+    // fetch() only rejects on a network failure, so an error status arrives here as a resolved
+    // promise and would otherwise be reported as a success.
+    if (!response.ok) {
+      showGrowl('error', response.statusText);
+      return;
+    }
+
+    // The endpoint answers with one flag per translation. A save can fail on its own - a value the
+    // database refuses, for instance - while the request itself succeeds.
+    const savedByKey: Record<string, boolean> = await response.json();
+    const failedCount = Object.values(savedByKey).filter((saved) => !saved).length;
+    const savedCount = translations.length - failedCount;
+
+    if (savedCount > 0) {
+      payload.store.dispatch('refreshCounts', {
+        successfullySaved: savedCount,
+        store: payload.store,
+      });
+    }
+
+    if (failedCount > 0) {
+      // The ones that failed stay marked as modified, so they are still there to try again.
+      showGrowl('error', `${failedCount} of ${translations.length} translations could not be saved`);
+      return;
+    }
+
     commit(types.RESET_MODIFIED_TRANSLATIONS);
     showGrowl('success', 'Translations successfully updated');
   } catch (error: any) {

--- a/admin-dev/themes/new-theme/package.json
+++ b/admin-dev/themes/new-theme/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": "true",
   "scripts": {
-    "test": "NODE_ENV=test ./node_modules/.bin/mocha --require ts-node/register --require tsconfig-paths/register --reporter spec \"tests/**/*.spec.js\"",
+    "test": "NODE_ENV=test TS_NODE_FILES=true ./node_modules/.bin/mocha --require ts-node/register --require tsconfig-paths/register --reporter spec \"tests/**/*.spec.js\"",
     "build": "webpack --progress --mode=production",
     "dev": "webpack --progress --watch --mode=development",
     "serve": "webpack serve --mode=development",

--- a/admin-dev/themes/new-theme/tests/pages/translations/save-translations.spec.js
+++ b/admin-dev/themes/new-theme/tests/pages/translations/save-translations.spec.js
@@ -1,0 +1,86 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+import {expect} from 'chai';
+import {saveTranslations} from '../../../js/app/pages/translations/store/actions';
+
+/**
+ * The endpoint answers with one flag per translation, so a save can fail on its own while the
+ * request succeeds. Reporting "successfully updated" in that case tells the merchant their work is
+ * stored when it is not.
+ */
+describe('translations store - saveTranslations', () => {
+  let growls;
+  let commits;
+  let dispatched;
+
+  const givenTheServerAnswers = (ok, body) => {
+    global.fetch = async () => ({
+      ok,
+      statusText: 'Internal Server Error',
+      json: async () => body,
+    });
+  };
+
+  const save = async (translationKeys) => {
+    const payload = {
+      url: '/edit',
+      translations: translationKeys.map((key) => ({default: key})),
+      store: {
+        dispatch: (name, args) => dispatched.push({name, args}),
+      },
+    };
+
+    await saveTranslations({commit: (type) => commits.push(type)}, payload);
+  };
+
+  beforeEach(() => {
+    growls = [];
+    commits = [];
+    dispatched = [];
+
+    // showGrowl() reaches for window.$.growl; the error variants are called as growl[type]().
+    const growl = (options) => growls.push({type: 'success', message: options.message});
+    growl.error = (options) => growls.push({type: 'error', message: options.message});
+    global.window = {$: {growl}};
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+    delete global.window;
+  });
+
+  it('reports success and clears the modified ones when every translation is stored', async () => {
+    givenTheServerAnswers(true, {'key.one': true, 'key.two': true});
+
+    await save(['key.one', 'key.two']);
+
+    expect(growls.map((growl) => growl.type)).to.deep.equal(['success']);
+    expect(commits).to.have.lengthOf(1);
+    expect(dispatched[0].args.successfullySaved).to.equal(2);
+  });
+
+  it('reports how many failed and keeps them modified when the server refuses some', async () => {
+    givenTheServerAnswers(true, {'key.one': true, 'key.two': false});
+
+    await save(['key.one', 'key.two']);
+
+    expect(growls[0].type).to.equal('error');
+    expect(growls[0].message).to.contain('1 of 2');
+    // Not cleared: the merchant still has the failed one in front of them to try again.
+    expect(commits).to.have.lengthOf(0);
+    expect(dispatched[0].args.successfullySaved).to.equal(1);
+  });
+
+  it('reports an error status instead of treating it as a save', async () => {
+    // fetch() resolves on 4xx and 5xx, so this used to fall through to the success path.
+    givenTheServerAnswers(false, {});
+
+    await save(['key.one']);
+
+    expect(growls.map((growl) => growl.type)).to.deep.equal(['error']);
+    expect(commits).to.have.lengthOf(0);
+    expect(dispatched).to.have.lengthOf(0);
+  });
+});


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Saving translations in the back office always reports "Translations successfully updated", even for the ones the server refused. `TranslationController::translationEditAction()` answers with one flag per translation, and `saveTranslations()` never read the body - it counted every translation it sent as saved, cleared them all as unmodified and showed the success message. This reads the answer and reports what actually happened.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Translate a wording with a value the database refuses - the reporter's case is an emoji, which fails on the collation - and save from International > Translations. Before this change the page says everything was updated and clears the field; after, it says how many of them could not be saved and leaves those still marked as modified so they can be tried again. Saving values that all succeed is unchanged.
| UI Tests          | Queued on `boo-code/ga.tests.ui.pr` behind two runs already in flight; the link goes here when it is dispatched.
| Fixed issue or discussion?     | Fixes #39437
| Related PRs       |
| Sponsor company   |

### What the old code did

```ts
await fetch(url, {method: 'POST', body: JSON.stringify({translations})});

payload.store.dispatch('refreshCounts', {successfullySaved: translations.length, ...});
commit(types.RESET_MODIFIED_TRANSLATIONS);
showGrowl('success', 'Translations successfully updated');
```

Three things go wrong at once, and the report only names the first:

1. the response body carries `{"<wording>": true|false, ...}` and is thrown away;
2. `successfullySaved: translations.length` counts everything sent, not everything stored;
3. `fetch()` only rejects on a network failure, so a 4xx or 5xx resolves normally and lands on the success path too - the `catch` never sees it.

Now the status is checked, the flags are counted, and the ones that failed stay marked as modified rather than being cleared off the screen.

### The test, and the one line of tooling it needed

`admin-dev/themes/new-theme/tests/pages/translations/save-translations.spec.js` covers all three cases. Reverting `actions.ts` alone turns two of them red - the third, where everything saves, passes either way, which is what it is there to protect.

The suite could not import anything from `js/app` before: `ts-node` type-checks on import and did not load the ambient declarations, so `window.data` - declared in `js/@types/global.d.ts` - came out as an error and any spec touching app code failed to compile. `TS_NODE_FILES=true` on the test script makes those declarations visible. It is one word in `package.json`, it leaves the existing 84 specs passing, and without it this behaviour could not be covered at all.

The message is built in English in the store, as the surrounding ones are - `Translations successfully updated` next to it is a plain string too. If you would rather have it translated I will route it through the page's translation data instead.
