### PR TITLE
Fix HTTP 500 for inactive products with product redirect and no target

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -180,6 +180,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             if (!$this->product->id_type_redirected) {
                 if (in_array($this->product->redirect_type, [RedirectType::TYPE_CATEGORY_PERMANENT, RedirectType::TYPE_CATEGORY_TEMPORARY])) {
                     $this->product->id_type_redirected = $this->product->id_category_default;
+                } elseif (in_array($this->product->redirect_type, [RedirectType::TYPE_PRODUCT_PERMANENT, RedirectType::TYPE_PRODUCT_TEMPORARY])) {
+                    // A product redirect without a target cannot be resolved — treat as not found
+                    // instead of calling getProductLink(0) which throws "Invalid product vars".
+                    $this->product->redirect_type = RedirectType::TYPE_NOT_FOUND;
                 }
             } elseif (in_array($this->product->redirect_type, [RedirectType::TYPE_PRODUCT_PERMANENT, RedirectType::TYPE_PRODUCT_TEMPORARY]) && $this->product->id_type_redirected == $this->product->id) {
                 $this->product->redirect_type = RedirectType::TYPE_NOT_FOUND;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix HTTP 500 returned for inactive products whose `redirect_type` is `301-product`/`302-product` but `id_type_redirected` is 0 (no redirect target). `checkPermissionsToViewProduct()` only guarded category redirects (fallback to `id_category_default`); product redirects with no target were left unresolved, so the switch called `Link::getProductLink(0)`, which throws `PrestaShopException('Invalid product vars')` → uncaught → HTTP 500. The fix treats product redirects without a target as not found (404), matching the existing behavior for category redirects with a missing default category. Verified against PrestaShop 9.1.4 (byte-for-byte identical to official tag) and the same gap is present on `develop`. |
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create a product with `active = 0`, `redirect_type = '301-product'`, `id_type_redirected = 0` (reachable via webservice API — see #37823 — or after the redirect target product is deleted). 2. Visit the product URL in the front office. 3. Before fix: HTTP 500 + `Invalid product vars at line 154 in file classes/Link.php` in the exception log. 4. After fix: HTTP 404 (product not found). 5. Regression check: an inactive product with a *valid* `301-product` target still redirects with 301; an inactive product with `301-category` and an active default category still redirects with 301. |
| UI Tests          | Not run (front-office behavior change only; no UI test campaign executed).
| Fixed issue or discussion?     | Fixes #42288
| Related PRs       | N/A
| Sponsor company   | N/A