### PR TITLE
Read on the master when the result is written back

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4671,7 +4671,7 @@ class CartCore extends ObjectModel
                 'INSERT INTO `' . _DB_PREFIX_ . 'customization` (id_cart, id_product_attribute, id_product, `id_address_delivery`, `in_cart`)
                 VALUES(' . (int) $cart->id . ', ' . (int) $val['id_product_attribute'] . ', ' . (int) $val['id_product'] . ', 0, 1)'
             );
-            $custom_ids[$customization_id] = Db::getInstance(_PS_USE_SQL_SLAVE_)->Insert_ID();
+            $custom_ids[$customization_id] = Db::getInstance()->Insert_ID();
         }
 
         // Insert customized_data

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2244,7 +2244,7 @@ class ProductCore extends ObjectModel
             return false;
         }
 
-        $total_quantity = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+        $total_quantity = (int) Db::getInstance()->getValue(
             'SELECT SUM(quantity) as quantity
             FROM ' . _DB_PREFIX_ . 'stock_available
             WHERE id_product = ' . (int) $this->id . '

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -325,7 +325,7 @@ class StockAvailableCore extends ObjectModel
         }
 
         // Get the total quantity of all combinations
-        $total_quantity = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+        $total_quantity = (int) Db::getInstance()->getValue(
             '
 			SELECT SUM(quantity) as quantity
 			FROM ' . _DB_PREFIX_ . 'stock_available

--- a/tests/Integration/Classes/db/DbTest.php
+++ b/tests/Integration/Classes/db/DbTest.php
@@ -58,6 +58,39 @@ class DbTest extends TestCase
         $this->assertTwoCallsOnFirst_ThenOneOnSecondSlave();
     }
 
+    /**
+     * Insert_ID() is PDO::lastInsertId(), a per-connection property: only the connection that
+     * performed the INSERT knows the generated id. Reading it from a slave instance yields 0,
+     * silently losing the id — which is why an INSERT and its Insert_ID() must share a connection.
+     *
+     * No replication is needed to show this: the slave here points at the same server, so the
+     * result depends solely on which connection is asked.
+     */
+    public function testInsertIdIsOnlyKnownByTheConnectionThatInserted(): void
+    {
+        $this->loadSlaves(1);
+
+        $master = Db::getInstance();
+        $slave = Db::getInstance((bool) _PS_USE_SQL_SLAVE_);
+        $this->assertNotSame($master, $slave);
+
+        $table = _DB_PREFIX_ . 'test_insert_id';
+        $master->execute('DROP TABLE IF EXISTS `' . $table . '`');
+        $master->execute(
+            'CREATE TABLE `' . $table . '` (`id` INT AUTO_INCREMENT PRIMARY KEY, `label` VARCHAR(8))'
+            . ' ENGINE=' . _MYSQL_ENGINE_
+        );
+
+        try {
+            $master->execute('INSERT INTO `' . $table . "` (`label`) VALUES ('a')");
+
+            $this->assertGreaterThan(0, (int) $master->Insert_ID());
+            $this->assertSame(0, (int) $slave->Insert_ID());
+        } finally {
+            $master->execute('DROP TABLE IF EXISTS `' . $table . '`');
+        }
+    }
+
     private function assertTwoCallsOnFirst_ThenOneOnSecondSlave(): void
     {
         // Third and fourth calls are on first slave


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Three call sites read on the slave connection and then persist the result. Under replication lag the stale value is written to the database, not merely displayed. See below.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" below.
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes #42235
| Related PRs       | —
| Sponsor company   | Softizy

## What this changes

Three reads are moved from the slave connection to the master. They share one shape: **read on the slave → write the result back on the master**. Under replication lag the stale value is persisted and stays wrong until something else recomputes it.

**`classes/Cart.php` — `Cart::duplicate()`**

```php
Db::getInstance()->execute('INSERT INTO `…customization` (…) VALUES (…)');
-$custom_ids[$customization_id] = Db::getInstance(_PS_USE_SQL_SLAVE_)->Insert_ID();
+$custom_ids[$customization_id] = Db::getInstance()->Insert_ID();
```

`Insert_ID()` is `PDO::lastInsertId()`, a **per-connection** property. The slave connection never executed that `INSERT`, so it returns `0` and the duplicated customizations lose their id.

**`classes/stock/StockAvailable.php` — `postSave()`** sums the combination quantities on the slave, then persists that sum as the parent product quantity.

**`classes/Product.php` — `addAttribute()`** follows the same pattern, with a harsher outcome: an empty read triggers `UPDATE stock_available SET quantity = 0` for the whole product.

The other slave reads in these classes are deliberately left untouched — they feed display or checks, which is what the slave mode is for. Only the three whose result reaches an `INSERT`/`UPDATE` are moved.

## Why this went unnoticed

`_PS_USE_SQL_SLAVE_` is `false` and `config/db_slave_server.inc.php` declares no server on a standard install. `$total_servers` is then `1`, so `Db::getInstance(false)` returns instance `0` — the master — and everything works by accident. The bugs only surface once a real replica is declared, which is presumably why the three lines are unchanged from 8.2.x through `develop`.

## How to test

Two MySQL 8.0 servers, **no replication between them** so the "replica" is deterministically behind (the lag, held at its maximum), and `config/db_slave_server.inc.php` declaring the second one:

```php
return array(array('server' => '<second host>', 'user' => 'root', 'password' => 'root', 'database' => 'shop'));
```

With two servers declared, `Db::getInstance()` and `Db::getInstance(false)` return two distinct objects and two distinct PDO connections.

**1. `Insert_ID()`** — `INSERT` into `ps_customization` on the master, then read `Insert_ID()` from both connections. Before: `'2'` on the master, `'0'` on the slave. After: `'2'` from the call site.

**2. `postSave()`** — product `1`, two combinations at `10` each on both servers; raise one to `50` on the master only, then trigger `postSave()`. Before: parent quantity persisted as `20` while the real sum is `60`. After: `60`.

**3. `addAttribute()`** — product `1` with parent row `100` on both servers, plus combination rows `40` and `60` on the master only (the import/ERP case: combinations and their stock were just written, another combination is added in the same request). Before: `SUM` reads `0` on the slave and the whole product stock is reset to `0`, erasing 200 units. After: the stock is preserved.

Full reproduction output is in #42235.

Note on the harness: I ran these by loading `classes/db/Db.php` and `classes/db/DbPDO.php` from a `develop` checkout with minimal stubs (`Cache`, `Tools`, and `pSQL`/`bqSQL` from `config/alias.php`), rather than clicking through the Back Office. The mechanism exercised is the core one and the incriminated lines are verbatim from upstream, but it is not a full-install verification. I can share the scripts if useful.

