### PR TITLE
Fix: Shop selector cannot be expanded when creating or editing a Tax rule group

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -168,6 +168,7 @@ module.exports = {
     tax_rules: './js/pages/tax-rules',
     tax_rules_form: './js/pages/tax-rules/form',
     tax_rules_group: './js/pages/tax-rules-group',
+    tax_rules_group_form: './js/pages/tax-rules-group/form',
     theme: './scss/theme.scss',
     themes: './js/pages/themes',
     title: './js/pages/title',

--- a/admin-dev/themes/new-theme/js/pages/tax-rules-group/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax-rules-group/form/index.ts
@@ -1,0 +1,12 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+import TaxRulesGroupFormMap from '@pages/tax-rules-group/form/tax-rules-group-form-map';
+
+const {$} = window;
+
+$(() => {
+  new window.prestashop.component.ChoiceTree(TaxRulesGroupFormMap.taxRulesGroupShopAssociationInput).enableAutoCheckChildren();
+});

--- a/admin-dev/themes/new-theme/js/pages/tax-rules-group/form/tax-rules-group-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax-rules-group/form/tax-rules-group-form-map.ts
@@ -1,0 +1,11 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * Defines all selectors that are used in tax rules group add/edit form.
+ */
+export default {
+  taxRulesGroupShopAssociationInput: '#tax_rules_group_shop_association',
+};

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/create.html.twig
@@ -7,3 +7,8 @@
 {% block content %}
   {{ include('@PrestaShop/Admin/Improve/International/TaxRulesGroup/Blocks/form.html.twig', {taxRulesGroupForm: taxRulesGroupForm}) }}
 {% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+  <script src="{{ asset('themes/new-theme/public/tax_rules_group_form.bundle.js') }}"></script>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/edit.html.twig
@@ -10,6 +10,6 @@
 
 {% block javascripts %}
   {{ parent() }}
-
+  <script src="{{ asset('themes/new-theme/public/tax_rules_group_form.bundle.js') }}"></script>
   <script src="{{ asset('themes/new-theme/public/tax_rules.bundle.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | This PR fixes a Back Office regression in the Tax rule groups form where the multistore shop association tree was displayed but not interactive on both create and edit pages.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1. Install or use PrestaShop 9.2.x.<br/>2. Enable multistore.<br/>3. Create at least two shops.<br/>4. Enable the new **Tax rule groups** feature.<br/>5. Open the Tax rule groups page.<br/>6. Create a new Tax rule group.<br/>7. Expand the shop groups in the shop association field.<br/>8. Verify that the shop groups can be expanded and that individual shops can be selected and unselected.<br/>9. Save the Tax rule group.<br/>10. Edit the newly created Tax rule group or another existing one.<br/>11. Expand the shop groups in the shop association field.<br/>12. Verify that the shop groups can be expanded and that individual shops can be selected and unselected.<br/>13. Save the form and verify that the selected shop associations are correctly preserved.
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/30607002411
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42244
| Related PRs       | 
| Sponsor company   | Codencode snc

---
### Why a dedicated bundle
The Tax rule group form and the tax rules management page do not have the same UI responsibilities.
The create page only needs the Tax rule group form behavior, while the edit page also includes tax rules management.
For this reason, the shop association tree initialization is kept in a dedicated form bundle instead of extending the existing `tax_rules.bundle.js`, which is focused on tax rules page behavior.