### PR TITLE
Skip the traffic-source lookup for orders without a customer

### DIFF
--- a/classes/ConnectionsSource.php
+++ b/classes/ConnectionsSource.php
@@ -17,6 +17,11 @@ class ConnectionsSourceCore extends ObjectModel
     public static $uri_max_size = 255;
 
     /**
+     * Upper bound on the traffic sources loaded for a single order view.
+     */
+    public const ORDER_SOURCES_LIMIT = 100;
+
+    /**
      * @see ObjectModel::$definition
      */
     public static $definition = [
@@ -95,6 +100,8 @@ class ConnectionsSourceCore extends ObjectModel
      */
     public static function getOrderSources($idOrder)
     {
+        // Anonymous visitors are stored in `guest` with id_customer = 0, so an order left with
+        // id_customer = 0 joins the entire guest table and every connection behind it.
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 		SELECT cos.`http_referer`, cos.`request_uri`, cos.`keywords`, cos.`date_add`
 		FROM `' . _DB_PREFIX_ . 'orders` o
@@ -102,6 +109,8 @@ class ConnectionsSourceCore extends ObjectModel
 		INNER JOIN `' . _DB_PREFIX_ . 'connections` co  ON co.`id_guest` = g.`id_guest`
 		INNER JOIN `' . _DB_PREFIX_ . 'connections_source` cos ON cos.`id_connections` = co.`id_connections`
 		WHERE `id_order` = ' . (int) $idOrder . '
-		ORDER BY cos.`date_add` DESC');
+			AND o.`id_customer` > 0
+		ORDER BY cos.`date_add` DESC
+		LIMIT ' . self::ORDER_SOURCES_LIMIT);
     }
 }

--- a/tests/Integration/Classes/ConnectionsSourceTest.php
+++ b/tests/Integration/Classes/ConnectionsSourceTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use ConnectionsSource;
+use Db;
+use PHPUnit\Framework\TestCase;
+
+class ConnectionsSourceTest extends TestCase
+{
+    /** @var int[] */
+    private $orderIds = [];
+
+    /** @var int[] */
+    private $guestIds = [];
+
+    /** @var int[] */
+    private $connectionIds = [];
+
+    protected function tearDown(): void
+    {
+        $db = Db::getInstance();
+        foreach ($this->connectionIds as $id) {
+            $db->delete('connections_source', 'id_connections = ' . $id);
+            $db->delete('connections', 'id_connections = ' . $id);
+        }
+        foreach ($this->guestIds as $id) {
+            $db->delete('guest', 'id_guest = ' . $id);
+        }
+        foreach ($this->orderIds as $id) {
+            $db->delete('orders', 'id_order = ' . $id);
+        }
+        $this->connectionIds = $this->guestIds = $this->orderIds = [];
+
+        parent::tearDown();
+    }
+
+    public function testItReturnsNoSourcesForAnOrderWithoutACustomer(): void
+    {
+        // A guest row with id_customer = 0 is what every anonymous visit produces, so this one
+        // stands in for the whole anonymous population the orphan order would otherwise join.
+        $anonymousGuestId = $this->createGuest(0);
+        $this->createSource($anonymousGuestId);
+        $orphanOrderId = $this->createOrder(0);
+
+        $this->assertSame(
+            [],
+            ConnectionsSource::getOrderSources($orphanOrderId),
+            'an order with no customer must not match every anonymous guest'
+        );
+    }
+
+    public function testItStillReturnsTheSourcesOfARealCustomer(): void
+    {
+        $customerId = 999123;
+        $guestId = $this->createGuest($customerId);
+        $this->createSource($guestId, 'https://example.com/referer');
+        $orderId = $this->createOrder($customerId);
+
+        $sources = ConnectionsSource::getOrderSources($orderId);
+
+        $this->assertCount(1, $sources);
+        $this->assertSame('https://example.com/referer', $sources[0]['http_referer']);
+    }
+
+    private function createGuest(int $customerId): int
+    {
+        Db::getInstance()->insert('guest', ['id_customer' => $customerId]);
+        $id = (int) Db::getInstance()->Insert_ID();
+        $this->guestIds[] = $id;
+
+        return $id;
+    }
+
+    private function createSource(int $guestId, string $referer = 'https://example.com/'): void
+    {
+        Db::getInstance()->insert('connections', [
+            'id_guest' => $guestId,
+            'id_page' => 1,
+            'date_add' => date('Y-m-d H:i:s'),
+        ]);
+        $connectionId = (int) Db::getInstance()->Insert_ID();
+        $this->connectionIds[] = $connectionId;
+
+        Db::getInstance()->insert('connections_source', [
+            'id_connections' => $connectionId,
+            'http_referer' => $referer,
+            'request_uri' => '/index.php',
+            'keywords' => '',
+            'date_add' => date('Y-m-d H:i:s'),
+        ]);
+    }
+
+    private function createOrder(int $customerId): int
+    {
+        $now = date('Y-m-d H:i:s');
+        Db::getInstance()->insert('orders', [
+            'id_customer' => $customerId,
+            'id_cart' => 0,
+            'id_currency' => 1,
+            'id_lang' => 1,
+            'id_carrier' => 0,
+            'id_address_delivery' => 0,
+            'id_address_invoice' => 0,
+            'current_state' => 1,
+            'payment' => 'Test',
+            'date_add' => $now,
+            'date_upd' => $now,
+            'invoice_date' => $now,
+            'delivery_date' => $now,
+        ]);
+        $id = (int) Db::getInstance()->Insert_ID();
+        $this->orderIds[] = $id;
+
+        return $id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ConnectionsSource::getOrderSources()` joins `guest` on `g.id_customer = o.id_customer` with no guard and no limit. Anonymous visits are stored with `id_customer = 0`, so an order left with `id_customer = 0` matches the whole anonymous guest population, every connection behind it and every row of `connections_source`. `Db::executeS()` materialises all of it, and the back office order page dies with an out-of-memory error before it renders.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set `id_customer = 0` on an order (a failed guest checkout leaves one) on a shop with real traffic in `guest` / `connections` / `connections_source`, then open that order in the back office. Before: fatal memory exhaustion in `getOrderSources()`. After: the page loads with an empty Sources block. `tests/Integration/Classes/ConnectionsSourceTest.php` covers both directions.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30759450520 - 45 of 45 jobs green
| Fixed issue or discussion?     | Fixes #42213
| Related PRs       |
| Sponsor company   |

### Why `id_customer = 0` and not a rare edge case

Measured on a stock install: 42 of 43 `ps_guest` rows carry `id_customer = 0` and none are `NULL`, because every anonymous visit writes one. So the join is not merely unfiltered on such an order, it selects essentially the entire table.

### The limit

`ORDER BY cos.date_add DESC` was already there but unbounded, so a legitimate customer with years of traffic feeds the same page an arbitrarily large array. The lookup is now capped at 100 of the most recent sources.

### Not addressed here

`connections` carries `id_shop` and `id_shop_group`, and this query scopes by neither, so in multistore an order's sources include connections made on other shops. That is a separate defect and a visible behaviour change, so it is not bundled into an out-of-memory fix.

