### PR TITLE
Add the business entities listing and detail pages in the Back Office

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -51,6 +51,7 @@ module.exports = {
     attribute_group: './js/pages/attribute-group',
     attribute_group_form: './js/pages/attribute-group/form',
     backup: './js/pages/backup',
+    business_entity: './js/pages/business-entity',
     business_entity_form: './js/pages/business-entity/form',
     carrier: './js/pages/carrier',
     carrier_form: './js/pages/carrier/form',

--- a/admin-dev/themes/new-theme/js/pages/business-entity/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/business-entity/index.ts
@@ -1,0 +1,16 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+$(() => {
+  const grid = new window.prestashop.component.Grid('business_entity');
+
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+});

--- a/admin-dev/themes/new-theme/scss/pages/_business_entity.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_business_entity.scss
@@ -1,0 +1,244 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+#business_entity_grid {
+  td.column-customers_count .badge {
+    background-color: var(--#{$cdk}primary-400);
+  }
+
+  .column-headers th[data-column-id="actions"] .grid-actions-header-text {
+    padding-right: 0;
+    text-align: center;
+  }
+
+  .column-filters td[data-column-id="actions"] {
+    .grid-search-button,
+    .grid-reset-button {
+      margin-right: auto;
+      margin-left: auto;
+    }
+  }
+
+  td.column-actions .btn-group-action {
+    display: flex;
+    justify-content: center;
+  }
+}
+
+.business-entity-view-header {
+  &__main {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  &__titles {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  &__name {
+    margin: 0;
+    font-size: var(--#{$cdk}size-24);
+    font-weight: 600;
+  }
+
+  &__legal-name {
+    margin-top: 0.25rem;
+    font-size: var(--#{$cdk}size-14);
+    color: $gray-600;
+  }
+
+  &__divider {
+    width: var(--#{$cdk}size-1);
+    height: var(--#{$cdk}size-40);
+    margin: 0 0.75rem;
+    background-color: var(--#{$cdk}primary-400);
+
+    @include media-breakpoint-down(sm) {
+      display: none;
+    }
+  }
+}
+
+.business-entity-view-avatar {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: var(--#{$cdk}size-56);
+  height: var(--#{$cdk}size-56);
+  font-size: var(--#{$cdk}size-18);
+  font-weight: 600;
+  color: var(--#{$cdk}primary-800);
+  letter-spacing: 0.05em;
+  background-color: transparent;
+  border: var(--#{$cdk}size-1) solid var(--#{$cdk}primary-400);
+  border-radius: 50%;
+}
+
+.business-entity-view-info,
+.business-entity-view-summary,
+.business-entity-view-addresses,
+.business-entity-linked-customers {
+  margin-bottom: 0;
+}
+
+#business_entity_grid,
+.business-entity-view-header,
+.business-entity-view-info,
+.business-entity-view-addresses,
+.business-entity-linked-customers {
+  .badge {
+    font-size: 0.8125rem;
+
+    .material-icons {
+      font-size: 1.25em;
+      vertical-align: text-bottom;
+    }
+  }
+}
+
+.business-entity-linked-customers__count {
+  background-color: var(--#{$cdk}primary-400);
+}
+
+.business-entity-view-info,
+.business-entity-view-summary {
+  height: 100%;
+}
+
+.business-entity-view-info {
+  .card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    justify-content: space-between;
+  }
+
+  hr {
+    margin: 0;
+  }
+}
+
+.business-entity-view-summary {
+  .card-body {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  &__block {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    margin-bottom: 0.75rem;
+    border-radius: var(--#{$cdk}size-8);
+
+    .material-icons {
+      font-size: var(--#{$cdk}size-28);
+    }
+  }
+
+  &__block--customers {
+    background-color: var(--#{$cdk}purple-50);
+
+    .material-icons {
+      color: var(--#{$cdk}purple-700);
+    }
+  }
+
+  &__block--addresses {
+    background-color: var(--#{$cdk}ocean-blue-50);
+
+    .material-icons {
+      color: var(--#{$cdk}ocean-blue-700);
+    }
+  }
+
+  &__text {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.1;
+  }
+
+  &__value {
+    font-size: var(--#{$cdk}size-28);
+    font-weight: $font-weight-bold;
+    color: var(--#{$cdk}primary-800);
+  }
+
+  &__label {
+    margin-top: 0.25rem;
+    font-size: var(--#{$cdk}size-14);
+    color: $gray-700;
+  }
+
+  &__meta {
+    margin-top: auto;
+    font-size: var(--#{$cdk}size-14);
+    color: $gray-600;
+  }
+
+  &__meta-line {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+
+    .material-icons {
+      font-size: var(--#{$cdk}size-16);
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.business-entity-view-addresses {
+  .business-entity-view-address {
+    padding: var(--#{$cdk}size-16);
+    border: var(--#{$cdk}size-1) solid var(--#{$cdk}primary-400);
+    border-radius: var(--#{$cdk}size-5);
+  }
+
+  .business-entity-view-address__title {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+
+    strong {
+      font-weight: $font-weight-bold;
+    }
+  }
+
+  .business-entity-view-address__default-badge {
+    padding: var(--#{$cdk}size-2) var(--#{$cdk}size-8);
+    font-weight: $font-weight-semibold;
+    color: var(--#{$cdk}primary-800);
+    background-color: var(--#{$cdk}ocean-blue-50);
+    border: var(--#{$cdk}size-1) solid var(--#{$cdk}ocean-blue-700);
+    border-radius: var(--#{$cdk}size-10);
+  }
+}
+
+.business-entity-pending-banner {
+  &__content {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__title {
+    font-size: var(--#{$cdk}size-18);
+  }
+}

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -104,6 +104,7 @@
 @import "pages/carrier";
 @import "pages/cms_page";
 @import "pages/extra_property";
+@import "pages/business_entity";
 
 // Main Layout
 @import "pages/modules";

--- a/src/Adapter/BusinessEntity/Address/BusinessEntityAddressFormatter.php
+++ b/src/Adapter/BusinessEntity/Address/BusinessEntityAddressFormatter.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\Address;
+
+use Address;
+use AddressFormat;
+use PrestaShop\PrestaShop\Core\Address\AddressFormatterInterface;
+use PrestaShop\PrestaShop\Core\Domain\Address\ValueObject\AddressId;
+
+final class BusinessEntityAddressFormatter implements AddressFormatterInterface
+{
+    private const PLACEHOLDER_NAME_PATTERNS = ['firstname', 'lastname'];
+
+    public function format(AddressId $addressId): string
+    {
+        return AddressFormat::generateAddress(
+            new Address($addressId->getValue()),
+            ['avoid' => self::PLACEHOLDER_NAME_PATTERNS]
+        );
+    }
+}

--- a/src/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandler.php
+++ b/src/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandler.php
@@ -10,7 +10,8 @@ namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler;
 
 use DateTimeImmutable;
 use PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository\BusinessEntityAddressRepository;
-use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+use PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository\BusinessEntityAddressRow;
+use PrestaShop\PrestaShop\Adapter\Customer\Group\Repository\GroupRepository;
 use PrestaShop\PrestaShop\Core\Address\AddressFormatterInterface;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
@@ -22,6 +23,8 @@ use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryHandler\GetBusinessEnt
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\AddressForViewing;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\BusinessEntityForViewing;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\IdentifierForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Exception\GroupNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Group\ValueObject\GroupId;
 use PrestaShopBundle\Entity\B2B\BusinessEntity;
 use PrestaShopBundle\Entity\Enum\AddressTypeEnum;
 use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
@@ -33,7 +36,7 @@ final class GetBusinessEntityForViewingHandler implements GetBusinessEntityForVi
     public function __construct(
         private readonly BusinessEntityRepository $businessEntityRepository,
         private readonly BusinessEntityAddressRepository $businessEntityAddressRepository,
-        private readonly GroupDataProvider $groupDataProvider,
+        private readonly GroupRepository $groupRepository,
         private readonly LanguageContext $languageContext,
         private readonly ShopContext $shopContext,
         private readonly AddressFormatterInterface $addressFormatter,
@@ -42,19 +45,19 @@ final class GetBusinessEntityForViewingHandler implements GetBusinessEntityForVi
     }
 
     /**
-     * @return string[]
+     * @return AddressTypeEnum[]
      */
     private static function invoiceAddressTypes(): array
     {
-        return [AddressTypeEnum::INVOICE->value, AddressTypeEnum::BOTH->value];
+        return [AddressTypeEnum::INVOICE, AddressTypeEnum::BOTH];
     }
 
     /**
-     * @return string[]
+     * @return AddressTypeEnum[]
      */
     private static function deliveryAddressTypes(): array
     {
-        return [AddressTypeEnum::DELIVERY->value, AddressTypeEnum::BOTH->value];
+        return [AddressTypeEnum::DELIVERY, AddressTypeEnum::BOTH];
     }
 
     /**
@@ -72,7 +75,7 @@ final class GetBusinessEntityForViewingHandler implements GetBusinessEntityForVi
         }
 
         $languageId = $this->languageContext->getId();
-        $addresses = $this->mapAddresses($this->businessEntityAddressRepository->getAddresses($businessEntityId, AddressTypeEnum::values()));
+        $addresses = $this->mapAddresses($this->businessEntityAddressRepository->getAddresses($businessEntityId));
         $invoiceAddresses = $this->filterAddressesByType($addresses, self::invoiceAddressTypes());
         $deliveryAddresses = $this->filterAddressesByType($addresses, self::deliveryAddressTypes());
         $identifiers = $this->mapIdentifiers($businessEntity);
@@ -86,7 +89,7 @@ final class GetBusinessEntityForViewingHandler implements GetBusinessEntityForVi
             $businessEntity->getName(),
             $businessEntity->getLegalName(),
             $businessEntity->isDeliveryAuthorized(),
-            $businessEntity->getStatus()->value,
+            $businessEntity->getStatus(),
             $businessEntity->getStatus()->trans($this->translator),
             DateTimeImmutable::createFromInterface($businessEntity->getCreatedAt()),
             DateTimeImmutable::createFromInterface($businessEntity->getUpdatedAt()),
@@ -102,16 +105,15 @@ final class GetBusinessEntityForViewingHandler implements GetBusinessEntityForVi
 
     /**
      * @param AddressForViewing[] $addresses
-     * @param string[] $types
+     * @param AddressTypeEnum[] $types
      *
      * @return AddressForViewing[]
      */
     private function filterAddressesByType(array $addresses, array $types): array
     {
-        return array_values(array_filter(
-            $addresses,
-            static fn (AddressForViewing $address): bool => in_array($address->getAddressType(), $types, true)
-        ));
+        $hasOneOfTheTypes = static fn (AddressForViewing $address): bool => in_array($address->getAddressType(), $types, true);
+
+        return array_values(array_filter($addresses, $hasOneOfTheTypes));
     }
 
     /**
@@ -129,17 +131,17 @@ final class GetBusinessEntityForViewingHandler implements GetBusinessEntityForVi
 
     private function getCustomerGroupName(int $idGroup, int $idLang): string
     {
-        foreach ($this->groupDataProvider->getGroups($idLang) as $group) {
-            if ((int) $group['id_group'] === $idGroup) {
-                return (string) $group['name'];
-            }
+        // The schema has no foreign key and deleting a customer group never cleans up
+        // business_entity, so an entity can outlive its group: fall back instead of failing.
+        try {
+            return $this->groupRepository->get(new GroupId($idGroup))->name[$idLang] ?? '';
+        } catch (GroupNotFoundException) {
+            return '';
         }
-
-        return '';
     }
 
     /**
-     * @param array<int, array<string, mixed>> $rows
+     * @param BusinessEntityAddressRow[] $rows
      *
      * @return AddressForViewing[]
      */
@@ -147,13 +149,12 @@ final class GetBusinessEntityForViewingHandler implements GetBusinessEntityForVi
     {
         $addresses = [];
         foreach ($rows as $row) {
-            $addressId = (int) $row['id_address'];
             $addresses[] = new AddressForViewing(
-                $addressId,
-                (string) $row['alias'],
-                $this->addressFormatter->format(new AddressId($addressId)),
-                (string) $row['address_type'],
-                (bool) $row['is_default'],
+                $row->getAddressId(),
+                $row->getAlias(),
+                $this->addressFormatter->format(new AddressId($row->getAddressId())),
+                $row->getAddressType(),
+                $row->isDefault(),
             );
         }
 

--- a/src/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandler.php
+++ b/src/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandler.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler;
+
+use DateTimeImmutable;
+use PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository\BusinessEntityAddressRepository;
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+use PrestaShop\PrestaShop\Core\Address\AddressFormatterInterface;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\Address\ValueObject\AddressId;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryHandler\GetBusinessEntityForViewingHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\AddressForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\BusinessEntityForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\IdentifierForViewing;
+use PrestaShopBundle\Entity\B2B\BusinessEntity;
+use PrestaShopBundle\Entity\Enum\AddressTypeEnum;
+use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[AsQueryHandler]
+final class GetBusinessEntityForViewingHandler implements GetBusinessEntityForViewingHandlerInterface
+{
+    public function __construct(
+        private readonly BusinessEntityRepository $businessEntityRepository,
+        private readonly BusinessEntityAddressRepository $businessEntityAddressRepository,
+        private readonly GroupDataProvider $groupDataProvider,
+        private readonly LanguageContext $languageContext,
+        private readonly ShopContext $shopContext,
+        private readonly AddressFormatterInterface $addressFormatter,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function invoiceAddressTypes(): array
+    {
+        return [AddressTypeEnum::INVOICE->value, AddressTypeEnum::BOTH->value];
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function deliveryAddressTypes(): array
+    {
+        return [AddressTypeEnum::DELIVERY->value, AddressTypeEnum::BOTH->value];
+    }
+
+    /**
+     * @throws BusinessEntityNotFoundException
+     */
+    public function handle(GetBusinessEntityForViewing $query): BusinessEntityForViewing
+    {
+        $businessEntityId = $query->getBusinessEntityId()->getValue();
+
+        $shopIds = $this->shopContext->isAllShopContext() ? null : $this->shopContext->getAssociatedShopIds();
+        $businessEntity = $this->businessEntityRepository->findById($businessEntityId, $shopIds);
+
+        if (null === $businessEntity) {
+            throw new BusinessEntityNotFoundException(sprintf('Business entity with id %d was not found.', $businessEntityId));
+        }
+
+        $languageId = $this->languageContext->getId();
+        $addresses = $this->mapAddresses($this->businessEntityAddressRepository->getAddresses($businessEntityId, AddressTypeEnum::values()));
+        $invoiceAddresses = $this->filterAddressesByType($addresses, self::invoiceAddressTypes());
+        $deliveryAddresses = $this->filterAddressesByType($addresses, self::deliveryAddressTypes());
+        $identifiers = $this->mapIdentifiers($businessEntity);
+        $linkedCustomersCount = $this->businessEntityRepository->getLinkedCustomersCount($businessEntityId);
+        $addressesCount = $this->countUniqueAddresses($addresses);
+        $customerGroupName = $this->getCustomerGroupName($businessEntity->getIdCustomerGroup(), $languageId);
+
+        return new BusinessEntityForViewing(
+            $businessEntity->getId(),
+            $businessEntity->getExternalRef(),
+            $businessEntity->getName(),
+            $businessEntity->getLegalName(),
+            $businessEntity->isDeliveryAuthorized(),
+            $businessEntity->getStatus()->value,
+            $businessEntity->getStatus()->trans($this->translator),
+            DateTimeImmutable::createFromInterface($businessEntity->getCreatedAt()),
+            DateTimeImmutable::createFromInterface($businessEntity->getUpdatedAt()),
+            $linkedCustomersCount,
+            $addressesCount,
+            $businessEntity->getIdCustomerGroup(),
+            $customerGroupName,
+            $invoiceAddresses,
+            $deliveryAddresses,
+            $identifiers,
+        );
+    }
+
+    /**
+     * @param AddressForViewing[] $addresses
+     * @param string[] $types
+     *
+     * @return AddressForViewing[]
+     */
+    private function filterAddressesByType(array $addresses, array $types): array
+    {
+        return array_values(array_filter(
+            $addresses,
+            static fn (AddressForViewing $address): bool => in_array($address->getAddressType(), $types, true)
+        ));
+    }
+
+    /**
+     * @param AddressForViewing[] $addresses
+     */
+    private function countUniqueAddresses(array $addresses): int
+    {
+        $uniqueAddressIds = [];
+        foreach ($addresses as $address) {
+            $uniqueAddressIds[$address->getAddressId()] = true;
+        }
+
+        return count($uniqueAddressIds);
+    }
+
+    private function getCustomerGroupName(int $idGroup, int $idLang): string
+    {
+        foreach ($this->groupDataProvider->getGroups($idLang) as $group) {
+            if ((int) $group['id_group'] === $idGroup) {
+                return (string) $group['name'];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return AddressForViewing[]
+     */
+    private function mapAddresses(array $rows): array
+    {
+        $addresses = [];
+        foreach ($rows as $row) {
+            $addressId = (int) $row['id_address'];
+            $addresses[] = new AddressForViewing(
+                $addressId,
+                (string) $row['alias'],
+                $this->addressFormatter->format(new AddressId($addressId)),
+                (string) $row['address_type'],
+                (bool) $row['is_default'],
+            );
+        }
+
+        return $addresses;
+    }
+
+    /**
+     * @return IdentifierForViewing[]
+     */
+    private function mapIdentifiers(BusinessEntity $businessEntity): array
+    {
+        $identifiers = [];
+        foreach ($businessEntity->getBusinessEntityIdentifiers() as $businessEntityIdentifier) {
+            $identifier = $businessEntityIdentifier->getBusinessIdentifier();
+            if ($identifier->isDeleted()) {
+                continue;
+            }
+
+            $identifiers[$identifier->getId()] = new IdentifierForViewing(
+                $identifier->getId(),
+                $identifier->getLabel(),
+                $businessEntityIdentifier->getValue(),
+            );
+        }
+
+        ksort($identifiers);
+
+        return array_values($identifiers);
+    }
+}

--- a/src/Adapter/BusinessEntity/QueryHandler/GetPendingBusinessEntitiesCountHandler.php
+++ b/src/Adapter/BusinessEntity/QueryHandler/GetPendingBusinessEntitiesCountHandler.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetPendingBusinessEntitiesCount;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryHandler\GetPendingBusinessEntitiesCountHandlerInterface;
+use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
+
+#[AsQueryHandler]
+final class GetPendingBusinessEntitiesCountHandler implements GetPendingBusinessEntitiesCountHandlerInterface
+{
+    public function __construct(
+        private readonly BusinessEntityRepository $businessEntityRepository,
+        private readonly ShopContext $shopContext,
+    ) {
+    }
+
+    public function handle(GetPendingBusinessEntitiesCount $query): int
+    {
+        $shopIds = $this->shopContext->isAllShopContext()
+            ? null
+            : $this->shopContext->getAssociatedShopIds();
+
+        return $this->businessEntityRepository->getPendingCount($shopIds);
+    }
+}

--- a/src/Adapter/BusinessEntity/Repository/BusinessEntityAddressRepository.php
+++ b/src/Adapter/BusinessEntity/Repository/BusinessEntityAddressRepository.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository;
 
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use PrestaShopBundle\Entity\Enum\AddressTypeEnum;
 
 class BusinessEntityAddressRepository
 {
@@ -20,13 +20,13 @@ class BusinessEntityAddressRepository
     }
 
     /**
-     * @param string[] $addressTypes
+     * Default addresses first, then insertion order, soft-deleted addresses excluded.
      *
-     * @return array<int, array<string, mixed>>
+     * @return BusinessEntityAddressRow[]
      */
-    public function getAddresses(int $businessEntityId, array $addressTypes): array
+    public function getAddresses(int $businessEntityId): array
     {
-        return $this->connection->createQueryBuilder()
+        $rows = $this->connection->createQueryBuilder()
             ->select(
                 'a.id_address',
                 'a.alias',
@@ -36,13 +36,21 @@ class BusinessEntityAddressRepository
             ->from($this->dbPrefix . 'business_entity_address', 'bea')
             ->innerJoin('bea', $this->dbPrefix . 'address', 'a', 'a.id_address = bea.id_address')
             ->where('bea.id_business_entity = :businessEntityId')
-            ->andWhere('bea.address_type IN (:addressTypes)')
             ->andWhere('a.deleted = 0')
             ->orderBy('bea.is_default', 'DESC')
             ->addOrderBy('bea.id_business_entity_address', 'ASC')
             ->setParameter('businessEntityId', $businessEntityId)
-            ->setParameter('addressTypes', $addressTypes, ArrayParameterType::STRING)
             ->executeQuery()
             ->fetchAllAssociative();
+
+        return array_map(
+            static fn (array $row): BusinessEntityAddressRow => new BusinessEntityAddressRow(
+                (int) $row['id_address'],
+                (string) $row['alias'],
+                AddressTypeEnum::from((string) $row['address_type']),
+                (bool) $row['is_default'],
+            ),
+            $rows
+        );
     }
 }

--- a/src/Adapter/BusinessEntity/Repository/BusinessEntityAddressRepository.php
+++ b/src/Adapter/BusinessEntity/Repository/BusinessEntityAddressRepository.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+
+class BusinessEntityAddressRepository
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $dbPrefix,
+    ) {
+    }
+
+    /**
+     * @param string[] $addressTypes
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getAddresses(int $businessEntityId, array $addressTypes): array
+    {
+        return $this->connection->createQueryBuilder()
+            ->select(
+                'a.id_address',
+                'a.alias',
+                'bea.address_type',
+                'bea.is_default'
+            )
+            ->from($this->dbPrefix . 'business_entity_address', 'bea')
+            ->innerJoin('bea', $this->dbPrefix . 'address', 'a', 'a.id_address = bea.id_address')
+            ->where('bea.id_business_entity = :businessEntityId')
+            ->andWhere('bea.address_type IN (:addressTypes)')
+            ->andWhere('a.deleted = 0')
+            ->orderBy('bea.is_default', 'DESC')
+            ->addOrderBy('bea.id_business_entity_address', 'ASC')
+            ->setParameter('businessEntityId', $businessEntityId)
+            ->setParameter('addressTypes', $addressTypes, ArrayParameterType::STRING)
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+}

--- a/src/Adapter/BusinessEntity/Repository/BusinessEntityAddressRow.php
+++ b/src/Adapter/BusinessEntity/Repository/BusinessEntityAddressRow.php
@@ -6,16 +6,19 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult;
+namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository;
 
 use PrestaShopBundle\Entity\Enum\AddressTypeEnum;
 
-class AddressForViewing
+/**
+ * A business entity to address link, with the alias resolved from the address table.
+ * Typed counterpart of what BusinessEntityAddressRepository::getAddresses() selects.
+ */
+class BusinessEntityAddressRow
 {
     public function __construct(
         private readonly int $addressId,
         private readonly string $alias,
-        private readonly string $formattedAddress,
         private readonly AddressTypeEnum $addressType,
         private readonly bool $isDefault,
     ) {
@@ -29,11 +32,6 @@ class AddressForViewing
     public function getAlias(): string
     {
         return $this->alias;
-    }
-
-    public function getFormattedAddress(): string
-    {
-        return $this->formattedAddress;
     }
 
     public function getAddressType(): AddressTypeEnum

--- a/src/Core/Domain/BusinessEntity/Exception/BusinessEntityNotFoundException.php
+++ b/src/Core/Domain/BusinessEntity/Exception/BusinessEntityNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception;
+
+class BusinessEntityNotFoundException extends BusinessEntityException
+{
+}

--- a/src/Core/Domain/BusinessEntity/Query/GetBusinessEntityForViewing.php
+++ b/src/Core/Domain/BusinessEntity/Query/GetBusinessEntityForViewing.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityId;
+
+class GetBusinessEntityForViewing
+{
+    private readonly BusinessEntityId $businessEntityId;
+
+    public function __construct(int $businessEntityId)
+    {
+        $this->businessEntityId = new BusinessEntityId($businessEntityId);
+    }
+
+    public function getBusinessEntityId(): BusinessEntityId
+    {
+        return $this->businessEntityId;
+    }
+}

--- a/src/Core/Domain/BusinessEntity/Query/GetPendingBusinessEntitiesCount.php
+++ b/src/Core/Domain/BusinessEntity/Query/GetPendingBusinessEntitiesCount.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query;
+
+/**
+ * Gets the number of business entities awaiting validation (pending status)
+ * within the current shop context.
+ */
+class GetPendingBusinessEntitiesCount
+{
+}

--- a/src/Core/Domain/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandlerInterface.php
+++ b/src/Core/Domain/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandlerInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\BusinessEntityForViewing;
+
+interface GetBusinessEntityForViewingHandlerInterface
+{
+    public function handle(GetBusinessEntityForViewing $query): BusinessEntityForViewing;
+}

--- a/src/Core/Domain/BusinessEntity/QueryHandler/GetPendingBusinessEntitiesCountHandlerInterface.php
+++ b/src/Core/Domain/BusinessEntity/QueryHandler/GetPendingBusinessEntitiesCountHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetPendingBusinessEntitiesCount;
+
+interface GetPendingBusinessEntitiesCountHandlerInterface
+{
+    public function handle(GetPendingBusinessEntitiesCount $query): int;
+}

--- a/src/Core/Domain/BusinessEntity/QueryResult/AddressForViewing.php
+++ b/src/Core/Domain/BusinessEntity/QueryResult/AddressForViewing.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult;
+
+class AddressForViewing
+{
+    public function __construct(
+        private readonly int $addressId,
+        private readonly string $alias,
+        private readonly string $formattedAddress,
+        private readonly string $addressType,
+        private readonly bool $isDefault,
+    ) {
+    }
+
+    public function getAddressId(): int
+    {
+        return $this->addressId;
+    }
+
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    public function getFormattedAddress(): string
+    {
+        return $this->formattedAddress;
+    }
+
+    public function getAddressType(): string
+    {
+        return $this->addressType;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+}

--- a/src/Core/Domain/BusinessEntity/QueryResult/BusinessEntityForViewing.php
+++ b/src/Core/Domain/BusinessEntity/QueryResult/BusinessEntityForViewing.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult;
+
+use DateTimeImmutable;
+
+class BusinessEntityForViewing
+{
+    /**
+     * @param AddressForViewing[] $invoiceAddresses
+     * @param AddressForViewing[] $deliveryAddresses
+     * @param IdentifierForViewing[] $identifiers
+     */
+    public function __construct(
+        private readonly int $businessEntityId,
+        private readonly ?string $externalRef,
+        private readonly string $name,
+        private readonly ?string $legalName,
+        private readonly bool $deliveryAuthorized,
+        private readonly string $status,
+        private readonly string $statusLabel,
+        private readonly DateTimeImmutable $createdAt,
+        private readonly DateTimeImmutable $updatedAt,
+        private readonly int $linkedCustomersCount,
+        private readonly int $addressesCount,
+        private readonly int $customerGroupId,
+        private readonly string $customerGroupName,
+        private readonly array $invoiceAddresses,
+        private readonly array $deliveryAddresses,
+        private readonly array $identifiers,
+    ) {
+    }
+
+    public function getBusinessEntityId(): int
+    {
+        return $this->businessEntityId;
+    }
+
+    public function getExternalRef(): ?string
+    {
+        return $this->externalRef;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Up to two uppercase initials derived from the name, used by the detail page avatar.
+     */
+    public function getInitials(): string
+    {
+        $words = array_slice(array_values(array_filter(explode(' ', trim($this->name)))), 0, 2);
+
+        $initials = '';
+        foreach ($words as $word) {
+            $initials .= mb_strtoupper(mb_substr($word, 0, 1));
+        }
+
+        return $initials;
+    }
+
+    public function getLegalName(): ?string
+    {
+        return $this->legalName;
+    }
+
+    public function isDeliveryAuthorized(): bool
+    {
+        return $this->deliveryAuthorized;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getStatusLabel(): string
+    {
+        return $this->statusLabel;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function getLinkedCustomersCount(): int
+    {
+        return $this->linkedCustomersCount;
+    }
+
+    public function getCustomerGroupId(): int
+    {
+        return $this->customerGroupId;
+    }
+
+    public function getCustomerGroupName(): string
+    {
+        return $this->customerGroupName;
+    }
+
+    /**
+     * @return AddressForViewing[]
+     */
+    public function getInvoiceAddresses(): array
+    {
+        return $this->invoiceAddresses;
+    }
+
+    /**
+     * @return AddressForViewing[]
+     */
+    public function getDeliveryAddresses(): array
+    {
+        return $this->deliveryAddresses;
+    }
+
+    /**
+     * @return IdentifierForViewing[]
+     */
+    public function getIdentifiers(): array
+    {
+        return $this->identifiers;
+    }
+
+    public function getAddressesCount(): int
+    {
+        return $this->addressesCount;
+    }
+}

--- a/src/Core/Domain/BusinessEntity/QueryResult/BusinessEntityForViewing.php
+++ b/src/Core/Domain/BusinessEntity/QueryResult/BusinessEntityForViewing.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult;
 
 use DateTimeImmutable;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 
 class BusinessEntityForViewing
 {
@@ -23,7 +24,7 @@ class BusinessEntityForViewing
         private readonly string $name,
         private readonly ?string $legalName,
         private readonly bool $deliveryAuthorized,
-        private readonly string $status,
+        private readonly BusinessEntityStatus $status,
         private readonly string $statusLabel,
         private readonly DateTimeImmutable $createdAt,
         private readonly DateTimeImmutable $updatedAt,
@@ -57,7 +58,7 @@ class BusinessEntityForViewing
      */
     public function getInitials(): string
     {
-        $words = array_slice(array_values(array_filter(explode(' ', trim($this->name)))), 0, 2);
+        $words = array_slice(array_filter(explode(' ', trim($this->name))), 0, 2);
 
         $initials = '';
         foreach ($words as $word) {
@@ -77,7 +78,7 @@ class BusinessEntityForViewing
         return $this->deliveryAuthorized;
     }
 
-    public function getStatus(): string
+    public function getStatus(): BusinessEntityStatus
     {
         return $this->status;
     }

--- a/src/Core/Domain/BusinessEntity/QueryResult/IdentifierForViewing.php
+++ b/src/Core/Domain/BusinessEntity/QueryResult/IdentifierForViewing.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult;
+
+class IdentifierForViewing
+{
+    public function __construct(
+        private readonly int $businessIdentifierId,
+        private readonly string $label,
+        private readonly ?string $value,
+    ) {
+    }
+
+    public function getBusinessIdentifierId(): int
+    {
+        return $this->businessIdentifierId;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+}

--- a/src/Core/Form/ChoiceProvider/BusinessEntityStatusChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/BusinessEntityStatusChoiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Provides the business entity status choices for the grid filter. Labels come from
+ * BusinessEntityStatus itself, so the filter, the grid rows and the detail view all display the
+ * same wording.
+ */
+final class BusinessEntityStatusChoiceProvider implements FormChoiceProviderInterface
+{
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChoices(): array
+    {
+        $choices = [];
+        foreach (BusinessEntityStatus::cases() as $status) {
+            $choices[$status->trans($this->translator)] = $status->value;
+        }
+
+        return $choices;
+    }
+}

--- a/src/Core/Grid/Data/Factory/BusinessEntityGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/BusinessEntityGridDataFactory.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Decorates the business entity grid data with the translated status label and the badge
+ * type expected by BadgeColumn, so the Status badge is localized and colored like the
+ * detail view and the status filter choices.
+ */
+final class BusinessEntityGridDataFactory implements GridDataFactoryInterface
+{
+    public function __construct(
+        private readonly GridDataFactoryInterface $businessEntityDataFactory,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria): GridData
+    {
+        $data = $this->businessEntityDataFactory->getData($searchCriteria);
+
+        return new GridData(
+            $this->addStatusPresentation($data->getRecords()),
+            $data->getRecordsTotal(),
+            $data->getQuery()
+        );
+    }
+
+    private function addStatusPresentation(RecordCollectionInterface $records): RecordCollectionInterface
+    {
+        $modifiedRecords = [];
+        foreach ($records as $record) {
+            $status = BusinessEntityStatus::tryFrom((string) $record['status']);
+            $record['status_label'] = null === $status
+                ? (string) $record['status']
+                : $status->trans($this->translator);
+            $record['status_badge_type'] = $this->getStatusBadgeType($status);
+            $modifiedRecords[] = $record;
+        }
+
+        return new RecordCollection($modifiedRecords);
+    }
+
+    private function getStatusBadgeType(?BusinessEntityStatus $status): string
+    {
+        return match ($status) {
+            BusinessEntityStatus::ACTIVE => 'success',
+            BusinessEntityStatus::PENDING => 'info',
+            BusinessEntityStatus::INACTIVE => 'light-info',
+            BusinessEntityStatus::REJECTED => 'danger',
+            default => '',
+        };
+    }
+}

--- a/src/Core/Grid/Data/Factory/BusinessEntityGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/BusinessEntityGridDataFactory.php
@@ -46,25 +46,12 @@ final class BusinessEntityGridDataFactory implements GridDataFactoryInterface
     {
         $modifiedRecords = [];
         foreach ($records as $record) {
-            $status = BusinessEntityStatus::tryFrom((string) $record['status']);
-            $record['status_label'] = null === $status
-                ? (string) $record['status']
-                : $status->trans($this->translator);
-            $record['status_badge_type'] = $this->getStatusBadgeType($status);
+            $status = BusinessEntityStatus::from((string) $record['status']);
+            $record['status_label'] = $status->trans($this->translator);
+            $record['status_badge_type'] = $status->badgeType();
             $modifiedRecords[] = $record;
         }
 
         return new RecordCollection($modifiedRecords);
-    }
-
-    private function getStatusBadgeType(?BusinessEntityStatus $status): string
-    {
-        return match ($status) {
-            BusinessEntityStatus::ACTIVE => 'success',
-            BusinessEntityStatus::PENDING => 'info',
-            BusinessEntityStatus::INACTIVE => 'light-info',
-            BusinessEntityStatus::REJECTED => 'danger',
-            default => '',
-        };
     }
 }

--- a/src/Core/Grid/Definition/Factory/BusinessEntityGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/BusinessEntityGridDefinitionFactory.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\BusinessEntityStatusChoiceProvider;
+use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BadgeColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
+use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class BusinessEntityGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    public const GRID_ID = 'business_entity';
+
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        private readonly ShopContext $shopContext,
+        private readonly BusinessEntityStatusChoiceProvider $statusChoiceProvider,
+    ) {
+        parent::__construct($hookDispatcher);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId(): string
+    {
+        return self::GRID_ID;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName(): string
+    {
+        return $this->trans('Business entities', [], 'Admin.Navigation.Menu');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns(): ColumnCollection
+    {
+        $columns = (new ColumnCollection())
+            ->add(
+                (new DataColumn('id_business_entity'))
+                    ->setName($this->trans('ID', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'id_business_entity',
+                    ])
+            )
+            ->add(
+                (new DataColumn('name'))
+                    ->setName($this->trans('Company', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'name',
+                    ])
+            )
+            ->add(
+                (new DataColumn('legal_name'))
+                    ->setName($this->trans('Legal name', [], 'Admin.Orderscustomers.Feature'))
+                    ->setOptions([
+                        'field' => 'legal_name',
+                    ])
+            );
+
+        if ($this->shopContext->isMultiShopUsed()) {
+            $columns->add(
+                (new DataColumn('shop_name'))
+                    ->setName($this->trans('Shop', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'shop_name',
+                    ])
+            );
+        }
+
+        return $columns
+            ->add(
+                (new BadgeColumn('customers_count'))
+                    ->setName($this->trans('Customers', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'customers_count',
+                        'alignment' => 'left',
+                    ])
+            )
+            ->add(
+                (new BadgeColumn('status'))
+                    ->setName($this->trans('Status', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'status_label',
+                        'alignment' => 'left',
+                        'badge_type' => '',
+                        'badge_type_field' => 'status_badge_type',
+                    ])
+            )
+            ->add(
+                (new ActionColumn('actions'))
+                    ->setName($this->trans('Actions', [], 'Admin.Global'))
+                    ->setOptions([
+                        'actions' => (new RowActionCollection())
+                            ->add(
+                                (new LinkRowAction('view'))
+                                    ->setName($this->trans('View details', [], 'Admin.Actions'))
+                                    ->setIcon('visibility')
+                                    ->setOptions([
+                                        'route' => 'admin_business_entities_view',
+                                        'route_param_name' => 'businessEntityId',
+                                        'route_param_field' => 'id_business_entity',
+                                        'clickable_row' => true,
+                                    ])
+                            ),
+                    ])
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFilters()
+    {
+        $filters = (new FilterCollection())
+            ->add(
+                (new Filter('id_business_entity', NumberType::class))
+                    ->setTypeOptions([
+                        'attr' => [
+                            'placeholder' => $this->trans('Search ID', [], 'Admin.Actions'),
+                        ],
+                        'required' => false,
+                    ])
+                    ->setAssociatedColumn('id_business_entity')
+            )
+            ->add(
+                (new Filter('name', TextType::class))
+                    ->setTypeOptions([
+                        'attr' => [
+                            'placeholder' => $this->trans('Search name', [], 'Admin.Actions'),
+                        ],
+                        'required' => false,
+                    ])
+                    ->setAssociatedColumn('name')
+            )
+            ->add(
+                (new Filter('legal_name', TextType::class))
+                    ->setTypeOptions([
+                        'attr' => [
+                            'placeholder' => $this->trans('Search legal name', [], 'Admin.Actions'),
+                        ],
+                        'required' => false,
+                    ])
+                    ->setAssociatedColumn('legal_name')
+            )
+        ;
+
+        if ($this->shopContext->isMultiShopUsed()) {
+            $filters->add(
+                (new Filter('shop_name', TextType::class))
+                    ->setTypeOptions([
+                        'attr' => [
+                            'placeholder' => $this->trans('Search shop', [], 'Admin.Actions'),
+                        ],
+                        'required' => false,
+                    ])
+                    ->setAssociatedColumn('shop_name')
+            );
+        }
+
+        return $filters
+            ->add(
+                (new Filter('status', ChoiceType::class))
+                    ->setTypeOptions([
+                        'required' => false,
+                        'placeholder' => $this->trans('All', [], 'Admin.Global'),
+                        'choices' => $this->statusChoiceProvider->getChoices(),
+                    ])
+                    ->setAssociatedColumn('status')
+            )
+            ->add(
+                (new Filter('actions', SearchAndResetType::class))
+                    ->setTypeOptions([
+                        'reset_route' => 'admin_common_reset_search_by_filter_id',
+                        'reset_route_params' => [
+                            'filterId' => self::GRID_ID,
+                        ],
+                        'redirect_route' => 'admin_business_entities_list',
+                    ])
+                    ->setAssociatedColumn('actions')
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGridActions()
+    {
+        return (new GridActionCollection())
+            ->add(
+                (new SimpleGridAction('common_refresh_list'))
+                    ->setName($this->trans('Refresh list', [], 'Admin.Advparameters.Feature'))
+                    ->setIcon('refresh')
+            )
+            ->add(
+                (new SimpleGridAction('common_show_query'))
+                    ->setName($this->trans('Show SQL query', [], 'Admin.Actions'))
+                    ->setIcon('code')
+            )
+            ->add(
+                (new SimpleGridAction('common_export_sql_manager'))
+                    ->setName($this->trans('Export to SQL Manager', [], 'Admin.Actions'))
+                    ->setIcon('storage')
+            );
+    }
+}

--- a/src/Core/Grid/Query/BusinessEntityQueryBuilder.php
+++ b/src/Core/Grid/Query/BusinessEntityQueryBuilder.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Builds search and count queries for the business entity grid.
+ *
+ * Soft-deleted entities are excluded, rows are scoped to the associated shops outside
+ * of an all-shop context, and customers_count is an aggregate alias rather than a column.
+ */
+final class BusinessEntityQueryBuilder extends AbstractDoctrineQueryBuilder
+{
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        private readonly DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
+        private readonly ShopContext $shopContext,
+    ) {
+        parent::__construct($connection, $dbPrefix);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->getBaseQueryBuilder($searchCriteria->getFilters());
+
+        $qb->select('be.id_business_entity')
+            ->addSelect('be.name')
+            ->addSelect('be.legal_name')
+            ->addSelect('be.status')
+            ->addSelect('s.name AS shop_name')
+            ->addSelect('COUNT(DISTINCT becb.id_customer_b2b) AS customers_count')
+            ->leftJoin(
+                'be',
+                $this->dbPrefix . 'business_entity_customer_b2b',
+                'becb',
+                'becb.id_business_entity = be.id_business_entity'
+            )
+            ->groupBy('be.id_business_entity')
+        ;
+
+        $this->applySorting($qb, $searchCriteria);
+
+        $this->searchCriteriaApplicator
+            ->applyPagination($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'be', 'id_business_entity')
+        ;
+
+        return $qb;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->getBaseQueryBuilder($searchCriteria->getFilters());
+        $qb->select('COUNT(DISTINCT be.id_business_entity)');
+
+        return $qb;
+    }
+
+    private function applySorting(QueryBuilder $qb, SearchCriteriaInterface $searchCriteria): void
+    {
+        $sortableFields = [
+            'id_business_entity' => 'be.id_business_entity',
+            'name' => 'be.`name`',
+            'legal_name' => 'be.`legal_name`',
+            'status' => 'be.`status`',
+            'shop_name' => 's.`name`',
+            'customers_count' => 'customers_count',
+        ];
+
+        if (isset($sortableFields[$searchCriteria->getOrderBy()])) {
+            $qb->orderBy(
+                $sortableFields[$searchCriteria->getOrderBy()],
+                $searchCriteria->getOrderWay()
+            );
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    private function getBaseQueryBuilder(array $filters): QueryBuilder
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->from($this->dbPrefix . 'business_entity', 'be')
+            ->leftJoin(
+                'be',
+                $this->dbPrefix . 'shop',
+                's',
+                's.id_shop = be.id_shop'
+            )
+            ->andWhere('be.deleted = 0')
+        ;
+
+        if (!$this->shopContext->isAllShopContext()) {
+            $qb->andWhere('be.id_shop IN (:beShopIds)')
+                ->setParameter('beShopIds', $this->shopContext->getAssociatedShopIds(), Connection::PARAM_INT_ARRAY);
+        }
+
+        foreach ($filters as $filterName => $filterValue) {
+            if ($filterValue === '' || $filterValue === null) {
+                continue;
+            }
+
+            if ('id_business_entity' === $filterName) {
+                $qb->andWhere("be.id_business_entity = :$filterName");
+                $qb->setParameter($filterName, (int) $filterValue);
+                continue;
+            }
+
+            if ('name' === $filterName) {
+                $qb->andWhere("be.name LIKE :$filterName");
+                $qb->setParameter($filterName, '%' . $this->escapePercent((string) $filterValue) . '%');
+                continue;
+            }
+
+            if ('legal_name' === $filterName) {
+                $qb->andWhere("be.legal_name LIKE :$filterName");
+                $qb->setParameter($filterName, '%' . $this->escapePercent((string) $filterValue) . '%');
+                continue;
+            }
+
+            if ('shop_name' === $filterName) {
+                $qb->andWhere("s.name LIKE :$filterName");
+                $qb->setParameter($filterName, '%' . $this->escapePercent((string) $filterValue) . '%');
+                continue;
+            }
+
+            if ('status' === $filterName) {
+                $qb->andWhere("be.status = :$filterName");
+                $qb->setParameter($filterName, (string) $filterValue);
+                continue;
+            }
+        }
+
+        return $qb;
+    }
+}

--- a/src/Core/Search/Filters/BusinessEntityFilters.php
+++ b/src/Core/Search/Filters/BusinessEntityFilters.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BusinessEntityGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+final class BusinessEntityFilters extends Filters
+{
+    /** @var string */
+    protected $filterId = BusinessEntityGridDefinitionFactory::GRID_ID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults(): array
+    {
+        return [
+            'limit' => 20,
+            'offset' => 0,
+            'orderBy' => 'id_business_entity',
+            'sortOrder' => 'asc',
+            'filters' => [],
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -167,8 +167,6 @@ class LegacyLinkLinterCommand extends Command
      */
     private const CONTROLLER_WHITE_LIST = [
         'AdminAdminAPI',
-        'AdminBusinessEntities',
-        'AdminCustomersB2B',
         'AdminExtraPropertyDefinitions',
     ];
 

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -167,6 +167,8 @@ class LegacyLinkLinterCommand extends Command
      */
     private const CONTROLLER_WHITE_LIST = [
         'AdminAdminAPI',
+        'AdminBusinessEntities',
+        'AdminCustomersB2B',
         'AdminExtraPropertyDefinitions',
     ];
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
@@ -10,10 +10,20 @@ namespace PrestaShopBundle\Controller\Admin\Sell\BusinessEntity;
 
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityBillingAddressConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\UnableToCreateBusinessEntityAddress;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetPendingBusinessEntitiesCount;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\BusinessEntityForViewing;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BusinessEntityGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
+use PrestaShop\PrestaShop\Core\Search\Filters\BusinessEntityFilters;
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityAddressType;
 use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
@@ -26,15 +36,80 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class BusinessEntitiesController extends PrestaShopAdminController
 {
-    #[AdminSecurity("is_granted('read', 'AdminBusinessEntities')")]
-    public function listAction(): Response
-    {
-        return $this->render('@PrestaShop/Admin/Sell/BusinessEntity/list.html.twig', [
-            'layoutHeaderToolbarBtn' => $this->getBusinessEntitiesToolbarButtons(),
+    /**
+     * Lists the business entities the employee is allowed to see, scoped to the current shop context.
+     */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+    public function listAction(
+        Request $request,
+        BusinessEntityFilters $filters,
+        #[Autowire(service: 'prestashop.core.grid.factory.business_entity')]
+        GridFactoryInterface $businessEntityGridFactory,
+    ): Response {
+        $pendingCount = $this->dispatchQuery(new GetPendingBusinessEntitiesCount());
+
+        $currentStatusFilter = $filters->getFilters()['status'] ?? null;
+        $isPendingFilter = ($currentStatusFilter === BusinessEntityStatus::PENDING->value);
+
+        $pendingUrl = $this->generateUrl('admin_business_entities_list', [
+            BusinessEntityGridDefinitionFactory::GRID_ID => [
+                'filters' => ['status' => BusinessEntityStatus::PENDING->value],
+            ],
         ]);
+
+        return $this->render(
+            '@PrestaShop/Admin/Sell/BusinessEntity/list.html.twig',
+            [
+                'enableSidebar' => true,
+                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+                'layoutTitle' => $this->trans('Business entities', [], 'Admin.Navigation.Menu'),
+                'layoutHeaderToolbarBtn' => $this->getBusinessEntitiesToolbarButtons(),
+                'businessEntityGrid' => $this->presentGrid($businessEntityGridFactory->getGrid($filters)),
+                'pendingCount' => $pendingCount,
+                'pendingUrl' => $pendingUrl,
+                'isPendingFilter' => $isPendingFilter,
+            ]
+        );
     }
 
-    #[AdminSecurity("is_granted('create', 'AdminBusinessEntities')", message: 'You do not have permission to create this.', redirectRoute: 'admin_business_entities_list')]
+    /**
+     * Shows a single business entity in read-only. An entity belonging to another shop is reported
+     * as not found rather than as an access error, so the listing does not leak its existence.
+     */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute: 'admin_business_entities_list')]
+    public function viewAction(
+        Request $request,
+        int $businessEntityId,
+    ): Response {
+        try {
+            /** @var BusinessEntityForViewing $businessEntityForViewing */
+            $businessEntityForViewing = $this->dispatchQuery(
+                new GetBusinessEntityForViewing($businessEntityId)
+            );
+        } catch (BusinessEntityException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            return $this->redirectToRoute('admin_business_entities_list');
+        }
+
+        return $this->render(
+            '@PrestaShop/Admin/Sell/BusinessEntity/view.html.twig',
+            [
+                'enableSidebar' => true,
+                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+                'layoutTitle' => $this->trans(
+                    'Business entity %name%',
+                    [
+                        '%name%' => $businessEntityForViewing->getName(),
+                    ],
+                    'Admin.Navigation.Menu'
+                ),
+                'businessEntity' => $businessEntityForViewing,
+            ]
+        );
+    }
+
+    #[AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message: 'You do not have permission to create this.', redirectRoute: 'admin_business_entities_list')]
     public function createAction(
         Request $request,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.business_entity_form_builder')]
@@ -80,12 +155,12 @@ class BusinessEntitiesController extends PrestaShopAdminController
                 'layoutTitle' => $this->trans('New business entity', [], 'Admin.Navigation.Menu'),
                 'businessEntityForm' => $form->createView(),
                 'enableSidebar' => true,
-                'help_link' => $this->generateSidebarLink('AdminBusinessEntities'),
+                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             ]
         );
     }
 
-    protected function getBusinessEntitiesToolbarButtons(): array
+    private function getBusinessEntitiesToolbarButtons(): array
     {
         $toolbarButtons = [];
 
@@ -101,6 +176,18 @@ class BusinessEntitiesController extends PrestaShopAdminController
     private function getErrorMessages(): array
     {
         return [
+            BusinessEntityNotFoundException::class => $this->trans(
+                'The object cannot be loaded (or found).',
+                [],
+                'Admin.Notifications.Error'
+            ),
+            BusinessEntityConstraintException::class => [
+                BusinessEntityConstraintException::INVALID_ID => $this->trans(
+                    'The object cannot be loaded (the identifier is missing or invalid)',
+                    [],
+                    'Admin.Notifications.Error'
+                ),
+            ],
             UnableToCreateBusinessEntityAddress::class => $this->trans(
                 'An error occurred while creating the business entity.',
                 [],

--- a/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
@@ -20,6 +20,7 @@ use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\BusinessEntityF
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BusinessEntityGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\BusinessEntityFilters;
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
@@ -28,6 +29,7 @@ use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityAddressType;
 use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -68,6 +70,23 @@ class BusinessEntitiesController extends PrestaShopAdminController
                 'pendingUrl' => $pendingUrl,
                 'isPendingFilter' => $isPendingFilter,
             ]
+        );
+    }
+
+    /**
+     * Applies the filters submitted from the listing and redirects back to it.
+     */
+    #[AdminSecurity("is_granted('read', 'AdminBusinessEntities')")]
+    public function searchAction(
+        Request $request,
+        #[Autowire(service: BusinessEntityGridDefinitionFactory::class)]
+        GridDefinitionFactoryInterface $businessEntityGridDefinitionFactory,
+    ): RedirectResponse {
+        return $this->buildSearchResponse(
+            $businessEntityGridDefinitionFactory,
+            $request,
+            BusinessEntityGridDefinitionFactory::GRID_ID,
+            'admin_business_entities_list'
         );
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
@@ -39,9 +39,8 @@ class BusinessEntitiesController extends PrestaShopAdminController
     /**
      * Lists the business entities the employee is allowed to see, scoped to the current shop context.
      */
-    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+    #[AdminSecurity("is_granted('read', 'AdminBusinessEntities')")]
     public function listAction(
-        Request $request,
         BusinessEntityFilters $filters,
         #[Autowire(service: 'prestashop.core.grid.factory.business_entity')]
         GridFactoryInterface $businessEntityGridFactory,
@@ -61,7 +60,7 @@ class BusinessEntitiesController extends PrestaShopAdminController
             '@PrestaShop/Admin/Sell/BusinessEntity/list.html.twig',
             [
                 'enableSidebar' => true,
-                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+                'help_link' => $this->generateSidebarLink('AdminBusinessEntities'),
                 'layoutTitle' => $this->trans('Business entities', [], 'Admin.Navigation.Menu'),
                 'layoutHeaderToolbarBtn' => $this->getBusinessEntitiesToolbarButtons(),
                 'businessEntityGrid' => $this->presentGrid($businessEntityGridFactory->getGrid($filters)),
@@ -76,9 +75,8 @@ class BusinessEntitiesController extends PrestaShopAdminController
      * Shows a single business entity in read-only. An entity belonging to another shop is reported
      * as not found rather than as an access error, so the listing does not leak its existence.
      */
-    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute: 'admin_business_entities_list')]
+    #[AdminSecurity("is_granted('read', 'AdminBusinessEntities')", redirectRoute: 'admin_business_entities_list')]
     public function viewAction(
-        Request $request,
         int $businessEntityId,
     ): Response {
         try {
@@ -96,7 +94,7 @@ class BusinessEntitiesController extends PrestaShopAdminController
             '@PrestaShop/Admin/Sell/BusinessEntity/view.html.twig',
             [
                 'enableSidebar' => true,
-                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+                'help_link' => $this->generateSidebarLink('AdminBusinessEntities'),
                 'layoutTitle' => $this->trans(
                     'Business entity %name%',
                     [
@@ -109,7 +107,7 @@ class BusinessEntitiesController extends PrestaShopAdminController
         );
     }
 
-    #[AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message: 'You do not have permission to create this.', redirectRoute: 'admin_business_entities_list')]
+    #[AdminSecurity("is_granted('create', 'AdminBusinessEntities')", message: 'You do not have permission to create this.', redirectRoute: 'admin_business_entities_list')]
     public function createAction(
         Request $request,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.business_entity_form_builder')]
@@ -155,7 +153,7 @@ class BusinessEntitiesController extends PrestaShopAdminController
                 'layoutTitle' => $this->trans('New business entity', [], 'Admin.Navigation.Menu'),
                 'businessEntityForm' => $form->createView(),
                 'enableSidebar' => true,
-                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+                'help_link' => $this->generateSidebarLink('AdminBusinessEntities'),
             ]
         );
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerB2b/CustomerB2bController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerB2b/CustomerB2bController.php
@@ -20,7 +20,7 @@ class CustomerB2bController extends PrestaShopAdminController
     /**
      * Lists the B2B customers. The grid itself lands with the customer/entity link management.
      */
-    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+    #[AdminSecurity("is_granted('read', 'AdminCustomersB2B')")]
     public function listAction(): Response
     {
         return $this->render('@PrestaShop/Admin/Sell/CustomerB2b/list.html.twig');

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerB2b/CustomerB2bController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerB2b/CustomerB2bController.php
@@ -4,6 +4,8 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace PrestaShopBundle\Controller\Admin\Sell\CustomerB2b;
 
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
@@ -15,7 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class CustomerB2bController extends PrestaShopAdminController
 {
-    #[AdminSecurity("is_granted('read', 'AdminCustomersB2b')")]
+    /**
+     * Lists the B2B customers. The grid itself lands with the customer/entity link management.
+     */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
     public function listAction(): Response
     {
         return $this->render('@PrestaShop/Admin/Sell/CustomerB2b/list.html.twig');

--- a/src/PrestaShopBundle/Entity/Enum/AddressTypeEnum.php
+++ b/src/PrestaShopBundle/Entity/Enum/AddressTypeEnum.php
@@ -11,4 +11,12 @@ enum AddressTypeEnum: string
     case BOTH = 'both';
     case INVOICE = 'invoice';
     case DELIVERY = 'delivery';
+
+    /**
+     * @return string[]
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
 }

--- a/src/PrestaShopBundle/Entity/Enum/AddressTypeEnum.php
+++ b/src/PrestaShopBundle/Entity/Enum/AddressTypeEnum.php
@@ -11,12 +11,4 @@ enum AddressTypeEnum: string
     case BOTH = 'both';
     case INVOICE = 'invoice';
     case DELIVERY = 'delivery';
-
-    /**
-     * @return string[]
-     */
-    public static function values(): array
-    {
-        return array_column(self::cases(), 'value');
-    }
 }

--- a/src/PrestaShopBundle/Entity/Enum/BusinessEntityStatus.php
+++ b/src/PrestaShopBundle/Entity/Enum/BusinessEntityStatus.php
@@ -6,13 +6,26 @@
 
 namespace PrestaShopBundle\Entity\Enum;
 
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
 /**
  * Enum status BusinessEntity.
  */
-enum BusinessEntityStatus: string
+enum BusinessEntityStatus: string implements TranslatableInterface
 {
     case PENDING = 'pending';
     case ACTIVE = 'active';
     case INACTIVE = 'inactive';
     case REJECTED = 'rejected';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return match ($this) {
+            self::PENDING => $translator->trans('Pending', [], 'Admin.Global', $locale),
+            self::ACTIVE => $translator->trans('Active', [], 'Admin.Global', $locale),
+            self::INACTIVE => $translator->trans('Inactive', [], 'Admin.Global', $locale),
+            self::REJECTED => $translator->trans('Rejected', [], 'Admin.Global', $locale),
+        };
+    }
 }

--- a/src/PrestaShopBundle/Entity/Enum/BusinessEntityStatus.php
+++ b/src/PrestaShopBundle/Entity/Enum/BusinessEntityStatus.php
@@ -28,4 +28,17 @@ enum BusinessEntityStatus: string implements TranslatableInterface
             self::REJECTED => $translator->trans('Rejected', [], 'Admin.Global', $locale),
         };
     }
+
+    /**
+     * Badge type expected by BadgeColumn and by the detail page status badge.
+     */
+    public function badgeType(): string
+    {
+        return match ($this) {
+            self::PENDING => 'info',
+            self::ACTIVE => 'success',
+            self::INACTIVE => 'light-info',
+            self::REJECTED => 'danger',
+        };
+    }
 }

--- a/src/PrestaShopBundle/Entity/Repository/BusinessEntityRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/BusinessEntityRepository.php
@@ -9,7 +9,10 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Entity\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NonUniqueResultException;
 use PrestaShopBundle\Entity\B2B\BusinessEntity;
+use PrestaShopBundle\Entity\B2B\BusinessEntityCustomerB2b;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 
 class BusinessEntityRepository extends EntityRepository
 {
@@ -19,5 +22,69 @@ class BusinessEntityRepository extends EntityRepository
         $this->getEntityManager()->flush();
 
         return $businessEntity->getId();
+    }
+
+    /**
+     * @param int[]|null $shopIds
+     *
+     * @throws NonUniqueResultException
+     */
+    public function findById(int $businessEntityId, ?array $shopIds = null): ?BusinessEntity
+    {
+        $qb = $this->createQueryBuilder('be')
+            ->leftJoin('be.businessEntityIdentifiers', 'bei')
+            ->addSelect('bei')
+            ->leftJoin('bei.businessIdentifier', 'bi')
+            ->addSelect('bi')
+            ->where('be.id = :businessEntityId')
+            ->andWhere('be.deleted = false')
+            ->setParameter('businessEntityId', $businessEntityId);
+
+        if (null !== $shopIds) {
+            $qb->andWhere('be.idShop IN (:shopIds)')
+                ->setParameter('shopIds', $shopIds);
+        }
+
+        /** @var BusinessEntity|null $businessEntity */
+        $businessEntity = $qb->getQuery()->getOneOrNullResult();
+
+        return $businessEntity;
+    }
+
+    /**
+     * Counts every b2b customer linked to the entity, whatever the customer's own b2b status:
+     * a link is a link, and filtering on the customer status is deliberately left out until
+     * the link management screens exist.
+     */
+    public function getLinkedCustomersCount(int $businessEntityId): int
+    {
+        return (int) $this->getEntityManager()
+            ->createQueryBuilder()
+            ->select('COUNT(bec.id)')
+            ->from(BusinessEntityCustomerB2b::class, 'bec')
+            ->where('bec.businessEntity = :businessEntityId')
+            ->setParameter('businessEntityId', $businessEntityId)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+    }
+
+    /**
+     * @param int[]|null $shopIds
+     */
+    public function getPendingCount(?array $shopIds = null): int
+    {
+        $qb = $this->createQueryBuilder('be')
+            ->select('COUNT(be.id)')
+            ->where('be.status = :status')
+            ->andWhere('be.deleted = false')
+            ->setParameter('status', BusinessEntityStatus::PENDING);
+
+        if (null !== $shopIds) {
+            $qb->andWhere('be.idShop IN (:shopIds)')
+                ->setParameter('shopIds', $shopIds);
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationType.php
@@ -70,7 +70,7 @@ class BusinessEntityGeneralInformationType extends TranslatorAwareType
                 'class' => BusinessEntityStatus::class,
             ])
             ->add(self::FIELD_CUSTOMER_GROUP_ID, ChoiceType::class, [
-                'label' => $this->trans('Customer group', 'Admin.Orderscustomers.Feature'),
+                'label' => $this->trans('Customer group', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Customer group attached to this business entity.', 'Admin.Catalog.Feature'),
                 'choices' => $this->groupByIdChoiceProvider->getChoices(),
                 'required' => true,

--- a/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationType.php
@@ -52,7 +52,7 @@ class BusinessEntityGeneralInformationType extends TranslatorAwareType
                 'required' => true,
             ])
             ->add(self::FIELD_LEGAL_NAME, TextType::class, [
-                'label' => $this->trans('Legal Name', 'Admin.Global'),
+                'label' => $this->trans('Legal name', 'Admin.Orderscustomers.Feature'),
                 'help' => $this->trans('The official registered name of the company.', 'Admin.Catalog.Feature'),
                 'constraints' => $this->getNameConstraints(),
                 'required' => true,
@@ -70,7 +70,7 @@ class BusinessEntityGeneralInformationType extends TranslatorAwareType
                 'class' => BusinessEntityStatus::class,
             ])
             ->add(self::FIELD_CUSTOMER_GROUP_ID, ChoiceType::class, [
-                'label' => $this->trans('Customer group', 'Admin.Global'),
+                'label' => $this->trans('Customer group', 'Admin.Orderscustomers.Feature'),
                 'help' => $this->trans('Customer group attached to this business entity.', 'Admin.Catalog.Feature'),
                 'choices' => $this->groupByIdChoiceProvider->getChoices(),
                 'required' => true,

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/business_entities.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/business_entities.yml
@@ -6,10 +6,32 @@ admin_business_entities_list:
     _legacy_controller: AdminBusinessEntities
     _legacy_link: AdminBusinessEntities
 
+admin_business_entities_search:
+  path: /
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
+    _legacy_controller: AdminBusinessEntities
+    _legacy_link: AdminBusinessEntities:submitFilterbusiness_entity
+    gridDefinitionFactoryServiceId: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BusinessEntityGridDefinitionFactory
+    redirectRoute: admin_business_entities_list
+
+admin_business_entities_view:
+  path: /{businessEntityId}/view
+  methods: [ GET ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::viewAction
+    _legacy_controller: AdminBusinessEntities
+    _legacy_link: AdminBusinessEntities:viewbusiness_entity
+    _legacy_parameters:
+      id_business_entity: businessEntityId
+  requirements:
+    businessEntityId: \d+
+
 admin_business_entities_create:
   path: /new
   methods: [ GET, POST ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::createAction
     _legacy_controller: AdminBusinessEntities
-    _legacy_link: AdminBusinessEntities
+    _legacy_link: AdminBusinessEntities:addbusiness_entity

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/business_entities.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/business_entities.yml
@@ -3,23 +3,19 @@ admin_business_entities_list:
   methods: [ GET ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::listAction
-    _legacy_controller: AdminBusinessEntities
 
 admin_business_entities_search:
   path: /
   methods: [ POST ]
   defaults:
-    _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
-    _legacy_controller: AdminBusinessEntities
-    gridDefinitionFactoryServiceId: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BusinessEntityGridDefinitionFactory
-    redirectRoute: admin_business_entities_list
+    _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::searchAction
 
 admin_business_entities_view:
   path: /{businessEntityId}/view
   methods: [ GET ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::viewAction
-    _legacy_controller: AdminBusinessEntities
+    _parent: admin_business_entities_list
   requirements:
     businessEntityId: \d+
 
@@ -28,4 +24,4 @@ admin_business_entities_create:
   methods: [ GET, POST ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::createAction
-    _legacy_controller: AdminBusinessEntities
+    _parent: admin_business_entities_list

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/business_entities.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/business_entities.yml
@@ -4,7 +4,6 @@ admin_business_entities_list:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::listAction
     _legacy_controller: AdminBusinessEntities
-    _legacy_link: AdminBusinessEntities
 
 admin_business_entities_search:
   path: /
@@ -12,7 +11,6 @@ admin_business_entities_search:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
     _legacy_controller: AdminBusinessEntities
-    _legacy_link: AdminBusinessEntities:submitFilterbusiness_entity
     gridDefinitionFactoryServiceId: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BusinessEntityGridDefinitionFactory
     redirectRoute: admin_business_entities_list
 
@@ -22,9 +20,6 @@ admin_business_entities_view:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::viewAction
     _legacy_controller: AdminBusinessEntities
-    _legacy_link: AdminBusinessEntities:viewbusiness_entity
-    _legacy_parameters:
-      id_business_entity: businessEntityId
   requirements:
     businessEntityId: \d+
 
@@ -34,4 +29,3 @@ admin_business_entities_create:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::createAction
     _legacy_controller: AdminBusinessEntities
-    _legacy_link: AdminBusinessEntities:addbusiness_entity

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/customer_b2b.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/customer_b2b.yml
@@ -3,4 +3,3 @@ admin_customer_b2b_list:
   methods: [ GET ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerB2b\CustomerB2bController::listAction
-    _legacy_controller: AdminCustomersB2B

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/customer_b2b.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/customer_b2b.yml
@@ -3,3 +3,5 @@ admin_customer_b2b_list:
   methods: [ GET ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerB2b\CustomerB2bController::listAction
+    _legacy_controller: AdminCustomersB2B
+    _legacy_link: AdminCustomersB2B

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/customer_b2b.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/customer_b2b.yml
@@ -4,4 +4,3 @@ admin_customer_b2b_list:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerB2b\CustomerB2bController::listAction
     _legacy_controller: AdminCustomersB2B
-    _legacy_link: AdminCustomersB2B

--- a/src/PrestaShopBundle/Resources/config/services/adapter/business_entity.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/business_entity.yml
@@ -1,5 +1,19 @@
 services:
   _defaults:
+    public: false
     autoconfigure: true
     autowire: true
   PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler\AddBusinessEntityHandler: ~
+
+  PrestaShop\PrestaShop\Adapter\BusinessEntity\Address\BusinessEntityAddressFormatter: ~
+
+  PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler\GetBusinessEntityForViewingHandler:
+    arguments:
+      $addressFormatter: '@PrestaShop\PrestaShop\Adapter\BusinessEntity\Address\BusinessEntityAddressFormatter'
+
+  PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler\GetPendingBusinessEntitiesCountHandler: ~
+
+  PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository\BusinessEntityAddressRepository:
+    arguments:
+      $connection: '@doctrine.dbal.default_connection'
+      $dbPrefix: '%database_prefix%'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/business_entity.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/business_entity.yml
@@ -1,6 +1,5 @@
 services:
   _defaults:
-    public: false
     autoconfigure: true
     autowire: true
   PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler\AddBusinessEntityHandler: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -571,3 +571,10 @@ services:
     arguments:
       $searchCriteriaApplicator: '@prestashop.core.query.doctrine_search_criteria_applicator'
       $languageContext: '@PrestaShop\PrestaShop\Core\Context\LanguageContext'
+
+  PrestaShop\PrestaShop\Core\Grid\Query\BusinessEntityQueryBuilder:
+    parent: 'prestashop.core.grid.abstract_query_builder'
+    public: false
+    arguments:
+      $searchCriteriaApplicator: '@prestashop.core.query.doctrine_search_criteria_applicator'
+      $shopContext: '@PrestaShop\PrestaShop\Core\Context\ShopContext'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -755,3 +755,16 @@ services:
       - '@prestashop.core.hook.dispatcher'
       - '@prestashop.core.grid.query.doctrine_query_parser'
       - 'quick_access'
+
+  prestashop.core.grid.data.factory.business_entity:
+    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Grid\Query\BusinessEntityQueryBuilder'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.core.grid.query.doctrine_query_parser'
+      - 'business_entity'
+
+  PrestaShop\PrestaShop\Core\Grid\Data\Factory\BusinessEntityGridDataFactory:
+    arguments:
+      - '@prestashop.core.grid.data.factory.business_entity'
+      - '@translator'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -511,6 +511,11 @@ services:
     autowire: true
     public: true
 
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BusinessEntityGridDefinitionFactory:
+    parent: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory
+    autowire: true
+    public: true
+
   # deprecated services
   # Alias for this abstract definition causes tests in vendor fail for some reason, so we stick to full definition instead
   prestashop.core.grid.definition.factory.abstract_grid_definition:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -582,3 +582,11 @@ services:
       - '@prestashop.core.grid.data_factory.quick_access'
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
+
+  prestashop.core.grid.factory.business_entity:
+    class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BusinessEntityGridDefinitionFactory'
+      - '@PrestaShop\PrestaShop\Core\Grid\Data\Factory\BusinessEntityGridDataFactory'
+      - '@prestashop.core.grid.filter.form_factory'
+      - '@prestashop.core.hook.dispatcher'

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/business_entity_customers_count_badge.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/business_entity_customers_count_badge.html.twig
@@ -1,0 +1,16 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+{#
+ # Override of the badge column content for business_entity/customers_count: the count is rendered
+ # with a leading icon, and unconditionally, because the shared badge template treats a "0" count as
+ # empty and would render nothing.
+ #}
+<div class="text-{{ column.options.alignment }}">
+  <span class="badge rounded">
+    {{ record[column.options.field] }}
+    <i class="material-icons">info</i>
+  </span>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/_address_card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/_address_card.html.twig
@@ -1,0 +1,34 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+<div class="card business-entity-view-addresses">
+  <h3 class="card-header">
+    {{ title }}
+  </h3>
+
+  <div class="card-body">
+    {% if addresses is empty %}
+      <div class="text-center">
+        <p class="text-muted">{{ emptyLabel }}</p>
+      </div>
+    {% else %}
+      {% for address in addresses %}
+        <div class="business-entity-view-address{% if not loop.first %} mt-3{% endif %}">
+          <div class="business-entity-view-address__title">
+            <strong>{{ address.alias ?: 'Address'|trans({}, 'Admin.Global') }}</strong>
+            {% if address.default %}
+              <span class="badge business-entity-view-address__default-badge">
+                {{ 'Default'|trans({}, 'Admin.Global') }}
+              </span>
+            {% endif %}
+          </div>
+          {% for line in address.formattedAddress|split('\n') %}
+            <p class="mb-0">{{ line }}</p>
+          {% endfor %}
+        </div>
+      {% endfor %}
+    {% endif %}
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/_status_badge.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/_status_badge.html.twig
@@ -1,0 +1,13 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+{% set badgeType = {
+  active: 'success',
+  pending: 'info',
+  inactive: 'light-info',
+  rejected: 'danger',
+}[businessEntity.status]|default('') %}
+
+<span class="badge rounded badge-{{ badgeType }}{{ extraClass is defined ? ' ' ~ extraClass }}">{{ businessEntity.statusLabel }}</span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/_status_badge.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/_status_badge.html.twig
@@ -3,11 +3,4 @@
  # docs/licenses/LICENSE.txt file that was distributed with this source code.
  #}
 
-{% set badgeType = {
-  active: 'success',
-  pending: 'info',
-  inactive: 'light-info',
-  rejected: 'danger',
-}[businessEntity.status]|default('') %}
-
-<span class="badge rounded badge-{{ badgeType }}{{ extraClass is defined ? ' ' ~ extraClass }}">{{ businessEntity.statusLabel }}</span>
+<span class="badge rounded badge-{{ businessEntity.status.badgeType }}{{ extraClass is defined ? ' ' ~ extraClass }}">{{ businessEntity.statusLabel }}</span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/billing_address.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/billing_address.html.twig
@@ -1,0 +1,10 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+{{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/_address_card.html.twig', {
+  addresses: businessEntity.invoiceAddresses,
+  title: 'Billing address'|trans({}, 'Admin.Orderscustomers.Feature'),
+  emptyLabel: 'No billing addresses configured'|trans({}, 'Admin.Orderscustomers.Feature'),
+}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/company_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/company_information.html.twig
@@ -1,0 +1,48 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+<div class="card business-entity-view-info">
+  <h3 class="card-header">
+    {{ 'Company information'|trans({}, 'Admin.Orderscustomers.Feature') }}
+  </h3>
+
+  <div class="card-body">
+    <div class="row">
+      <div class="col-md-4 mb-3 mb-md-0">
+        <div class="text-muted mb-2">{{ 'Name'|trans({}, 'Admin.Global') }}</div>
+        <div><strong>{{ businessEntity.name }}</strong></div>
+      </div>
+      <div class="col-md-4 mb-3 mb-md-0">
+        <div class="text-muted mb-2">{{ 'Legal name'|trans({}, 'Admin.Orderscustomers.Feature') }}</div>
+        <div><strong>{{ businessEntity.legalName ?: 'N/A'|trans({}, 'Admin.Global') }}</strong></div>
+      </div>
+    </div>
+
+    {% set identifiers = businessEntity.identifiers %}
+    {% if identifiers is not empty %}
+      <hr>
+      <div class="row">
+        {% for identifier in identifiers %}
+          <div class="col-md-4 mb-3">
+            <div class="text-muted mb-2">{{ identifier.label }}</div>
+            <div><strong>{{ identifier.value ?: 'N/A'|trans({}, 'Admin.Global') }}</strong></div>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <hr>
+    <div class="row">
+      <div class="col-md-4 mb-3 mb-md-0">
+        <div class="text-muted mb-2">{{ 'Status'|trans({}, 'Admin.Global') }}</div>
+        <div>{{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/_status_badge.html.twig') }}</div>
+      </div>
+      <div class="col-md-4 mb-3 mb-md-0">
+        <div class="text-muted mb-2">{{ 'Customer group'|trans({}, 'Admin.Orderscustomers.Feature') }}</div>
+        <div><strong>{{ businessEntity.customerGroupName ?: 'N/A'|trans({}, 'Admin.Global') }}</strong></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/company_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/company_information.html.twig
@@ -40,7 +40,7 @@
         <div>{{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/_status_badge.html.twig') }}</div>
       </div>
       <div class="col-md-4 mb-3 mb-md-0">
-        <div class="text-muted mb-2">{{ 'Customer group'|trans({}, 'Admin.Orderscustomers.Feature') }}</div>
+        <div class="text-muted mb-2">{{ 'Customer group'|trans({}, 'Admin.Shopparameters.Feature') }}</div>
         <div><strong>{{ businessEntity.customerGroupName ?: 'N/A'|trans({}, 'Admin.Global') }}</strong></div>
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/company_summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/company_summary.html.twig
@@ -1,0 +1,52 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+{% set linkedCustomers = businessEntity.linkedCustomersCount %}
+{% set addressesCount = businessEntity.addressesCount %}
+
+<div class="card business-entity-view-summary">
+  <div class="card-body">
+    <div class="business-entity-view-summary__block business-entity-view-summary__block--customers">
+      <i class="material-icons">people</i>
+      <div class="business-entity-view-summary__text">
+        <div class="business-entity-view-summary__value">{{ linkedCustomers }}</div>
+        <div class="business-entity-view-summary__label">
+          {{ (linkedCustomers != 1
+            ? 'linked customers'|trans({}, 'Admin.Orderscustomers.Feature')
+            : 'linked customer'|trans({}, 'Admin.Orderscustomers.Feature')) }}
+        </div>
+      </div>
+    </div>
+
+    <div class="business-entity-view-summary__block business-entity-view-summary__block--addresses">
+      <i class="material-icons">location_on</i>
+      <div class="business-entity-view-summary__text">
+        <div class="business-entity-view-summary__value">{{ addressesCount }}</div>
+        <div class="business-entity-view-summary__label">
+          {{ (addressesCount != 1
+            ? 'addresses'|trans({}, 'Admin.Orderscustomers.Feature')
+            : 'address'|trans({}, 'Admin.Orderscustomers.Feature')) }}
+        </div>
+      </div>
+    </div>
+
+    <hr>
+
+    <div class="business-entity-view-summary__meta">
+      <div class="business-entity-view-summary__meta-line">
+        <i class="material-icons">schedule</i>
+        <span>
+          {{ 'Created on'|trans({}, 'Admin.Global') }} {{ businessEntity.createdAt|date_format_full }}
+        </span>
+      </div>
+      <div class="business-entity-view-summary__meta-line">
+        <i class="material-icons">update</i>
+        <span>
+          {{ 'Updated on'|trans({}, 'Admin.Orderscustomers.Feature') }} {{ businessEntity.updatedAt|date_format_full }}
+        </span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/company_summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/company_summary.html.twig
@@ -13,9 +13,7 @@
       <div class="business-entity-view-summary__text">
         <div class="business-entity-view-summary__value">{{ linkedCustomers }}</div>
         <div class="business-entity-view-summary__label">
-          {{ (linkedCustomers != 1
-            ? 'linked customers'|trans({}, 'Admin.Orderscustomers.Feature')
-            : 'linked customer'|trans({}, 'Admin.Orderscustomers.Feature')) }}
+          {{ 'linked customer(s)'|trans({}, 'Admin.Orderscustomers.Feature') }}
         </div>
       </div>
     </div>
@@ -25,9 +23,7 @@
       <div class="business-entity-view-summary__text">
         <div class="business-entity-view-summary__value">{{ addressesCount }}</div>
         <div class="business-entity-view-summary__label">
-          {{ (addressesCount != 1
-            ? 'addresses'|trans({}, 'Admin.Orderscustomers.Feature')
-            : 'address'|trans({}, 'Admin.Orderscustomers.Feature')) }}
+          {{ 'address(es)'|trans({}, 'Admin.Orderscustomers.Feature') }}
         </div>
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/header.html.twig
@@ -1,0 +1,22 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+<div class="business-entity-view-header">
+  <div class="business-entity-view-header__main">
+    <div class="business-entity-view-avatar" aria-hidden="true">
+      {{ businessEntity.initials }}
+    </div>
+    <div class="business-entity-view-header__titles">
+      <h1 class="business-entity-view-header__name">{{ businessEntity.name }}</h1>
+      {% if businessEntity.legalName %}
+        <div class="business-entity-view-header__legal-name">{{ businessEntity.legalName }}</div>
+      {% endif %}
+    </div>
+    <span class="business-entity-view-header__divider" aria-hidden="true"></span>
+    {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/_status_badge.html.twig', {
+      extraClass: 'business-entity-view-header__status',
+    }) }}
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/linked_customers.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/linked_customers.html.twig
@@ -1,0 +1,21 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+<div class="card business-entity-linked-customers">
+  <h3 class="card-header">
+    {{ 'Linked B2B customers'|trans({}, 'Admin.Orderscustomers.Feature') }}
+    <span class="badge rounded business-entity-linked-customers__count">{{ businessEntity.linkedCustomersCount }}</span>
+  </h3>
+
+  <div class="card-body">
+    <div class="text-center">
+      {% if businessEntity.linkedCustomersCount > 0 %}
+        <p class="text-muted">{{ 'The list of linked customers is not available yet.'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
+      {% else %}
+        <p class="text-muted">{{ 'No customer linked yet.'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/shipping_address.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/View/shipping_address.html.twig
@@ -1,0 +1,10 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+{{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/_address_card.html.twig', {
+  addresses: businessEntity.deliveryAddresses,
+  title: 'Shipping address'|trans({}, 'Admin.Orderscustomers.Feature'),
+  emptyLabel: 'No shipping addresses configured'|trans({}, 'Admin.Orderscustomers.Feature'),
+}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/form.html.twig
@@ -66,7 +66,7 @@
     <h3 class="card-header d-flex justify-content-between">
       <span>
         <i class="material-icons">place</i>
-        {{ 'Billing address'|trans({}, 'Admin.Global') }}
+        {{ 'Billing address'|trans({}, 'Admin.Orderscustomers.Feature') }}
       </span>
 
       <button type="button" id="add_business_entity_billing_address" class="btn btn-outline-secondary"
@@ -101,7 +101,7 @@
     <h3 class="card-header d-flex justify-content-between">
       <span>
         <i class="material-icons">place</i>
-        {{ 'Shipping address'|trans({}, 'Admin.Global') }}
+        {{ 'Shipping address'|trans({}, 'Admin.Orderscustomers.Feature') }}
       </span>
 
       <button type="button" id="add_business_entity_shipping_address"

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/list.html.twig
@@ -5,5 +5,38 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-{# empty for now #}
+
+  {% if pendingCount > 0 %}
+    <div class="alert alert-info business-entity-pending-banner" role="alert">
+      <div class="business-entity-pending-banner__content">
+        <div class="business-entity-pending-banner__text">
+          <p class="alert-text business-entity-pending-banner__title mb-1">
+            <strong>{{ 'Pending validation(s).'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+          </p>
+          <p class="alert-text mb-0">
+            {% if pendingCount == 1 %}
+              {{ 'There is %pendingCount% business entity waiting for validation.'|trans({'%pendingCount%': pendingCount}, 'Admin.Orderscustomers.Feature') }}
+            {% else %}
+              {{ 'There are %pendingCount% business entities waiting for validation.'|trans({'%pendingCount%': pendingCount}, 'Admin.Orderscustomers.Feature') }}
+            {% endif %}
+          </p>
+        </div>
+        {% if not isPendingFilter %}
+          <a class="btn btn-outline-primary business-entity-pending-banner__btn" href="{{ pendingUrl }}">
+            {{ 'Review pending'|trans({}, 'Admin.Orderscustomers.Feature') }}
+          </a>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+
+  {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {grid: businessEntityGrid}) }}
+
+{% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+
+  <script src="{{ asset('themes/new-theme/public/business_entity.bundle.js') }}"></script>
+  <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/view.html.twig
@@ -1,0 +1,36 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% block pageTitle %}
+  {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/header.html.twig') }}
+{% endblock %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-md-8 mb-3 mb-md-0">
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/company_information.html.twig') }}
+    </div>
+
+    <div class="col-md-4">
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/company_summary.html.twig') }}
+    </div>
+  </div>
+
+  <div class="row mt-3">
+    <div class="col-md-6 mb-3 mb-md-0">
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/billing_address.html.twig') }}
+    </div>
+
+    <div class="col-md-6">
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/shipping_address.html.twig') }}
+    </div>
+  </div>
+
+  <div class="row mt-3">
+    <div class="col">
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/linked_customers.html.twig') }}
+    </div>
+  </div>
+{% endblock %}

--- a/tests/Integration/Behaviour/Features/Context/Domain/BusinessEntityFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/BusinessEntityFeatureContext.php
@@ -272,7 +272,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
             Assert::assertSame($data['legal_name'], $viewed->getLegalName());
         }
         if (isset($data['status'])) {
-            Assert::assertSame($data['status'], $viewed->getStatus());
+            Assert::assertSame(BusinessEntityStatus::from($data['status']), $viewed->getStatus());
         }
         if (isset($data['linked_customers_count'])) {
             Assert::assertSame((int) $data['linked_customers_count'], $viewed->getLinkedCustomersCount());

--- a/tests/Integration/Behaviour/Features/Context/Domain/BusinessEntityFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/BusinessEntityFeatureContext.php
@@ -10,29 +10,65 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Address;
 use Behat\Gherkin\Node\TableNode;
+use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\AddBusinessEntityCommand;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetPendingBusinessEntitiesCount;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\AddressForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\BusinessEntityForViewing;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityBillingAddress;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityId;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityShippingAddress;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShopBundle\Entity\B2B\B2bRole;
 use PrestaShopBundle\Entity\B2B\BusinessEntity;
 use PrestaShopBundle\Entity\B2B\BusinessEntityAddress;
+use PrestaShopBundle\Entity\B2B\BusinessEntityCustomerB2b;
+use PrestaShopBundle\Entity\B2B\CustomerB2b;
 use PrestaShopBundle\Entity\Enum\AddressTypeEnum;
 use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use PrestaShopBundle\Entity\Enum\CustomerB2bStatus;
+use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Validate;
 
 class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
 {
+    private const DEFAULT_SHOP_ID = 1;
+    private const DEFAULT_CUSTOMER_GROUP_ID = 3;
+    private const DEFAULT_COUNTRY_ID = 8;
+
+    /**
+     * Offset kept above the fixture customers so each linked CustomerB2b gets a distinct
+     * id_customer (unique index) without colliding with them.
+     */
+    private const FIRST_LINKED_CUSTOMER_ID = 1000;
+
     private array $businessEntityDetails = [];
     private array $billingAddresses = [];
     private array $shippingAddresses = [];
     private ?BusinessEntityId $lastBusinessEntityId;
+    private int $linkedCustomerSequence = 0;
+
+    /**
+     * @BeforeScenario
+     */
+    public function setUpDefaultShopContext(): void
+    {
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = CommonFeatureContext::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(self::DEFAULT_SHOP_ID));
+        $shopContextBuilder->setShopId(self::DEFAULT_SHOP_ID);
+    }
 
     /**
      * @Given there is a business entity with the following details:
      */
-    public function thereIsABusinessEntityWithFollowingDetails(TableNode $table)
+    public function thereIsABusinessEntityWithFollowingDetails(TableNode $table): void
     {
         $this->businessEntityDetails = $table->getRowsHash();
     }
@@ -40,7 +76,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Given the business entity has the following billing addresses:
      */
-    public function businessEntityHasFollowingBillingAddresses(TableNode $table)
+    public function businessEntityHasFollowingBillingAddresses(TableNode $table): void
     {
         foreach ($table->getHash() as $row) {
             $this->billingAddresses[] = new BusinessEntityBillingAddress(
@@ -61,7 +97,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Given the business entity has the following shipping addresses:
      */
-    public function businessEntityHasFollowingShippingAddresses(TableNode $table)
+    public function businessEntityHasFollowingShippingAddresses(TableNode $table): void
     {
         foreach ($table->getHash() as $row) {
             $this->shippingAddresses[] = new BusinessEntityShippingAddress(
@@ -82,7 +118,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @When I add the business entity
      */
-    public function iAddTheBusinessEntity()
+    public function iAddTheBusinessEntity(): void
     {
         $command = new AddBusinessEntityCommand(
             $this->businessEntityDetails['name'],
@@ -90,8 +126,8 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
             $this->businessEntityDetails['external_ref'] ?? null,
             (bool) ($this->businessEntityDetails['delivery_authorized'] ?? true),
             BusinessEntityStatus::from($this->businessEntityDetails['status']),
-            (int) ($this->businessEntityDetails['shop_id'] ?? 1),
-            (int) ($this->businessEntityDetails['customer_group_id'] ?? 3),
+            (int) ($this->businessEntityDetails['shop_id'] ?? self::DEFAULT_SHOP_ID),
+            (int) ($this->businessEntityDetails['customer_group_id'] ?? self::DEFAULT_CUSTOMER_GROUP_ID),
             (bool) ($this->businessEntityDetails['billing_as_shipping'] ?? false),
             $this->billingAddresses,
             $this->shippingAddresses
@@ -107,7 +143,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then the business entity should be successfully created
      */
-    public function businessEntityShouldBeSuccessfullyCreated()
+    public function businessEntityShouldBeSuccessfullyCreated(): void
     {
         Assert::assertNotNull($this->lastBusinessEntityId, 'Business entity was not created');
     }
@@ -115,7 +151,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then the business entity :name should exist in the database
      */
-    public function businessEntityShouldExistInDatabase(string $name)
+    public function businessEntityShouldExistInDatabase(string $name): void
     {
         // TODO: use CQRS when it will be available
         $entityManager = $this->getContainer()->get('doctrine.orm.entity_manager');
@@ -135,7 +171,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then the business entity :name should belong to customer group :groupId
      */
-    public function businessEntityShouldBelongToCustomerGroup(string $name, int $groupId)
+    public function businessEntityShouldBelongToCustomerGroup(string $name, int $groupId): void
     {
         $businessEntity = $this->getBusinessEntityByName($name);
         Assert::assertSame(
@@ -148,7 +184,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then the business entity :name should be attached to shop :shopId
      */
-    public function businessEntityShouldBeAttachedToShop(string $name, int $shopId)
+    public function businessEntityShouldBeAttachedToShop(string $name, int $shopId): void
     {
         $businessEntity = $this->getBusinessEntityByName($name);
         Assert::assertSame(
@@ -161,7 +197,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then the business entity :name should have :count address(es)
      */
-    public function businessEntityShouldHaveCountAddresses(string $name, int $count)
+    public function businessEntityShouldHaveCountAddresses(string $name, int $count): void
     {
         $businessEntity = $this->getBusinessEntityByName($name);
         Assert::assertCount($count, $businessEntity->getBusinessEntityAddresses());
@@ -170,7 +206,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then the address with alias :alias for business entity :name should have type :type
      */
-    public function addressWithAliasShouldHaveType(string $alias, string $name, string $type)
+    public function addressWithAliasShouldHaveType(string $alias, string $name, string $type): void
     {
         $businessEntityAddress = $this->getBusinessEntityAddressByAlias($name, $alias);
         Assert::assertEquals(AddressTypeEnum::from($type), $businessEntityAddress->getAddressType());
@@ -179,7 +215,7 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then the address with alias :alias for business entity :name should have type :type and be default
      */
-    public function addressWithAliasShouldHaveTypeAndBeDefault(string $alias, string $name, string $type)
+    public function addressWithAliasShouldHaveTypeAndBeDefault(string $alias, string $name, string $type): void
     {
         $businessEntityAddress = $this->getBusinessEntityAddressByAlias($name, $alias);
         Assert::assertEquals(AddressTypeEnum::from($type), $businessEntityAddress->getAddressType());
@@ -195,6 +231,227 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
         $address = new Address($businessEntityAddress->getAddressId());
         Assert::assertEquals($phone, $address->phone);
         Assert::assertEquals($mobile, $address->phone_mobile);
+    }
+
+    /**
+     * @When the address with alias :alias for business entity :name is soft deleted
+     */
+    public function softDeleteAddressWithAlias(string $alias, string $name): void
+    {
+        $businessEntityAddress = $this->getBusinessEntityAddressByAlias($name, $alias);
+
+        $address = new Address($businessEntityAddress->getAddressId());
+        $address->deleted = true;
+        $address->save();
+    }
+
+    /**
+     * @When I view the business entity with id :businessEntityId
+     */
+    public function iViewTheBusinessEntityWithId(int $businessEntityId): void
+    {
+        try {
+            $this->getQueryBus()->handle(new GetBusinessEntityForViewing($businessEntityId));
+        } catch (BusinessEntityException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then the business entity :name should have the following view properties:
+     */
+    public function businessEntityShouldHaveViewProperties(string $name, TableNode $tableNode): void
+    {
+        $viewed = $this->getBusinessEntityForViewingByName($name);
+        $data = $tableNode->getRowsHash();
+
+        if (isset($data['name'])) {
+            Assert::assertSame($data['name'], $viewed->getName());
+        }
+        if (isset($data['legal_name'])) {
+            Assert::assertSame($data['legal_name'], $viewed->getLegalName());
+        }
+        if (isset($data['status'])) {
+            Assert::assertSame($data['status'], $viewed->getStatus());
+        }
+        if (isset($data['linked_customers_count'])) {
+            Assert::assertSame((int) $data['linked_customers_count'], $viewed->getLinkedCustomersCount());
+        }
+        if (isset($data['addresses_count'])) {
+            Assert::assertSame((int) $data['addresses_count'], $viewed->getAddressesCount());
+        }
+        if (isset($data['customer_group_name'])) {
+            Assert::assertSame($data['customer_group_name'], $viewed->getCustomerGroupName());
+        }
+    }
+
+    /**
+     * @Then the business entity :name should have created and updated timestamps
+     */
+    public function businessEntityShouldHaveTimestamps(string $name): void
+    {
+        $viewed = $this->getBusinessEntityForViewingByName($name);
+
+        // The entity was just created by the scenario, so both timestamps must carry a real recent
+        // date and not merely look like one.
+        Assert::assertGreaterThan(new DateTimeImmutable('-1 hour'), $viewed->getCreatedAt());
+        Assert::assertLessThanOrEqual(new DateTimeImmutable('+1 minute'), $viewed->getCreatedAt());
+        Assert::assertGreaterThanOrEqual($viewed->getCreatedAt(), $viewed->getUpdatedAt());
+    }
+
+    /**
+     * @Then the business entity :name should have :count billing address(es)
+     */
+    public function businessEntityShouldHaveBillingAddresses(string $name, int $count): void
+    {
+        $viewed = $this->getBusinessEntityForViewingByName($name);
+        Assert::assertCount($count, $viewed->getInvoiceAddresses());
+    }
+
+    /**
+     * @Then the business entity :name should have :count shipping address(es)
+     */
+    public function businessEntityShouldHaveShippingAddresses(string $name, int $count): void
+    {
+        $viewed = $this->getBusinessEntityForViewingByName($name);
+        Assert::assertCount($count, $viewed->getDeliveryAddresses());
+    }
+
+    /**
+     * @Then the business entity :name :type address :alias formatted address should contain :value
+     */
+    public function businessEntityAddressFormattedAddressShouldContain(string $name, string $type, string $alias, string $value): void
+    {
+        Assert::assertStringContainsString($value, $this->getFormattedAddress($name, $type, $alias));
+    }
+
+    /**
+     * The formatted address must never expose the placeholder the creation handler stores in the
+     * legacy firstname/lastname columns: it is what the formatter's "avoid" rules exist for.
+     *
+     * @Then the business entity :name :type address :alias formatted address should not contain :value
+     */
+    public function businessEntityAddressFormattedAddressShouldNotContain(string $name, string $type, string $alias, string $value): void
+    {
+        Assert::assertStringNotContainsString($value, $this->getFormattedAddress($name, $type, $alias));
+    }
+
+    /**
+     * @Then the first :type address of business entity :name should be :alias
+     */
+    public function firstAddressOfTypeShouldBe(string $type, string $name, string $alias): void
+    {
+        $addresses = $this->getViewedAddressesByType($name, $type);
+
+        Assert::assertNotEmpty($addresses, sprintf('Business entity "%s" has no %s address', $name, $type));
+        Assert::assertSame(
+            $alias,
+            $addresses[0]->getAlias(),
+            sprintf('The default %s address of business entity "%s" is not listed first', $type, $name)
+        );
+    }
+
+    private function getFormattedAddress(string $name, string $type, string $alias): string
+    {
+        foreach ($this->getViewedAddressesByType($name, $type) as $address) {
+            if ($address->getAlias() === $alias) {
+                return $address->getFormattedAddress();
+            }
+        }
+
+        Assert::fail(sprintf('No %s address with alias "%s" for business entity "%s"', $type, $alias, $name));
+    }
+
+    /**
+     * @return AddressForViewing[]
+     */
+    private function getViewedAddressesByType(string $name, string $type): array
+    {
+        $viewed = $this->getBusinessEntityForViewingByName($name);
+
+        return AddressTypeEnum::DELIVERY->value === $type
+            ? $viewed->getDeliveryAddresses()
+            : $viewed->getInvoiceAddresses();
+    }
+
+    /**
+     * @Then I should get an error that the business entity was not found
+     */
+    public function assertLastErrorIsBusinessEntityNotFound(): void
+    {
+        $this->assertLastErrorIs(BusinessEntityNotFoundException::class);
+    }
+
+    /**
+     * @Given there is a business entity named :name with status :status
+     */
+    public function thereIsABusinessEntityNamedWithStatus(string $name, string $status): void
+    {
+        $command = new AddBusinessEntityCommand(
+            $name,
+            $name . ' Legal',
+            null,
+            true,
+            BusinessEntityStatus::from($status),
+            self::DEFAULT_SHOP_ID,
+            self::DEFAULT_CUSTOMER_GROUP_ID,
+            true,
+            [new BusinessEntityBillingAddress('Billing', '1 Main St', null, 'Paris', '75001', self::DEFAULT_COUNTRY_ID, true, null)],
+            []
+        );
+
+        $this->getCommandBus()->handle($command);
+    }
+
+    /**
+     * @Given the business entity :name is linked to :count b2b customers
+     */
+    public function businessEntityIsLinkedToB2bCustomers(string $name, int $count): void
+    {
+        $entityManager = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $businessEntity = $this->getBusinessEntityByName($name);
+
+        $role = new B2bRole();
+        $role->setRole(sprintf('behat-member-%d-%d', $businessEntity->getId(), ++$this->linkedCustomerSequence));
+        $entityManager->persist($role);
+
+        for ($i = 1; $i <= $count; ++$i) {
+            $customerB2b = new CustomerB2b();
+            // ps_customer_b2b carries a unique index on id_customer and the tables are only restored
+            // @BeforeFeature, so the ids have to stay distinct across every call of this step —
+            // including two calls on the same business entity.
+            $customerB2b->setIdCustomer(self::FIRST_LINKED_CUSTOMER_ID + ++$this->linkedCustomerSequence);
+            $customerB2b->setStatus(CustomerB2bStatus::ACTIVE);
+            $customerB2b->setCreatedAt(new DateTime());
+            $customerB2b->setUpdatedAt(new DateTime());
+            $entityManager->persist($customerB2b);
+
+            $link = new BusinessEntityCustomerB2b();
+            $link->setBusinessEntity($businessEntity);
+            $link->setCustomerB2b($customerB2b);
+            $link->setB2bRole($role);
+            $link->setCreatedAt(new DateTime());
+            $link->setUpdatedAt(new DateTime());
+            $entityManager->persist($link);
+        }
+
+        $entityManager->flush();
+    }
+
+    /**
+     * @Then the pending business entities count should be :count
+     */
+    public function thePendingBusinessEntitiesCountShouldBe(int $count): void
+    {
+        $actual = $this->getQueryBus()->handle(new GetPendingBusinessEntitiesCount());
+        Assert::assertSame($count, $actual);
+    }
+
+    private function getBusinessEntityForViewingByName(string $name): BusinessEntityForViewing
+    {
+        $businessEntityId = $this->getBusinessEntityByName($name)->getId();
+
+        return $this->getQueryBus()->handle(new GetBusinessEntityForViewing($businessEntityId));
     }
 
     private function getBusinessEntityByName(string $name): BusinessEntity

--- a/tests/Integration/Behaviour/Features/Scenario/BusinessEntity/business_entity_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/BusinessEntity/business_entity_management.feature
@@ -1,10 +1,10 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s business_entity --tags business-entity-management
 @restore-all-tables-before-feature
 @business-entity-management
-Feature: Add business entity
+Feature: Manage business entities
   In order to manage B2B entities
   As a BO user
-  I need to be able to add a new business entity
+  I need to be able to add, view and list business entities
 
   Scenario: Add a new business entity with billing address used as shipping address
     Given there is a business entity with the following details:
@@ -79,3 +79,107 @@ Feature: Add business entity
     Then the business entity should be successfully created
     And the business entity "Phone Entity" should exist in the database
     And the address with alias "Billing" for business entity "Phone Entity" should have phone "0102030405" and mobile phone "0611223344"
+
+  Scenario: View a business entity splits its addresses into billing and shipping and resolves the country
+    Given there is a business entity with the following details:
+      | name                | Viewable Entity      |
+      | legal_name          | Viewable Legal Name  |
+      | external_ref        | EXT-006              |
+      | delivery_authorized | 1                    |
+      | status              | active               |
+      | billing_as_shipping | 0                    |
+    And the business entity has the following billing addresses:
+      | alias   | address1       | city  | postcode | country_id | is_default |
+      | Billing | 456 Invoice St | Lyon  | 69001    | 8          | 1          |
+    And the business entity has the following shipping addresses:
+      | alias    | address1        | city      | postcode | country_id | is_default |
+      | Shipping | 789 Delivery Rd | Marseille | 13001    | 8          | 1          |
+    When I add the business entity
+    Then the business entity "Viewable Entity" should have the following view properties:
+      | name                | Viewable Entity     |
+      | legal_name          | Viewable Legal Name |
+      | status              | active              |
+      | addresses_count     | 2                   |
+      | customer_group_name | Customer            |
+    And the business entity "Viewable Entity" should have created and updated timestamps
+    And the business entity "Viewable Entity" should have 1 billing address
+    And the business entity "Viewable Entity" should have 1 shipping address
+    And the business entity "Viewable Entity" "invoice" address "Billing" formatted address should contain "France"
+    And the business entity "Viewable Entity" "invoice" address "Billing" formatted address should contain "Lyon"
+    And the business entity "Viewable Entity" "invoice" address "Billing" formatted address should not contain "business-entity"
+    And the business entity "Viewable Entity" "delivery" address "Shipping" formatted address should contain "Marseille"
+    And the business entity "Viewable Entity" "delivery" address "Shipping" formatted address should not contain "business-entity"
+
+  Scenario: A billing address also used for shipping is counted once in the summary
+    Given there is a business entity with the following details:
+      | name                | Shared Address Entity |
+      | legal_name          | Shared Legal Name     |
+      | external_ref        | EXT-005               |
+      | delivery_authorized | 1                     |
+      | status              | active                |
+      | billing_as_shipping | 1                     |
+    And the business entity has the following billing addresses:
+      | alias   | address1     | city  | postcode | country_id | is_default |
+      | Billing | 1 Shared St  | Paris | 75001    | 8          | 1          |
+    When I add the business entity
+    Then the business entity "Shared Address Entity" should have 1 billing address
+    And the business entity "Shared Address Entity" should have 1 shipping address
+    And the business entity "Shared Address Entity" should have the following view properties:
+      | addresses_count | 1 |
+
+  Scenario: A soft-deleted address is no longer exposed by the business entity view
+    Given there is a business entity with the following details:
+      | name                | Deleted Address Entity |
+      | legal_name          | Deleted Legal Name     |
+      | external_ref        | EXT-007                |
+      | delivery_authorized | 1                      |
+      | status              | active                 |
+      | billing_as_shipping | 0                      |
+    And the business entity has the following billing addresses:
+      | alias    | address1      | city | postcode | country_id | is_default |
+      | Billing  | 1 Kept St     | Lyon | 69001    | 8          | 1          |
+      | Obsolete | 2 Obsolete St | Lyon | 69002    | 8          | 0          |
+    And the business entity has the following shipping addresses:
+      | alias    | address1        | city      | postcode | country_id | is_default |
+      | Shipping | 789 Delivery Rd | Marseille | 13001    | 8          | 1          |
+    When I add the business entity
+    And the address with alias "Obsolete" for business entity "Deleted Address Entity" is soft deleted
+    Then the business entity "Deleted Address Entity" should have 1 billing address
+    And the business entity "Deleted Address Entity" should have 1 shipping address
+    And the business entity "Deleted Address Entity" should have the following view properties:
+      | addresses_count | 2 |
+
+  Scenario: The default address is listed first whatever the creation order
+    Given there is a business entity with the following details:
+      | name                | Ordered Address Entity |
+      | legal_name          | Ordered Legal Name     |
+      | external_ref        | EXT-008                |
+      | delivery_authorized | 1                      |
+      | status              | active                 |
+      | billing_as_shipping | 0                      |
+    And the business entity has the following billing addresses:
+      | alias     | address1       | city | postcode | country_id | is_default |
+      | Secondary | 1 Secondary St | Lyon | 69001    | 8          | 0          |
+      | Main      | 2 Main St      | Lyon | 69002    | 8          | 1          |
+    And the business entity has the following shipping addresses:
+      | alias    | address1        | city      | postcode | country_id | is_default |
+      | Shipping | 789 Delivery Rd | Marseille | 13001    | 8          | 1          |
+    When I add the business entity
+    Then the business entity "Ordered Address Entity" should have 2 billing addresses
+    And the first "invoice" address of business entity "Ordered Address Entity" should be "Main"
+
+  Scenario: Viewing a business entity that does not exist raises a not found error
+    When I view the business entity with id 999999
+    Then I should get an error that the business entity was not found
+
+  Scenario: The summary counts the b2b customers linked to the business entity
+    Given there is a business entity named "Linked Entity" with status "active"
+    And the business entity "Linked Entity" is linked to 2 b2b customers
+    Then the business entity "Linked Entity" should have the following view properties:
+      | linked_customers_count | 2 |
+
+  Scenario: The pending count reflects only business entities awaiting validation
+    Given there is a business entity named "Pending Alpha" with status "pending"
+    And there is a business entity named "Pending Beta" with status "pending"
+    And there is a business entity named "Active Gamma" with status "active"
+    Then the pending business entities count should be 2

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/BusinessEntity/BusinessEntityControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/BusinessEntity/BusinessEntityControllerTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Controller\Sell\BusinessEntity;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\AddBusinessEntityCommand;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityBillingAddress;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use Symfony\Component\DomCrawler\Crawler;
+use Tests\Integration\PrestaShopBundle\Controller\GridControllerTestCase;
+use Tests\Integration\PrestaShopBundle\Controller\TestEntityDTO;
+use Tests\Resources\Resetter\BusinessEntityResetter;
+
+class BusinessEntityControllerTest extends GridControllerTestCase
+{
+    private const DEFAULT_SHOP_ID = 1;
+    private const DEFAULT_CUSTOMER_GROUP_ID = 1;
+    private const DEFAULT_COUNTRY_ID = 8;
+
+    private const ACTIVE_COMPANY_NAME = 'Grid active company';
+    private const PENDING_COMPANY_NAME = 'Grid pending company';
+
+    private static int $activeBusinessEntityId;
+
+    private static int $pendingBusinessEntityId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        BusinessEntityResetter::resetBusinessEntities();
+
+        $commandBus = self::bootKernel()->getContainer()->get('prestashop.core.command_bus');
+        self::$activeBusinessEntityId = self::createBusinessEntity(
+            $commandBus,
+            self::ACTIVE_COMPANY_NAME,
+            'Grid active legal name',
+            BusinessEntityStatus::ACTIVE
+        );
+        self::$pendingBusinessEntityId = self::createBusinessEntity(
+            $commandBus,
+            self::PENDING_COMPANY_NAME,
+            'Grid pending legal name',
+            BusinessEntityStatus::PENDING
+        );
+        self::ensureKernelShutdown();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        BusinessEntityResetter::resetBusinessEntities();
+    }
+
+    public function testIndex(): void
+    {
+        $businessEntities = $this->getEntitiesFromGrid();
+
+        $this->assertCount(2, $businessEntities);
+        $this->assertCollectionContainsEntity($businessEntities, self::$activeBusinessEntityId);
+        $this->assertCollectionContainsEntity($businessEntities, self::$pendingBusinessEntityId);
+    }
+
+    /**
+     * @depends testIndex
+     */
+    public function testFilters(): void
+    {
+        $testCases = [
+            [
+                ['business_entity[id_business_entity]' => self::$activeBusinessEntityId],
+                self::$activeBusinessEntityId,
+            ],
+            [
+                ['business_entity[name]' => self::PENDING_COMPANY_NAME],
+                self::$pendingBusinessEntityId,
+            ],
+            [
+                ['business_entity[legal_name]' => 'Grid active legal name'],
+                self::$activeBusinessEntityId,
+            ],
+            [
+                ['business_entity[status]' => BusinessEntityStatus::ACTIVE->value],
+                self::$activeBusinessEntityId,
+            ],
+        ];
+
+        foreach ($testCases as [$testFilter, $expectedBusinessEntityId]) {
+            $this->resetGridFilters();
+            $businessEntities = $this->getFilteredEntitiesFromGrid($testFilter);
+            $this->assertCount(1, $businessEntities, sprintf(
+                'Expected exactly one business entity with filters %s',
+                var_export($testFilter, true)
+            ));
+            $this->assertCollectionContainsEntity($businessEntities, $expectedBusinessEntityId);
+        }
+
+        $this->resetGridFilters();
+        $this->assertEmpty($this->getFilteredEntitiesFromGrid([
+            'business_entity[name]' => 'No business entity bears this name',
+        ]));
+
+        $this->resetGridFilters();
+    }
+
+    private static function createBusinessEntity(
+        CommandBusInterface $commandBus,
+        string $name,
+        string $legalName,
+        BusinessEntityStatus $status
+    ): int {
+        $businessEntityId = $commandBus->handle(new AddBusinessEntityCommand(
+            $name,
+            $legalName,
+            null,
+            true,
+            $status,
+            self::DEFAULT_SHOP_ID,
+            self::DEFAULT_CUSTOMER_GROUP_ID,
+            true,
+            [
+                new BusinessEntityBillingAddress(
+                    'Billing',
+                    '123 Main St',
+                    null,
+                    'Paris',
+                    '75001',
+                    self::DEFAULT_COUNTRY_ID,
+                    true,
+                    null
+                ),
+            ]
+        ));
+
+        return $businessEntityId->getValue();
+    }
+
+    protected function getFilterSearchButtonSelector(): string
+    {
+        return 'business_entity[actions][search]';
+    }
+
+    protected function generateGridUrl(array $routeParams = []): string
+    {
+        if (empty($routeParams)) {
+            $routeParams = [
+                'business_entity[offset]' => 0,
+                'business_entity[limit]' => 100,
+            ];
+        }
+
+        return $this->router->generate('admin_business_entities_list', $routeParams);
+    }
+
+    protected function getGridSelector(): string
+    {
+        return '#business_entity_grid_table';
+    }
+
+    protected function parseEntityFromRow(Crawler $tr, int $i): TestEntityDTO
+    {
+        return new TestEntityDTO(
+            (int) trim($tr->filter('.column-id_business_entity')->text()),
+            []
+        );
+    }
+}

--- a/tests/Resources/Resetter/BusinessEntityResetter.php
+++ b/tests/Resources/Resetter/BusinessEntityResetter.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Resources\Resetter;
+
+use Tests\Resources\DatabaseDump;
+
+class BusinessEntityResetter
+{
+    public static function resetBusinessEntities(): void
+    {
+        DatabaseDump::restoreTables([
+            'address',
+            'business_entity',
+            'business_entity_address',
+            'business_entity_customer_b2b',
+            'business_entity_identifier',
+        ]);
+    }
+}

--- a/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandlerTest.php
+++ b/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandlerTest.php
@@ -10,19 +10,23 @@ namespace Tests\Unit\Adapter\BusinessEntity\QueryHandler;
 
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
+use Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler\GetBusinessEntityForViewingHandler;
 use PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository\BusinessEntityAddressRepository;
-use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+use PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository\BusinessEntityAddressRow;
+use PrestaShop\PrestaShop\Adapter\Customer\Group\Repository\GroupRepository;
 use PrestaShop\PrestaShop\Core\Address\AddressFormatterInterface;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Exception\GroupNotFoundException;
 use PrestaShopBundle\Entity\B2B\BusinessEntity;
 use PrestaShopBundle\Entity\B2B\BusinessEntityIdentifier;
 use PrestaShopBundle\Entity\B2B\BusinessIdentifier;
+use PrestaShopBundle\Entity\Enum\AddressTypeEnum;
 use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -40,7 +44,7 @@ class GetBusinessEntityForViewingHandlerTest extends TestCase
         $handler = new GetBusinessEntityForViewingHandler(
             $repository,
             $this->createMock(BusinessEntityAddressRepository::class),
-            $this->createMock(GroupDataProvider::class),
+            $this->createMock(GroupRepository::class),
             $this->getMockLanguageContext(),
             $this->getMockShopContext(false, [2, 3]),
             $this->createMock(AddressFormatterInterface::class),
@@ -63,14 +67,16 @@ class GetBusinessEntityForViewingHandlerTest extends TestCase
         $addressRepository = $this->createMock(BusinessEntityAddressRepository::class);
         $addressRepository->method('getAddresses')->willReturn([]);
 
-        $groupDataProvider = $this->createMock(GroupDataProvider::class);
-        // Customer group 99 is absent from the returned groups -> the handler must fall back to ''.
-        $groupDataProvider->method('getGroups')->willReturn([['id_group' => 1, 'name' => 'Visitor']]);
+        // The schema has no foreign key and deleting a customer group never cleans up
+        // business_entity, so a merchant can delete group 99 in three clicks and leave this entity
+        // pointing at nothing. The handler must fall back to '' rather than 500 the detail page.
+        $groupRepository = $this->createMock(GroupRepository::class);
+        $groupRepository->method('get')->willThrowException(new GroupNotFoundException());
 
         $handler = new GetBusinessEntityForViewingHandler(
             $repository,
             $addressRepository,
-            $groupDataProvider,
+            $groupRepository,
             $this->getMockLanguageContext(),
             $this->getMockShopContext(true),
             $this->createMock(AddressFormatterInterface::class),
@@ -81,11 +87,42 @@ class GetBusinessEntityForViewingHandlerTest extends TestCase
 
         $this->assertSame('', $result->getCustomerGroupName());
         $this->assertSame('Acme', $result->getName());
-        $this->assertSame('active', $result->getStatus());
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $result->getStatus());
         $this->assertSame('Active', $result->getStatusLabel());
         $this->assertSame('2026-01-01 10:00:00', $result->getCreatedAt()->format('Y-m-d H:i:s'));
         $this->assertSame(0, $result->getAddressesCount());
         $this->assertSame(4, $result->getLinkedCustomersCount(), 'AC11 summary count must reach the DTO');
+    }
+
+    public function testItFallsBackToAnEmptyCustomerGroupNameWhenTheGroupHasNoNameInTheCurrentLanguage(): void
+    {
+        // A group that exists but was created before the current language was installed has no
+        // group_lang row for it, so the multilang array has no entry for that language id. This is
+        // NOT covered by the GroupNotFoundException catch: the group is found, its name is not.
+        $entity = $this->getMockBusinessEntity();
+        $entity->method('getBusinessEntityIdentifiers')->willReturn(new ArrayCollection());
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($entity);
+        $repository->method('getLinkedCustomersCount')->willReturn(0);
+
+        $addressRepository = $this->createMock(BusinessEntityAddressRepository::class);
+        $addressRepository->method('getAddresses')->willReturn([]);
+
+        $handler = new GetBusinessEntityForViewingHandler(
+            $repository,
+            $addressRepository,
+            // Language 1 is the context language; the group only has a name for language 2.
+            $this->getMockGroupRepository(null, [2 => 'Grossistes']),
+            $this->getMockLanguageContext(),
+            $this->getMockShopContext(true),
+            $this->createMock(AddressFormatterInterface::class),
+            $this->getMockTranslator()
+        );
+
+        $result = $handler->handle(new GetBusinessEntityForViewing(5));
+
+        $this->assertSame('', $result->getCustomerGroupName());
     }
 
     public function testItMapsTheDefaultFlagAndSplitsAddressesByTypeWithoutCountingTheSharedOneTwice(): void
@@ -100,20 +137,16 @@ class GetBusinessEntityForViewingHandlerTest extends TestCase
         $repository->method('findById')->willReturn($entity);
         $repository->method('getLinkedCustomersCount')->willReturn(0);
 
-        // Keys and order mirror what BusinessEntityAddressRepository::getAddresses() selects.
         $addressRepository = $this->createMock(BusinessEntityAddressRepository::class);
         $addressRepository->method('getAddresses')->willReturn([
-            ['id_address' => 10, 'alias' => 'HQ', 'address_type' => 'both', 'is_default' => '1'],
-            ['id_address' => 11, 'alias' => 'Warehouse', 'address_type' => 'delivery', 'is_default' => '0'],
+            new BusinessEntityAddressRow(10, 'HQ', AddressTypeEnum::BOTH, true),
+            new BusinessEntityAddressRow(11, 'Warehouse', AddressTypeEnum::DELIVERY, false),
         ]);
-
-        $groupDataProvider = $this->createMock(GroupDataProvider::class);
-        $groupDataProvider->method('getGroups')->willReturn([['id_group' => 99, 'name' => 'Customers B2B']]);
 
         $handler = new GetBusinessEntityForViewingHandler(
             $repository,
             $addressRepository,
-            $groupDataProvider,
+            $this->getMockGroupRepository('Customers B2B'),
             $this->getMockLanguageContext(),
             $this->getMockShopContext(true),
             $this->createMock(AddressFormatterInterface::class),
@@ -158,13 +191,10 @@ class GetBusinessEntityForViewingHandlerTest extends TestCase
         $addressRepository = $this->createMock(BusinessEntityAddressRepository::class);
         $addressRepository->method('getAddresses')->willReturn([]);
 
-        $groupDataProvider = $this->createMock(GroupDataProvider::class);
-        $groupDataProvider->method('getGroups')->willReturn([['id_group' => 99, 'name' => 'Customers B2B']]);
-
         $handler = new GetBusinessEntityForViewingHandler(
             $repository,
             $addressRepository,
-            $groupDataProvider,
+            $this->getMockGroupRepository('Customers B2B'),
             $this->getMockLanguageContext(),
             $this->getMockShopContext(true),
             $this->createMock(AddressFormatterInterface::class),
@@ -213,6 +243,23 @@ class GetBusinessEntityForViewingHandlerTest extends TestCase
         $businessEntityIdentifier->method('getValue')->willReturn($value);
 
         return $businessEntityIdentifier;
+    }
+
+    /**
+     * GroupRepository::get() returns the legacy ObjectModel, loaded without a language, so its
+     * multilang name is an array keyed by language id.
+     *
+     * @param array<int, string>|null $namePerLanguage
+     */
+    private function getMockGroupRepository(?string $name, ?array $namePerLanguage = null): GroupRepository
+    {
+        $group = $this->createMock(Group::class);
+        $group->name = $namePerLanguage ?? [1 => $name];
+
+        $repository = $this->createMock(GroupRepository::class);
+        $repository->method('get')->willReturn($group);
+
+        return $repository;
     }
 
     private function getMockTranslator(): TranslatorInterface

--- a/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandlerTest.php
+++ b/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForViewingHandlerTest.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\BusinessEntity\QueryHandler;
+
+use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler\GetBusinessEntityForViewingHandler;
+use PrestaShop\PrestaShop\Adapter\BusinessEntity\Repository\BusinessEntityAddressRepository;
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+use PrestaShop\PrestaShop\Core\Address\AddressFormatterInterface;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForViewing;
+use PrestaShopBundle\Entity\B2B\BusinessEntity;
+use PrestaShopBundle\Entity\B2B\BusinessEntityIdentifier;
+use PrestaShopBundle\Entity\B2B\BusinessIdentifier;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class GetBusinessEntityForViewingHandlerTest extends TestCase
+{
+    public function testItThrowsNotFoundScopedToTheCurrentShopContext(): void
+    {
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->expects($this->once())
+            ->method('findById')
+            ->with(999, [2, 3])
+            ->willReturn(null);
+
+        $handler = new GetBusinessEntityForViewingHandler(
+            $repository,
+            $this->createMock(BusinessEntityAddressRepository::class),
+            $this->createMock(GroupDataProvider::class),
+            $this->getMockLanguageContext(),
+            $this->getMockShopContext(false, [2, 3]),
+            $this->createMock(AddressFormatterInterface::class),
+            $this->getMockTranslator()
+        );
+
+        $this->expectException(BusinessEntityNotFoundException::class);
+        $handler->handle(new GetBusinessEntityForViewing(999));
+    }
+
+    public function testItFallsBackToAnEmptyCustomerGroupNameWhenTheGroupIsNotFound(): void
+    {
+        $entity = $this->getMockBusinessEntity();
+        $entity->method('getBusinessEntityIdentifiers')->willReturn(new ArrayCollection());
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($entity);
+        $repository->method('getLinkedCustomersCount')->willReturn(4);
+
+        $addressRepository = $this->createMock(BusinessEntityAddressRepository::class);
+        $addressRepository->method('getAddresses')->willReturn([]);
+
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        // Customer group 99 is absent from the returned groups -> the handler must fall back to ''.
+        $groupDataProvider->method('getGroups')->willReturn([['id_group' => 1, 'name' => 'Visitor']]);
+
+        $handler = new GetBusinessEntityForViewingHandler(
+            $repository,
+            $addressRepository,
+            $groupDataProvider,
+            $this->getMockLanguageContext(),
+            $this->getMockShopContext(true),
+            $this->createMock(AddressFormatterInterface::class),
+            $this->getMockTranslator()
+        );
+
+        $result = $handler->handle(new GetBusinessEntityForViewing(5));
+
+        $this->assertSame('', $result->getCustomerGroupName());
+        $this->assertSame('Acme', $result->getName());
+        $this->assertSame('active', $result->getStatus());
+        $this->assertSame('Active', $result->getStatusLabel());
+        $this->assertSame('2026-01-01 10:00:00', $result->getCreatedAt()->format('Y-m-d H:i:s'));
+        $this->assertSame(0, $result->getAddressesCount());
+        $this->assertSame(4, $result->getLinkedCustomersCount(), 'AC11 summary count must reach the DTO');
+    }
+
+    public function testItMapsTheDefaultFlagAndSplitsAddressesByTypeWithoutCountingTheSharedOneTwice(): void
+    {
+        // AC10 asks for the billing address "with default indicator if applicable": the is_default
+        // column must reach AddressForViewing::isDefault(), which is what the Default badge of
+        // _address_card.html.twig renders. A "both" address belongs to the two lists but counts once.
+        $entity = $this->getMockBusinessEntity();
+        $entity->method('getBusinessEntityIdentifiers')->willReturn(new ArrayCollection());
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($entity);
+        $repository->method('getLinkedCustomersCount')->willReturn(0);
+
+        // Keys and order mirror what BusinessEntityAddressRepository::getAddresses() selects.
+        $addressRepository = $this->createMock(BusinessEntityAddressRepository::class);
+        $addressRepository->method('getAddresses')->willReturn([
+            ['id_address' => 10, 'alias' => 'HQ', 'address_type' => 'both', 'is_default' => '1'],
+            ['id_address' => 11, 'alias' => 'Warehouse', 'address_type' => 'delivery', 'is_default' => '0'],
+        ]);
+
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider->method('getGroups')->willReturn([['id_group' => 99, 'name' => 'Customers B2B']]);
+
+        $handler = new GetBusinessEntityForViewingHandler(
+            $repository,
+            $addressRepository,
+            $groupDataProvider,
+            $this->getMockLanguageContext(),
+            $this->getMockShopContext(true),
+            $this->createMock(AddressFormatterInterface::class),
+            $this->getMockTranslator()
+        );
+
+        $result = $handler->handle(new GetBusinessEntityForViewing(5));
+
+        $invoiceAddresses = $result->getInvoiceAddresses();
+        $this->assertCount(1, $invoiceAddresses, 'a "both" address is a billing address too');
+        $this->assertSame(10, $invoiceAddresses[0]->getAddressId());
+        $this->assertSame('HQ', $invoiceAddresses[0]->getAlias());
+        $this->assertTrue($invoiceAddresses[0]->isDefault(), 'AC10 default indicator must reach the DTO');
+
+        $deliveryAddresses = $result->getDeliveryAddresses();
+        $this->assertCount(2, $deliveryAddresses, 'the "both" address is also a shipping address');
+        $this->assertSame([10, 11], array_map(
+            static fn ($address): int => $address->getAddressId(),
+            $deliveryAddresses
+        ));
+        $this->assertFalse($deliveryAddresses[1]->isDefault(), 'a non-default address must not be flagged');
+
+        $this->assertSame(2, $result->getAddressesCount(), 'AC11 counts distinct addresses, not links');
+    }
+
+    public function testItSkipsDeletedIdentifierTypesAndOrdersTheRemainingOnesById(): void
+    {
+        // mapIdentifiers() feeds the "Company information" section: a deleted identifier type must
+        // never surface, and the display order must be deterministic (ksort) whatever the
+        // collection order.
+        $entity = $this->getMockBusinessEntity();
+        $entity->method('getBusinessEntityIdentifiers')->willReturn(new ArrayCollection([
+            $this->buildIdentifier(3, 'DUNS', '123456789', false),
+            $this->buildIdentifier(1, 'VAT number', 'FR123', false),
+            $this->buildIdentifier(2, 'Retired scheme', 'X', true),
+        ]));
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($entity);
+        $repository->method('getLinkedCustomersCount')->willReturn(0);
+
+        $addressRepository = $this->createMock(BusinessEntityAddressRepository::class);
+        $addressRepository->method('getAddresses')->willReturn([]);
+
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider->method('getGroups')->willReturn([['id_group' => 99, 'name' => 'Customers B2B']]);
+
+        $handler = new GetBusinessEntityForViewingHandler(
+            $repository,
+            $addressRepository,
+            $groupDataProvider,
+            $this->getMockLanguageContext(),
+            $this->getMockShopContext(true),
+            $this->createMock(AddressFormatterInterface::class),
+            $this->getMockTranslator()
+        );
+
+        $identifiers = $handler->handle(new GetBusinessEntityForViewing(5))->getIdentifiers();
+
+        $this->assertCount(2, $identifiers, 'the deleted identifier type must be skipped');
+        $this->assertSame([1, 3], array_map(
+            static fn ($identifier): int => $identifier->getBusinessIdentifierId(),
+            $identifiers
+        ));
+        $this->assertSame('VAT number', $identifiers[0]->getLabel());
+        $this->assertSame('FR123', $identifiers[0]->getValue());
+    }
+
+    /**
+     * @return BusinessEntity&MockObject
+     */
+    private function getMockBusinessEntity(): BusinessEntity
+    {
+        $entity = $this->createMock(BusinessEntity::class);
+        $entity->method('getId')->willReturn(5);
+        $entity->method('getExternalRef')->willReturn(null);
+        $entity->method('getName')->willReturn('Acme');
+        $entity->method('getLegalName')->willReturn(null);
+        $entity->method('isDeliveryAuthorized')->willReturn(true);
+        $entity->method('getStatus')->willReturn(BusinessEntityStatus::ACTIVE);
+        $entity->method('getCreatedAt')->willReturn(new DateTime('2026-01-01 10:00:00'));
+        $entity->method('getUpdatedAt')->willReturn(new DateTime('2026-01-02 11:00:00'));
+        $entity->method('getIdCustomerGroup')->willReturn(99);
+
+        return $entity;
+    }
+
+    private function buildIdentifier(int $id, string $label, string $value, bool $isDeleted): BusinessEntityIdentifier
+    {
+        $businessIdentifier = $this->createMock(BusinessIdentifier::class);
+        $businessIdentifier->method('getId')->willReturn($id);
+        $businessIdentifier->method('getLabel')->willReturn($label);
+        $businessIdentifier->method('isDeleted')->willReturn($isDeleted);
+
+        $businessEntityIdentifier = $this->createMock(BusinessEntityIdentifier::class);
+        $businessEntityIdentifier->method('getBusinessIdentifier')->willReturn($businessIdentifier);
+        $businessEntityIdentifier->method('getValue')->willReturn($value);
+
+        return $businessEntityIdentifier;
+    }
+
+    private function getMockTranslator(): TranslatorInterface
+    {
+        $mock = $this->createMock(TranslatorInterface::class);
+        $mock->method('trans')->willReturnCallback(static fn (string $id): string => $id);
+
+        return $mock;
+    }
+
+    private function getMockLanguageContext(): LanguageContext
+    {
+        $mock = $this->createMock(LanguageContext::class);
+        $mock->method('getId')->willReturn(1);
+
+        return $mock;
+    }
+
+    private function getMockShopContext(bool $isAllShop, array $associatedShopIds = []): ShopContext
+    {
+        $mock = $this->createMock(ShopContext::class);
+        $mock->method('isAllShopContext')->willReturn($isAllShop);
+        $mock->method('getAssociatedShopIds')->willReturn($associatedShopIds);
+
+        return $mock;
+    }
+}

--- a/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetPendingBusinessEntitiesCountHandlerTest.php
+++ b/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetPendingBusinessEntitiesCountHandlerTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\BusinessEntity\QueryHandler;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler\GetPendingBusinessEntitiesCountHandler;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetPendingBusinessEntitiesCount;
+use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
+
+class GetPendingBusinessEntitiesCountHandlerTest extends TestCase
+{
+    public function testItCountsAcrossAllShopsInAllShopContext(): void
+    {
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->expects($this->once())
+            ->method('getPendingCount')
+            ->with(null)
+            ->willReturn(5);
+
+        $handler = new GetPendingBusinessEntitiesCountHandler(
+            $repository,
+            $this->getMockShopContext(true)
+        );
+
+        $this->assertSame(5, $handler->handle(new GetPendingBusinessEntitiesCount()));
+    }
+
+    public function testItScopesToAssociatedShopsOutsideAllShopContext(): void
+    {
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->expects($this->once())
+            ->method('getPendingCount')
+            ->with([1, 2])
+            ->willReturn(3);
+
+        $handler = new GetPendingBusinessEntitiesCountHandler(
+            $repository,
+            $this->getMockShopContext(false, [1, 2])
+        );
+
+        $this->assertSame(3, $handler->handle(new GetPendingBusinessEntitiesCount()));
+    }
+
+    private function getMockShopContext(bool $isAllShop, array $associatedShopIds = []): ShopContext
+    {
+        $mock = $this->createMock(ShopContext::class);
+        $mock->method('isAllShopContext')->willReturn($isAllShop);
+        $mock->method('getAssociatedShopIds')->willReturn($associatedShopIds);
+
+        return $mock;
+    }
+}

--- a/tests/Unit/Core/Domain/BusinessEntity/QueryResult/AddressForViewingTest.php
+++ b/tests/Unit/Core/Domain/BusinessEntity/QueryResult/AddressForViewingTest.php
@@ -10,6 +10,7 @@ namespace Tests\Unit\Core\Domain\BusinessEntity\QueryResult;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\AddressForViewing;
+use PrestaShopBundle\Entity\Enum\AddressTypeEnum;
 
 class AddressForViewingTest extends TestCase
 {
@@ -19,14 +20,14 @@ class AddressForViewingTest extends TestCase
             12,
             'Warehouse',
             "Tan Emporium SAS\n1 Place des Ternes\n75017 Paris\nFrance",
-            'both',
+            AddressTypeEnum::BOTH,
             true,
         );
 
         $this->assertSame(12, $address->getAddressId());
         $this->assertSame('Warehouse', $address->getAlias());
         $this->assertSame("Tan Emporium SAS\n1 Place des Ternes\n75017 Paris\nFrance", $address->getFormattedAddress());
-        $this->assertSame('both', $address->getAddressType());
+        $this->assertSame(AddressTypeEnum::BOTH, $address->getAddressType());
         $this->assertTrue($address->isDefault());
     }
 
@@ -36,7 +37,7 @@ class AddressForViewingTest extends TestCase
             1,
             'Billing',
             "123 Main St\nNew York, New York 10001\nUnited States",
-            'invoice',
+            AddressTypeEnum::INVOICE,
             false,
         );
 
@@ -44,7 +45,7 @@ class AddressForViewingTest extends TestCase
             ['123 Main St', 'New York, New York 10001', 'United States'],
             explode("\n", $address->getFormattedAddress())
         );
-        $this->assertSame('invoice', $address->getAddressType());
+        $this->assertSame(AddressTypeEnum::INVOICE, $address->getAddressType());
         $this->assertFalse($address->isDefault());
     }
 }

--- a/tests/Unit/Core/Domain/BusinessEntity/QueryResult/AddressForViewingTest.php
+++ b/tests/Unit/Core/Domain/BusinessEntity/QueryResult/AddressForViewingTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\BusinessEntity\QueryResult;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\AddressForViewing;
+
+class AddressForViewingTest extends TestCase
+{
+    public function testItExposesAllConstructorParamsViaGetters(): void
+    {
+        $address = new AddressForViewing(
+            12,
+            'Warehouse',
+            "Tan Emporium SAS\n1 Place des Ternes\n75017 Paris\nFrance",
+            'both',
+            true,
+        );
+
+        $this->assertSame(12, $address->getAddressId());
+        $this->assertSame('Warehouse', $address->getAlias());
+        $this->assertSame("Tan Emporium SAS\n1 Place des Ternes\n75017 Paris\nFrance", $address->getFormattedAddress());
+        $this->assertSame('both', $address->getAddressType());
+        $this->assertTrue($address->isDefault());
+    }
+
+    public function testItKeepsTheFormattedAddressLineBreaksForRendering(): void
+    {
+        $address = new AddressForViewing(
+            1,
+            'Billing',
+            "123 Main St\nNew York, New York 10001\nUnited States",
+            'invoice',
+            false,
+        );
+
+        $this->assertSame(
+            ['123 Main St', 'New York, New York 10001', 'United States'],
+            explode("\n", $address->getFormattedAddress())
+        );
+        $this->assertSame('invoice', $address->getAddressType());
+        $this->assertFalse($address->isDefault());
+    }
+}

--- a/tests/Unit/Core/Domain/BusinessEntity/QueryResult/BusinessEntityForViewingTest.php
+++ b/tests/Unit/Core/Domain/BusinessEntity/QueryResult/BusinessEntityForViewingTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\BusinessEntity\QueryResult;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\AddressForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\BusinessEntityForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\IdentifierForViewing;
+
+class BusinessEntityForViewingTest extends TestCase
+{
+    public function testItExposesAllConstructorParamsViaGetters(): void
+    {
+        $invoice = [$this->buildAddress(1, 'invoice', true)];
+        $delivery = [$this->buildAddress(2, 'delivery', false)];
+        $identifiers = [new IdentifierForViewing(7, 'VAT number', 'FR123')];
+
+        $businessEntity = new BusinessEntityForViewing(
+            10,
+            'EXT-1',
+            'Tan Emporium',
+            'Tan Emporium SAS',
+            true,
+            'active',
+            'Active',
+            new DateTimeImmutable('2026-01-01 10:00:00'),
+            new DateTimeImmutable('2026-02-02 11:00:00'),
+            3,
+            2,
+            5,
+            'Customers B2B',
+            $invoice,
+            $delivery,
+            $identifiers,
+        );
+
+        $this->assertSame(10, $businessEntity->getBusinessEntityId());
+        $this->assertSame('EXT-1', $businessEntity->getExternalRef());
+        $this->assertSame('Tan Emporium', $businessEntity->getName());
+        $this->assertSame('Tan Emporium SAS', $businessEntity->getLegalName());
+        $this->assertTrue($businessEntity->isDeliveryAuthorized());
+        $this->assertSame('active', $businessEntity->getStatus());
+        $this->assertSame('Active', $businessEntity->getStatusLabel());
+        $this->assertSame('2026-01-01 10:00:00', $businessEntity->getCreatedAt()->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-02-02 11:00:00', $businessEntity->getUpdatedAt()->format('Y-m-d H:i:s'));
+        $this->assertSame(3, $businessEntity->getLinkedCustomersCount());
+        $this->assertSame(2, $businessEntity->getAddressesCount());
+        $this->assertSame(5, $businessEntity->getCustomerGroupId());
+        $this->assertSame('Customers B2B', $businessEntity->getCustomerGroupName());
+        $this->assertSame($invoice, $businessEntity->getInvoiceAddresses());
+        $this->assertSame($delivery, $businessEntity->getDeliveryAddresses());
+        $this->assertSame($identifiers, $businessEntity->getIdentifiers());
+    }
+
+    public function testItAcceptsNullableExternalRefAndLegalName(): void
+    {
+        $businessEntity = new BusinessEntityForViewing(
+            10,
+            null,
+            'Tan Emporium',
+            null,
+            true,
+            'active',
+            'Active',
+            new DateTimeImmutable('2026-01-01 10:00:00'),
+            new DateTimeImmutable('2026-02-02 11:00:00'),
+            3,
+            2,
+            5,
+            'Customers B2B',
+            [],
+            [],
+            [],
+        );
+
+        $this->assertNull($businessEntity->getExternalRef());
+        $this->assertNull($businessEntity->getLegalName());
+    }
+
+    /**
+     * @dataProvider provideNamesAndInitials
+     */
+    public function testItDerivesUpToTwoUppercaseInitialsFromTheName(string $name, string $expected): void
+    {
+        $businessEntity = $this->buildBusinessEntity($name);
+
+        $this->assertSame($expected, $businessEntity->getInitials());
+    }
+
+    public function provideNamesAndInitials(): iterable
+    {
+        yield 'two words' => ['Tan Emporium', 'TE'];
+        yield 'single word' => ['Acme', 'A'];
+        yield 'more than two words keeps the first two' => ['Tan Emporium And Co', 'TE'];
+        yield 'extra spaces are ignored' => ['  Tan   Emporium  ', 'TE'];
+        yield 'already uppercase' => ['ACME CORP', 'AC'];
+        yield 'multibyte name is uppercased safely' => ['éclair ölsen', 'ÉÖ'];
+    }
+
+    private function buildBusinessEntity(string $name): BusinessEntityForViewing
+    {
+        return new BusinessEntityForViewing(
+            10,
+            null,
+            $name,
+            null,
+            true,
+            'active',
+            'Active',
+            new DateTimeImmutable('2026-01-01 10:00:00'),
+            new DateTimeImmutable('2026-02-02 11:00:00'),
+            0,
+            0,
+            5,
+            'Customers B2B',
+            [],
+            [],
+            [],
+        );
+    }
+
+    private function buildAddress(int $id, string $type, bool $isDefault): AddressForViewing
+    {
+        return new AddressForViewing(
+            $id,
+            'Alias',
+            "Company\n1 Street\n75000 Paris\nFrance",
+            $type,
+            $isDefault,
+        );
+    }
+}

--- a/tests/Unit/Core/Domain/BusinessEntity/QueryResult/BusinessEntityForViewingTest.php
+++ b/tests/Unit/Core/Domain/BusinessEntity/QueryResult/BusinessEntityForViewingTest.php
@@ -13,13 +13,15 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\AddressForViewing;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\BusinessEntityForViewing;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\IdentifierForViewing;
+use PrestaShopBundle\Entity\Enum\AddressTypeEnum;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 
 class BusinessEntityForViewingTest extends TestCase
 {
     public function testItExposesAllConstructorParamsViaGetters(): void
     {
-        $invoice = [$this->buildAddress(1, 'invoice', true)];
-        $delivery = [$this->buildAddress(2, 'delivery', false)];
+        $invoice = [$this->buildAddress(1, AddressTypeEnum::INVOICE, true)];
+        $delivery = [$this->buildAddress(2, AddressTypeEnum::DELIVERY, false)];
         $identifiers = [new IdentifierForViewing(7, 'VAT number', 'FR123')];
 
         $businessEntity = new BusinessEntityForViewing(
@@ -28,7 +30,7 @@ class BusinessEntityForViewingTest extends TestCase
             'Tan Emporium',
             'Tan Emporium SAS',
             true,
-            'active',
+            BusinessEntityStatus::ACTIVE,
             'Active',
             new DateTimeImmutable('2026-01-01 10:00:00'),
             new DateTimeImmutable('2026-02-02 11:00:00'),
@@ -46,7 +48,7 @@ class BusinessEntityForViewingTest extends TestCase
         $this->assertSame('Tan Emporium', $businessEntity->getName());
         $this->assertSame('Tan Emporium SAS', $businessEntity->getLegalName());
         $this->assertTrue($businessEntity->isDeliveryAuthorized());
-        $this->assertSame('active', $businessEntity->getStatus());
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $businessEntity->getStatus());
         $this->assertSame('Active', $businessEntity->getStatusLabel());
         $this->assertSame('2026-01-01 10:00:00', $businessEntity->getCreatedAt()->format('Y-m-d H:i:s'));
         $this->assertSame('2026-02-02 11:00:00', $businessEntity->getUpdatedAt()->format('Y-m-d H:i:s'));
@@ -67,7 +69,7 @@ class BusinessEntityForViewingTest extends TestCase
             'Tan Emporium',
             null,
             true,
-            'active',
+            BusinessEntityStatus::ACTIVE,
             'Active',
             new DateTimeImmutable('2026-01-01 10:00:00'),
             new DateTimeImmutable('2026-02-02 11:00:00'),
@@ -112,7 +114,7 @@ class BusinessEntityForViewingTest extends TestCase
             $name,
             null,
             true,
-            'active',
+            BusinessEntityStatus::ACTIVE,
             'Active',
             new DateTimeImmutable('2026-01-01 10:00:00'),
             new DateTimeImmutable('2026-02-02 11:00:00'),
@@ -126,7 +128,7 @@ class BusinessEntityForViewingTest extends TestCase
         );
     }
 
-    private function buildAddress(int $id, string $type, bool $isDefault): AddressForViewing
+    private function buildAddress(int $id, AddressTypeEnum $type, bool $isDefault): AddressForViewing
     {
         return new AddressForViewing(
             $id,

--- a/tests/Unit/Core/Domain/BusinessEntity/QueryResult/IdentifierForViewingTest.php
+++ b/tests/Unit/Core/Domain/BusinessEntity/QueryResult/IdentifierForViewingTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\BusinessEntity\QueryResult;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\IdentifierForViewing;
+
+class IdentifierForViewingTest extends TestCase
+{
+    public function testItExposesAllConstructorParamsViaGetters(): void
+    {
+        $identifier = new IdentifierForViewing(5, 'SIREN/SIRET', '123 456 789 00012');
+
+        $this->assertSame(5, $identifier->getBusinessIdentifierId());
+        $this->assertSame('SIREN/SIRET', $identifier->getLabel());
+        $this->assertSame('123 456 789 00012', $identifier->getValue());
+    }
+
+    public function testItAcceptsNullableValue(): void
+    {
+        $identifier = new IdentifierForViewing(6, 'DUNS number', null);
+
+        $this->assertSame('DUNS number', $identifier->getLabel());
+        $this->assertNull($identifier->getValue());
+    }
+}

--- a/tests/Unit/Core/Form/ChoiceProvider/BusinessEntityStatusChoiceProviderTest.php
+++ b/tests/Unit/Core/Form/ChoiceProvider/BusinessEntityStatusChoiceProviderTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\BusinessEntityStatusChoiceProvider;
+
+class BusinessEntityStatusChoiceProviderTest extends ChoiceProviderTestCase
+{
+    /**
+     * The orientation matters: ChoiceType expects label => value, and inverting it would render the
+     * raw enum values in the status filter of the grid.
+     */
+    public function testItProvidesOneTranslatedChoicePerStatus(): void
+    {
+        $choiceProvider = new BusinessEntityStatusChoiceProvider($this->mockTranslator());
+
+        $this->assertSame([
+            'Pending' => 'pending',
+            'Active' => 'active',
+            'Inactive' => 'inactive',
+            'Rejected' => 'rejected',
+        ], $choiceProvider->getChoices(), 'a new status must not be silently missing from the grid filter');
+    }
+}

--- a/tests/Unit/Core/Grid/Data/Factory/BusinessEntityGridDataFactoryTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/BusinessEntityGridDataFactoryTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Grid\Data\Factory;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Grid\Data\Factory\BusinessEntityGridDataFactory;
+use PrestaShop\PrestaShop\Core\Grid\Data\Factory\GridDataFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class BusinessEntityGridDataFactoryTest extends TestCase
+{
+    public function testItAddsTranslatedStatusLabelAndBadgeTypeToEachRecordAndKeepsRawStatus(): void
+    {
+        $records = new RecordCollection([
+            ['id_business_entity' => 1, 'status' => 'active'],
+            ['id_business_entity' => 2, 'status' => 'pending'],
+            ['id_business_entity' => 3, 'status' => 'unknown_value'],
+            ['id_business_entity' => 4, 'status' => 'inactive'],
+            ['id_business_entity' => 5, 'status' => 'rejected'],
+        ]);
+
+        $query = 'SELECT be.id_business_entity FROM ps_business_entity be';
+
+        $inner = $this->createMock(GridDataFactoryInterface::class);
+        $inner->method('getData')->willReturn(new GridData($records, 5, $query));
+
+        $data = $this->buildFactory($inner)->getData($this->createMock(SearchCriteriaInterface::class));
+        $result = iterator_to_array($data->getRecords());
+
+        $this->assertSame('Active', $result[0]['status_label']);
+        $this->assertSame('active', $result[0]['status'], 'raw status is preserved');
+        $this->assertSame('success', $result[0]['status_badge_type']);
+
+        $this->assertSame('Pending', $result[1]['status_label']);
+        $this->assertSame('info', $result[1]['status_badge_type']);
+
+        // An unknown status falls back to the raw value and no badge type rather than throwing.
+        $this->assertSame('unknown_value', $result[2]['status_label']);
+        $this->assertSame('', $result[2]['status_badge_type']);
+
+        $this->assertSame('Inactive', $result[3]['status_label']);
+        $this->assertSame('light-info', $result[3]['status_badge_type']);
+
+        $this->assertSame('Rejected', $result[4]['status_label']);
+        $this->assertSame('danger', $result[4]['status_badge_type']);
+
+        $this->assertSame(5, $data->getRecordsTotal());
+    }
+
+    public function testItForwardsTheInnerRecordsTotalAndQueryUnchanged(): void
+    {
+        $query = 'SELECT be.id_business_entity FROM ps_business_entity be WHERE be.deleted = 0';
+
+        $inner = $this->createMock(GridDataFactoryInterface::class);
+        $inner->method('getData')->willReturn(new GridData(new RecordCollection([]), 42, $query));
+
+        $data = $this->buildFactory($inner)->getData($this->createMock(SearchCriteriaInterface::class));
+
+        $this->assertSame(42, $data->getRecordsTotal());
+        $this->assertSame($query, $data->getQuery(), 'the SQL query must reach "Show SQL query" untouched');
+    }
+
+    private function buildFactory(GridDataFactoryInterface $inner): BusinessEntityGridDataFactory
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        // trans() echoes the source string so we can assert the label went through translation.
+        $translator->method('trans')->willReturnCallback(static fn (string $id): string => $id);
+
+        return new BusinessEntityGridDataFactory($inner, $translator);
+    }
+}

--- a/tests/Unit/Core/Grid/Data/Factory/BusinessEntityGridDataFactoryTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/BusinessEntityGridDataFactoryTest.php
@@ -15,6 +15,7 @@ use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use ValueError;
 
 class BusinessEntityGridDataFactoryTest extends TestCase
 {
@@ -23,15 +24,14 @@ class BusinessEntityGridDataFactoryTest extends TestCase
         $records = new RecordCollection([
             ['id_business_entity' => 1, 'status' => 'active'],
             ['id_business_entity' => 2, 'status' => 'pending'],
-            ['id_business_entity' => 3, 'status' => 'unknown_value'],
-            ['id_business_entity' => 4, 'status' => 'inactive'],
-            ['id_business_entity' => 5, 'status' => 'rejected'],
+            ['id_business_entity' => 3, 'status' => 'inactive'],
+            ['id_business_entity' => 4, 'status' => 'rejected'],
         ]);
 
         $query = 'SELECT be.id_business_entity FROM ps_business_entity be';
 
         $inner = $this->createMock(GridDataFactoryInterface::class);
-        $inner->method('getData')->willReturn(new GridData($records, 5, $query));
+        $inner->method('getData')->willReturn(new GridData($records, 4, $query));
 
         $data = $this->buildFactory($inner)->getData($this->createMock(SearchCriteriaInterface::class));
         $result = iterator_to_array($data->getRecords());
@@ -43,17 +43,30 @@ class BusinessEntityGridDataFactoryTest extends TestCase
         $this->assertSame('Pending', $result[1]['status_label']);
         $this->assertSame('info', $result[1]['status_badge_type']);
 
-        // An unknown status falls back to the raw value and no badge type rather than throwing.
-        $this->assertSame('unknown_value', $result[2]['status_label']);
-        $this->assertSame('', $result[2]['status_badge_type']);
+        $this->assertSame('Inactive', $result[2]['status_label']);
+        $this->assertSame('light-info', $result[2]['status_badge_type']);
 
-        $this->assertSame('Inactive', $result[3]['status_label']);
-        $this->assertSame('light-info', $result[3]['status_badge_type']);
+        $this->assertSame('Rejected', $result[3]['status_label']);
+        $this->assertSame('danger', $result[3]['status_badge_type']);
 
-        $this->assertSame('Rejected', $result[4]['status_label']);
-        $this->assertSame('danger', $result[4]['status_badge_type']);
+        $this->assertSame(4, $data->getRecordsTotal());
+    }
 
-        $this->assertSame(5, $data->getRecordsTotal());
+    public function testItRejectsAStatusOutsideTheEnumInsteadOfDegrading(): void
+    {
+        // The status column is an ENUM NOT NULL, so an out-of-domain value can only come from a
+        // schema/enum desync. Failing loudly is the deliberate choice: the previous tryFrom() fallback
+        // rendered an unlabelled, uncoloured badge instead of surfacing the inconsistency.
+        $records = new RecordCollection([
+            ['id_business_entity' => 1, 'status' => 'unknown_value'],
+        ]);
+
+        $inner = $this->createMock(GridDataFactoryInterface::class);
+        $inner->method('getData')->willReturn(new GridData($records, 1, 'SELECT 1'));
+
+        $this->expectException(ValueError::class);
+
+        $this->buildFactory($inner)->getData($this->createMock(SearchCriteriaInterface::class));
     }
 
     public function testItForwardsTheInnerRecordsTotalAndQueryUnchanged(): void

--- a/tests/Unit/Core/Grid/Query/BusinessEntityQueryBuilderTest.php
+++ b/tests/Unit/Core/Grid/Query/BusinessEntityQueryBuilderTest.php
@@ -1,0 +1,470 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Grid\Query\BusinessEntityQueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicatorInterface;
+use PrestaShop\PrestaShop\Core\Search\Filters\BusinessEntityFilters;
+
+class BusinessEntityQueryBuilderTest extends TestCase
+{
+    private const DB_PREFIX = 'ps_';
+
+    private function getMockConnection(): Connection
+    {
+        $mock = $this->createMock(Connection::class);
+        $mock->method('getDatabasePlatform')->willReturn(new MySQLPlatform());
+        $mock->method('createQueryBuilder')->willReturnCallback(fn () => new QueryBuilder($mock));
+
+        return $mock;
+    }
+
+    private function getMockApplicator(): DoctrineSearchCriteriaApplicatorInterface
+    {
+        $mock = $this->createMock(DoctrineSearchCriteriaApplicatorInterface::class);
+        $mock->method('applyPagination')->willReturnSelf();
+        $mock->method('applySorting')->willReturnSelf();
+        $mock->method('applyDeterministicSorting')->willReturnSelf();
+
+        return $mock;
+    }
+
+    private function getMockShopContext(bool $isAllShop, array $associatedShopIds = []): ShopContext
+    {
+        $mock = $this->createMock(ShopContext::class);
+        $mock->method('isAllShopContext')->willReturn($isAllShop);
+        $mock->method('getAssociatedShopIds')->willReturn($associatedShopIds);
+
+        return $mock;
+    }
+
+    private function createQueryBuilder(ShopContext $shopContext): BusinessEntityQueryBuilder
+    {
+        return new BusinessEntityQueryBuilder(
+            $this->getMockConnection(),
+            self::DB_PREFIX,
+            $this->getMockApplicator(),
+            $shopContext
+        );
+    }
+
+    private function getFilters(array $extraFilters = [], ?string $orderBy = null, ?string $orderWay = null): BusinessEntityFilters
+    {
+        $filters = new BusinessEntityFilters(BusinessEntityFilters::getDefaults());
+        if ([] !== $extraFilters) {
+            $filters->addFilter($extraFilters);
+        }
+        if (null !== $orderBy) {
+            $filters->set('orderBy', $orderBy);
+        }
+        if (null !== $orderWay) {
+            $filters->set('sortOrder', $orderWay);
+        }
+
+        return $filters;
+    }
+
+    public function testSearchQuerySelectsAllGridColumnFields(): void
+    {
+        // The SELECT aliases must stay aligned with the grid column `field` ids or the cells render
+        // blank. status_label is intentionally NOT selected here — it is produced downstream by
+        // BusinessEntityGridDataFactory (translated), so it must be absent from the raw SQL.
+        $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters());
+
+        $select = implode(' | ', $qb->getQueryPart('select'));
+        $this->assertStringContainsString('be.id_business_entity', $select);
+        $this->assertStringContainsString('be.name', $select);
+        $this->assertStringContainsString('be.legal_name', $select);
+        $this->assertStringContainsString('be.status', $select);
+        $this->assertStringContainsString('s.name AS shop_name', $select);
+        $this->assertStringContainsString('COUNT(DISTINCT becb.id_customer_b2b) AS customers_count', $select);
+        $this->assertStringNotContainsString('status_label', $select);
+        // Presentation constants must never be injected in the SELECT: they would leak into
+        // "Show SQL query" and "Export to SQL Manager".
+        $this->assertStringNotContainsString('badge', $select);
+    }
+
+    public function testSearchQueryAlwaysExcludesDeletedAndGroupsByEntity(): void
+    {
+        $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters());
+
+        $where = (string) $qb->getQueryPart('where');
+        $this->assertStringContainsString('be.deleted = 0', $where);
+        $this->assertSame(['be.id_business_entity'], $qb->getQueryPart('groupBy'));
+    }
+
+    public function testSearchQueryIsNotShopScopedInAllShopContext(): void
+    {
+        $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters());
+
+        $this->assertStringNotContainsString('id_shop IN', (string) $qb->getQueryPart('where'));
+        $this->assertArrayNotHasKey('beShopIds', $qb->getParameters());
+    }
+
+    public function testSearchQueryIsShopScopedOutsideAllShopContext(): void
+    {
+        $qb = $this->createQueryBuilder($this->getMockShopContext(false, [1, 2]))
+            ->getSearchQueryBuilder($this->getFilters());
+
+        $this->assertStringContainsString('be.id_shop IN (:beShopIds)', (string) $qb->getQueryPart('where'));
+        $this->assertSame([1, 2], $qb->getParameter('beShopIds'));
+        // Without the array binding type the shop ids are bound as a single scalar and the IN ()
+        // silently matches nothing: the listing comes back empty on every non-all-shop context.
+        $this->assertSame(Connection::PARAM_INT_ARRAY, $qb->getParameterTypes()['beShopIds']);
+    }
+
+    /**
+     * @dataProvider provideTextFilters
+     */
+    public function testTextFiltersAreParameterizedWithLike(string $filterName, string $value, string $expectedClause): void
+    {
+        $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters([$filterName => $value]));
+
+        $this->assertStringContainsString($expectedClause, (string) $qb->getQueryPart('where'));
+        $this->assertSame('%' . $value . '%', $qb->getParameter($filterName));
+    }
+
+    public function provideTextFilters(): iterable
+    {
+        yield 'name' => ['name', 'Acme', 'be.name LIKE :name'];
+        yield 'legal_name' => ['legal_name', 'Acme Ltd', 'be.legal_name LIKE :legal_name'];
+        yield 'shop_name' => ['shop_name', 'Main shop', 's.name LIKE :shop_name'];
+    }
+
+    public function testIdFilterIsCastToInt(): void
+    {
+        $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters(['id_business_entity' => '7']));
+
+        $this->assertStringContainsString('be.id_business_entity = :id_business_entity', (string) $qb->getQueryPart('where'));
+        $this->assertSame(7, $qb->getParameter('id_business_entity'));
+    }
+
+    public function testStatusFilterIsExactMatch(): void
+    {
+        $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters(['status' => 'pending']));
+
+        $this->assertStringContainsString('be.status = :status', (string) $qb->getQueryPart('where'));
+        $this->assertSame('pending', $qb->getParameter('status'));
+    }
+
+    /**
+     * @dataProvider provideSortableColumns
+     */
+    public function testSortingAppliesWhitelistedColumnInBothDirections(string $orderBy, string $expectedColumn): void
+    {
+        // The direction has to be asserted too: an ORDER BY frozen on ASC would satisfy a test that
+        // only looks at the column, while breaking AC4 for every descending click.
+        foreach (['asc', 'desc'] as $orderWay) {
+            $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+                ->getSearchQueryBuilder($this->getFilters([], $orderBy, $orderWay));
+
+            $this->assertSame([$expectedColumn . ' ' . $orderWay], $qb->getQueryPart('orderBy'));
+        }
+    }
+
+    public function provideSortableColumns(): iterable
+    {
+        yield 'id' => ['id_business_entity', 'be.id_business_entity'];
+        yield 'name' => ['name', 'be.`name`'];
+        yield 'legal_name' => ['legal_name', 'be.`legal_name`'];
+        yield 'status' => ['status', 'be.`status`'];
+        yield 'shop_name' => ['shop_name', 's.`name`'];
+        yield 'customers_count aggregate alias' => ['customers_count', 'customers_count'];
+    }
+
+    public function testSortingIgnoresNonWhitelistedColumn(): void
+    {
+        // A syntactically valid column that is not in the whitelist (e.g. a column the grid does
+        // not expose, or an injection attempt sneaking a real column name) must never reach ORDER BY.
+        $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters([], 'created_at'));
+
+        $this->assertEmpty($qb->getQueryPart('orderBy'));
+    }
+
+    /**
+     * @dataProvider providePercentFilters
+     */
+    public function testTextFiltersEscapePercentInLikeBinding(string $filterName, string $value, string $expectedParameter): void
+    {
+        // '%' is escaped to '\%' before being bound, so it is treated as a literal character rather
+        // than a LIKE wildcard. '_' and '\' are NOT escaped — that is the documented behaviour of
+        // AbstractDoctrineQueryBuilder::escapePercent(), shared with the rest of the core.
+        $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters([$filterName => $value]));
+
+        $this->assertSame($expectedParameter, $qb->getParameter($filterName));
+    }
+
+    public function providePercentFilters(): iterable
+    {
+        yield 'name with percent' => ['name', 'da%ta', '%da\%ta%'];
+        yield 'legal_name with percent' => ['legal_name', 'da%ta', '%da\%ta%'];
+        yield 'shop_name with percent' => ['shop_name', 'da%ta', '%da\%ta%'];
+    }
+
+    /**
+     * Pins the whole shape of the search query, not just fragments of it: a stray andWhere(), a lost
+     * join or an extra bound parameter cannot slip through an assertEquals on every query part.
+     *
+     * @dataProvider dataProviderQueryBuilder
+     *
+     * @param array<string, mixed> $filters
+     * @param int[] $shopIds
+     * @param string[] $expectedWhereParts
+     * @param array<string, mixed> $expectedParameters
+     */
+    public function testQueryBuild(
+        array $filters,
+        bool $isAllShopContext,
+        array $shopIds,
+        array $expectedWhereParts,
+        array $expectedParameters
+    ): void {
+        $qb = $this->createQueryBuilder($this->getMockShopContext($isAllShopContext, $shopIds))
+            ->getSearchQueryBuilder($this->getFilters($filters));
+
+        $this->assertEquals($this->expectedSearchQueryParts($expectedWhereParts), $qb->getQueryParts());
+        $this->assertEquals($expectedParameters, $qb->getParameters());
+    }
+
+    /**
+     * Same fixtures as testQueryBuild: the count query must filter identically, and never group or
+     * sort, or the AC8 total drifts from the listed rows.
+     *
+     * @dataProvider dataProviderQueryBuilder
+     *
+     * @param array<string, mixed> $filters
+     * @param int[] $shopIds
+     * @param string[] $expectedWhereParts
+     * @param array<string, mixed> $expectedParameters
+     */
+    public function testCountQueryBuild(
+        array $filters,
+        bool $isAllShopContext,
+        array $shopIds,
+        array $expectedWhereParts,
+        array $expectedParameters
+    ): void {
+        $qb = $this->createQueryBuilder($this->getMockShopContext($isAllShopContext, $shopIds))
+            ->getCountQueryBuilder($this->getFilters($filters));
+
+        $this->assertEquals($this->expectedCountQueryParts($expectedWhereParts), $qb->getQueryParts());
+        $this->assertEquals($expectedParameters, $qb->getParameters());
+    }
+
+    public function dataProviderQueryBuilder(): iterable
+    {
+        yield 'no filter in all shop context' => [
+            [],
+            true,
+            [],
+            ['be.deleted = 0'],
+            [],
+        ];
+
+        yield 'shop scoped, no filter' => [
+            [],
+            false,
+            [1, 2],
+            ['be.deleted = 0', 'be.id_shop IN (:beShopIds)'],
+            ['beShopIds' => [1, 2]],
+        ];
+
+        yield 'several filters compose in a single AND' => [
+            ['name' => 'acme', 'status' => 'pending'],
+            false,
+            [1, 2],
+            [
+                'be.deleted = 0',
+                'be.id_shop IN (:beShopIds)',
+                'be.name LIKE :name',
+                'be.status = :status',
+            ],
+            ['beShopIds' => [1, 2], 'name' => '%acme%', 'status' => 'pending'],
+        ];
+
+        yield 'id filter is an exact match' => [
+            ['id_business_entity' => '7'],
+            true,
+            [],
+            ['be.deleted = 0', 'be.id_business_entity = :id_business_entity'],
+            ['id_business_entity' => 7],
+        ];
+
+        // Submitting the filter row with the status placeholder on "All" sends status => '', and the
+        // untouched text inputs come back empty too. Without the blank guard those would be bound as
+        // empty values and the listing would come back empty on the most common interaction.
+        yield 'blank filter values are ignored' => [
+            ['name' => '', 'legal_name' => null, 'shop_name' => '', 'status' => '', 'id_business_entity' => ''],
+            true,
+            [],
+            ['be.deleted = 0'],
+            [],
+        ];
+    }
+
+    /**
+     * @param string[] $whereParts
+     *
+     * @return array<string, mixed>
+     */
+    private function expectedSearchQueryParts(array $whereParts): array
+    {
+        $parts = $this->expectedBaseQueryParts($whereParts);
+        // The aggregate join belongs to the search query only: the count query must not pay for it.
+        $parts['join']['be'][] = [
+            'joinType' => 'left',
+            'joinTable' => self::DB_PREFIX . 'business_entity_customer_b2b',
+            'joinAlias' => 'becb',
+            'joinCondition' => 'becb.id_business_entity = be.id_business_entity',
+        ];
+
+        return array_merge($parts, [
+            'select' => [
+                'be.id_business_entity',
+                'be.name',
+                'be.legal_name',
+                'be.status',
+                's.name AS shop_name',
+                'COUNT(DISTINCT becb.id_customer_b2b) AS customers_count',
+            ],
+            'groupBy' => ['be.id_business_entity'],
+            'orderBy' => ['be.id_business_entity asc'],
+        ]);
+    }
+
+    /**
+     * @param string[] $whereParts
+     *
+     * @return array<string, mixed>
+     */
+    private function expectedCountQueryParts(array $whereParts): array
+    {
+        return array_merge($this->expectedBaseQueryParts($whereParts), [
+            'select' => ['COUNT(DISTINCT be.id_business_entity)'],
+            'groupBy' => [],
+            'orderBy' => [],
+        ]);
+    }
+
+    /**
+     * @param string[] $whereParts
+     *
+     * @return array<string, mixed>
+     */
+    private function expectedBaseQueryParts(array $whereParts): array
+    {
+        return [
+            'select' => [],
+            'distinct' => false,
+            'from' => [
+                ['table' => self::DB_PREFIX . 'business_entity', 'alias' => 'be'],
+            ],
+            'join' => [
+                'be' => [
+                    [
+                        'joinType' => 'left',
+                        'joinTable' => self::DB_PREFIX . 'shop',
+                        'joinAlias' => 's',
+                        'joinCondition' => 's.id_shop = be.id_shop',
+                    ],
+                ],
+            ],
+            'set' => [],
+            'where' => CompositeExpression::and(...$whereParts),
+            'groupBy' => [],
+            'having' => null,
+            'orderBy' => [],
+            'values' => [],
+            'for_update' => null,
+        ];
+    }
+
+    public function testCountQueryCountsDistinctEntitiesAndIsNeverPaginated(): void
+    {
+        // Paginating the count query would cap the total at the page size (AC8 shows a wrong
+        // number of results), so the applicator must not be called at all on that builder.
+        $applicator = $this->createMock(DoctrineSearchCriteriaApplicatorInterface::class);
+        $applicator->expects($this->never())->method('applyPagination');
+
+        $queryBuilder = new BusinessEntityQueryBuilder(
+            $this->getMockConnection(),
+            self::DB_PREFIX,
+            $applicator,
+            $this->getMockShopContext(true)
+        );
+
+        $qb = $queryBuilder->getCountQueryBuilder($this->getFilters());
+
+        $this->assertSame(['COUNT(DISTINCT be.id_business_entity)'], $qb->getQueryPart('select'));
+    }
+
+    public function testSearchQueryTargetsThePrefixedTablesAndJoinsTheAggregateTable(): void
+    {
+        // Guards the aggregate wiring: dropping the becb join or mistyping a prefixed table name
+        // leaves every other assertion of this suite green while breaking the Customers column.
+        $sql = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters())
+            ->getSQL();
+
+        $this->assertStringContainsString('FROM ' . self::DB_PREFIX . 'business_entity be', $sql);
+        $this->assertStringContainsString('LEFT JOIN ' . self::DB_PREFIX . 'business_entity_customer_b2b becb', $sql);
+        $this->assertStringContainsString('becb.id_business_entity = be.id_business_entity', $sql);
+        $this->assertStringContainsString('LEFT JOIN ' . self::DB_PREFIX . 'shop s', $sql);
+        $this->assertStringContainsString('GROUP BY be.id_business_entity', $sql);
+    }
+
+    public function testCountQuerySharesTheSearchFiltersButNeverGroups(): void
+    {
+        // count and search must stay in parity: a filter applied to only one of them desyncs the
+        // pagination total from the listed rows, and a GROUP BY on the count returns one row per
+        // entity instead of the total.
+        $filters = $this->getFilters(['name' => 'acme', 'status' => 'pending']);
+        $queryBuilder = $this->createQueryBuilder($this->getMockShopContext(true));
+
+        $searchQb = $queryBuilder->getSearchQueryBuilder($filters);
+        $countQb = $queryBuilder->getCountQueryBuilder($filters);
+
+        $this->assertSame(
+            (string) $searchQb->getQueryPart('where'),
+            (string) $countQb->getQueryPart('where')
+        );
+        $this->assertSame($searchQb->getParameters(), $countQb->getParameters());
+        $this->assertEmpty($countQb->getQueryPart('groupBy'));
+        $this->assertStringContainsString(
+            'FROM ' . self::DB_PREFIX . 'business_entity be',
+            $countQb->getSQL()
+        );
+    }
+
+    public function testSortingByCustomersCountUsesTheAggregateAlias(): void
+    {
+        // customers_count is a SELECT alias (aggregate) rather than a be.* column, so its ORDER BY
+        // path differs from a plain column and must still be whitelisted (AC4 + AC3 Customers column).
+        $qb = $this->createQueryBuilder($this->getMockShopContext(true))
+            ->getSearchQueryBuilder($this->getFilters([], 'customers_count'));
+
+        $orderBy = $qb->getQueryPart('orderBy');
+        $this->assertNotEmpty($orderBy);
+        $this->assertStringContainsString('customers_count', $orderBy[0]);
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Entity/Enum/BusinessEntityStatusTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/Enum/BusinessEntityStatusTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Entity\Enum;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+
+/**
+ * The enum owns the status to badge type mapping, so both the grid column and the
+ * detail page badge read it from a single place.
+ */
+class BusinessEntityStatusTest extends TestCase
+{
+    /**
+     * @dataProvider provideStatusesAndBadgeTypes
+     */
+    public function testItMapsEveryStatusToItsBadgeType(BusinessEntityStatus $status, string $expected): void
+    {
+        $this->assertSame($expected, $status->badgeType());
+    }
+
+    public function provideStatusesAndBadgeTypes(): iterable
+    {
+        yield 'pending' => [BusinessEntityStatus::PENDING, 'info'];
+        yield 'active' => [BusinessEntityStatus::ACTIVE, 'success'];
+        yield 'inactive' => [BusinessEntityStatus::INACTIVE, 'light-info'];
+        yield 'rejected' => [BusinessEntityStatus::REJECTED, 'danger'];
+    }
+
+    public function testEveryCaseHasABadgeType(): void
+    {
+        // badgeType() has no default arm on purpose: adding a case without extending the match
+        // must break here rather than reach BadgeColumn with an empty type.
+        foreach (BusinessEntityStatus::cases() as $status) {
+            $this->assertNotSame('', $status->badgeType(), sprintf('%s has no badge type', $status->value));
+        }
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Entity/Repository/BusinessEntityRepositoryTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/Repository/BusinessEntityRepositoryTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Entity\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Entity\B2B\BusinessEntity;
+use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
+
+/**
+ * Pins the multishop guard of the repository at DQL level. Dropping either
+ * `if (null !== $shopIds)` block would silently expose entities of another shop through the
+ * guessable /business-entities/{id}/view URL, and no other test in the suite would fail.
+ */
+class BusinessEntityRepositoryTest extends TestCase
+{
+    public function testFindByIdRestrictsToTheGivenShopsWhenScoped(): void
+    {
+        $dql = $this->captureDql(static fn (BusinessEntityRepository $repository) => $repository->findById(5, [1, 2]));
+
+        $this->assertStringContainsString('be.idShop IN (:shopIds)', $dql);
+        $this->assertStringContainsString('be.id = :businessEntityId', $dql);
+        $this->assertStringContainsString('be.deleted = false', $dql);
+    }
+
+    public function testFindByIdDoesNotRestrictShopsInAllShopContext(): void
+    {
+        $dql = $this->captureDql(static fn (BusinessEntityRepository $repository) => $repository->findById(5, null));
+
+        $this->assertStringNotContainsString('idShop', $dql);
+        $this->assertStringContainsString('be.id = :businessEntityId', $dql);
+    }
+
+    public function testGetPendingCountRestrictsToTheGivenShopsWhenScoped(): void
+    {
+        $dql = $this->captureDql(static fn (BusinessEntityRepository $repository) => $repository->getPendingCount([1, 2]));
+
+        $this->assertStringContainsString('be.idShop IN (:shopIds)', $dql);
+        $this->assertStringContainsString('COUNT(be.id)', $dql);
+        $this->assertStringContainsString('be.status = :status', $dql);
+    }
+
+    public function testGetPendingCountDoesNotRestrictShopsInAllShopContext(): void
+    {
+        $dql = $this->captureDql(static fn (BusinessEntityRepository $repository) => $repository->getPendingCount(null));
+
+        $this->assertStringNotContainsString('idShop', $dql);
+        $this->assertStringContainsString('COUNT(be.id)', $dql);
+    }
+
+    /**
+     * Runs a repository method against an entity manager that records the DQL it is asked to
+     * execute, and returns that DQL. No database and no metadata driver are involved: DQL is pure
+     * string assembly.
+     */
+    private function captureDql(callable $call): string
+    {
+        $capturedDql = '';
+
+        $query = $this->createMock(Query::class);
+        $query->method('setParameters')->willReturnSelf();
+        $query->method('setFirstResult')->willReturnSelf();
+        $query->method('setMaxResults')->willReturnSelf();
+        $query->method('getOneOrNullResult')->willReturn(null);
+        $query->method('getSingleScalarResult')->willReturn(0);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('createQueryBuilder')->willReturnCallback(
+            static fn (): QueryBuilder => new QueryBuilder($entityManager)
+        );
+        $entityManager->method('createQuery')->willReturnCallback(
+            static function (string $dql) use (&$capturedDql, $query): Query {
+                $capturedDql = $dql;
+
+                return $query;
+            }
+        );
+
+        $call(new BusinessEntityRepository($entityManager, new ClassMetadata(BusinessEntity::class)));
+
+        return $capturedDql;
+    }
+}


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds the Business Entities **listing** and **detail (view)** pages to the Back Office, behind the existing B2B feature flag, and splits the Customers B2B listing out of the Business Entities controller. Listing: sortable grid (id, company, legal name, shop, aggregated linked-customers count, status badge), per-column search on name / legal name / id, pagination, a "Pending validation(s)" banner linking to the pending-filtered list, and a "View details" row action. Detail page: company information, status, billing and shipping addresses (formatted through the core address formatter, with the default-address indicator), a summary card counting linked customers and addresses, and created/updated timestamps. All queries are shop-scoped through `ShopContext`. Read side is CQRS (`GetBusinessEntityForViewing`, `GetPendingBusinessEntitiesCount`); no ObjectModel, no raw SQL. Some AC10/AC3 items are intentionally deferred to the next user stories — see "Deferred" below.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" below.
| UI Tests          | https://github.com/soledis-contributeur/ga.tests.ui.pr/actions/runs/33170398607, https://github.com/soledis-contributeur/ga.tests.ui.pr/actions/runs/33170461766
| Fixed issue or discussion?     | Fixes #40617
| Related PRs       | Builds on #41190 (US2.1.1 — create a Business Entity), already merged into `develop`.
| Sponsor company   | Soledis

## How to test

**Prerequisites** — enable the B2B feature flag **and** B2B mode, then rebuild the admin theme
(`make assets` or `npm run build` in `admin-dev/themes/new-theme`) since a new page bundle is added.

**Listing** (`Sell > Business Entities > Business entities`)

1. Create a few business entities with different statuses (at least one `pending`).
2. The grid shows Company, Legal name, Shop, Customers (count with icon) and a Status badge.
   Sort on each header; search on Company, Legal name and ID from the column inputs.
3. Submit the filter row with the Status filter left on "All" — the listing must **not** come back
   empty (blank filter values are ignored).
4. With at least one `pending` entity, a "Pending validation(s)" banner appears above the grid; its
   button opens the list pre-filtered on `pending`.
5. Check the result count and pagination against the number of entities you created — the total must
   not be inflated by the linked-customers join.
6. In a multistore installation, confirm an entity attached to another shop is absent from the list,
   and that the pending count only reflects the current shop context.

**Detail page**

7. Click a row (or "View details"): the page shows the entity name with its status badge, company
   information, billing and shipping addresses, the summary card and the timestamps.
8. Give an entity a billing address flagged as default → the address card shows a "Default" badge.
9. Create an entity with a **US or Canadian** address (with a state) and check the address renders in
   the local postal order, state included, with no leftover placeholder name on the first line.
10. Resize the detail page down to 320-375 px with a long company name: the header wraps instead of
    scrolling the page horizontally.
11. Request `/business-entities/999999/view` (a non-existent id): you are redirected to the listing
    with an error message, not a 500.

**Automated tests**

- `php vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter BusinessEntity` — 72 tests, 199 assertions.
- `php vendor/bin/behat -c tests/Integration/Behaviour/behat.yml --suite=business_entity` — 11 scenarios,
  72 steps. Two of them cover the view read path end to end: a soft-deleted address disappearing from
  the detail page, and the default address being listed first whatever the creation order.

## Deferred — not in this PR

These are acceptance criteria of #40617 that are **consciously postponed**, not oversights:

- **AC10 "Edit" button** → US2.1.3. The button is **not rendered at all**. A disabled placeholder was
  tried and removed: the floating mobile toolbar (`Admin/Component/Layout/toolbar.html.twig`) ignores
  the `disabled` flag, so below 576 px the entry rendered as an active but inert button.
- **AC10 linked B2B customers table + "Add customer" button** → deferred. The card is rendered with a
  real linked-customers count and a neutral empty state; the table itself and the linking flow come
  later.
- **AC3 three-dot actions menu** → the Grid framework renders the first row action inline and only
  switches to the kebab menu from the second one. The menu will appear naturally in US2.1.3/US2.1.4
  once Edit and Delete exist.
- **AC3 bulk-action checkbox and bulk actions** → US2.1.4.
- **AC5 search on DUNS / SIRET / VAT** and **AC3 "unique identifier" column** → US2.1.6. The issue
  itself leaves the identifier question open.
- **AC3 status badge**: `inactive` uses `light-info` because the allowed `BadgeColumn` vocabulary has
  no grey; adding one would mean editing the shared `scss/components/_badges.scss`.
- **AC7 "Review pending" button**: the button is hidden while the pending filter is already active.
  The filter row and its reset button already expose that state.

## Deliberate choices worth flagging to reviewers

- **Status labels stay in `Admin.Global`.** `Active` and `Inactive` are already catalogued there and
  moving them would drop existing translations. `Pending` and `Rejected` are catalogued **nowhere**
  today, so they create new keys in any domain — keeping the four together in one domain keeps the
  enum a single source of truth.
- **The status → badge-type mapping lives in the presentation layer on both sides** — a private
  `match` in `BusinessEntityGridDataFactory` for the grid and a `{% set %}` map in a shared Twig
  partial for the view. The core does exactly this in both layers (`CartGridDataFactory`,
  `Sell/Order/Invoices/Blocks/generate_by_status.html.twig`); no shared home exists for such a token,
  and putting it in a `Core/Domain` QueryResult would have been the first occurrence in the codebase.
- **Two strings of the already-merged US2.1.1 form were re-pointed** (`Billing address`,
  `Shipping address`, `Legal name`, `Customer group`) so that a single label is not translated from
  two different domains inside the same feature. The core convention favoured the new view blocks.
- **Three BEM hooks are emitted without a matching CSS rule** —
  `business-entity-view-header__status` (passed as `extraClass` from `header.html.twig` into the
  shared status-badge partial) and `business-entity-pending-banner__btn` / `__text` in `list.html.twig`.
  They are styling anchors kept for the Edit/bulk toolbars arriving in US2.1.3/US2.1.4; the blocks
  they belong to declare only the selectors they actually use today. Say the word and we drop them
  and the `extraClass` argument with them.
- **The Actions column is centred for this grid only** (`scss/pages/_business_entity.scss:11-27`),
  where `components/_grid.scss:119-137` right-aligns it everywhere else in the BO. This follows the
  approved mock-up; the fork is scoped to `.business-entity-*` and touches no shared file.
- **The listing action is `listAction()` / `admin_business_entities_list`**, not the canonical
  `indexAction()` / `admin_<entity>_index`. The name comes from US2.1.1, already merged in `develop`
  (#41190); renaming here would make this branch diverge from what is live. Happy to rename both in
  a dedicated follow-up if you prefer.
- **`_status_badge.html.twig` and `_address_card.html.twig` keep their `_` prefix** outside a
  `_partials/` folder, matching the local convention already established in this feature folder.
- **`BusinessEntityAddressRepository::getAddresses()` still takes an `$addressTypes` argument** whose
  `IN ()` clause cannot currently exclude anything (the sole caller passes every enum case). It is
  kept as an explicit guard against out-of-enum values; the invoice/delivery split is done in PHP.
- **`BusinessEntityForViewing` carries `externalRef`, `deliveryAuthorized` and `customerGroupId`**
  which no template reads yet. They are collected by the US2.1.1 creation form and will be surfaced
  with the edit screen (US2.1.3).
- **The grid search route points at an action of our own, not
  `CommonController::searchGridAction`.** That shared action hardcodes
  `#[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]`, so once the legacy
  flags were removed the permission subject became empty and submitting a filter threw
  `The slug ROLE_MOD_TAB__READ is invalid`. `BusinessEntitiesController::searchAction()` hardcodes
  the subject like the four other actions, so no legacy flag is needed anywhere in this feature.
  Note that no automated test can catch this class of bug: `config_test.yml` swaps `PageVoter` for
  a double that always grants, so the integration harness is blind to broken security expressions —
  it was found by clicking the filter in the BO. The same crash exists on `develop` for an unrelated
  grid: #42436.

## Test coverage: what is deliberately not pinned

Mutation testing was run over the new code. These paths are correct but **not held by a test**, and
we would rather say so than let a reviewer discover it:

- the soft-delete guard of `getPendingCount()` (AC7 banner);
- the all-shop branch of the view handler's shop scoping;
- pagination and deterministic sorting on the grid search query (AC8/AC4).

Everything else the mutation run flagged has been closed: the `is_default` mapping that feeds the
AC10 "Default" badge, the array binding type of the shop scoping, and the two SQL guards of
`getAddresses()` — `a.deleted = 0` and `is_default DESC` — now covered end to end by two Behat
scenarios ("A soft-deleted address is no longer exposed by the business entity view" and "The
default address is listed first whatever the creation order"). Both were verified by mutation:
removing either guard fails its scenario and only its scenario.
