### PR TITLE
Do not unpack getimagesize() before checking that the source is an image

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -185,7 +185,14 @@ class ImageManagerCore
             return false;
         }
 
-        list($tmpWidth, $tmpHeight, $sourceFileType) = getimagesize($sourceFile);
+        $sourceInfo = getimagesize($sourceFile);
+        if ($sourceInfo === false) {
+            $error = self::ERROR_FILE_WIDTH;
+
+            return false;
+        }
+
+        list($tmpWidth, $tmpHeight, $sourceFileType) = $sourceInfo;
         $rotate = 0;
         if (function_exists('exif_read_data')) {
             $exif = @exif_read_data($sourceFile);


### PR DESCRIPTION
| Questions      | Answers
| -------------- | ------------------------------------------------------------
| Branch?        | 9.1.x
| Description?   | `ImageManager::resize()` unpacks the result of `getimagesize()` without checking it first. When the source file exists and is not empty but is not a valid image, `getimagesize()` returns `false` and the `list()` assignment emits three `Cannot use bool as array` warnings on PHP 8, followed by an `exif_read_data()` call on a file that is not an image. The returned value is unchanged, because `$sourceWidth` ends up `null` and the existing `if (!$sourceWidth)` check already returns `ERROR_FILE_WIDTH`. This only removes the warnings and the pointless work.
| Type?          | bug fix
| Category?      | CO
| BC breaks?     | no
| Deprecations?  | no
| How to test?   | Create a file that exists and is not empty but is not an image, for example `echo '<html>not an image</html>' > /tmp/broken.jpg`, then call `ImageManager::resize('/tmp/broken.jpg', '/tmp/out.jpg', 100, 100, 'jpg', false, $error)`. Before the change the log shows three `Cannot use bool as array` warnings; after it there are none. `$error` is `ImageManager::ERROR_FILE_WIDTH` and the return value is `false` in both cases.
| UI Tests       | Not applicable, this does not change any behaviour reachable from the UI.
| Fixed issue    | -
| Related PRs    | -
| Sponsor company| OpenServis.cz

This shows up in practice when product images are imported from a supplier feed:
a URL that answers with an HTML error page still produces a file that exists and
has a non-zero size, so it passes the `file_exists() || filesize()` guard above
and only fails one step later.

`ImageManager::cut()` reads `getimagesize()` the same way on line 572. I left it
out to keep this change to one thing, but I am happy to add it here if you would
rather have both in one PR.
