### PR TITLE
Allow to translate overrided modules

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -3,6 +3,7 @@ parameters:
   test_translations_dir: "%resources_dir%/translations"
   translations_theme_dir: "%resources_dir%/themes"
   translations_modules_dir: "%resources_dir%/modules"
+  override_modules_dir: "%resources_dir%/override/modules"
   prestashop.security.voter.product.class: Tests\Integration\Utility\PageVoter
 
 imports:

--- a/src/Core/Translation/Storage/Extractor/LegacyModuleExtractor.php
+++ b/src/Core/Translation/Storage/Extractor/LegacyModuleExtractor.php
@@ -41,6 +41,11 @@ final class LegacyModuleExtractor implements LegacyModuleExtractorInterface
     private $modulesDirectory;
 
     /**
+     * @var string the "override/modules" directory path
+     */
+    private $overrideModulesDirectory;
+
+    /**
      * @var array
      */
     private $catalogueExtractExcludedDirectories;
@@ -51,19 +56,22 @@ final class LegacyModuleExtractor implements LegacyModuleExtractorInterface
      * @param TwigExtractor $twigExtractor
      * @param string $modulesDirectory
      * @param array $catalogueExtractExcludedDirectories
+     * @param string $overrideModulesDirectory
      */
     public function __construct(
         PhpExtractor $phpExtractor,
         SmartyExtractor $smartyExtractor,
         TwigExtractor $twigExtractor,
         string $modulesDirectory,
-        array $catalogueExtractExcludedDirectories
+        array $catalogueExtractExcludedDirectories,
+        string $overrideModulesDirectory
     ) {
         $this->phpExtractor = $phpExtractor;
         $this->smartyExtractor = $smartyExtractor;
         $this->twigExtractor = $twigExtractor;
         $this->modulesDirectory = $modulesDirectory;
         $this->catalogueExtractExcludedDirectories = $catalogueExtractExcludedDirectories;
+        $this->overrideModulesDirectory = $overrideModulesDirectory;
     }
 
     /**
@@ -74,18 +82,28 @@ final class LegacyModuleExtractor implements LegacyModuleExtractorInterface
     public function extract(string $moduleName, string $locale): MessageCatalogue
     {
         $extractedCatalogue = new MessageCatalogue($locale);
+        $directories = [$this->modulesDirectory . '/' . $moduleName];
 
-        $this->phpExtractor
-            ->setExcludedDirectories($this->catalogueExtractExcludedDirectories)
-            ->extract($this->modulesDirectory . '/' . $moduleName, $extractedCatalogue);
+        $overridePath = $this->overrideModulesDirectory . '/' . $moduleName;
+        if (is_dir($overridePath)) {
+            $directories[] = $overridePath;
+        }
+
+        foreach ($directories as $directory) {
+            $this->phpExtractor
+                ->setExcludedDirectories($this->catalogueExtractExcludedDirectories)
+                ->extract($directory, $extractedCatalogue);
+        }
         $extractedCatalogue = $this->postprocessPhpCatalogue($extractedCatalogue, $moduleName);
 
-        $this->smartyExtractor
-            ->setExcludedDirectories($this->catalogueExtractExcludedDirectories)
-            ->extract($this->modulesDirectory . '/' . $moduleName, $extractedCatalogue);
-        $this->twigExtractor
-            ->setExcludedDirectories($this->catalogueExtractExcludedDirectories)
-            ->extract($this->modulesDirectory . '/' . $moduleName, $extractedCatalogue);
+        foreach ($directories as $directory) {
+            $this->smartyExtractor
+                ->setExcludedDirectories($this->catalogueExtractExcludedDirectories)
+                ->extract($directory, $extractedCatalogue);
+            $this->twigExtractor
+                ->setExcludedDirectories($this->catalogueExtractExcludedDirectories)
+                ->extract($directory, $extractedCatalogue);
+        }
 
         return $extractedCatalogue;
     }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -4,6 +4,7 @@ parameters:
   translations_dir: "%kernel.project_dir%/translations"
   themes_translations_dir: "%kernel.cache_dir%/themes"
   modules_dir: "%kernel.project_dir%/modules"
+  override_modules_dir: "%kernel.project_dir%/override/modules"
   themes_dir: "%kernel.project_dir%/themes"
   translation_catalogues_export_dir: "%kernel.cache_dir%/export"
   translations_catalogue_extract_excluded_dirs: [ 'vendor', 'lib', 'tests' ]

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -228,6 +228,7 @@ services:
       - "@prestashop.translation.extractor.twig"
       - "%modules_dir%"
       - "%translations_catalogue_extract_excluded_dirs%"
+      - "%override_modules_dir%"
 
   prestashop.translation.extractor.extra_property:
     class: PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\ExtraPropertyTranslationExtractor

--- a/tests/Integration/Core/Translation/Storage/Provider/ModuleCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/ModuleCatalogueLayersProviderTest.php
@@ -53,6 +53,11 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
     private $modulesDir;
 
     /**
+     * @var string
+     */
+    private $overrideModulesDir;
+
+    /**
      * @var array<int, string>
      */
     private $moduleExtractorExcludedDirs = ['vendor', 'lib', 'tests'];
