### PR TITLE
Offer the default route for every language in the SEO and URLs form

### DIFF
--- a/src/Adapter/Meta/UrlSchemaDataConfiguration.php
+++ b/src/Adapter/Meta/UrlSchemaDataConfiguration.php
@@ -54,19 +54,36 @@ final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
         $configResult = [];
         $shopConstraint = $this->getShopConstraint();
 
+        // The languages arrive as LanguageInterface objects, so array_column() cannot reach their id:
+        // it reads public properties and Lang exposes the id through getId() only. It answered an empty
+        // list for every route, which made both fallbacks below produce an empty value - so a route with
+        // no stored configuration, and a route still holding the pre-translation string, both rendered
+        // as an empty field instead of the default.
+        $languageIds = array_map(
+            static function (LanguageInterface $language): int {
+                return $language->getId();
+            },
+            $this->languages
+        );
+
         foreach ($this->rules as $routeId => $defaultRule) {
             // Get value from configuration
             $currentValue = $this->configuration->get($this->getConfigurationKey($routeId), null, $shopConstraint);
-            if (is_array($currentValue)) {
-                $configResult[$routeId] = $currentValue;
-                continue;
-            } elseif (is_string($currentValue)) {
-                $configResult[$routeId] = array_fill_keys(array_column($this->languages, 'id_lang'), $currentValue);
-                continue;
-            } else {
-                $configResult[$routeId] = array_fill_keys(array_column($this->languages, 'id_lang'), $defaultRule);
-                continue;
+            // A value stored before a language was added holds no entry for it, and one stored
+            // before a language was removed still holds its key. Starting from the default for
+            // every current language and overlaying only the keys that are still languages covers
+            // both: a missing entry falls back instead of rendering empty, a stale one is dropped.
+            if (is_string($currentValue)) {
+                $currentValue = array_fill_keys($languageIds, $currentValue);
             }
+            if (!is_array($currentValue)) {
+                $currentValue = [];
+            }
+
+            $configResult[$routeId] = array_replace(
+                array_fill_keys($languageIds, $defaultRule),
+                array_intersect_key($currentValue, array_flip($languageIds))
+            );
         }
 
         return $configResult;

--- a/tests/Unit/Adapter/Meta/UrlSchemaDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/UrlSchemaDataConfigurationTest.php
@@ -10,6 +10,7 @@ namespace Tests\Unit\Adapter\Meta;
 
 use PrestaShop\PrestaShop\Adapter\Meta\UrlSchemaDataConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
@@ -63,12 +64,23 @@ class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
     ];
 
     /**
-     * @var array
+     * The service definition injects the result of the language repository, which is
+     * LanguageInterface objects. Feeding plain ['id_lang' => n] arrays here is what let
+     * array_column() keep working in the test while returning nothing in production.
+     *
+     * @return LanguageInterface[]
      */
