### PR TITLE
Update the UI testing library to the commit that fixes the product type race

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -547,7 +547,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#c9ef920127e4d6ba66a9ff0834e9068d36342470",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a781d9f4fb2c930bdc150d5f626050ca9e74a2a3",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8975,7 +8975,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#c9ef920127e4d6ba66a9ff0834e9068d36342470",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a781d9f4fb2c930bdc150d5f626050ca9e74a2a3",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `Sanity (8.5, firefox, mysql)` fails intermittently on this branch and on the pull requests based on it, always on the same assertion. The cause was fixed in the UI testing library on 28 July, but the tests still run the old code: `tests/UI/package.json` asks for `#main` while `tests/UI/package-lock.json` pins a commit from earlier that day, and the lock wins. This moves the pin to the commit that carries the fix.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `npm install` under `tests/UI` and check that `node_modules/@prestashop-core/ui-testing/dist/versions/develop/pages/BO/catalog/products/index.js` resolves the create-product iframe through `getProductCreateFrame()` rather than `page.frame({url: ...})`. The Sanity run that exercises it is `sanity/03_productsBO/06_deleteProductsWithBulkActions.ts`.
| UI Tests          | This change only moves the pin the campaigns install from, so the campaigns themselves are the test.
| Fixed issue or discussion?     | Fixes #42072
| Related PRs       | PrestaShop/ui-testing-library#1083 is the fix being picked up here.
| Sponsor company   |

### Why the lock is the problem

`tests/UI/package.json` requests the library at `#main`, which reads as "always current", but a lock file records the commit a git dependency resolved to and `npm ci` installs exactly that:

```
package-lock.json  ...ui-testing-library.git#c9ef920127e4d6ba66a9ff0834e9068d36342470
library main       a781d9f4fb2c930bdc150d5f626050ca9e74a2a3
```

The pinned commit is from 28 July 08:48 and still contains the code the failure points at:

```php
const createProductFrame: Frame | null = page.frame({url: this.newProductIframeURL});
expect(createProductFrame).not.toBeNull();
```

which is what the stack trace in the failing job names - `.../products/index.js:240`, `expect(received).not.toBeNull()`. The library merged the fix at 13:59 the same day, so every run since has installed the version from five hours before it.

### What the failure actually was

The helper waits for the iframe element and for the product-type control inside it through `frameLocator`, and then looks the frame up again by URL. Those are different conditions: the element can be visible and interactive while `page.frame({url})` still returns null because the frame's URL has not settled. The library now resolves the frame from the element it already waited on, so there is nothing left to race.

### Scale

Measured on this branch, not on pull requests: of the last 15 `sanity.yml` runs on `9.1.x` itself, 11 concluded and 3 of those failed on `Sanity (8.5, firefox, mysql)` with that identical test and assertion, no pull request involved. It is currently the only failing check on about 25 open pull requests of mine, and it costs a maintainer a re-run each time.

Only the pin moves here - `npm install --package-lock-only` re-resolves to the same package set, so the diff stays at the two lines that name the commit.
