### PR TITLE
Bump the UI testing library to the commit fixing the product type race

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -688,7 +688,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#6cca3abede56fd987fbd1087ecf39ff1d1b1682f",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a781d9f4fb2c930bdc150d5f626050ca9e74a2a3",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Pin `@prestashop-core/ui-testing` to the commit that fixes the create-product iframe race, completing the same bump already proposed for `9.1.x` and `develop`. The three branches pin unrelated commits, so the bump does not travel between them.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `cd tests/UI && npm ci` resolves `@prestashop-core/ui-testing` at `a781d9f4fb2c930bdc150d5f626050ca9e74a2a3`. The `sanity:fast-fail` campaign then stops failing on `should choose 'Standard product'`.
| UI Tests          | This change is the UI test dependency itself, so the `Sanity` jobs on this pull request are the test of it.
| Fixed issue or discussion?     | Fixes #42072
| Related PRs       | PrestaShop/ui-testing-library#1083 (the fix), #42157 and #42232 (`9.1.x`), #42237 (`develop`)
| Sponsor company   |

## Context

The rationale is in #42237 and not repeated here. The short version: `tests/UI/package.json` points at `#main`, but `.github/actions/ui-test` installs with `npm ci`, so the commit a run tests against is the one pinned in `tests/UI/package-lock.json`. Each branch pins a different one:

| Base | Pinned commit | Covered by |
| --- | --- | --- |
| `9.1.x` | `c9ef920127e4` | #42157, #42232 |
| `9.2.x` | `6cca3abede56` | this pull request |
| `develop` | `9861904d5b6a` | #42237 |

Three open pull requests are currently red on this flake with `9.2.x` as their base.

## Why this diff is one line and #42237's is two

The lockfiles differ in shape per branch, so the same edit does not apply to all three:

| Base | `lockfileVersion` | `integrity` on this entry | Lines to change |
| --- | --- | --- | --- |
| `9.1.x` | 2 | absent | 4 (the entry appears twice) |
| `9.2.x` | 3 | absent | 1 |
| `develop` | 3 | present | 2 |

`npm install --package-lock-only` would additionally add an `integrity` field here. It is left out deliberately: this entry has never carried one on this branch, npm reports `skipping integrity check for git dependency` for git specs anyway, and adding it would be an unrelated difference in a one-line change.

## Verification

`npm ci` against the result adds 652 packages and exits 0, and `node_modules/.package-lock.json` records

```
"resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a781d9f4fb2c930bdc150d5f626050ca9e74a2a3"
```
