### PR TITLE
API WS : Fix WebserviceKey::add()/delete() PHP warning when no employee is in context

### DIFF
--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -52,7 +52,7 @@ class WebserviceKeyCore extends ObjectModel
                 'WebserviceKey',
                 (int) $this->id,
                 false,
-                (int) Context::getContext()->employee->id
+                (int) (Context::getContext()->employee->id ?? 0)
             );
         }
 
@@ -85,7 +85,7 @@ class WebserviceKeyCore extends ObjectModel
                 'WebserviceKey',
                 (int) $this->id,
                 false,
-                (int) Context::getContext()->employee->id
+                (int) (Context::getContext()->employee->id ?? 0)
             );
         }
 

--- a/tests/Integration/Classes/WebserviceKeyTest.php
+++ b/tests/Integration/Classes/WebserviceKeyTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Db;
+use ErrorException;
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\Utility\ContextMockerTrait;
+use WebserviceKey;
+
+class WebserviceKeyTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    /**
+     * @var WebserviceKey|null
+     */
+    private $webserviceKey;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+        // The bug only reproduces when no employee is attached to the context,
+        // e.g. a CLI/cron execution or an install script.
+        static::getContext()->employee = null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->webserviceKey && $this->webserviceKey->id) {
+            $this->webserviceKey->delete();
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * WebserviceKey::add() reads Context::getContext()->employee->id to log the creation.
+     * When no employee is attached to the context this must not emit a PHP warning
+     * ("Attempt to read property 'id' on null") and the log must be written with
+     * id_employee = 0 instead.
+     */
+    public function testAddWithoutEmployeeInContextDoesNotTriggerWarning(): void
+    {
+        $this->webserviceKey = $this->buildWebserviceKey();
+
+        $result = $this->withWarningsAsExceptions(function () {
+            return $this->webserviceKey->add();
+        });
+
+        $this->assertTrue($result);
+        $this->assertNotFalse($this->webserviceKey->id);
+        $this->assertSame(0, $this->getLastLoggedEmployeeId());
+    }
+
+    /**
+     * Same regression as above, but for WebserviceKey::delete().
+     */
+    public function testDeleteWithoutEmployeeInContextDoesNotTriggerWarning(): void
+    {
+        $this->webserviceKey = $this->buildWebserviceKey();
+        $this->webserviceKey->add();
+
+        $result = $this->withWarningsAsExceptions(function () {
+            return $this->webserviceKey->delete();
+        });
+
+        $this->assertTrue($result);
+        $this->assertSame(0, $this->getLastLoggedEmployeeId());
+    }
+
+    private function buildWebserviceKey(): WebserviceKey
+    {
+        $webserviceKey = new WebserviceKey();
+        $webserviceKey->key = substr(sha1(uniqid('webservice_key_test', true)), 0, 32);
+        $webserviceKey->description = 'Webservice key created without employee in context';
+        $webserviceKey->active = true;
+
+        return $webserviceKey;
+    }
+
+    private function withWarningsAsExceptions(callable $callback)
+    {
+        set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
+            if (E_WARNING === $severity) {
+                throw new ErrorException($message, 0, $severity, $file, $line);
+            }
+
+            return false;
+        });
+
+        try {
+            return $callback();
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    private function getLastLoggedEmployeeId(): int
+    {
+        return (int) Db::getInstance()->getValue('
+            SELECT `id_employee`
+            FROM `' . _DB_PREFIX_ . 'log`
+            WHERE `object_type` = "WebserviceKey" AND `object_id` = ' . (int) $this->webserviceKey->id . '
+            ORDER BY `id_log` DESC
+        ');
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | WebserviceKey::add() and WebserviceKey::delete() read Context::getContext()->employee->id to log the action via PrestaShopLogger::addLog(). When no employee is attached to the context (e.g. CLI/cron execution, install scripts, or any code path invoking these methods outside a BO session), this raises a PHP warning: Attempt to read property "id" on null. The fix falls back to 0 for id_employee in that case, matching PrestaShopLogger::addLog()'s own null-safe handling.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| UI Tests          | :dolphin: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/30811588612<br/>:seal: : 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | lefevre.dev