### PR TITLE
Keep only the real file extension when renaming an uploaded attachment

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3483,7 +3483,12 @@ exit;
     {
         $file_attachment = null;
         if (isset($_FILES[$input]['name']) && !empty($_FILES[$input]['name']) && !empty($_FILES[$input]['tmp_name'])) {
-            $file_attachment['rename'] = uniqid() . Tools::strtolower(substr($_FILES[$input]['name'], -5));
+            $extension = preg_replace(
+                '/[^a-z0-9]/',
+                '',
+                Tools::strtolower(pathinfo($_FILES[$input]['name'], PATHINFO_EXTENSION))
+            );
+            $file_attachment['rename'] = uniqid() . ($extension !== '' ? '.' . $extension : '');
             if ($return_content) {
                 $file_attachment['content'] = file_get_contents($_FILES[$input]['tmp_name']);
             }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Tools::fileAttachment()` builds the stored name of an uploaded attachment with `uniqid() . substr($_FILES[$input]['name'], -5)`. The last 5 characters only match the extension when it is 5 characters long (`.jpeg`, `.webp`, `.docx`); with `.pdf`, `.png`, `.jpg`, `.gif`, `.txt`, `.rtf`, `.doc` or `.zip` the 5th character is whatever preceded the extension, so `factura (2).pdf` is stored as `<uniqid>).pdf`. `AdminCustomerThreadsController::initContent()` validates that name with `Validate::isFileName()`, which only allows `/^[a-zA-Z0-9_.-]+$/`, so the merchant gets a 404 instead of the attachment. This PR takes the real extension with `pathinfo()`, lowercases it and strips anything outside `[a-z0-9]`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Front office, open the contact page, fill in the form and attach a file named `factura (2).pdf` (any allowed 4 character extension reproduces it), then send the message. Back office, go to Customer Service, open the thread and click the attachment: before this change it redirects to the 404 page, now the file opens. Files with a 5 character extension (`.jpeg`, `.webp`, `.docx`) are unaffected, and names without a special character before the extension keep working as before.
| UI Tests          | Not run yet.
| Fixed issue or discussion?     | Fixes #42290
| Related PRs       | None
| Sponsor company   | idnovate

Behaviour of the generated name, before and after:

| Uploaded file | Before | After |
| --- | --- | --- |
| `factura (2).pdf` | `<uniqid>).pdf` → 404 | `<uniqid>.pdf` |
| `imagen(1).png` | `<uniqid>).png` → 404 | `<uniqid>.png` |
| `presupuesto.pdf` | `<uniqid>o.pdf` | `<uniqid>.pdf` |
| `captura.jpeg` | `<uniqid>.jpeg` | `<uniqid>.jpeg` |
| `evil.php.png` | `<uniqid>p.png` | `<uniqid>.png` |

Files without an extension are not a regression: `README` produced `<uniqid>eadme` before and `<uniqid>` now, and `openUploadedFile()` throws `Invalid file extension.` in both cases.
