### PR TITLE
Read the date where it is used so a run crossing midnight still passes

### DIFF
--- a/tests/UI/campaigns/functional/BO/05_customerService/03_merchandiseReturns/03_updateStatus.ts
+++ b/tests/UI/campaigns/functional/BO/05_customerService/03_merchandiseReturns/03_updateStatus.ts
@@ -61,7 +61,9 @@ describe('BO - Customer Service - Merchandise Returns : Update status', async ()
   let allEmails: MailDevEmail[];
   let numberOfEmails: number;
   let mailListener: MailDev;
-  const todayDate: string = utilsDate.getDateFormat('mm/dd/yyyy');
+  // Read when the PDF is generated rather than when this file is imported: the run can cross local
+  // midnight, and a date captured at import then differs from the one printed on the document.
+  let todayDate: string = '';
   const orderData: FakerOrder = new FakerOrder({
     customer: dataCustomers.johnDoe,
     products: [
@@ -287,6 +289,7 @@ describe('BO - Customer Service - Merchandise Returns : Update status', async ()
             await testContext.addContextItem(this, 'testIdentifier', 'checkPDF', baseContext);
 
             filePath = await boMerchandiseReturnsEditPage.downloadPDF(page);
+            todayDate = utilsDate.getDateFormat('mm/dd/yyyy');
 
             const exist = await utilsFile.doesFileExist(filePath);
             expect(exist, 'File does not exist').to.eq(true);

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/08_logs/01_filterSortAndPagination.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/08_logs/01_filterSortAndPagination.ts
@@ -29,7 +29,9 @@ describe('BO - Advanced Parameters - Logs : Filter, sort and pagination logs tab
   let browserContext: BrowserContext;
   let page: Page;
   let numberOfLogs: number = 0;
-  const today = utilsDate.getDateFormat('mm/dd/yyyy');
+  // Read when the logs start being written rather than when this file is imported: the run can cross
+  // local midnight, and a date captured at import then matches none of the rows the run just created.
+  let firstLogDate: string = '';
 
   // before and after functions
   before(async function () {
@@ -69,6 +71,8 @@ describe('BO - Advanced Parameters - Logs : Filter, sort and pagination logs tab
 
     const numberOfElements = await boLogsPage.getNumberOfElementInGrid(page);
     expect(numberOfElements).to.be.equal(0);
+
+    firstLogDate = utilsDate.getDateFormat('mm/dd/yyyy');
   });
 
   it('should set the log minimum severity to Debug or the login logs will not be created', async function () {
@@ -319,14 +323,18 @@ describe('BO - Advanced Parameters - Logs : Filter, sort and pagination logs tab
     it('should filter logs by date sent \'From\' and \'To\'', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'filterByDateSent', baseContext);
 
-      await boLogsPage.filterLogsByDate(page, today, today);
+      // The logs were written between the erase and now, which is one day unless the run crossed
+      // local midnight, so the window has to span both ends rather than a single captured day.
+      const lastLogDate: string = utilsDate.getDateFormat('mm/dd/yyyy');
+
+      await boLogsPage.filterLogsByDate(page, firstLogDate, lastLogDate);
 
       const numberOfLogsAfterFilter = await boLogsPage.getNumberOfElementInGrid(page);
       expect(numberOfLogsAfterFilter).to.be.at.greaterThanOrEqual(11);
 
       for (let row: number = 1; row <= await boLogsPage.getNumberOfRowsInGrid(page); row++) {
         const textColumn = await boLogsPage.getTextColumn(page, row, 'date_add');
-        expect(textColumn).to.contains(today);
+        expect([firstLogDate, lastLogDate]).to.include(textColumn.substring(0, 10));
       }
     });
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Both specs read `utilsDate.getDateFormat()` once at module scope and later compare it against rows, PDFs and orders the run itself produced. A campaign that crosses local midnight compares against the previous day and fails. The logs spec now takes its window from the erase to the filter, so a run that legitimately spans two days still matches, and the merchandise-returns spec reads the date when the PDF is downloaded, which is when the document gets its own.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run either campaign so that it crosses local midnight. Before this change the logs filter matches nothing and the return PDF header check fails; after it both pass. Outside that window the behaviour is unchanged.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30790640354 - 45 of 45 jobs green
| Fixed issue or discussion?     | Fixes #42259
| Related PRs       |
| Sponsor company   |

### Where this came from

Both of these were red on 2026-08-02 in one campaign, and they are the only two reds it had. The jobs ran 22:50-23:01 UTC; the shop clock is UTC+2, so 00:50-01:01 local:

```
BO - Advanced Parameters - Logs : should filter logs by date sent 'From' and 'To'
  AssertionError: expected +0 to be at least 11

BO - Customer Service - Merchandise Returns : should check the header of the return PDF
  The header of the PDF is not correct!
```

Two more of the same shape hit a concurrent campaign in the same window, in `BO customers` and in both FO suites, which is what pointed at the clock rather than at either branch.

### Scope

`getDateFormat` is called in 54 specs and at least 12 capture it at module scope. This PR changes only the two that failed, so the change stays reviewable against evidence; the rest are listed in #42259 and are worth a follow-up once the shape is agreed.

### Not claimed

I did not reproduce the rollover on demand - it needs a run straddling local midnight. The evidence that the fault is real is the four failures above with their timestamps; the change itself is a move of where the date is read.

