### PR TITLE
Flag modules customized by overrides in Module Manager and warn before replacing them

### DIFF
--- a/.header-stamp-config.yml
+++ b/.header-stamp-config.yml
@@ -56,6 +56,7 @@ excludedFiles:
   - 'themes/hummingbird'
   - 'themes/_libraries/font-awesome'
   # tests folders (ignore resources mainly, PHPUnit classes still need to be fixed for example)
+  - 'tests/Resources/module_overrides_tests'
   - 'tests/Resources/modules'
   - 'tests/Resources/modules_tests/override'
   - 'tests/Resources/themes'

--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -4,6 +4,7 @@
  */
 import {EventEmitter} from 'events';
 import ConfirmModal from '@components/modal';
+import {getModuleOverridesWarning} from '@components/module-overrides-warning';
 import ComponentsMap from './components-map';
 
 const ModuleCardMap = ComponentsMap.moduleCard;
@@ -160,6 +161,7 @@ export default class ModuleCard {
       event.preventDefault();
       const modal = $(`#${$(this).data('confirm_modal')}`);
       const isMaintenanceMode = window.isShopMaintenance;
+      const overridesWarning = getModuleOverridesWarning($(this));
 
       if (modal.length !== 1) {
         // Modal body element
@@ -181,8 +183,8 @@ export default class ModuleCard {
               ? 'btn-primary'
               : 'btn-secondary',
             confirmMessage: isMaintenanceMode
-              ? ''
-              : window.moduleTranslations.moduleModalUpdateConfirmMessage,
+              ? overridesWarning
+              : overridesWarning + window.moduleTranslations.moduleModalUpdateConfirmMessage,
             closable: true,
             customButtons: isMaintenanceMode ? [] : [maintenanceLink],
           },

--- a/admin-dev/themes/new-theme/js/components/module-overrides-warning.ts
+++ b/admin-dev/themes/new-theme/js/components/module-overrides-warning.ts
@@ -97,7 +97,7 @@ function buildWarning(message: string, listIntro: string, items: string[]): stri
  * Override file paths and module names are injected through innerHTML, they come from the
  * filesystem and from module manifests, so they must not be trusted as markup.
  */
-function escapeHtml(value: string): string {
+export function escapeHtml(value: string): string {
   const container = document.createElement('div');
   container.textContent = value;
 

--- a/admin-dev/themes/new-theme/js/components/module-overrides-warning.ts
+++ b/admin-dev/themes/new-theme/js/components/module-overrides-warning.ts
@@ -32,6 +32,20 @@ export function getModuleOverrides(element: JQuery): ModuleOverrides | null {
 }
 
 /**
+ * Warning for an explicit list of overriding files, used when the files are known from a server
+ * response rather than from the page (module upload).
+ */
+export function getOverriddenFilesWarning(files: string[]): string {
+  if (files.length === 0) {
+    return '';
+  }
+
+  const {overridesUpdateWarning, overridesUpdateFilesIntro} = window.moduleTranslations;
+
+  return buildWarning(overridesUpdateWarning, overridesUpdateFilesIntro, files);
+}
+
+/**
  * Warning displayed before updating a single module customized by override files:
  * the update may silently break them.
  */
@@ -42,9 +56,7 @@ export function getModuleOverridesWarning(element: JQuery): string {
     return '';
   }
 
-  const {overridesUpdateWarning, overridesUpdateFilesIntro} = window.moduleTranslations;
-
-  return buildWarning(overridesUpdateWarning, overridesUpdateFilesIntro, overrides.files);
+  return getOverriddenFilesWarning(overrides.files);
 }
 
 /**

--- a/admin-dev/themes/new-theme/js/components/module-overrides-warning.ts
+++ b/admin-dev/themes/new-theme/js/components/module-overrides-warning.ts
@@ -1,0 +1,93 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+const {$} = window;
+
+const moduleItemSelector = '.module-item-list';
+
+export interface ModuleOverrides {
+  displayName: string;
+  files: string[];
+}
+
+/**
+ * Reads the override data exposed by the module card the given element belongs to,
+ * or null when the module is not overridden.
+ */
+export function getModuleOverrides(element: JQuery): ModuleOverrides | null {
+  const moduleItem = element.closest(moduleItemSelector);
+
+  if (!moduleItem.data('has-overrides')) {
+    return null;
+  }
+
+  return {
+    displayName: moduleItem.data('name') || moduleItem.data('tech-name'),
+    files: String(moduleItem.data('overridden-files') ?? '')
+      .split('|')
+      .filter((file) => file !== ''),
+  };
+}
+
+/**
+ * Warning displayed before updating a single module customized by override files:
+ * the update may silently break them.
+ */
+export function getModuleOverridesWarning(element: JQuery): string {
+  const overrides = getModuleOverrides(element);
+
+  if (overrides === null) {
+    return '';
+  }
+
+  const {overridesUpdateWarning, overridesUpdateFilesIntro} = window.moduleTranslations;
+
+  return buildWarning(overridesUpdateWarning, overridesUpdateFilesIntro, overrides.files);
+}
+
+/**
+ * Same warning for a bulk update, listing every overridden module of the selection.
+ */
+export function getModulesOverridesWarning(elements: JQuery): string {
+  const overriddenModules: string[] = [];
+
+  elements.each((index: number, element: HTMLElement) => {
+    const overrides = getModuleOverrides($(element));
+
+    if (overrides !== null && !overriddenModules.includes(overrides.displayName)) {
+      overriddenModules.push(overrides.displayName);
+    }
+  });
+
+  if (overriddenModules.length === 0) {
+    return '';
+  }
+
+  const {overridesUpdateAllWarning, overridesUpdateModulesIntro} = window.moduleTranslations;
+
+  return buildWarning(overridesUpdateAllWarning, overridesUpdateModulesIntro, overriddenModules);
+}
+
+function buildWarning(message: string, listIntro: string, items: string[]): string {
+  const list = items.length
+    ? `${escapeHtml(listIntro)}<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`
+    : '';
+
+  return `<div class="alert alert-warning module-overrides-warning" role="alert">
+    <p class="alert-text">${escapeHtml(message)}</p>
+    ${list}
+  </div>`;
+}
+
+/**
+ * Override file paths and module names are injected through innerHTML, they come from the
+ * filesystem and from module manifests, so they must not be trusted as markup.
+ */
+function escapeHtml(value: string): string {
+  const container = document.createElement('div');
+  container.textContent = value;
+
+  return container.innerHTML;
+}

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -4,6 +4,7 @@
  */
 
 import ConfirmModal from '@components/modal';
+import {getModulesOverridesWarning} from '@components/module-overrides-warning';
 
 const {$} = window;
 
@@ -860,6 +861,7 @@ class AdminModuleController {
     $('body').on('click', self.upgradeAllSource, (event) => {
       event.preventDefault();
       const isMaintenanceMode = window.isShopMaintenance;
+      const overridesWarning = getModulesOverridesWarning($(self.upgradeAllTargets));
 
       // Modal body element
       const maintenanceLink = document.createElement('a');
@@ -876,7 +878,9 @@ class AdminModuleController {
             ? window.moduleTranslations.moduleModalUpdateUpgrade
             : window.moduleTranslations.upgradeAnywayButtonText,
           confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
-          confirmMessage: isMaintenanceMode ? '' : window.moduleTranslations.moduleModalUpdateConfirmMessage,
+          confirmMessage: isMaintenanceMode
+            ? overridesWarning
+            : overridesWarning + window.moduleTranslations.moduleModalUpdateConfirmMessage,
           closable: true,
           customButtons: isMaintenanceMode ? [] : [maintenanceLink],
         },

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -5,6 +5,7 @@
 
 import ConfirmModal, {Modal} from '@components/modal';
 import {
+  escapeHtml,
   getModuleOverrides,
   getModulesOverridesWarning,
   getOverriddenFilesWarning,
@@ -146,7 +147,8 @@ class AdminModuleController {
 
       new Modal({
         id: 'module-overrides-modal',
-        modalTitle: `${window.moduleTranslations.overridesModalTitle} - ${overrides.displayName}`,
+        // The title is assigned with innerHTML, and the display name comes from the module manifest
+        modalTitle: `${window.moduleTranslations.overridesModalTitle} - ${escapeHtml(overrides.displayName)}`,
         closable: true,
       })
         .render(getOverriddenFilesWarning(overrides.files))
@@ -662,6 +664,9 @@ class AdminModuleController {
       timeout: 0,
       addedfile: () => {
         $(`${self.moduleImportSuccessSelector}, ${self.moduleImportFailureSelector}`).hide();
+        // A pending confirmation belongs to the previous archive, keeping it would let the
+        // employee install a file they have moved on from
+        self.clearImportConfirm();
         self.animateStartUpload();
       },
       processing: () => {

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -3,8 +3,12 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
-import ConfirmModal from '@components/modal';
-import {getModulesOverridesWarning, getOverriddenFilesWarning} from '@components/module-overrides-warning';
+import ConfirmModal, {Modal} from '@components/modal';
+import {
+  getModuleOverrides,
+  getModulesOverridesWarning,
+  getOverriddenFilesWarning,
+} from '@components/module-overrides-warning';
 
 const {$} = window;
 
@@ -107,6 +111,7 @@ class AdminModuleController {
     this.initPageChangeProtection();
     this.initFilterStatusDropdown();
     this.initOverriddenBadgeTooltip();
+    this.initOverriddenBadgeModal();
     this.fetchModulesList();
     this.getNotificationsCount();
   }
@@ -119,8 +124,33 @@ class AdminModuleController {
   initOverriddenBadgeTooltip() {
     $('body').pstooltip({
       selector: this.overriddenBadgeSelector,
-      html: true,
       placement: 'top',
+    });
+  }
+
+  /**
+   * The badge lists the overriding files in a modal rather than in its tooltip, which would grow
+   * unreadable on a module carrying several overrides.
+   */
+  initOverriddenBadgeModal() {
+    $('body').on('click', this.overriddenBadgeSelector, function showOverriddenFiles(event) {
+      event.preventDefault();
+
+      const overrides = getModuleOverrides($(this));
+
+      if (overrides === null) {
+        return;
+      }
+
+      $(this).pstooltip('hide');
+
+      new Modal({
+        id: 'module-overrides-modal',
+        modalTitle: `${window.moduleTranslations.overridesModalTitle} - ${overrides.displayName}`,
+        closable: true,
+      })
+        .render(getOverriddenFilesWarning(overrides.files))
+        .show();
     });
   }
 

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -4,7 +4,7 @@
  */
 
 import ConfirmModal from '@components/modal';
-import {getModulesOverridesWarning} from '@components/module-overrides-warning';
+import {getModulesOverridesWarning, getOverriddenFilesWarning} from '@components/module-overrides-warning';
 
 const {$} = window;
 
@@ -629,13 +629,15 @@ class AdminModuleController {
         if (file.status !== 'error') {
           const responseObject = $.parseJSON(file.xhr.response);
 
-          if (typeof responseObject.is_configurable === 'undefined') responseObject.is_configurable = null;
-          if (typeof responseObject.module_name === 'undefined') responseObject.module_name = null;
+          // The server holds back an upload replacing an overridden module until the employee confirms
+          if (responseObject.confirmation_needed === 'overrides') {
+            self.isUploadStarted = false;
+            self.confirmOverriddenModuleUpload(file, responseObject);
 
-          self.displayOnUploadDone(responseObject);
+            return;
+          }
 
-          const elem = $(`<div data-tech-name="${responseObject.module_name}"></div>`);
-          this.eventEmitter.emit((responseObject.upgraded ? 'Module Upgraded' : 'Module Installed'), elem);
+          self.handleImportResponse(responseObject);
         }
         // State that we have finish the process to unlock some actions
         self.isUploadStarted = false;
@@ -696,6 +698,108 @@ class AdminModuleController {
       $(self.moduleImportFailureMsgDetailsSelector).html(message);
       $(self.moduleImportFailureSelector).fadeIn();
     });
+  }
+
+  /**
+   * Common handling of a finished import, whether it came from the dropzone or from a replayed upload.
+   *
+   * @param object result containing the server response
+   */
+  handleImportResponse(result) {
+    if (typeof result.is_configurable === 'undefined') result.is_configurable = null;
+    if (typeof result.module_name === 'undefined') result.module_name = null;
+
+    this.displayOnUploadDone(result);
+
+    const elem = $(`<div data-tech-name="${result.module_name}"></div>`);
+    this.eventEmitter.emit(result.upgraded ? 'Module Upgraded' : 'Module Installed', elem);
+  }
+
+  /**
+   * The server refuses to replace an installed module customized in override/modules until the
+   * employee acknowledges the update may break those customizations.
+   *
+   * @param File file the archive the employee dropped
+   * @param object result containing the server response
+   */
+  confirmOverriddenModuleUpload(file, result) {
+    const self = this;
+
+    self.animateEndUpload(() => {
+      // Asked for inside the import modal, using its own confirm block and footer, rather than
+      // stacking a second modal on top of it
+      $(self.moduleImportConfirmSelector)
+        .html(getOverriddenFilesWarning(result.overridden_files || []))
+        .show();
+
+      const cancelButton = $('<button type="button" class="btn btn-outline-secondary"></button>')
+        .text(window.moduleTranslations.moduleModalUpdateCancel)
+        .on('click', () => {
+          self.clearImportConfirm();
+          self.resetImportModal();
+        });
+
+      const confirmButton = $('<button type="button" class="btn btn-primary"></button>')
+        .text(window.moduleTranslations.upgradeAnywayButtonText)
+        .on('click', () => {
+          self.clearImportConfirm();
+          self.replayOverriddenModuleUpload(file);
+        });
+
+      $(self.dropZoneModalFooterSelector).empty().append(cancelButton, confirmButton);
+    });
+  }
+
+  /**
+   * Removes the in-modal confirmation, so the modal can show the upload outcome instead.
+   */
+  clearImportConfirm() {
+    $(this.moduleImportConfirmSelector).hide().empty();
+    $(this.dropZoneModalFooterSelector).empty();
+  }
+
+  /**
+   * Sends the archive again, this time allowed to replace the overridden module.
+   *
+   * @param File file the archive the employee dropped
+   */
+  replayOverriddenModuleUpload(file) {
+    const self = this;
+    const formData = new FormData();
+    formData.append('file_uploaded', file);
+    formData.append('confirm_overrides', '1');
+
+    self.isUploadStarted = true;
+    self.animateStartUpload();
+
+    $.ajax({
+      url: window.moduleURLs.moduleImport,
+      method: 'POST',
+      data: formData,
+      processData: false,
+      contentType: false,
+      dataType: 'json',
+    })
+      .done((result) => self.handleImportResponse(result))
+      .fail((jqXHR) => self.displayOnUploadError(
+        (jqXHR.responseJSON && jqXHR.responseJSON.msg) || jqXHR.statusText,
+      ))
+      .always(() => {
+        self.isUploadStarted = false;
+      });
+  }
+
+  /**
+   * Puts the import modal back to its initial state, so the employee can drop another archive.
+   */
+  resetImportModal() {
+    const self = this;
+
+    $(self.moduleImportProcessingSelector).hide();
+    $(`${self.moduleImportSuccessSelector}, ${self.moduleImportFailureSelector}`).hide();
+    $(self.moduleImportStartSelector).fadeIn();
+    $('.dropzone').removeAttr('style');
+    self.isUploadStarted = false;
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -49,6 +49,7 @@ class AdminModuleController {
 
     // Selectors into vars to make it easier to change them while keeping same code logic
     this.moduleItemListSelector = '.module-item-list';
+    this.overriddenBadgeSelector = '.module-overridden-badge';
     this.categorySelectorLabelSelector = '.module-category-selector-label';
     this.categorySelector = '.module-category-selector';
     this.categoryItemSelector = '.module-category-menu';
@@ -105,8 +106,22 @@ class AdminModuleController {
     this.initDropzone();
     this.initPageChangeProtection();
     this.initFilterStatusDropdown();
+    this.initOverriddenBadgeTooltip();
     this.fetchModulesList();
     this.getNotificationsCount();
+  }
+
+  /**
+   * `pstooltip` is an alias of the Bootstrap tooltip, deliberately named so that Bootstrap does not
+   * pick it up on its own, and nothing initialises it globally in the back office. It is delegated
+   * from the body here because module cards are also appended after the page has loaded.
+   */
+  initOverriddenBadgeTooltip() {
+    $('body').pstooltip({
+      selector: this.overriddenBadgeSelector,
+      html: true,
+      placement: 'top',
+    });
   }
 
   initFilterStatusDropdown() {

--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -256,6 +256,11 @@
       }
     }
 
+    // Clicking the badge opens the list of overriding files
+    .module-overridden-badge {
+      cursor: pointer;
+    }
+
     .module-version-author-list {
       overflow: hidden;
       font-weight: 600;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -46,7 +46,7 @@ parameters:
     - '#^Unsafe usage of new static\(\)\.$#'
     - '#constructor expects Symfony\\Contracts\\Translation\\TranslatorInterface\|null, Symfony\\Component\\Translation\\TranslatorInterface given\.$#'
     - '#^Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface\:\:dispatch\(\) invoked with 2 parameters, 1 required\.$#'
-    - '~^Access to an undefined property PrestaShop\\PrestaShop\\Core\\Module\\ModuleInterface::\$(attributes|disk|database)\.$~'
+    - '~^Access to an undefined property PrestaShop\\PrestaShop\\Core\\Module\\ModuleInterface::\$(attributes|disk|database|overrides)\.$~'
     - message: "#^Dead catch \\- Symfony\\\\Component\\\\HttpFoundation\\\\File\\\\Exception\\\\FileNotFoundException is never thrown in the try block\\.$#"
       count: 1
       path: src/PrestaShopBundle/Controller/Admin/SecuredFileReaderController.php

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -56,6 +56,13 @@ class Module implements ModuleInterface
     public $database;
 
     /**
+     * Files customizing this module in the shop `override/modules/` folder.
+     *
+     * @var ParameterBag
+     */
+    public $overrides;
+
+    /**
      * Default values for ParameterBag attributes.
      *
      * @var array
@@ -125,19 +132,32 @@ class Module implements ModuleInterface
     ];
 
     /**
+     * Default values for ParameterBag overrides.
+     *
+     * @var array
+     */
+    private $overrides_default = [
+        'is_overridden' => false,
+        'files' => [],
+    ];
+
+    /**
      * @param array $attributes
      * @param array $disk
      * @param array $database
+     * @param array $overrides
      */
-    public function __construct(array $attributes = [], array $disk = [], array $database = [])
+    public function __construct(array $attributes = [], array $disk = [], array $database = [], array $overrides = [])
     {
         $this->attributes = new ParameterBag($this->attributes_default);
         $this->disk = new ParameterBag($this->disk_default);
         $this->database = new ParameterBag($this->database_default);
+        $this->overrides = new ParameterBag($this->overrides_default);
         // Set all attributes
         $this->attributes->add($attributes);
         $this->disk->add($disk);
         $this->database->add($database);
+        $this->overrides->add($overrides);
 
         if ($this->isInstalled()) {
             $version = $this->database->get('version');
@@ -342,6 +362,22 @@ class Module implements ModuleInterface
     public function getDatabaseAttributes(): ParameterBag
     {
         return $this->database;
+    }
+
+    public function getOverrides(): ParameterBag
+    {
+        return $this->overrides;
+    }
+
+    /**
+     * @param string[] $files Paths of the files overriding this module, relative to the shop root
+     */
+    public function setOverrides(array $files): void
+    {
+        $this->overrides = new ParameterBag([
+            'is_overridden' => [] !== $files,
+            'files' => $files,
+        ]);
     }
 
     /**

--- a/src/Adapter/Module/QueryHandler/GetModuleInfosHandler.php
+++ b/src/Adapter/Module/QueryHandler/GetModuleInfosHandler.php
@@ -33,6 +33,8 @@ class GetModuleInfosHandler implements GetModuleInfosHandlerInterface
             $module->database->get('version', null),
             $module->isActive(),
             $module->isInstalled(),
+            $module->overrides->get('is_overridden'),
+            $module->overrides->get('files'),
         );
     }
 }

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -14,7 +14,6 @@ use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
-use PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider;
 
 class ModulePresenter implements PresenterInterface
 {
@@ -26,17 +25,10 @@ class ModulePresenter implements PresenterInterface
     /** @var PriceFormatter */
     private $priceFormatter;
 
-    /** @var OverriddenModulesProvider */
-    private $overriddenModulesProvider;
-
-    public function __construct(
-        Currency $currency,
-        PriceFormatter $priceFormatter,
-        OverriddenModulesProvider $overriddenModulesProvider
-    ) {
+    public function __construct(Currency $currency, PriceFormatter $priceFormatter)
+    {
         $this->currency = $currency;
         $this->priceFormatter = $priceFormatter;
-        $this->overriddenModulesProvider = $overriddenModulesProvider;
     }
 
     /**
@@ -62,22 +54,11 @@ class ModulePresenter implements PresenterInterface
             $attributes['multistoreCompatibility'] = $moduleInstance->getMultistoreCompatibility();
         }
 
-        $overriddenFiles = $this->overriddenModulesProvider->getOverriddenFiles($attributes['name']);
-
         $result = [
             'attributes' => $attributes,
             'disk' => $module->disk->all(),
             'database' => $module->database->all(),
-            'overrides' => [
-                'is_overridden' => [] !== $overriddenFiles,
-                // Displayed as is, so paths are relative to the shop root to be locatable
-                'files' => array_map(
-                    static function (string $overriddenFile) use ($attributes): string {
-                        return 'override/modules/' . $attributes['name'] . '/' . $overriddenFile;
-                    },
-                    $overriddenFiles
-                ),
-            ],
+            'overrides' => $module->overrides->all(),
         ];
 
         Hook::exec('actionPresentModule',

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -14,6 +14,7 @@ use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
+use PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider;
 
 class ModulePresenter implements PresenterInterface
 {
@@ -25,10 +26,17 @@ class ModulePresenter implements PresenterInterface
     /** @var PriceFormatter */
     private $priceFormatter;
 
-    public function __construct(Currency $currency, PriceFormatter $priceFormatter)
-    {
+    /** @var OverriddenModulesProvider */
+    private $overriddenModulesProvider;
+
+    public function __construct(
+        Currency $currency,
+        PriceFormatter $priceFormatter,
+        OverriddenModulesProvider $overriddenModulesProvider
+    ) {
         $this->currency = $currency;
         $this->priceFormatter = $priceFormatter;
+        $this->overriddenModulesProvider = $overriddenModulesProvider;
     }
 
     /**
@@ -54,10 +62,22 @@ class ModulePresenter implements PresenterInterface
             $attributes['multistoreCompatibility'] = $moduleInstance->getMultistoreCompatibility();
         }
 
+        $overriddenFiles = $this->overriddenModulesProvider->getOverriddenFiles($attributes['name']);
+
         $result = [
             'attributes' => $attributes,
             'disk' => $module->disk->all(),
             'database' => $module->database->all(),
+            'overrides' => [
+                'is_overridden' => [] !== $overriddenFiles,
+                // Displayed as is, so paths are relative to the shop root to be locatable
+                'files' => array_map(
+                    static function (string $overriddenFile) use ($attributes): string {
+                        return 'override/modules/' . $attributes['name'] . '/' . $overriddenFile;
+                    },
+                    $overriddenFiles
+                ),
+            ],
         ];
 
         Hook::exec('actionPresentModule',

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -26,6 +26,7 @@ use PrestaShop\PrestaShop\Core\Localization\Specification\NumberSymbolList;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Price as PriceSpecification;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
+use PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerFactory;
 use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
@@ -129,6 +130,7 @@ class ModuleManagerBuilder
                     new HookManager(),
                     _PS_MODULE_DIR_,
                     $this->getLanguageContext(),
+                    new OverriddenModulesProvider(_PS_OVERRIDE_DIR_),
                 );
             }
         }

--- a/src/Core/Domain/Module/QueryResult/ModuleInfos.php
+++ b/src/Core/Domain/Module/QueryResult/ModuleInfos.php
@@ -10,6 +10,9 @@ namespace PrestaShop\PrestaShop\Core\Domain\Module\QueryResult;
 
 class ModuleInfos
 {
+    /**
+     * @param string[] $overriddenFiles Paths of the files overriding this module, relative to the shop root
+     */
     public function __construct(
         private readonly ?int $moduleId,
         private readonly string $technicalName,
@@ -17,6 +20,8 @@ class ModuleInfos
         private readonly ?string $installedVersion,
         private readonly bool $enabled,
         private readonly bool $installed,
+        private readonly bool $overridden = false,
+        private readonly array $overriddenFiles = [],
     ) {
     }
 
@@ -48,5 +53,22 @@ class ModuleInfos
     public function isInstalled(): bool
     {
         return $this->installed;
+    }
+
+    /**
+     * Whether files in the shop `override/modules/` folder customize this module, which an update
+     * is likely to break.
+     */
+    public function isOverridden(): bool
+    {
+        return $this->overridden;
+    }
+
+    /**
+     * @return string[] Paths of the files overriding this module, relative to the shop root
+     */
+    public function getOverriddenFiles(): array
+    {
+        return $this->overriddenFiles;
     }
 }

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -65,6 +65,7 @@ class ModuleRepository implements ModuleRepositoryInterface
         HookManager $hookManager,
         string $modulePath,
         private LanguageContext $languageContext,
+        private OverriddenModulesProvider $overriddenModulesProvider,
     ) {
         $this->moduleDataProvider = $moduleDataProvider;
         $this->adminModuleDataProvider = $adminModuleDataProvider;
@@ -149,7 +150,10 @@ class ModuleRepository implements ModuleRepositoryInterface
             /** @var Module $module */
             $module = $this->cacheProvider->fetch($cacheKey);
             if ($module->getDiskAttributes()->get('filemtime') === $filemtime) {
-                return $this->enrichModuleAttributesFromHook($module);
+                /** @var Module $enrichedModule */
+                $enrichedModule = $this->enrichModuleAttributesFromHook($module);
+
+                return $this->enrichModuleOverrides($enrichedModule);
             }
         }
 
@@ -165,7 +169,10 @@ class ModuleRepository implements ModuleRepositoryInterface
         $coreModule = new Module($attributes, $disk, $database);
         $this->cacheProvider->save($cacheKey, $coreModule);
 
-        return $this->enrichModuleAttributesFromHook($coreModule);
+        /** @var Module $enrichedModule */
+        $enrichedModule = $this->enrichModuleAttributesFromHook($coreModule);
+
+        return $this->enrichModuleOverrides($enrichedModule);
     }
 
     public function getModulePath(string $moduleName): ?string
@@ -331,6 +338,24 @@ class ModuleRepository implements ModuleRepositoryInterface
      *
      * @return Module
      */
+    /**
+     * Fills the overrides of a module, deliberately after the cache has been read or written: the
+     * cached module is only invalidated when its own files change, while the files overriding it
+     * live outside the module folder and can appear or disappear at any time.
+     */
+    protected function enrichModuleOverrides(Module $module): Module
+    {
+        $moduleName = (string) $module->get('name');
+        $module->setOverrides(array_map(
+            static function (string $overriddenFile) use ($moduleName): string {
+                return 'override/modules/' . $moduleName . '/' . $overriddenFile;
+            },
+            $this->overriddenModulesProvider->getOverriddenFiles($moduleName)
+        ));
+
+        return $module;
+    }
+
     protected function enrichModuleAttributesFromHook(Module $module): ModuleInterface
     {
         try {

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -334,11 +334,6 @@ class ModuleRepository implements ModuleRepositoryInterface
     }
 
     /**
-     * @param Module $module
-     *
-     * @return Module
-     */
-    /**
      * Fills the overrides of a module, deliberately after the cache has been read or written: the
      * cached module is only invalidated when its own files change, while the files overriding it
      * live outside the module folder and can appear or disappear at any time.
@@ -346,16 +341,16 @@ class ModuleRepository implements ModuleRepositoryInterface
     protected function enrichModuleOverrides(Module $module): Module
     {
         $moduleName = (string) $module->get('name');
-        $module->setOverrides(array_map(
-            static function (string $overriddenFile) use ($moduleName): string {
-                return 'override/modules/' . $moduleName . '/' . $overriddenFile;
-            },
-            $this->overriddenModulesProvider->getOverriddenFiles($moduleName)
-        ));
+        $module->setOverrides($this->overriddenModulesProvider->getOverriddenFilePaths($moduleName));
 
         return $module;
     }
 
+    /**
+     * @param Module $module
+     *
+     * @return Module
+     */
     protected function enrichModuleAttributesFromHook(Module $module): ModuleInterface
     {
         try {

--- a/src/Core/Module/OverriddenModulesProvider.php
+++ b/src/Core/Module/OverriddenModulesProvider.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Module;
 
 use Symfony\Component\Finder\Finder;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Lists the modules customized through the shop `override/modules/` folder.
@@ -20,7 +21,7 @@ use Symfony\Component\Finder\Finder;
  * Any other PHP file found in a module override folder is reported too: it does not alter the module
  * behaviour on its own, but it means the module has been customized and an update may break it.
  */
-final class OverriddenModulesProvider
+final class OverriddenModulesProvider implements ResetInterface
 {
     /**
      * Blank guard files PrestaShop generates in every folder, they are never actual overrides.
@@ -40,6 +41,15 @@ final class OverriddenModulesProvider
     public function isOverridden(string $moduleName): bool
     {
         return [] !== $this->getOverriddenFiles($moduleName);
+    }
+
+    /**
+     * The scan is memoized for the request, which is long enough for a web request but not for a
+     * worker or a test suite, where override files can be added or removed while the process lives.
+     */
+    public function reset(): void
+    {
+        $this->overriddenFiles = null;
     }
 
     /**

--- a/src/Core/Module/OverriddenModulesProvider.php
+++ b/src/Core/Module/OverriddenModulesProvider.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Module;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Lists the modules customized through the shop `override/modules/` folder.
+ *
+ * Two override mechanisms are resolved at runtime by the core:
+ * - the main module class, from `override/modules/<module>/<module>.php` (see Module::coreLoadModule())
+ * - a module front controller, from `override/modules/<module>/controllers/front/<controller>.php` (see Dispatcher::dispatch())
+ *
+ * Any other PHP file found in a module override folder is reported too: it does not alter the module
+ * behaviour on its own, but it means the module has been customized and an update may break it.
+ */
+final class OverriddenModulesProvider
+{
+    /**
+     * Blank guard files PrestaShop generates in every folder, they are never actual overrides.
+     */
+    private const IGNORED_FILE_NAMES = ['index.php'];
+
+    /**
+     * @var array<string, string[]>|null Module technical name => overridden file paths
+     */
+    private ?array $overriddenFiles = null;
+
+    public function __construct(
+        private readonly string $overrideDir,
+    ) {
+    }
+
+    public function isOverridden(string $moduleName): bool
+    {
+        return [] !== $this->getOverriddenFiles($moduleName);
+    }
+
+    /**
+     * @return string[] Overridden file paths, relative to `override/modules/<module>/`
+     */
+    public function getOverriddenFiles(string $moduleName): array
+    {
+        return $this->getAllOverriddenFiles()[$moduleName] ?? [];
+    }
+
+    /**
+     * The override folder is scanned once, so that listing pages displaying hundreds of modules
+     * only pay for a single filesystem traversal.
+     *
+     * @return array<string, string[]> Module technical name => overridden file paths
+     */
+    public function getAllOverriddenFiles(): array
+    {
+        if (null === $this->overriddenFiles) {
+            $this->overriddenFiles = $this->findOverriddenFiles();
+        }
+
+        return $this->overriddenFiles;
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    private function findOverriddenFiles(): array
+    {
+        $modulesOverrideDir = rtrim($this->overrideDir, '/\\') . DIRECTORY_SEPARATOR . 'modules';
+        if (!is_dir($modulesOverrideDir)) {
+            return [];
+        }
+
+        $finder = (new Finder())
+            ->files()
+            ->in($modulesOverrideDir)
+            ->name('*.php')
+            ->notName(self::IGNORED_FILE_NAMES)
+            // An override always sits in a folder named after the module it applies to
+            ->depth('>= 1');
+
+        $overriddenFiles = [];
+        foreach ($finder as $file) {
+            [$moduleName, $overriddenFile] = explode('/', str_replace('\\', '/', $file->getRelativePathname()), 2);
+            $overriddenFiles[$moduleName][] = $overriddenFile;
+        }
+
+        foreach ($overriddenFiles as &$moduleFiles) {
+            sort($moduleFiles);
+        }
+
+        ksort($overriddenFiles);
+
+        return $overriddenFiles;
+    }
+}

--- a/src/Core/Module/OverriddenModulesProvider.php
+++ b/src/Core/Module/OverriddenModulesProvider.php
@@ -61,6 +61,22 @@ final class OverriddenModulesProvider implements ResetInterface
     }
 
     /**
+     * Same list as getOverriddenFiles(), with paths relative to the shop root so they can be
+     * displayed or located as is.
+     *
+     * @return string[]
+     */
+    public function getOverriddenFilePaths(string $moduleName): array
+    {
+        return array_map(
+            static function (string $overriddenFile) use ($moduleName): string {
+                return 'override/modules/' . $moduleName . '/' . $overriddenFile;
+            },
+            $this->getOverriddenFiles($moduleName)
+        );
+    }
+
+    /**
      * The override folder is scanned once, so that listing pages displaying hundreds of modules
      * only pay for a single filesystem traversal.
      *
@@ -91,7 +107,9 @@ final class OverriddenModulesProvider implements ResetInterface
             ->name('*.php')
             ->notName(self::IGNORED_FILE_NAMES)
             // An override always sits in a folder named after the module it applies to
-            ->depth('>= 1');
+            ->depth('>= 1')
+            // A folder the shop cannot read must not bring down every page listing modules
+            ->ignoreUnreadableDirs();
 
         $overriddenFiles = [];
         foreach ($finder as $file) {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -15,6 +15,7 @@ use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Module as ModuleAdapter;
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
+use PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerFactory;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerNotFoundException;
 use PrestaShop\PrestaShop\Core\Security\Permission;
@@ -312,6 +313,7 @@ class ModuleController extends ModuleAbstractController
         Request $request,
         ModuleManager $moduleManager,
         SourceHandlerFactory $sourceHandlerFactory,
+        OverriddenModulesProvider $overriddenModulesProvider,
     ): JsonResponse {
         if ($this->isDemoModeEnabled()) {
             return new JsonResponse(
@@ -386,6 +388,35 @@ class ModuleController extends ModuleAbstractController
             $moduleName = $sourceHandlerFactory->getHandler($uploadedPath)->getModuleName($uploadedPath);
 
             $moduleWasAlreadyInstalled = $moduleManager->isInstalled($moduleName);
+
+            // Uploading over an installed module replaces its files, which is likely to break the
+            // customizations made in override/modules. The archive is the only place the target module
+            // name can be read from, so the confirmation can only be asked for at this point.
+            $overriddenFiles = $overriddenModulesProvider->getOverriddenFiles($moduleName);
+            if (
+                $moduleWasAlreadyInstalled
+                && [] !== $overriddenFiles
+                && !$request->request->getBoolean('confirm_overrides')
+            ) {
+                return new JsonResponse([
+                    'status' => false,
+                    'confirmation_needed' => 'overrides',
+                    'module_name' => $moduleName,
+                    'overridden_files' => array_map(
+                        static function (string $overriddenFile) use ($moduleName): string {
+                            return 'override/modules/' . $moduleName . '/' . $overriddenFile;
+                        },
+                        $overriddenFiles
+                    ),
+                    // Also stated as a plain message, so a client unaware of the confirmation
+                    // does not report an empty failure
+                    'msg' => $this->trans(
+                        'Module %module% is customized by override files, updating it may break them. Confirm the upload to replace it anyway.',
+                        ['%module%' => $moduleName],
+                        'Admin.Modules.Notification',
+                    ),
+                ]);
+            }
             $installationResult = $moduleManager->install($moduleName, $uploadedPath);
 
             // Install the module

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -392,7 +392,7 @@ class ModuleController extends ModuleAbstractController
             // Uploading over an installed module replaces its files, which is likely to break the
             // customizations made in override/modules. The archive is the only place the target module
             // name can be read from, so the confirmation can only be asked for at this point.
-            $overriddenFiles = $overriddenModulesProvider->getOverriddenFiles($moduleName);
+            $overriddenFiles = $overriddenModulesProvider->getOverriddenFilePaths($moduleName);
             if (
                 $moduleWasAlreadyInstalled
                 && [] !== $overriddenFiles
@@ -402,12 +402,7 @@ class ModuleController extends ModuleAbstractController
                     'status' => false,
                     'confirmation_needed' => 'overrides',
                     'module_name' => $moduleName,
-                    'overridden_files' => array_map(
-                        static function (string $overriddenFile) use ($moduleName): string {
-                            return 'override/modules/' . $moduleName . '/' . $overriddenFile;
-                        },
-                        $overriddenFiles
-                    ),
+                    'overridden_files' => $overriddenFiles,
                     // Also stated as a plain message, so a client unaware of the confirmation
                     // does not report an empty failure
                     'msg' => $this->trans(

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -92,7 +92,10 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Presenter\Module\ModulePresenter:
     public: false
-    arguments: [ "@=service('prestashop.adapter.legacy.context').getContext().currency", "@prestashop.adapter.formatter.price" ]
+    arguments:
+      - "@=service('prestashop.adapter.legacy.context').getContext().currency"
+      - '@prestashop.adapter.formatter.price'
+      - '@PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider'
 
   prestashop.adapter.presenter.module:
     alias: PrestaShop\PrestaShop\Adapter\Presenter\Module\ModulePresenter

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -92,10 +92,7 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Presenter\Module\ModulePresenter:
     public: false
-    arguments:
-      - "@=service('prestashop.adapter.legacy.context').getContext().currency"
-      - '@prestashop.adapter.formatter.price'
-      - '@PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider'
+    arguments: [ "@=service('prestashop.adapter.legacy.context').getContext().currency", "@prestashop.adapter.formatter.price" ]
 
   prestashop.adapter.presenter.module:
     alias: PrestaShop\PrestaShop\Adapter\Presenter\Module\ModulePresenter

--- a/src/PrestaShopBundle/Resources/config/services/core/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/module.yml
@@ -89,3 +89,5 @@ services:
   PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider:
     arguments:
       - !php/const _PS_OVERRIDE_DIR_
+    tags:
+      - { name: kernel.reset, method: reset }

--- a/src/PrestaShopBundle/Resources/config/services/core/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/module.yml
@@ -85,3 +85,7 @@ services:
     arguments:
       - '@translator'
       - !php/const _PS_OVERRIDE_DIR_
+
+  PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider:
+    arguments:
+      - !php/const _PS_OVERRIDE_DIR_

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -3,6 +3,7 @@
  # docs/licenses/LICENSE.txt file that was distributed with this source code.
  #}
 {% set isModuleActive = module.database.active|default('0') %}
+{% set overriddenFiles = module.overrides.files|default([]) %}
 
 <div
   class="module-item module-item-list col-md-12 {% if origin == 'manage' and isModuleActive == '0' %}module-item-list-isNotActive{% endif %}"
@@ -21,6 +22,10 @@
   data-active="{{ isModuleActive }}"
   data-installed="{{ module.database.installed|default('0') }}"
   data-last-access="{{ module.database.last_access_date }}"
+  {% if overriddenFiles is not empty %}
+    data-has-overrides="1"
+    data-overridden-files="{{ overriddenFiles|join('|') }}"
+  {% endif %}
 >
   <div class="container-fluid">
     <div class="module-item-wrapper-list row">
@@ -58,6 +63,16 @@
           <div>
             {% if module.attributes.urls.upgrade is defined %}
                 <span class="badge badge-success my-1">{{ 'Upgrade available'|trans({}, 'Admin.Modules.Feature') }}</span>
+            {% endif %}
+            {% if overriddenFiles is not empty %}
+                {# Warn the employee the module is customized: an update is likely to break the override #}
+                <span
+                  class="badge badge-warning my-1 module-overridden-badge"
+                  data-toggle="pstooltip"
+                  data-placement="top"
+                  data-html="true"
+                  title="{{ 'This module is customized by files in the override folder. Updating it may break these customizations.'|trans({}, 'Admin.Modules.Help') }}{% for file in overriddenFiles %}<br>{{ file }}{% endfor %}"
+                >{{ 'Overridden'|trans({}, 'Admin.Modules.Feature') }}</span>
             {% endif %}
           </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -65,13 +65,13 @@
                 <span class="badge badge-success my-1">{{ 'Upgrade available'|trans({}, 'Admin.Modules.Feature') }}</span>
             {% endif %}
             {% if overriddenFiles is not empty %}
-                {# Warn the employee the module is customized: an update is likely to break the override #}
+                {# Warn the employee the module is customized: an update is likely to break the override.
+                   The overriding files are listed in a modal, to keep the tooltip short. #}
                 <span
                   class="badge badge-warning my-1 module-overridden-badge"
                   data-toggle="pstooltip"
                   data-placement="top"
-                  data-html="true"
-                  title="{{ 'This module is customized by files in the override folder. Updating it may break these customizations.'|trans({}, 'Admin.Modules.Help') }}{% for file in overriddenFiles %}<br>{{ file }}{% endfor %}"
+                  title="{{ 'This module is customized by files in the override folder. Updating it may break these customizations. Click to see the files.'|trans({}, 'Admin.Modules.Help') }}"
                 >{{ 'Overridden'|trans({}, 'Admin.Modules.Feature') }}</span>
             {% endif %}
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -26,6 +26,7 @@
       'overridesUpdateFilesIntro': '{{ 'Files overriding this module:'|trans({}, 'Admin.Modules.Notification') }}',
       'overridesUpdateAllWarning': '{{ 'Some of these modules are customized by override files. Nothing guarantees the new versions will remain compatible with them: proceed with caution and check your shop afterwards.'|trans({}, 'Admin.Modules.Notification') }}',
       'overridesUpdateModulesIntro': '{{ 'Overridden modules:'|trans({}, 'Admin.Modules.Notification') }}',
+      'overridesModalTitle': '{{ 'Module customized by overrides'|trans({}, 'Admin.Modules.Feature') }}',
     };
 
     // Need to come from the backend

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -22,11 +22,11 @@
       'moduleModalUpdateUpgrade': '{{ 'Upgrade'|trans({}, 'Admin.Actions') }}',
       'upgradeAnywayButtonText': '{{ 'Update anyway'|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateConfirmMessage': '{{ 'We strongly advise you to update the modules on maintenance mode to avoid any cache issues.'|trans({}, 'Admin.Modules.Notification') }}',
-      'overridesUpdateWarning': '{{ 'This module is customized by override files. Nothing guarantees the new version will remain compatible with them: proceed with caution and check your shop afterwards.'|trans({}, 'Admin.Modules.Notification') }}',
-      'overridesUpdateFilesIntro': '{{ 'Files overriding this module:'|trans({}, 'Admin.Modules.Notification') }}',
-      'overridesUpdateAllWarning': '{{ 'Some of these modules are customized by override files. Nothing guarantees the new versions will remain compatible with them: proceed with caution and check your shop afterwards.'|trans({}, 'Admin.Modules.Notification') }}',
-      'overridesUpdateModulesIntro': '{{ 'Overridden modules:'|trans({}, 'Admin.Modules.Notification') }}',
-      'overridesModalTitle': '{{ 'Module customized by overrides'|trans({}, 'Admin.Modules.Feature') }}',
+      'overridesUpdateWarning': '{{ 'This module is customized by override files. Nothing guarantees the new version will remain compatible with them: proceed with caution and check your shop afterwards.'|trans({}, 'Admin.Modules.Notification')|e('js') }}',
+      'overridesUpdateFilesIntro': '{{ 'Files overriding this module:'|trans({}, 'Admin.Modules.Notification')|e('js') }}',
+      'overridesUpdateAllWarning': '{{ 'Some of these modules are customized by override files. Nothing guarantees the new versions will remain compatible with them: proceed with caution and check your shop afterwards.'|trans({}, 'Admin.Modules.Notification')|e('js') }}',
+      'overridesUpdateModulesIntro': '{{ 'Overridden modules:'|trans({}, 'Admin.Modules.Notification')|e('js') }}',
+      'overridesModalTitle': '{{ 'Module customized by overrides'|trans({}, 'Admin.Modules.Feature')|e('js') }}',
     };
 
     // Need to come from the backend

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -22,6 +22,10 @@
       'moduleModalUpdateUpgrade': '{{ 'Upgrade'|trans({}, 'Admin.Actions') }}',
       'upgradeAnywayButtonText': '{{ 'Update anyway'|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateConfirmMessage': '{{ 'We strongly advise you to update the modules on maintenance mode to avoid any cache issues.'|trans({}, 'Admin.Modules.Notification') }}',
+      'overridesUpdateWarning': '{{ 'This module is customized by override files. Nothing guarantees the new version will remain compatible with them: proceed with caution and check your shop afterwards.'|trans({}, 'Admin.Modules.Notification') }}',
+      'overridesUpdateFilesIntro': '{{ 'Files overriding this module:'|trans({}, 'Admin.Modules.Notification') }}',
+      'overridesUpdateAllWarning': '{{ 'Some of these modules are customized by override files. Nothing guarantees the new versions will remain compatible with them: proceed with caution and check your shop afterwards.'|trans({}, 'Admin.Modules.Notification') }}',
+      'overridesUpdateModulesIntro': '{{ 'Overridden modules:'|trans({}, 'Admin.Modules.Notification') }}',
     };
 
     // Need to come from the backend

--- a/tests/Integration/Behaviour/Features/Context/Domain/ModuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ModuleFeatureContext.php
@@ -27,6 +27,7 @@ use PrestaShop\PrestaShop\Core\Domain\Module\Exception\ModuleNotInstalledExcepti
 use PrestaShop\PrestaShop\Core\Domain\Module\Query\GetModuleInfos;
 use PrestaShop\PrestaShop\Core\Domain\Module\QueryResult\ModuleInfos;
 use PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider;
+use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
@@ -47,6 +48,17 @@ class ModuleFeatureContext extends AbstractDomainFeatureContext
     {
         $overriddenFilePath = _PS_OVERRIDE_DIR_ . 'modules/' . $technicalName . '/' . $overrideFile;
         $overriddenFileDir = dirname($overriddenFilePath);
+
+        // The scenario writes in the shop override folder, which may hold real overrides on a
+        // developer machine: never overwrite a file the scenario did not create, as the clean up
+        // would then delete it for good
+        if (file_exists($overriddenFilePath) && !in_array($overriddenFilePath, $this->createdOverrideFiles, true)) {
+            throw new RuntimeException(sprintf(
+                'Cannot override module %s for the test, %s already exists',
+                $technicalName,
+                $overriddenFilePath
+            ));
+        }
 
         if (!is_dir($overriddenFileDir)) {
             mkdir($overriddenFileDir, 0777, true);

--- a/tests/Integration/Behaviour/Features/Context/Domain/ModuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ModuleFeatureContext.php
@@ -26,10 +26,76 @@ use PrestaShop\PrestaShop\Core\Domain\Module\Exception\ModuleNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Module\Exception\ModuleNotInstalledException;
 use PrestaShop\PrestaShop\Core\Domain\Module\Query\GetModuleInfos;
 use PrestaShop\PrestaShop\Core\Domain\Module\QueryResult\ModuleInfos;
+use PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider;
+use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class ModuleFeatureContext extends AbstractDomainFeatureContext
 {
+    /**
+     * @var string[] Override files created by the scenario, removed once it ends
+     */
+    private array $createdOverrideFiles = [];
+
+    /**
+     * @Given module :technicalName is overridden by file :overrideFile
+     *
+     * The file only has to exist for the module to be reported as overridden, its content is
+     * irrelevant, so a bare php file is enough and cannot interfere with the rest of the scenario.
+     */
+    public function overrideModule(string $technicalName, string $overrideFile): void
+    {
+        $overriddenFilePath = _PS_OVERRIDE_DIR_ . 'modules/' . $technicalName . '/' . $overrideFile;
+        $overriddenFileDir = dirname($overriddenFilePath);
+
+        if (!is_dir($overriddenFileDir)) {
+            mkdir($overriddenFileDir, 0777, true);
+        }
+        file_put_contents($overriddenFilePath, '<?php' . PHP_EOL);
+
+        $this->createdOverrideFiles[] = $overriddenFilePath;
+        $this->resetOverriddenModulesProvider();
+    }
+
+    /**
+     * Override files live outside the module folder, so they are removed by hand once the scenario
+     * is over to leave the shop as it was found.
+     *
+     * @AfterScenario
+     */
+    public function cleanUpOverrideFiles(): void
+    {
+        foreach ($this->createdOverrideFiles as $overriddenFilePath) {
+            if (is_file($overriddenFilePath)) {
+                unlink($overriddenFilePath);
+            }
+
+            // Remove the folders created for that file, as long as they are left empty
+            $directory = dirname($overriddenFilePath);
+            while (str_starts_with($directory, _PS_OVERRIDE_DIR_ . 'modules') && $this->isEmptyDirectory($directory)) {
+                rmdir($directory);
+                $directory = dirname($directory);
+            }
+        }
+
+        $this->createdOverrideFiles = [];
+        $this->resetOverriddenModulesProvider();
+    }
+
+    private function isEmptyDirectory(string $directory): bool
+    {
+        return is_dir($directory) && [] === array_diff(scandir($directory) ?: [], ['.', '..']);
+    }
+
+    /**
+     * The provider only scans the override folder once, so it has to be told the folder changed.
+     * In production this is not needed: the scan happens once per request.
+     */
+    private function resetOverriddenModulesProvider(): void
+    {
+        CommonFeatureContext::getContainer()->get(OverriddenModulesProvider::class)->reset();
+    }
+
     /**
      * @Given module :technicalName has following infos:
      */
@@ -242,6 +308,13 @@ class ModuleFeatureContext extends AbstractDomainFeatureContext
         }
         if (isset($data['installed'])) {
             Assert::assertEquals(PrimitiveUtils::castStringBooleanIntoBoolean($data['installed']), $moduleInfos->isInstalled(), 'Invalid installed value');
+        }
+        if (isset($data['overridden'])) {
+            Assert::assertEquals(PrimitiveUtils::castStringBooleanIntoBoolean($data['overridden']), $moduleInfos->isOverridden(), 'Invalid overridden value');
+        }
+        if (isset($data['overridden_files'])) {
+            $expectedFiles = '' === $data['overridden_files'] ? [] : array_map('trim', explode(',', $data['overridden_files']));
+            Assert::assertEquals($expectedFiles, $moduleInfos->getOverriddenFiles(), 'Invalid overridden files');
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Module/module.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Module/module.feature
@@ -93,6 +93,38 @@ Feature: Module
       | enabled           | true                 |
       | installed         | true                 |
 
+  Scenario: Get module infos of a module which is not overridden
+    Then module ps_emailsubscription has following infos:
+      | technical_name   | ps_emailsubscription |
+      | overridden       | false                |
+      | overridden_files |                      |
+
+  Scenario: Get module infos of a module overridden by its main class
+    Given module ps_emailsubscription is overridden by file "ps_emailsubscription.php"
+    Then module ps_emailsubscription has following infos:
+      | technical_name   | ps_emailsubscription                                           |
+      | overridden       | true                                                           |
+      | overridden_files | override/modules/ps_emailsubscription/ps_emailsubscription.php |
+    # Overriding a module says nothing about its status
+    And module ps_emailsubscription has following infos:
+      | enabled   | true |
+      | installed | true |
+
+  Scenario: Get module infos of a module overridden by several files
+    Given module ps_emailsubscription is overridden by file "ps_emailsubscription.php"
+    And module ps_emailsubscription is overridden by file "controllers/front/verification.php"
+    Then module ps_emailsubscription has following infos:
+      | overridden       | true                                                                                                                             |
+      | overridden_files | override/modules/ps_emailsubscription/controllers/front/verification.php, override/modules/ps_emailsubscription/ps_emailsubscription.php |
+
+  Scenario: Overriding a module does not override another one
+    Given module ps_emailsubscription is overridden by file "ps_emailsubscription.php"
+    Then module ps_emailsubscription has following infos:
+      | overridden | true |
+    And module ps_featuredproducts has following infos:
+      | overridden       | false |
+      | overridden_files |       |
+
   Scenario: Get module not present
     When module ps_notthere has following infos:
       | technical_name    | ps_notthere |

--- a/tests/Integration/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Integration/Core/Module/ModuleRepositoryTest.php
@@ -17,6 +17,7 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
+use PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Translation\Translator;
 
@@ -93,6 +94,7 @@ class ModuleRepositoryTest extends TestCase
                 'm/d/Y H:i:s',
                 $this->createMock(LocaleInterface::class),
             ),
+            new OverriddenModulesProvider(_PS_OVERRIDE_DIR_),
         );
     }
 

--- a/tests/Resources/module_overrides_tests/index.php
+++ b/tests/Resources/module_overrides_tests/index.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+// Blank guard file, mimics the index.php PrestaShop generates in every folder.

--- a/tests/Resources/module_overrides_tests/modules/index.php
+++ b/tests/Resources/module_overrides_tests/modules/index.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+// Blank guard file, mimics the index.php PrestaShop generates in every folder.

--- a/tests/Resources/module_overrides_tests/modules/notoverridden/index.php
+++ b/tests/Resources/module_overrides_tests/modules/notoverridden/index.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+// Blank guard file, mimics the index.php PrestaShop generates in every folder.

--- a/tests/Resources/module_overrides_tests/modules/notoverridden/readme.md
+++ b/tests/Resources/module_overrides_tests/modules/notoverridden/readme.md
@@ -1,0 +1,3 @@
+# notoverridden
+
+Leftover folder holding no PHP file: the module must not be reported as overridden.

--- a/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/controllers/front/ajax.php
+++ b/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/controllers/front/ajax.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * Second overridden front controller, used to check overridden files are returned sorted.
+ */
+class OverriddenFrontControllerAjaxModuleFrontControllerOverride
+{
+}

--- a/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/controllers/front/display.php
+++ b/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/controllers/front/display.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * Overrides a front controller of the "overriddenfrontcontroller" module, loaded by Dispatcher::dispatch().
+ */
+class OverriddenFrontControllerDisplayModuleFrontControllerOverride
+{
+}

--- a/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/controllers/front/index.php
+++ b/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/controllers/front/index.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+// Blank guard file, mimics the index.php PrestaShop generates in every folder.

--- a/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/controllers/index.php
+++ b/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/controllers/index.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+// Blank guard file, mimics the index.php PrestaShop generates in every folder.

--- a/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/index.php
+++ b/tests/Resources/module_overrides_tests/modules/overriddenfrontcontroller/index.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+// Blank guard file, mimics the index.php PrestaShop generates in every folder.

--- a/tests/Resources/module_overrides_tests/modules/overriddenmoduleclass/index.php
+++ b/tests/Resources/module_overrides_tests/modules/overriddenmoduleclass/index.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+// Blank guard file, mimics the index.php PrestaShop generates in every folder.

--- a/tests/Resources/module_overrides_tests/modules/overriddenmoduleclass/overriddenmoduleclass.php
+++ b/tests/Resources/module_overrides_tests/modules/overriddenmoduleclass/overriddenmoduleclass.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * Overrides the main class of the "overriddenmoduleclass" module, loaded by Module::coreLoadModule().
+ */
+class OverriddenModuleClassOverride
+{
+}

--- a/tests/Unit/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Unit/Core/Module/ModuleRepositoryTest.php
@@ -17,6 +17,7 @@ use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
+use PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider;
 
 class ModuleRepositoryTest extends TestCase
 {
@@ -62,6 +63,7 @@ class ModuleRepositoryTest extends TestCase
                 $this->createMock(HookManager::class),
                 dirname(__DIR__, 3) . '/Resources/modules',
                 $this->createMock(LanguageContext::class),
+                new OverriddenModulesProvider(dirname(__DIR__, 3) . '/Resources/module_overrides_tests/'),
             ])
             ->onlyMethods(['getModule'])
             ->getMock()

--- a/tests/Unit/Core/Module/OverriddenModulesProviderTest.php
+++ b/tests/Unit/Core/Module/OverriddenModulesProviderTest.php
@@ -53,6 +53,24 @@ class OverriddenModulesProviderTest extends TestCase
         $this->assertSame([], $provider->getOverriddenFiles('unknownmodule'));
     }
 
+    public function testGetOverriddenFilePathsReturnsPathsRelativeToTheShopRoot(): void
+    {
+        $provider = new OverriddenModulesProvider($this->overrideDir);
+
+        $this->assertSame(
+            ['override/modules/overriddenmoduleclass/overriddenmoduleclass.php'],
+            $provider->getOverriddenFilePaths('overriddenmoduleclass')
+        );
+        $this->assertSame(
+            [
+                'override/modules/overriddenfrontcontroller/controllers/front/ajax.php',
+                'override/modules/overriddenfrontcontroller/controllers/front/display.php',
+            ],
+            $provider->getOverriddenFilePaths('overriddenfrontcontroller')
+        );
+        $this->assertSame([], $provider->getOverriddenFilePaths('unknownmodule'));
+    }
+
     /**
      * The blank index.php guard files PrestaShop generates in every folder are not overrides,
      * and neither are non-PHP leftovers.

--- a/tests/Unit/Core/Module/OverriddenModulesProviderTest.php
+++ b/tests/Unit/Core/Module/OverriddenModulesProviderTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Module;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Module\OverriddenModulesProvider;
+
+class OverriddenModulesProviderTest extends TestCase
+{
+    private string $overrideDir;
+
+    protected function setUp(): void
+    {
+        $this->overrideDir = dirname(__DIR__, 3) . '/Resources/module_overrides_tests/';
+    }
+
+    /**
+     * @dataProvider provideModuleNames
+     */
+    public function testIsOverridden(string $moduleName, bool $expectedResult): void
+    {
+        $provider = new OverriddenModulesProvider($this->overrideDir);
+
+        $this->assertSame($expectedResult, $provider->isOverridden($moduleName));
+    }
+
+    public static function provideModuleNames(): iterable
+    {
+        yield 'overridden main module class' => ['overriddenmoduleclass', true];
+        yield 'overridden front controllers' => ['overriddenfrontcontroller', true];
+        yield 'override folder without any php file' => ['notoverridden', false];
+        yield 'module without any override folder' => ['unknownmodule', false];
+    }
+
+    public function testGetOverriddenFilesReturnsSortedRelativePaths(): void
+    {
+        $provider = new OverriddenModulesProvider($this->overrideDir);
+
+        $this->assertSame(
+            ['overriddenmoduleclass.php'],
+            $provider->getOverriddenFiles('overriddenmoduleclass')
+        );
+        $this->assertSame(
+            ['controllers/front/ajax.php', 'controllers/front/display.php'],
+            $provider->getOverriddenFiles('overriddenfrontcontroller')
+        );
+        $this->assertSame([], $provider->getOverriddenFiles('unknownmodule'));
+    }
+
+    /**
+     * The blank index.php guard files PrestaShop generates in every folder are not overrides,
+     * and neither are non-PHP leftovers.
+     */
+    public function testGetAllOverriddenFilesIgnoresGuardFilesAndNonPhpFiles(): void
+    {
+        $provider = new OverriddenModulesProvider($this->overrideDir);
+
+        $this->assertSame(
+            [
+                'overriddenfrontcontroller' => ['controllers/front/ajax.php', 'controllers/front/display.php'],
+                'overriddenmoduleclass' => ['overriddenmoduleclass.php'],
+            ],
+            $provider->getAllOverriddenFiles()
+        );
+    }
+
+    /**
+     * @dataProvider provideEmptyOverrideDirs
+     */
+    public function testItReturnsNothingWhenTheModulesOverrideFolderIsMissing(string $overrideDir): void
+    {
+        $provider = new OverriddenModulesProvider($overrideDir);
+
+        $this->assertSame([], $provider->getAllOverriddenFiles());
+        $this->assertFalse($provider->isOverridden('overriddenmoduleclass'));
+    }
+
+    public static function provideEmptyOverrideDirs(): iterable
+    {
+        // A brand new shop has an override folder holding no `modules` subfolder at all
+        yield 'override folder without modules subfolder' => [
+            dirname(__DIR__, 3) . '/Resources/module_overrides_tests/modules/overriddenmoduleclass/',
+        ];
+        yield 'missing override folder' => [
+            dirname(__DIR__, 3) . '/Resources/module_overrides_tests/this-folder-does-not-exist/',
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Flags modules that are customized through the `override/modules/` folder, in both Module Manager tabs, and warns the employee before anything replaces their files. Shops maintained by agencies commonly override a module's main class (`override/modules/<module>/<module>.php`, loaded by `Module::coreLoadModule()`) or one of its front controllers (`override/modules/<module>/controllers/front/<controller>.php`, loaded by `Dispatcher::dispatch()`). Nothing in the BO currently surfaces this, so updating such a module can silently break the customization. This PR adds an "Overridden" badge on the module cards, listing the overriding files in a modal, and a "proceed with caution" warning on all three paths that replace module files: a single update, "Update all", and uploading an archive over an installed module. The information is carried by the `Module` DTO and exposed through the `GetModuleInfos` query, so it is available beyond the Module Manager page.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the detailed steps below the table.
| UI Tests          | Please run UI tests and paste here the link to the run.
| Fixed issue or discussion?     | —
| Related PRs       | —
| Sponsor company   | —

## What changed

| Layer | Change |
| --- | --- |
| Core | `OverriddenModulesProvider` — scans `override/modules/` once with a `Finder`, groups the PHP files it finds per module. Blank `index.php` guard files and non-PHP leftovers are ignored. Implements `ResetInterface` so the memoized scan is dropped between requests in long-running processes. |
| Adapter | `Module` DTO carries a new `overrides` parameter bag (`is_overridden`, `files`), filled by `ModuleRepository` for every module it returns. |
| CQRS | `GetModuleInfos` returns `isOverridden()` / `getOverriddenFiles()`, so the data is reachable from the Admin API and not only from the BO. |
| Adapter (presenter) | `ModulePresenter` simply passes the DTO's `overrides` bag to the templates. |
| Controller | `ModuleController::importModuleAction()` holds back an upload that would replace an overridden module, returning `confirmation_needed: 'overrides'` **before** calling `install()`, until the request carries `confirm_overrides`. |
| BO template | `card_list.html.twig` renders the badge and exposes `data-has-overrides` / `data-overridden-files`. Inherited by `card_manage_installed` and `card_notification_update`, hence both tabs. |
| BO JS | New `module-overrides-warning.ts` helper shared by every warning; `module-card.ts` (single update) and `pages/module/controller.js` ("Update all", the upload confirmation, the badge tooltip and its modal). |
| Tests | `OverriddenModulesProviderTest` unit test + fixtures, and four Behat scenarios covering the overrides returned by `GetModuleInfos`. |

## How to test

Detection is filesystem-based, so any override file will do — these steps use `ps_featuredproducts`.

1. **Overridden main module class.** Create `override/modules/ps_featuredproducts/ps_featuredproducts.php`:
   ```php
   <?php
   class Ps_FeaturedProductsOverride extends Ps_FeaturedProducts {}
   ```
   Note the folder named after the module — a file dropped straight into `override/modules/` is not an override and PrestaShop ignores it too. Clear the cache, then open **Improve > Modules > Module Manager**. `ps_featuredproducts` shows a yellow **Overridden** badge; hovering it explains why, and clicking it opens a modal listing `override/modules/ps_featuredproducts/ps_featuredproducts.php`.
2. **Overridden front controller.** Add `override/modules/ps_emailsubscription/controllers/front/verification.php` (any class body). The badge appears on that module too, and the modal lists the controller path. Several overrides on one module are all listed, sorted.
3. **Both tabs.** Make an overridden module updatable (lower its `version` in `ps_module` or drop in an older zip) and open **Module updates** — the badge is there as well.
4. **Single update warning.** Click **Update** on an overridden module: the confirmation modal opens with a warning block naming the overriding files, above the existing maintenance-mode message. Confirming still updates normally.
5. **Update all warning.** With at least one overridden module in the update list, click **Update all**: the modal lists every overridden module of the batch. With no overridden module in the list, the modal is unchanged from today.
6. **Upload over an overridden module.** Zip an overridden module as a newer version and drop it on **Upload a module**. The modal shows the warning with Cancel / *Update anyway* in its own footer, and nothing is installed until confirmed — previously the upload replaced the files silently. Cancel returns to the drop zone; confirming re-sends the archive and ends on "Module installed!".
7. **No confirmation when not overridden.** Upload an archive of a module with no override — it installs directly, exactly as today.
8. **No false positives.** Create `override/modules/ps_banner/` containing only PrestaShop's blank `index.php` — no badge, no warning.

**Note:** steps 4 to 7 depend on `admin-dev/themes/new-theme` being rebuilt (`npm run build`), and the asset URL is not versioned, so a hard reload is needed to pick the new bundle up.

Automated tests:

```
composer unit-tests                                    # OverriddenModulesProviderTest, 8 cases
./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s module --tags module
```

## Notes for reviewers

- Overrides are filled **after** the module cache is read or written, on purpose. `ModuleRepository::getModule()` only invalidates its cache when the module's own `filemtime` changes, while the files overriding it live outside the module folder and can appear at any time — filling the bag before `cacheProvider->save()` would serve stale data indefinitely.
- `ModuleInfos` gained two constructor arguments, both with defaults, so existing callers keep working.
- The `overrides` property on the `Module` DTO is deliberately untyped, like its three siblings: these objects are serialized into the Doctrine cache, and a typed property would be uninitialized when an object cached before the upgrade is unserialized.
- Any PHP file under a module's override folder is reported, not only the two paths the core actually resolves. A stray file does not change behaviour by itself, but it does mean the module has been customized — which is the signal the badge is meant to carry. Happy to narrow it to the two resolved paths if you'd rather the badge mean "an override is active".
- Overrides are looked up by the module's reported name (`attributes['name']`). These are the same in practice, but an override that rewrites `$this->name` makes the badge attach to the folder entry rather than the live module. Such an override already breaks PrestaShop's own module resolution, so flagging the folder seems right; keying on the disk path instead is a one-line change if preferred.
- The upload gate returns `status: false` alongside `confirmation_needed`, plus a plain `msg`, so a client that does not know about the confirmation reports something meaningful rather than an empty failure.
- Still uncovered by automated tests: the upload gate itself, since the decision lives in a controller action. The detection, the DTO enrichment and the query result are covered. Suggestions welcome on where a test for the controller would best live.
- `data-toggle="pstooltip"` is not initialised anywhere globally in the back office (`$.fn.pstooltip` is an alias of the Bootstrap tooltip, renamed so Bootstrap does not pick it up), so the badge initialises its own tooltip, delegated from the body because module cards can be appended after page load. Worth noting that the module name tooltip in the same template has never been initialised either — left untouched here as it is unrelated to this PR.
- The feature is aimed at agency-maintained shops; a merchant who only installs modules from the BO will never see the badge.
