### PR TITLE
Fix BO/Admin API SSL behind reverse proxy when PS_TRUSTED_PROXIES is set via process env

### DIFF
--- a/admin-api/index.php
+++ b/admin-api/index.php
@@ -59,7 +59,9 @@ $request = Request::createFromGlobals();
  */
 Dispatcher::setRequest($request);
 
-Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
+$trustedProxies = getenv('PS_TRUSTED_PROXIES') ?: ($_SERVER['PS_TRUSTED_PROXIES'] ?? '');
+$trustedProxiesArray = $trustedProxies ? array_filter(array_map('trim', explode(',', $trustedProxies))) : [];
+Request::setTrustedProxies($trustedProxiesArray, Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
 
 $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, true);
 $response->send();

--- a/admin-dev/index.php
+++ b/admin-dev/index.php
@@ -67,7 +67,9 @@ $request = Request::createFromGlobals();
  */
 Dispatcher::setRequest($request);
 
-Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
+$trustedProxies = getenv('PS_TRUSTED_PROXIES') ?: ($_SERVER['PS_TRUSTED_PROXIES'] ?? '');
+$trustedProxiesArray = $trustedProxies ? array_filter(array_map('trim', explode(',', $trustedProxies))) : [];
+Request::setTrustedProxies($trustedProxiesArray, Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
 
 $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, true);
 $response->send();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Continues [@prusayn](https://github.com/prusayn)’s work from closed [#39800](https://github.com/PrestaShop/PrestaShop/pull/39800). BO and Admin API front controllers called `Request::setTrustedProxies([])`, ignoring `PS_TRUSTED_PROXIES`. That breaks HTTPS detection behind a TLS-terminating reverse proxy (`X-Forwarded-Proto` ignored -> `SSLMiddlewareListener` redirect / loop when `PS_SSL_ENABLED` is on).<br><br>In many setups Symfony’s kernel later applies `framework.trusted_proxies` and overwrites that `[]`. It fails when Compose/Swarm sets a real process env (`getenv()` works) while `.env` still has an empty `PS_TRUSTED_PROXIES=` Dotenv (with `usePutenv(false)`) writes that empty value into `$_ENV`/`$_SERVER`, Symfony prefers it, kernel skips `setTrustedProxies`, and the hardcoded `[]` wins. This change reads `getenv()` first, then `$_SERVER`, and passes the parsed list into `setTrustedProxies` in `admin-dev/index.php` and `admin-api/index.php`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1) Put PrestaShop behind HTTPS reverse proxy (e.g. Traefik) terminating TLS to the app over HTTP; forward `X-Forwarded-*`.<br>2) Enable `PS_SSL_ENABLED`.<br>3) Reproduce the Docker/Swarm case: leave `PS_TRUSTED_PROXIES=` empty in `.env`, but inject a real value via Compose/Swarm env, e.g. `PS_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,REMOTE_ADDR`.<br>4) Without the patch: BO/Admin API should mis-detect HTTP and hit SSL redirect issues.<br>5) With the patch: BO and Admin API should work over the public HTTPS URL.
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39282, https://github.com/PrestaShop/PrestaShop/issues/39657, https://github.com/PrestaShop/PrestaShop/discussions/39526, (also tagging https://github.com/PrestaShop/PrestaShop/issues/39190 for closing since this appears to be a wont-fix in 8.x branch https://github.com/PrestaShop/PrestaShop/pull/39801#issuecomment-3431278859)
| Related PRs       | Original PR #39800, supersedes #41249 (retargeted from 9.1.x -> 9.2.x)