@@ -75,6 +80,7 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
          */
         $this->translationsDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
         $this->modulesDir = self::$kernel->getContainer()->getParameter('translations_modules_dir');
+        $this->overrideModulesDir = self::$kernel->getContainer()->getParameter('override_modules_dir');
 
         $this->legacyModuleExtractor = $this->createMock(LegacyModuleExtractorInterface::class);
         $this->legacyModuleExtractor->method('extract')
@@ -159,7 +165,8 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
             $smartyExtractor,
             $twigExtractor,
             $this->modulesDir,
-            $this->moduleExtractorExcludedDirs
+            $this->moduleExtractorExcludedDirs,
+            $this->overrideModulesDir
         );
 
         $providerDefinition = new ModuleProviderDefinition('translationtest');
@@ -248,7 +255,8 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
             $smartyExtractor,
             $twigExtractor,
             $this->modulesDir,
-            $this->moduleExtractorExcludedDirs
+            $this->moduleExtractorExcludedDirs,
+            $this->overrideModulesDir
         );
         $providerDefinition = new ModuleProviderDefinition('translationtest');
         $provider = new ModuleCatalogueLayersProvider(
@@ -284,11 +292,12 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
                 ],
             ],
             'ModulesTranslationtestTranslationtest' => [
-                'count' => 3,
+                'count' => 4,
                 'translations' => [
                     'Hello World' => 'Hello World',
                     'An error occured, please check your zip file' => 'An error occured, please check your zip file',
                     'his wording belongs to the module file' => 'his wording belongs to the module file',
+                    'Wording from module override' => 'Wording from module override',
                 ],
             ],
         ];

--- a/tests/Resources/override/modules/translationtest/translationtest.php
+++ b/tests/Resources/override/modules/translationtest/translationtest.php
@@ -1,0 +1,13 @@
+<?php
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class translationtestOverride
+{
+    public function getContent()
+    {
+        return $this->l('Wording from module override');
+    }
+}

