### PR TITLE
Fix tax rule groups grid duplicates in multistore context

### DIFF
--- a/src/Core/Grid/Query/TaxRulesGroupQueryBuilder.php
+++ b/src/Core/Grid/Query/TaxRulesGroupQueryBuilder.php
@@ -52,6 +52,7 @@ class TaxRulesGroupQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $qb
             ->select('trg.`id_tax_rules_group`, trg.`name`, trg.`active`')
+            ->groupBy('trg.`id_tax_rules_group`')
         ;
 
         $this->searchCriteriaApplicator

--- a/tests/Unit/Core/Grid/Query/TaxRulesGroupQueryBuilderTest.php
+++ b/tests/Unit/Core/Grid/Query/TaxRulesGroupQueryBuilderTest.php
@@ -149,7 +149,7 @@ class TaxRulesGroupQueryBuilderTest extends TestCase
                     'trg.`deleted` = 0',
                 ]
             ),
-            'groupBy' => [],
+            'groupBy' => ['trg.`id_tax_rules_group`'],
             'having' => null,
             'orderBy' => [],
             'values' => [],
@@ -162,7 +162,7 @@ class TaxRulesGroupQueryBuilderTest extends TestCase
         yield [
             $defaultFilters,
             $defaultQueryParts,
-            array_merge($defaultQueryParts, ['select' => [0 => 'COUNT(DISTINCT trg.`id_tax_rules_group`)']]),
+            array_merge($defaultQueryParts, ['select' => [0 => 'COUNT(DISTINCT trg.`id_tax_rules_group`)'], 'distinct' => false, 'groupBy' => []]),
             $defaultParameters,
         ];
 
@@ -186,7 +186,7 @@ class TaxRulesGroupQueryBuilderTest extends TestCase
         yield [
             $filters1,
             $queryParts1,
-            array_merge($queryParts1, ['select' => [0 => 'COUNT(DISTINCT trg.`id_tax_rules_group`)']]),
+            array_merge($queryParts1, ['select' => [0 => 'COUNT(DISTINCT trg.`id_tax_rules_group`)'], 'distinct' => false, 'groupBy' => []]),
             $parameters1,
         ];
 
@@ -210,7 +210,7 @@ class TaxRulesGroupQueryBuilderTest extends TestCase
         yield [
             $filters2,
             $queryParts2,
-            array_merge($queryParts2, ['select' => [0 => 'COUNT(DISTINCT trg.`id_tax_rules_group`)']]),
+            array_merge($queryParts2, ['select' => [0 => 'COUNT(DISTINCT trg.`id_tax_rules_group`)'], 'distinct' => false, 'groupBy' => []]),
             $parameters2,
         ];
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | This PR fixes a multistore regression in the `Tax rule groups` grid where the same group could appear multiple times in All shops context.
| Type?             | bug fix 
| Category?         |  BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      |1. Install or use PrestaShop 9.2.x.<br/>2. Enable multistore.3. Create at least two shops.<br/>4. Enable the new **Tax rule groups** feature.<br/>5. Create or edit a Tax rule group and associate it with multiple shops.<br/>6. Select the **All shops** context.<br/>7. Open the Tax rule groups page.<br/>8. Verify that each Tax rule group is displayed only once and that no duplicate rows are present.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/30559000687
| Fixed issue or discussion?     | Fixes https://github.com/prestaShop/PrestaShop/issues/42243
| Related PRs       | 
| Sponsor company   | Codencode snc
