### PR TITLE
Bump the UI testing library to the commit fixing the product type race

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -688,8 +688,8 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#9861904d5b6a5bb8498d8c9afe8bd1e2fff58135",
-      "integrity": "sha512-Es2i2KgdhZ8ihvRPavXFBrswubzFdW5PhGIVhnHw7zkblsZjKKs1domDMnGpWIJrOZhJWquk4AXvfGDiP2jdGQ==",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a781d9f4fb2c930bdc150d5f626050ca9e74a2a3",
+      "integrity": "sha512-rRqMLXsUMIXb1upy95hOaWiOyCPMx9nDMoC7f0OboRqsMfXBX5rn636aMp1V7IYB9t2/rDWXqXSmy66Flo+/yw==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Pin `@prestashop-core/ui-testing` to the commit that fixes the create-product iframe race, so the `Sanity (…, firefox, …)` flake stops failing pull requests based on `develop`. #42157 does the same for `9.1.x`; the pins have diverged so the bump does not travel between branches on its own.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `cd tests/UI && npm ci` resolves `@prestashop-core/ui-testing` at `a781d9f4fb2c930bdc150d5f626050ca9e74a2a3`, and `dist/versions/develop/pages/BO/catalog/products/index.js` is the fixed page object. Then any run of the `sanity:fast-fail` campaign stops failing on `should choose 'Standard product'`.
| UI Tests          | This change is the UI test dependency itself, so the `Sanity` jobs on this pull request are the test of it.
| Fixed issue or discussion?     | Fixes #42072
| Related PRs       | PrestaShop/ui-testing-library#1083 (the fix), #42157 and #42232 (same bump for `9.1.x`)
| Sponsor company   |

## Why this is needed separately

`tests/UI/package.json` points at a branch:

```
"@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main"
```

but `.github/actions/ui-test` installs with `npm ci`, which honours `tests/UI/package-lock.json` exactly. The commit a run actually tests against is therefore the one pinned in the lockfile, never `main`. Each base branch pins a different one, and none of them carries the fix:

| Base | Pinned commit | Has the fix |
| --- | --- | --- |
| `9.1.x` | `c9ef920127e4` | no, #42157 and #42232 bump it |
| `9.2.x` | `6cca3abede56` | no |
| `develop` | `9861904d5b6a` | no, this pull request bumps it |

Because the three pins are unrelated commits, merging `9.1.x` upward conflicts on that file instead of carrying the bump, so the branches need their own.

Of the open pull requests currently red on this flake, 33 are based on `develop`. None of them carries its own `tests/UI/package-lock.json`, so their merge tree takes this one verbatim and they pick the fix up on their next run without needing a rebase.

## Verification

The lockfile entry was produced by npm rather than hand-written, then reduced to the two lines that actually change:

```
npm install --package-lock-only \
  "@prestashop-core/ui-testing@github:PrestaShop/ui-testing-library#a781d9f4fb2c930bdc150d5f626050ca9e74a2a3"
```

npm also rewrote the root dependency spec from `#main` to the explicit commit; that part is deliberately not included, so `package.json` and the lockfile's root entry still say `#main`, exactly as before and as on `9.1.x`.

`npm ci` against the result exits 0, adds 652 packages, and `node_modules/.package-lock.json` records

```
"resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a781d9f4fb2c930bdc150d5f626050ca9e74a2a3"
```

with `dist/versions/develop/pages/BO/catalog/products/index.js` present. Worth noting for anyone reviewing the `integrity` line: npm reports `skipping integrity check for git dependency`, so it is informational here rather than load-bearing, but it is updated to the value npm itself writes rather than left pointing at the previous commit.

Also verified that the `develop` page-object folder is the one `9.1.x` runs use too - a stack trace from a `9.1.x` pull request resolves `dist/versions/develop/pages/BO/...` - so the single library commit covers both branches.
