### PR TITLE
Fix: Display attributes' public names for pack products instead of internal names in front office

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -174,7 +174,7 @@ class PackCore extends Product
             $p->pack_quantity = $row['quantity'];
             $p->id_pack_product_attribute = (isset($row['id_product_attribute_item']) && $row['id_product_attribute_item'] ? $row['id_product_attribute_item'] : 0);
             if (isset($row['id_product_attribute_item']) && $row['id_product_attribute_item']) {
-                $sql = 'SELECT agl.`name` AS group_name, al.`name` AS attribute_name, pa.`reference` AS attribute_reference
+                $sql = 'SELECT agl.`public_name` AS group_name, al.`name` AS attribute_name, pa.`reference` AS attribute_reference
 					FROM `' . _DB_PREFIX_ . 'product_attribute` pa
 					' . Shop::addSqlAssociation('product_attribute', 'pa') . '
 					LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac ON pac.`id_product_attribute` = pa.`id_product_attribute`
@@ -371,7 +371,7 @@ class PackCore extends Product
             if (Combination::isFeatureActive() && isset($line['id_product_attribute_item']) && $line['id_product_attribute_item']) {
                 $line['cache_default_attribute'] = $line['id_product_attribute'] = $line['id_product_attribute_item'];
 
-                $sql = 'SELECT pa.`reference` AS attribute_reference, agl.`name` AS group_name, al.`name` AS attribute_name,  pai.`id_image` AS id_product_attribute_image
+                $sql = 'SELECT pa.`reference` AS attribute_reference, agl.`public_name` AS group_name, al.`name` AS attribute_name,  pai.`id_image` AS id_product_attribute_image
 				FROM `' . _DB_PREFIX_ . 'product_attribute` pa
 				' . Shop::addSqlAssociation('product_attribute', 'pa') . '
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac ON pac.`id_product_attribute` = ' . $line['id_product_attribute_item'] . '


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In v9.1.4 in the front office I noticed pack products of product combinations display the attribute's internal name instead of the public name. I installed the `develop` branch locally to reproduce the bug. This fix selects the correct public name for front office display. Screenshots below to illustrate.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | <ol><li>Create a product with combinations using an attribute with different internal and public names.</li><li>Create a pack product containing one of these combinations.</li><li>Check the pack product front office page, combination names will be listed and should use the public attribute name.</li></ol>As shown in screenshots below
| UI Tests          | UI test runs: [MySQL](https://github.com/gumgl/ga.tests.ui.pr/actions/runs/30925159293) and [MariaDB](https://github.com/gumgl/ga.tests.ui.pr/actions/runs/30927074135)
| Fixed issue or discussion?     | I have not filed an issue for this bug
| Related PRs       | n/a
| Sponsor company   | n/a

Internal and public name values for an attribute:
<img width="471" height="285" alt="Screenshot 2026-08-04 165519" src="https://github.com/user-attachments/assets/e877af20-d42b-4a76-a806-8ed425f0fca2" />
Product with combinations showing the correct internal names in back office:
<img width="493" height="622" alt="Screenshot 2026-08-04 165623" src="https://github.com/user-attachments/assets/45ca2139-2503-4781-a75c-cdf4684c94a1" />
Pack product containing these product combinations, also correctly displayed in back office:
<img width="352" height="514" alt="Screenshot 2026-08-04 165648" src="https://github.com/user-attachments/assets/6ea84e91-598b-43d2-9084-b1008c27aa8b" />
Front office product with combinations correctly using attributes' public names: 
<img width="617" height="368" alt="Screenshot 2026-08-04 165806" src="https://github.com/user-attachments/assets/9c1d20c8-d633-461b-bc9c-163d1d93bc8e" />
Front office pack product incorrectly using attributes' internal names **(before fix)**:
<img width="711" height="398" alt="Screenshot 2026-08-04 165822" src="https://github.com/user-attachments/assets/fd37f367-915f-43bd-8ab6-ae959fbb395a" />
Front office pack product correctly using attributes' public names **(after fix)**:
<img width="707" height="392" alt="Screenshot 2026-08-04 171333" src="https://github.com/user-attachments/assets/d457eacb-2c61-4446-9436-8694730965c7" />
Front office pack product correctly using attributes' public names in other language **(after fix)**:
<img width="707" height="390" alt="Screenshot 2026-08-04 175508" src="https://github.com/user-attachments/assets/ac7dd2b2-895b-47d6-8391-e79db858b885" />