### PR TITLE
Bound the shop readiness wait and report why it failed

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -94,7 +94,22 @@ runs:
         cd ${{ inputs.PRESTASHOP_DIR }}
         if [[ "${{ inputs.DOCKER_DAEMON }}" = "true" ]]; then
           USER_ID=$(id -u) GROUP_ID=$(id -g) docker compose -f ${{ (inputs.DB_SERVER == 'mysql') && 'docker-compose.yml' || 'docker-compose.mariadb.yml' }} up -d prestashop-git --build
-          bash -c 'while [[ "$(curl -L -s -o /dev/null -w %{http_code} ${{ env.URL_FO }}${{ env.URL_PING }})" != "200" ]]; do sleep 5; done'
+          # Bounded, so a shop that never answers fails with its reason attached. Left unbounded the
+          # loop spins until the runner kills the step, and the job reports only "The action has
+          # timed out." with the log ending mid-build - nothing a contributor can act on.
+          ready=0
+          for _ in $(seq 1 120); do
+            if [[ "$(curl -L -s -o /dev/null -w %{http_code} ${{ env.URL_FO }}${{ env.URL_PING }} || true)" = "200" ]]; then
+              ready=1
+              break
+            fi
+            sleep 5
+          done
+          if [[ "$ready" != "1" ]]; then
+            echo "::error::the shop did not answer 200 at ${{ env.URL_FO }}${{ env.URL_PING }} within 600s"
+            docker compose -f ${{ (inputs.DB_SERVER == 'mysql') && 'docker-compose.yml' || 'docker-compose.mariadb.yml' }} logs --no-color --tail=300 prestashop-git || true
+            exit 1
+          fi
         else
           USER_ID=$(id -u) GROUP_ID=$(id -g) docker compose -f ${{ (inputs.DB_SERVER == 'mysql') && 'docker-compose.yml' || 'docker-compose.mariadb.yml' }} up prestashop-git --build
         fi


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The readiness wait in `setup-env` has no bound and no diagnostic, so a shop that never comes up spins until the runner kills the step. The job then reports only "The action has timed out." with the log ending mid-build. This bounds the wait at 600s and, on failure, emits the reason and the container log.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make the shop fail to boot (for instance point `URL_PING` at a path the container will not serve) and run any workflow that uses `setup-env`. Before: the step hangs for about 15 minutes and ends with "The action has timed out." and no explanation. After: it fails at 600s with `::error::the shop did not answer 200 at ...` followed by the last 300 lines of the container log.
| UI Tests          | Not applicable, CI only.
| Fixed issue or discussion?     |
| Related PRs       | Same area as #42233 (also a `.github` fix on `9.1.x`); the diagnostic this adds is what was missing while investigating #42072
| Sponsor company   |

## Problem

`DOCKER_DAEMON` defaults to `'true'` and neither `symfony-console.yml` nor `sanity.yml` overrides it, so both take this branch of the step:

```bash
docker compose up -d prestashop-git --build
bash -c 'while [[ "$(curl -L -s -o /dev/null -w %{http_code} $URL_FO$URL_PING)" != "200" ]]; do sleep 5; done'
```

The loop has no exit condition other than success. When the shop does not come up it runs until the runner terminates the step, and the only thing the job reports is:

```
##[error]The action has timed out.
```

with the log ending in webpack progress output. There is no statement of what was being waited for, no status code, and no container log, so the failure cannot be diagnosed from the run.

Measured on `9.1.x`, the gap between a healthy run and this state is wide and unambiguous:

| | Duration |
| --- | --- |
| Successful `Symfony Console` jobs (12 samples) | 306s to 404s |
| Jobs ending in "The action has timed out." | 921s to 1049s |

Instances read while auditing open pull requests, across four different authors:

```
#42217  Admin Security Attribute Linter   925s
#42217  Sanity (8.5, chromium, mariadb)   922s
#42216  Symfony Console (admin-api)       999s
#42201  Symfony Console (admin)          1026s
#41632  Symfony Console (admin)          1040s
#41634  Admin Security Attribute Linter   921s
#41663  Admin Security Attribute Linter   925s
#41121  Admin Security Attribute Linter   921s
#38632  Symfony Console (admin)          1049s
```

## Fix

Bound the loop at 120 attempts of 5s, and on expiry state the URL and status expectation and dump the container log before failing. 600s is about 1.5 times the slowest healthy run observed and well under every hang above, so it does not turn a slow-but-working boot into a failure.

The wait is written as an `if` inside the loop rather than `[[ ... ]] && break`, because GitHub runs `shell: bash` as `bash -eo pipefail` and a failing `&&` list would abort the step. `curl` is guarded with `|| true` for the same reason: it exits 7 while the container is still refusing connections.

## Verification

The two paths were run under `bash -eo pipefail` with `curl` stubbed:

- stub answering `200`: breaks immediately, step continues.
- stub exiting `7`: loops to the bound, emits `::error::the shop did not answer 200 at ...`, exits 1. No early `-e` abort, which was the thing worth checking.

`yamllint -c .github/workflows/yamllint/.yamllint.yml .github/actions/setup-env/action.yml` reports no findings. The change adds no new `${{ }}` expression: the two it uses were already interpolated on the line being replaced, and the third selects between two literal filenames.

## What imposes the kill

`timeout-minutes: 15` on the `Setup Environment` step, in both `sanity.yml` and `symfony-console.yml`. That accounts for the cluster: the job durations above are whole-job figures, so they sit a little over the 900s the step itself is allowed.

That timeout is doing its job - it stops the loop from running for the six-hour job default. What it cannot do is say anything about why the shop never answered, because the loop it interrupts writes nothing. So the two are complementary: the step limit remains the backstop, and this change makes the wait end first, on its own terms, with the URL it was polling and the container log attached.

The three workflows that reach `setup-env` without a `timeout-minutes` at all - `integration.yml`, `behaviour.yml`, `api-module.yml` - currently have no backstop other than the job default, and would also stop hanging with this change.