--- a/tests/Unit/Core/Translation/Storage/Extractor/LegacyModuleExtractorTest.php
+++ b/tests/Unit/Core/Translation/Storage/Extractor/LegacyModuleExtractorTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Translation\Storage\Extractor;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\LegacyModuleExtractor;
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\PhpExtractor;
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\SmartyExtractor;
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\TwigExtractor;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class LegacyModuleExtractorTest extends TestCase
+{
+    private string $modulesDir;
+
+    private string $overrideModulesDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $base = sys_get_temp_dir() . '/ps_legacy_module_extractor_' . uniqid('', true);
+        $this->modulesDir = $base . '/modules';
+        $this->overrideModulesDir = $base . '/override/modules';
+        $this->filesystem->mkdir($this->modulesDir . '/dummymodule');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove(dirname($this->modulesDir));
+    }
+
+    public function testItAlsoExtractsFromOverrideModulesDirectoryWhenPresent(): void
+    {
+        $this->filesystem->mkdir($this->overrideModulesDir . '/dummymodule');
+
+        $modulePath = $this->modulesDir . '/dummymodule';
+        $overridePath = $this->overrideModulesDir . '/dummymodule';
+
+        /** @var PhpExtractor&MockObject $phpExtractor */
+        $phpExtractor = $this->createMock(PhpExtractor::class);
+        $phpExtractor->method('setExcludedDirectories')->willReturnSelf();
+        $phpExtractor->expects($this->exactly(2))
+            ->method('extract')
+            ->with(
+                $this->callback(function (string $path) use ($modulePath, $overridePath): bool {
+                    static $call = 0;
+                    ++$call;
+
+                    return 1 === $call ? $path === $modulePath : $path === $overridePath;
+                }),
+                $this->isInstanceOf(MessageCatalogue::class)
+            );
+
+        /** @var SmartyExtractor&MockObject $smartyExtractor */
+        $smartyExtractor = $this->createMock(SmartyExtractor::class);
+        $smartyExtractor->method('setExcludedDirectories')->willReturnSelf();
+        $smartyExtractor->expects($this->exactly(2))
+            ->method('extract')
+            ->with(
+                $this->callback(function (string $path) use ($modulePath, $overridePath): bool {
+                    static $call = 0;
+                    ++$call;
+
+                    return 1 === $call ? $path === $modulePath : $path === $overridePath;
+                }),
+                $this->isInstanceOf(MessageCatalogue::class)
+            );
+
+        /** @var TwigExtractor&MockObject $twigExtractor */
+        $twigExtractor = $this->createMock(TwigExtractor::class);
+        $twigExtractor->method('setExcludedDirectories')->willReturnSelf();
+        $twigExtractor->expects($this->exactly(2))
+            ->method('extract')
+            ->with(
+                $this->callback(function (string $path) use ($modulePath, $overridePath): bool {
+                    static $call = 0;
+                    ++$call;
+
+                    return 1 === $call ? $path === $modulePath : $path === $overridePath;
+                }),
+                $this->isInstanceOf(MessageCatalogue::class)
+            );
+
+        $extractor = new LegacyModuleExtractor(
+            $phpExtractor,
+            $smartyExtractor,
+            $twigExtractor,
+            $this->modulesDir,
+            ['vendor'],
+            $this->overrideModulesDir
+        );
+
+        $catalogue = $extractor->extract('dummymodule', 'en-US');
+
+        $this->assertSame('en-US', $catalogue->getLocale());
+    }
+
+    public function testItSkipsOverrideExtractionWhenDirectoryIsMissing(): void
+    {
+        $modulePath = $this->modulesDir . '/dummymodule';
+
+        /** @var PhpExtractor&MockObject $phpExtractor */
+        $phpExtractor = $this->createMock(PhpExtractor::class);
+        $phpExtractor->method('setExcludedDirectories')->willReturnSelf();
+        $phpExtractor->expects($this->once())
+            ->method('extract')
+            ->with($modulePath, $this->isInstanceOf(MessageCatalogue::class));
+
+        /** @var SmartyExtractor&MockObject $smartyExtractor */
+        $smartyExtractor = $this->createMock(SmartyExtractor::class);
+        $smartyExtractor->method('setExcludedDirectories')->willReturnSelf();
+        $smartyExtractor->expects($this->once())
+            ->method('extract')
+            ->with($modulePath, $this->isInstanceOf(MessageCatalogue::class));
+
+        /** @var TwigExtractor&MockObject $twigExtractor */
+        $twigExtractor = $this->createMock(TwigExtractor::class);
+        $twigExtractor->method('setExcludedDirectories')->willReturnSelf();
+        $twigExtractor->expects($this->once())
+            ->method('extract')
+            ->with($modulePath, $this->isInstanceOf(MessageCatalogue::class));
+
+        $extractor = new LegacyModuleExtractor(
+            $phpExtractor,
+            $smartyExtractor,
+            $twigExtractor,
+            $this->modulesDir,
+            ['vendor'],
+            $this->overrideModulesDir
+        );
+
+        $extractor->extract('dummymodule', 'en-US');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The module translation extractor only scanned `modules/{moduleName}/`, so wordings from module overrides under `override/modules/{moduleName}/` (e.g. `override/modules/ps_banner/ps_banner.php`) never appeared in International > Translations.<br><br>This PR updates core `LegacyModuleExtractor` so extraction also scans `override/modules/{moduleName}/` when that directory exists (same PHP/Smarty/Twig extractors + `messages` → module domain postprocess).<br><br>Adds `%override_modules_dir%` (`%kernel.project_dir%/override/modules`) and unit/integration coverage. |
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Clear Symfony cache.<br>2. Ensure a module override with `$this->l(...)` / `l()` calls exists, e.g. `override/modules/ps_banner/ps_banner.php`.<br>3. BO → International → Translations → type Modules → select the module → locale.<br>4. Confirm wordings that exist only in the override appear in the catalogue.<br>5. Translate one string, save, reload FO/BO where it is used and check the translation is applied. |
| Fixed issue or discussion?     | N/A |