-    private const LANGUAGES = [
-        ['id_lang' => 1],
-        ['id_lang' => 2],
-    ];
+    private function getLanguages(): array
+    {
+        $languages = [];
+        foreach ([1, 2] as $id) {
+            $language = $this->createMock(LanguageInterface::class);
+            $language->method('getId')->willReturn($id);
+            $languages[] = $language;
+        }
+
+        return $languages;
+    }
 
     /**
      * @dataProvider provideShopConstraints
@@ -82,7 +94,7 @@ class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
             $this->mockShopConfiguration,
             $this->mockMultistoreFeature,
             self::RULES,
-            self::LANGUAGES
+            $this->getLanguages()
         );
 
         $this->mockShopConfiguration
@@ -109,6 +121,74 @@ class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
     }
 
     /**
+     * A value stored before a language existed has no entry for it. Returning it unchanged leaves
+     * that language's field empty - the same symptom this fix is about - so the default fills the gap.
+     *
+     * @dataProvider provideShopConstraints
+     *
+     * @param ShopConstraint $shopConstraint
+     */
+    public function testGetConfigurationFillsLanguagesMissingFromAStoredValue(ShopConstraint $shopConstraint): void
+    {
+        $urlSchemaDataConfiguration = new UrlSchemaDataConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature,
+            self::RULES,
+            $this->getLanguages()
+        );
+
+        $this->mockShopConfiguration->method('getShopConstraint')->willReturn($shopConstraint);
+        // Language 2 is absent, and language 9 no longer exists.
+        $this->mockConfiguration->method('get')->willReturn([1 => 'stored/{id}', 9 => 'ghost/{id}']);
+
+        $result = $urlSchemaDataConfiguration->getConfiguration();
+
+        self::assertSame(
+            [1 => 'stored/{id}', 2 => self::RULES['category_rule']],
+            $result['category_rule'],
+            'a language missing from the stored value takes the default, and a removed one is dropped'
+        );
+    }
+
+    /**
+     * The case no test covered: nothing stored for the route, so the default has to be
+     * offered for every language. It rendered as an empty field instead.
+     *
+     * @dataProvider provideShopConstraints
+     *
+     * @param ShopConstraint $shopConstraint
+     */
+    public function testGetConfigurationFallsBackToTheDefaultRouteForEveryLanguage(ShopConstraint $shopConstraint): void
+    {
+        $urlSchemaDataConfiguration = new UrlSchemaDataConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature,
+            self::RULES,
+            $this->getLanguages()
+        );
+
+        $this->mockShopConfiguration
+            ->method('getShopConstraint')
+            ->willReturn($shopConstraint);
+
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturn(null);
+
+        $result = $urlSchemaDataConfiguration->getConfiguration();
+
+        foreach (self::RULES as $routeId => $defaultRule) {
+            self::assertSame(
+                [1 => $defaultRule, 2 => $defaultRule],
+                $result[$routeId],
+                sprintf('route "%s" should offer its default for every language', $routeId)
+            );
+        }
+    }
+
+    /**
      * @dataProvider provideShopConstraints
      *
      * @param ShopConstraint $shopConstraint
@@ -120,7 +200,7 @@ class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
             $this->mockShopConfiguration,
             $this->mockMultistoreFeature,
             self::RULES,
-            self::LANGUAGES
+            $this->getLanguages()
         );
 
         $this->mockShopConfiguration
@@ -180,7 +260,7 @@ class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
             $this->mockShopConfiguration,
             $this->mockMultistoreFeature,
             self::RULES,
-            self::LANGUAGES
+            $this->getLanguages()
         );
 
         $this->expectException($exception);
@@ -210,7 +290,7 @@ class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
             $this->mockShopConfiguration,
             $this->mockMultistoreFeature,
             self::RULES,
-            self::LANGUAGES
+            $this->getLanguages()
         );
 
         $res = $urlSchemaDataConfiguration->updateConfiguration(self::VALID_CONFIGURATION);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Every route field in Traffic & SEO > SEO & URLs renders empty unless its configuration already holds the translated array form, because the language ids are extracted with `array_column()` from `LanguageInterface` objects, which yields nothing. Both fallbacks then produce an empty value instead of the default route.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On an install with no `PS_ROUTE_*` rows in `ps_configuration`, open Traffic & SEO > SEO & URLs. Before: every route field is empty. After: each shows its default, per language. `getConfiguration()` can be inspected directly through `prestashop.adapter.meta.url_schema.configuration`.
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/31001803547
| Fixed issue or discussion?     | Fixes #42242
| Related PRs       | Surfaced while answering the empty-field question on #41395; the multilingual route form arrived in #41405
| Sponsor company   |

## Problem

`UrlSchemaDataConfiguration::getConfiguration()` builds the per-language value with

```php
array_fill_keys(array_column($this->languages, 'id_lang'), $defaultRule)
```

but `$this->languages` is the result of `service("prestashop.core.admin.lang.repository").findAll()`, which is `LanguageInterface` objects. `array_column()` reads public properties, and `Lang` exposes its id through `getId()` only, so the extraction returns an empty list and `array_fill_keys([], …)` returns an empty array.

Measured on a stock 9.2.x install:

```
languages=2 type=PrestaShopBundle\Entity\Lang
array_column($langs,'id_lang') = []
product_rule => []
```

Two of the three branches are affected: a route with nothing stored, and a route still holding the pre-translation string. Only the branch where the configuration already holds an array survives. So on any install that has not saved this form since the multilingual routes landed, every field on the page is blank, and saving that page writes the blanks back.

`getRules()` itself is fine - it returns all nine defaults, `product_rule` among them.

## Fix

Extract the ids through the interface once, and use it in both branches.

## Why no test caught it

The fixture fed a type the service never injects:

```php
private const LANGUAGES = [
    ['id_lang' => 1],
    ['id_lang' => 2],
];
```

`array_column()` works on those arrays, so the suite stayed green while production returned nothing. The fixture now builds `LanguageInterface` mocks, which is what the service definition passes, and a test covers the case that had none - nothing stored, so the default must be offered for every language.

## Verification

With the fix the same probe returns the defaults per language:

```
product_rule    => {"1":"{id}{-:id_product_attribute}-{rewrite}.html","2":"…"}
category_rule   => {"1":"{id}-{rewrite}","2":"{id}-{rewrite}"}
attachment_rule => {"1":"attachment\/{id}-{rewrite}","2":"…"}
```

`UrlSchemaDataConfigurationTest` is 17 tests / 35 assertions green. Reverting only the `src/` change puts 6 of them back to failing, so the coverage is attached to the behaviour rather than passing by construction. `php-cs-fixer` reports 0 of 2 files to fix and PHPStan reports no errors.

