### PR TITLE
Lay out the help panel as a column instead of subtracting fixed heights

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_right-sidebar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_right-sidebar.scss
@@ -20,6 +20,7 @@
 
   .quicknav-header {
     display: flex;
+    flex: 0 0 auto;
     flex-direction: row-reverse;
     align-items: center;
     justify-content: space-between;
@@ -27,6 +28,13 @@
 
   .quicknav-container {
     height: 100%;
+  }
+
+  // The panel is a column of header, scrollable document and footer. Laying it out here lets the
+  // document claim whatever the other two leave, instead of subtracting their heights by hand.
+  #ps-quicknav-sidebar {
+    display: flex;
+    flex-direction: column;
   }
 }
 
@@ -70,10 +78,9 @@
   }
 
   .quicknav-fixed-bottom {
-    position: fixed;
-    right: 3em;
-    bottom: 0;
-    left: 0;
+    // Fixed positioning anchored this to the viewport rather than to the panel, so the 3em inset
+    // that suited a narrow column left it short of the edge once the panel was wide.
+    flex: 0 0 auto;
     height: 50px;
     margin-bottom: 0;
 
@@ -115,7 +122,10 @@
   }
 
   .quicknav-scroller {
-    height: calc(100% - 50px - 50px);
+    // Was calc(100% - 50px - 50px); the header is 56px, so the document ran 6px under the footer.
+    flex: 1 1 auto;
+    height: auto;
+    min-height: 0;
     overflow: auto;
 
     table {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The help panel sized its scrollable area with `height: calc(100% - 50px - 50px)` and pinned its footer with `position: fixed; right: 3em; left: 0`. Both numbers were written for a narrow column. The header actually measures 56px, so the document overran the footer by 6px, and at full width the `3em` inset left the footer 42px short of the panel edge. The panel is a header, a scrolling document and a footer stacked vertically, so it is laid out as a flex column and the hardcoded heights and the inset are removed rather than corrected.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open any back-office page that offers help, widen the window so the panel is wide, and open the panel. Before: the last few pixels of the document sit under the footer bar, and the footer stops short of the right edge. After: the document ends exactly where the footer starts and the footer spans the panel.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30766801896 - 45 of 45 jobs green
| Fixed issue or discussion?     | Fixes #41016
| Related PRs       |
| Sponsor company   |

### Measured

Panel markup from `_sidebar.html.twig` with the shipped stylesheet, viewport 900x900. Before, as posted on the issue, against after:

```
                    before                    after
header        900 x  56  top   0        900 x  56  top   0
document      900 x 800  bottom 856     900 x 794  bottom 850
footer        858 x  50  top  850       900 x  50  top  850

document/footer overlap      6px   ->   0
footer short of panel edge  42px   ->   0
```

### Not covered

The report's video shows the panel after the "I understand the risk" step. These two are what the geometry shows at a wide viewport; if something specific to that step remains, it is a separate matter rather than something this hides.

