### PR TITLE
Set the PR milestone from the pull request state instead of the event type

### DIFF
--- a/.github/workflows/validate-pr-metadata.yml
+++ b/.github/workflows/validate-pr-metadata.yml
@@ -22,19 +22,25 @@ jobs:
             const baseBranch = pr.base.ref;
             const action = context.payload.action;
 
-            // Only attempt to set a milestone on opened, or on edited when the
-            // base branch changed. Other activity types (reopened, milestoned,
-            // demilestoned) must not retrigger milestone selection.
-            if (action !== 'opened' && action !== 'edited') {
-              console.log(`Skipping set-milestone for event action: ${action}`);
+            // Decide from the pull request state rather than from the activity type.
+            // Keying on 'opened' alone loses the milestone for good whenever that run
+            // does not survive: the concurrency group is shared by every
+            // pull_request_target activity, so an edit arriving while the opened run
+            // is still going cancels it, and every later event took the skip branch.
+            const changes = context.payload.changes;
+            const baseChanged = action === 'edited' && !!(changes && changes.base);
+
+            // A removal is deliberate, so it is never undone.
+            if (action === 'demilestoned') {
+              console.log('Milestone was removed deliberately, not restoring it.');
               return;
             }
-            if (action === 'edited') {
-              const changes = context.payload.changes;
-              if (!changes || !changes.base) {
-                console.log('Edit event but base branch did not change, skipping.');
-                return;
-              }
+            // A milestone already chosen at triage is never overwritten. Re-selecting
+            // it when the base branch changes stays the one exception, and this also
+            // stops the write below from looping through its own milestoned event.
+            if (pr.milestone && !baseChanged) {
+              console.log(`Pull request already carries milestone "${pr.milestone.title}", nothing to do.`);
+              return;
             }
 
             // Fetch all open milestones


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `set-milestone` decides from the event activity type, so a pull request whose `opened` run does not survive never receives a milestone and `convention-check` then fails forever on a field its author cannot set. This makes the job decide from the pull request state instead. Retargeted to `9.2.x`, where the same job carries the same defect; the `9.1.x` port this originally also carried is dropped with that branch.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a pull request and edit its description before the `opened` run finishes. Before: no milestone is ever set and `convention-check` reports `No milestone defined` permanently. After: the next `edited` event assigns the milestone and the check passes. Existing milestones are still never overwritten.
| UI Tests          | Not applicable, CI workflow only.
| Fixed issue or discussion?     |
| Related PRs       | Fixes a defect in #41556 (`aed7c4f0`); companion of PrestaShop/.github#47
| Sponsor company   |

### What this deliberately does not do

A pull request that already carries a milestone which no longer matches its base is left alone. That is
live right now: the PRs retargeted off `9.1.x` keep milestone `9.1.5` on a `9.2.x` base, because their
base change happened while Actions was down, so no run consumed it and no later event re-opens the
question - `pr.milestone` is set and `baseChanged` is false, so this returns early every time.

Re-selecting whenever the milestone disagrees with the base would fix those, but it would also overwrite
a milestone a maintainer set on purpose - pulling a `develop` pull request into `9.2.0`, for instance,
would be reverted on the next edit. Not overwriting a triage decision seemed the more important of the
two, so those milestones need a bulk edit rather than this workflow. Say if you would rather have the
re-selection and I will add it.


## Problem

`set-milestone` keys its decision on the event activity type:

```js
if (action !== 'opened' && action !== 'edited') { return; }
if (action === 'edited') {
  const changes = context.payload.changes;
  if (!changes || !changes.base) {
    console.log('Edit event but base branch did not change, skipping.');
    return;
  }
}
```

So only the `opened` run can assign a milestone. That run is not guaranteed to survive: the concurrency group is

```yaml
group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
cancel-in-progress: true
```

which is shared by every `pull_request_target` activity on the same pull request. An edit arriving while the `opened` run is still going cancels it, and every later event falls into the skip branch above. The milestone is then never assigned, and because `convention-check` has `needs: set-milestone` and `if: always()`, it fails on `No milestone defined` for the rest of the pull request's life. Nothing re-evaluates it.

This is observable rather than theoretical. Both `pull_request_target` runs on #42175 log the same decision:

```
run 30409603241  set-milestone  Edit event but base branch did not change, skipping.
run 30436135846  set-milestone  Edit event but base branch did not change, skipping.
```

The pull request has no milestone and `convention-check` is red. On #42216 a milestone did arrive, at `15:59:38Z` for a pull request opened at `12:34:17Z`, and no new `Validate PR metadata` run was created afterwards, so the check stayed red anyway. Same on #42067, milestone changed at `15:42:35Z` with the newest run from `08:37`.

Repository-wide, 214 of 459 open pull requests currently have no milestone. The cost is not only noise: `validate_milestone` appends to the same `ERRORS` array as `validate_category`, `validate_type` and `validate_title` before a single `exit 1`, so a triage attribute the author cannot act on masks the three failures the author does have to fix.

Separately, `9.1.x` never received #41556 at all. Branches merge upward, so that work reached `9.2.x` and `develop` and left `9.1.x` on the pre-May file, which has no `set-milestone` job and does not pass `GITHUB_TOKEN`. The missing token also makes the live-API fetch from PrestaShop/.github#47 inert there, so a rerun re-reads the cached event payload. That is the same situation as #42031, where a workflow fix present on `develop` had to be brought to `9.1.x` separately.

## Fix

Decide from the pull request state rather than from the activity type. The job now assigns a milestone whenever the pull request has none, on any activity that reaches it, which makes the assignment self-healing regardless of which run survives.

The invariants the original guard was protecting are kept, and are now explicit:

| Situation | Behaviour |
| --- | --- |
| Milestone already set at triage | Never overwritten |
| Base branch changed on an edit | Re-selected, as before |
| `milestoned`, fired by this job's own write | Returns early, so no loop |
| `demilestoned` | Not restored, the removal is deliberate |
| Any activity while no milestone is set | Assigns it, which is the fix |

The workflow file otherwise matches `9.2.x` and `develop`, so merging `9.1.x` upward carries only this fix and the three branches stop drifting.

## Verification

The decision gate was extracted and run against the full activity set before and after, covering the five rows above: the only two outcomes that change are `edited` and `reopened` while no milestone is set, both from skip to assign. No loop, no overwrite, no restore after a deliberate removal.

The workflow passes the repository's own configuration:

```
yamllint -c .github/workflows/yamllint/.yamllint.yml .github/workflows/validate-pr-metadata.yml
```

no findings. No `${{ }}` interpolation is added, so no new expression reaches a shell.


