### PR TITLE
Fix residual cent when an order amount discount exceeds the products total

### DIFF
--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -19,6 +19,12 @@ use PrestaShopDatabaseException;
 class CartRuleCalculator
 {
     /**
+     * reduction_product value meaning the amount reduction applies to the whole order
+     * (as opposed to a specific product id, -1 for the cheapest or -2 for a selection).
+     */
+    private const REDUCTION_ON_WHOLE_ORDER = 0;
+
+    /**
      * @var Calculator
      */
     protected $calculator;
@@ -269,6 +275,8 @@ class CartRuleCalculator
             // apply weighted discount:
             // on each line we apply a part of the discount corresponding to discount*rowWeight/total
             $taxRate = 0;
+            $lastConcernedRow = null;
+            $appliedDiscountTaxIncl = $appliedDiscountTaxExcl = 0;
             foreach ($concernedRows as $concernedRow) {
                 // Get current line tax rate
                 $taxRate = $this->getTaxRateFromRow($concernedRow);
@@ -303,6 +311,35 @@ class CartRuleCalculator
 
                 // Apply the discount amount
                 $cartRuleData->addDiscountApplied($amount);
+
+                $appliedDiscountTaxIncl += $discountAmountTaxIncl;
+                $appliedDiscountTaxExcl += $discountAmountTaxExcl;
+                $lastConcernedRow = $concernedRow;
+            }
+
+            // When an order-level amount discount is greater than or equal to the whole
+            // products total, the discount is distributed row by row on each row's rounded
+            // final price. The sum of those per-row rounded amounts can fall a fraction short
+            // of the (unrounded) products total the cart total is subtracted from, leaving a
+            // residual cent on an order that should be free (see #39436). Offset that
+            // remainder on the last concerned row so the discount fully covers the products.
+            $productsTotal = $cartRule->reduction_tax ? $totalTaxIncl : $totalTaxExcl;
+            if ($lastConcernedRow !== null
+                && $cartRule->reduction_product == self::REDUCTION_ON_WHOLE_ORDER
+                && $totalDiscountConverted >= $productsTotal
+            ) {
+                $rowsTotalTaxIncl = $rowsTotalTaxExcl = 0;
+                foreach ($concernedRows as $concernedRow) {
+                    $rowsTotalTaxIncl += $concernedRow->getInitialTotalPrice()->getTaxIncluded();
+                    $rowsTotalTaxExcl += $concernedRow->getInitialTotalPrice()->getTaxExcluded();
+                }
+                $remainderTaxIncl = max(0, $rowsTotalTaxIncl - $appliedDiscountTaxIncl);
+                $remainderTaxExcl = max(0, $rowsTotalTaxExcl - $appliedDiscountTaxExcl);
+                if ($remainderTaxIncl > 0 || $remainderTaxExcl > 0) {
+                    $remainder = new AmountImmutable($remainderTaxIncl, $remainderTaxExcl);
+                    $lastConcernedRow->applyFlatDiscount($remainder);
+                    $cartRuleData->addDiscountApplied($remainder);
+                }
             }
 
             if ($this->isDiscountFeatureFlagEnabled() && $cartRule->getType() === DiscountType::ORDER_LEVEL) {

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/Amount/amount_over_total_specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/Amount/amount_over_total_specific_price.feature
@@ -1,0 +1,52 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags fo-cart-rule-amount-over-total-specific-price
+@restore-all-tables-before-feature
+@fo-cart-rule-amount-over-total-specific-price
+Feature: Cart rule (amount) greater than the products total on products with specific prices
+  As a customer
+  When I apply a cart discount greater than my whole products total on taxed products
+  that carry a specific price, the remaining products total must be exactly 0,
+  not a residual cent (https://github.com/PrestaShop/PrestaShop/issues/39436)
+
+  Background:
+    Given I add new zone "zone1" with following properties:
+      | name    | zone1 |
+      | enabled | true  |
+    And there is a country named "country1" and iso code "FR" in zone "zone1"
+    And there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
+    And there is an address named "address1" with postcode "1" in state "state1"
+    And there is a currency named "usd" with iso code "USD" and exchange rate of 0.92
+    And shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a tax named "tax20" and rate 20.0%
+    And there is a tax rule named "taxrule20" in country "country1" and state "state1" where tax "tax20" is applied
+    And there is a product in the catalog named "product1" with a price of 12.34 and 1000 items in stock
+    And product "product1" belongs to tax group "taxrule20"
+    And product "product1" has a specific price named "sp1" with a discount of 10.0 percent
+    And there is a product in the catalog named "product2" with a price of 45.67 and 1000 items in stock
+    And product "product2" belongs to tax group "taxrule20"
+    And product "product2" has a specific price named "sp2" with a discount of 10.0 percent
+    And there is a cart rule "overTotal" with following properties:
+      | name[en-US]           | over total voucher |
+      | priority              | 1                  |
+      | free_shipping         | false              |
+      | code                  | overtotal          |
+      | discount_amount       | 1000               |
+      | discount_currency     | usd                |
+      | discount_includes_tax | true               |
+
+  Scenario: an amount discount over the products total leaves no residual cent (quantities 2 + 1)
+    Given I have an empty default cart
+    When I select address "address1" in my cart
+    And I add 2 items of product "product1" in my cart
+    And I add 1 items of product "product2" in my cart
+    And I apply the voucher code "overtotal"
+    Then my cart total should be precisely 0.0 tax included
+    And my cart total should be precisely 0.0 tax excluded
+
+  Scenario: an amount discount over the products total leaves no residual cent (quantities 3 + 1)
+    Given I have an empty default cart
+    When I select address "address1" in my cart
+    And I add 3 items of product "product1" in my cart
+    And I add 1 items of product "product2" in my cart
+    And I apply the voucher code "overtotal"
+    Then my cart total should be precisely 0.0 tax included
+    And my cart total should be precisely 0.0 tax excluded


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When an order-level amount cart rule (a voucher covering the whole cart) is greater than or equal to the products total, the resulting cart total can be `0.01` instead of `0`. The amount discount is distributed row by row on each row's **rounded** final price; in round-per-line mode the sum of those per-row rounded amounts falls a fraction short of the **unrounded** products total the cart total is subtracted from, leaving a residual cent. It shows up typically with taxed products that carry a specific price and depends on quantities. The fix offsets that rounding remainder on the last concerned row so a whole-cart amount discount that is meant to cover the cart fully zeroes the products total.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | **Manual:** create a cart-level amount discount with a value greater than the cart total, apply it on a cart containing taxed products with a specific price (e.g. the reproduction steps in #39436) — the cart total must be `0`, not `0.01`. **Automated:** a new Behat scenario is added at `tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/Amount/amount_over_total_specific_price.feature`. Run it with `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags fo-cart-rule-amount-over-total-specific-price`.
| UI Tests          | N/A — the change is core cart-calculation logic with no UI surface; it is covered by the added integration (Behat) scenario.
| Fixed issue or discussion?     | Fixes #39436
| Related PRs       | —
| Sponsor company   | —

## Root cause

`Calculator::getTotal()` computes the cart total as `round(rowTotalWithoutDiscount) - round(discountTotal)`. `rowTotalWithoutDiscount` sums each row's **unrounded** initial total (`CartRow::getInitialTotalPrice()`), while the amount discount in `CartRuleCalculator::applyCartRule()` is capped and distributed on each row's **rounded** final total (`CartRow::getFinalTotalPrice()`, rounded per line in round-per-line mode). When a whole-order amount voucher is meant to cover the entire cart, the sum of the per-row rounded discounts is "sum of rounded lines", which can differ from "rounded sum of lines" by one cent — so the products total is not fully offset.

The fix only affects the exact reported case: an **order-level** amount discount (`reduction_product == 0`) whose requested amount is **greater than or equal to** the products total. In that case the leftover between the (unrounded) products total and the distributed discount is offset on the last concerned row. Partial vouchers and product-restricted vouchers are untouched.

## Test verification (RED → GREEN)

New scenario run on the unmodified `9.1.x` base (RED), then with the fix (GREEN).

**RED — unmodified `9.1.x` (fix reverted, test present):**
```
Then my cart total should be precisely 0.0 tax included
  Expects 0.0, got 0.01 instead (RuntimeException)
2 scenarios (2 failed)
```

**GREEN — with the fix:**
```
2 scenarios (2 passed)
44 steps (44 passed)
```

**No regression — full Behat suites on `9.1.x` with the fix:**
```
cart      244 scenarios (244 passed)   # 242 on the base + 2 new
discount  186 scenarios (186 passed)
order     259 scenarios (259 passed)
```
Baseline `cart` suite on the unmodified base: `242 scenarios (242 passed)`.

`php-cs-fixer` and `phpstan` (level 5) report no issues on the changed file.
