### PR TITLE
Read the docker prefix from env so the shop log is captured on failure

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           mkdir -p ./var/docker-logs
           docker logs prestashop-${{ matrix.db }}-1 > ./var/docker-logs/${{ matrix.db }}.log
-          docker logs ${{ inputs.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log
+          docker logs ${{ env.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log
 
       - name: Upload Screenshots and logs
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `sanity.yml` runs on `push` and `pull_request`, so it has no `inputs`. The `Export docker logs` step reads `${{ inputs.DOCKER_PREFIX }}`, which is therefore always empty, while the surrounding workflow sets and reads the value as `env.DOCKER_PREFIX`. The command becomes `docker logs -prestashop-git-1`, docker parses the leading dash as a flag, and the step exits 125. The shop container log is never written, and the job reports 125 instead of the test's own exit code.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Let a Sanity job fail. Before this change the `Export docker logs` step prints `unknown shorthand flag: 'p' in -prestashop-git-1` and no `prestashop.log` reaches the artifact; after it, the shop log is uploaded with the screenshots.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/30795300504 - 45 of 45 jobs green
| Fixed issue or discussion? |
| Related PRs       |
| Sponsor company   |

### Evidence

From a Sanity job on 2026-08-02, after the test result was already known:

```
  1) BO - Orders - Orders : Edit Order BO
  33 passing (3m)
  1 failing
##[error]Process completed with exit code 1.
...
unknown shorthand flag: 'p' in -prestashop-git-1
Usage:  docker logs [OPTIONS] CONTAINER
##[error]Process completed with exit code 125.
```

Line 68 immediately above already builds its container name without the prefix, and line 50 passes the value correctly as `env.DOCKER_PREFIX`, so line 69 is the only place using `inputs`.

`.github/actions/setup-env-export-logs/action.yml` uses `inputs.DOCKER_PREFIX` correctly - it is a composite action and does declare that input. Only the workflow copy is wrong, so this is a one-line change.

