### PR TITLE
Fix product image reordering in multistore when the cover differs between shops

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -871,6 +871,7 @@ class AdminProductWrapper
         foreach ($data as $id => $position) {
             $img = new Image((int) $id);
             $img->position = (int) $position;
+            $img->setFieldsToUpdate(['position' => true]);
             $img->update();
         }
     }


### PR DESCRIPTION
`cover` is shop-scoped but still ends up in the UPDATE on the main `image` table, so in multistore a reorder could break on UNIQUE(id_product, cover).

<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Reordering product images in the back office writes the current shop's cover image into the global `image` table, which breaks in multistore as soon as a product has a different cover per shop. This restricts the write to the `position` column.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the "How to test" section below the table.
| UI Tests          | Not run — I do not have the setup for the two campaigns (MySQL + MariaDB). Happy to follow up if needed, or feel free to launch them on this PR.
| Fixed issue or discussion?     | Fixes #42282
| Related PRs       | —
| Sponsor company   | 


````markdown
### The problem

`ajaxProcessUpdateImagePosition()` only wants to change `position`, but it calls a
plain `Image::update()`, which writes every field of the object — including `cover`.

`cover` is declared shop-scoped on `Image` (`'shop' => true`), yet:

- `EntityMapper::load()` LEFT JOINs `image_shop` on the **current shop**, and since both
  tables have a `cover` column the shop value overwrites the global one on the object;
- `ObjectModel::getFields()` merges the shop-scoped fields back into the UPDATE on the
  **main** `image` table (the code comments it as *"For retro compatibility"*).

So a reorder writes the **current shop's** cover into the global `image` table. The two
tables disagree on how many covers a product may have:

| table        | unique key                            | meaning                    |
| ------------ | ------------------------------------- | -------------------------- |
| `image`      | `UNIQUE (id_product, cover)`          | one cover per product      |
| `image_shop` | `UNIQUE (id_product, id_shop, cover)` | one cover per product/shop |

Multistore legitimately relies on the second rule, so as soon as a product has a
different cover in two shops, the write above hits the first one:

```
PrestaShopException: SQLSTATE[23000]: Integrity constraint violation: 1062
Duplicate entry '<id_product>-1' for key 'id_product_cover'
```

The exception is uncaught, so the endpoint returns a 500 and the new order is lost. As
the loop is not transactional, images processed before the failing one keep their new
position, leaving a partially applied ordering.

Nothing in the shop is broken or corrupted when this happens — the data is in a valid
state. That state is in fact produced by the core itself: `Image::deleteCover()` clears
`image.cover` for **all** images of a product but clears `image_shop.cover` only for the
**current shop context**, so setting a per-shop cover necessarily makes the global cover
point at one shop's image while the other shop keeps its own.

### The fix

`setFieldsToUpdate(['position' => true])` limits the write to `position`, so `cover` is
never touched by a reorder. Nothing else changes:

- `image_shop` rows that are missing are still inserted with all their fields —
  `ObjectModel::update()` resets `update_fields` on its own to build the INSERT payload;
- the `actionObjectImageUpdateBefore` / `...UpdateAfter` hooks still fire, since the fix
  does not bypass `ObjectModel::update()`.

This is the same approach the new product page already takes: it never runs positions
through `ObjectModel::update()` (`ProductImageUpdater::updatePosition()` uses
`GridPositionUpdater`) and it writes the cover through
`ProductImageRepository::partialUpdateForShops($image, ['cover'], …)`, i.e. an explicit
field list. The PR only brings the legacy page in line with that.

### Why there is no `develop` counterpart

`AdminProductWrapper` and the legacy product page no longer exist in 9.x, and the new
product page never had this bug, so this fix applies to `8.2.x` only.

### Notes

- Verified on a live 8.2.3 multistore shop (2 shops, PHP 8.2.31): reordering works in
  both shops afterwards and the per-shop cover images stay exactly as they were.
  I did not re-test on 8.2.7 — the shop is still on 8.2.3 — but
  `ajaxProcessUpdateImagePosition()` is unchanged on the current head of `8.2.x`, so the
  patch applies as-is and the bug is still present there.
- The same one-line change was already suggested in #12832, which was closed as
  "can't reproduce" — the linked issue explains the precondition that was missing there.
- I could not find an existing automated test covering this legacy endpoint. Glad to add
  one if you can point me at the right place for it.
- `controllers/admin/AdminProductsController::ajaxProcessUpdateImagePosition()` holds a
  legacy copy of the same loop with the same flaw. It looks unreachable in 8.x (the JS
  posts to the Symfony route) and the class is `@deprecated since 8.1`, so I left it
  alone — happy to include it if you prefer.
````

---

## HOW TO TEST (paste into the "How to test?" row or below the table)

````markdown
Requires a multistore installation with two shops (A and B) and the
`product_page_v2` feature flag DISABLED (the bug is in the legacy product page).

1. Create a product, associate it with both shops.
2. In Shop A context: open the product > Images, upload 2 images, set one as cover.
3. In Shop B context: open the same product, upload 2 other images, set one of THOSE
   as cover. This is what creates the divergence — `image.cover` now points at a
   Shop B image while Shop A keeps its own cover in `image_shop`.
4. Back in Shop A context, drag an image to reorder it.

Before the patch: HTTP 500, `Duplicate entry '<id_product>-1' for key 'id_product_cover'`.
After the patch: the new order is saved.

Then check that the covers were not touched:

```sql
SELECT 'global' AS scope, id_image FROM ps_image
  WHERE id_product = <ID> AND cover = 1
UNION ALL
SELECT CONCAT('shop ', id_shop), id_image FROM ps_image_shop
  WHERE id_product = <ID> AND cover = 1;
```

Each shop must still show the cover it had before the reorder.

Non-regression, single shop: reordering, setting a cover and editing an image caption
must keep working as before.
````
