### PR TITLE
Correct the component and domain counts in the AI context index

### DIFF
--- a/.ai/CONTEXT.md
+++ b/.ai/CONTEXT.md
@@ -86,13 +86,13 @@ Common slips unrelated to the feature itself — check before pushing:
 
 ## Domain contexts
 
-All 58 domains under `src/Core/Domain/` have a context file at `Domain/{DomainName}/CONTEXT.md`. Read the relevant one before working in a domain.
+The 58 domains listed below have a context file at `Domain/{DomainName}/CONTEXT.md`. Read the relevant one before working in a domain. `src/Core/Domain/` also holds folders of shared classes (`Exception`, `QueryResult`, `ValueObject`, `TaxRule`) and three domains that do not have one yet: `ExtraProperty`, `QuickAccess`, `BusinessEntity`.
 
 Domains: Address, Alias, ApiClient, Attachment, AttributeGroup, Carrier, Cart, CartRule, CatalogPriceRule, Category, CmsPage, CmsPageCategory, Combination (code lives under `src/Core/Domain/Product/Combination/`), Configuration, Contact, Country, CreditSlip, Currency, Customer, CustomerMessage, CustomerService, Discount, Employee, Feature, Hook, ImageSettings, Language, MailTemplate, Manufacturer, Meta, Module, Notification, Order, OrderMessage, OrderReturn, OrderReturnState, OrderState, Position, Product, Profile, Search, SearchEngine, Security, Shipment, Shop, ShowcaseCard, SqlManagement, State, Store, Supplier, Tab, Tag, Tax, TaxRulesGroup, Theme, Title, Webservice, Zone
 
 ## Component contexts
 
-All 28 shared infrastructure components have a context file at `Component/{ComponentName}/CONTEXT.md`.
+All 29 shared infrastructure components have a context file at `Component/{ComponentName}/CONTEXT.md`.
 
 Components: AdminAPI, BackOfficeHelp, Behat, Configuration, Console, Context, ContextStateManager, Controller, Cookie, CQRS, Database, Export, ExtraProperty, FacetedSearch, Forms, Grid, Hook, Import, Javascript, Link, Locale, MailTemplate, Migration, Playwright, PositionUpdater, Router, Smarty, TinyMCE, Twig
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `.ai/CONTEXT.md` says "All 28 shared infrastructure components" while listing 29 and while `.ai/Component/` holds 29 directories, and it says "All 58 domains under `src/Core/Domain/` have a context file" while that directory holds 65. The component number is corrected, and the domain sentence now says what it actually covers instead of claiming completeness: the four folders of shared classes, and the three domains that have no context yet.
| Type?             | bug fix
| Category?         | ME
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `ls .ai/Component | wc -l` returns 29, and `ls src/Core/Domain | wc -l` returns 65 against the 58 names listed. Reading the file after this change, neither sentence claims something the tree contradicts.
| UI Tests          | Not applicable: documentation only, no code or template is touched.
| Fixed issue or discussion?     | Fixes #42264
| Related PRs       |
| Sponsor company   |

### The three domains without a context

Of the seven directories not named in the Domains list, four are leaf folders of shared classes and reasonably have none. These three carry CQRS structure:

```
ExtraProperty   Command CommandHandler Exception Query QueryHandler QueryResult ValueObject
QuickAccess     Command CommandHandler Exception Query QueryHandler QueryResult ValueObject
BusinessEntity  Command CommandHandler Exception ValueObject
```

Writing those three contexts is deliberately not in this PR: it is authoring work per domain, and `ExtraProperty` is currently listed under Components, so where it belongs is a call for whoever owns that split. This change only stops the file asserting a completeness it does not have.
