### PR TITLE
Do not block working with order if it's shipped

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -117,7 +117,6 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
     {
         $order = $this->getOrder($command->getOrderId());
 
-        $this->assertOrderWasNotShipped($order);
         $this->assertProductNotDuplicate($order, $command);
 
         $cart = Cart::getCartByOrderId($order->id);
@@ -228,18 +227,6 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             Hook::exec('actionOrderEdited', ['order' => $order]);
         } finally {
             $this->contextStateManager->restorePreviousContext();
-        }
-    }
-
-    /**
-     * @param Order $order
-     *
-     * @throws OrderException
-     */
-    private function assertOrderWasNotShipped(Order $order)
-    {
-        if ($order->hasBeenShipped()) {
-            throw new OrderException('Cannot add product to shipped order.');
         }
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | For some reason there is this stupid behavior where PrestaShop will block the merchant from adding a product to shipped order. There are many scenarios where this is needed - exchange, customer wants to add something after the status is already changed, whatever.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI + UI. Set order to shipped status, then try to add a product. Will work now.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/34362427492
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://shop.recart-sim.com/cs/