### PR TITLE
Filter a shop scoped webservice field on the table the response reads

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1202,11 +1202,11 @@ class WebserviceRequestCore
 
                                     return false;
                                 } else {
-                                    if (isset($this->resourceConfiguration['retrieveData']['tableAlias'])) {
-                                        $sql_filter .= $this->getSQLRetrieveFilter($this->resourceConfiguration['fields'][$field]['sqlId'], $url_param, $this->resourceConfiguration['retrieveData']['tableAlias'] . '.');
-                                    } else {
-                                        $sql_filter .= $this->getSQLRetrieveFilter($this->resourceConfiguration['fields'][$field]['sqlId'], $url_param);
-                                    }
+                                    $sql_filter .= $this->getSQLRetrieveFilter(
+                                        $this->resourceConfiguration['fields'][$field]['sqlId'],
+                                        $url_param,
+                                        $this->getFilterTableAlias($this->resourceConfiguration['fields'][$field]['sqlId'])
+                                    );
                                 }
                             }
                         }
@@ -1695,6 +1695,42 @@ class WebserviceRequestCore
         }
 
         return false;
+    }
+
+    /**
+     * Returns the table alias a filter on $sqlId has to be qualified with.
+     *
+     * A shop-scoped field exists in two tables: the base one and the shop one. For a multishop
+     * association, getWebserviceObjectList() joins the shop table as `multi_shop_<table>` and the
+     * response is read from there, so qualifying the filter with `main` compares a different column
+     * from the one the response reports.
+     *
+     * @param string $sqlId
+     *
+     * @return string
+     */
+    protected function getFilterTableAlias($sqlId)
+    {
+        $defaultAlias = isset($this->resourceConfiguration['retrieveData']['tableAlias'])
+            ? $this->resourceConfiguration['retrieveData']['tableAlias'] . '.'
+            : 'main.';
+
+        if (!isset($this->resourceConfiguration['retrieveData']['className'])) {
+            return $defaultAlias;
+        }
+
+        $definition = ObjectModel::getDefinition($this->resourceConfiguration['retrieveData']['className']);
+        if (empty($definition['fields'][$sqlId]['shop'])) {
+            return $defaultAlias;
+        }
+
+        // Only a non fk_shop association produces the multi_shop_<table> join.
+        $assoc = Shop::getAssoTable($definition['table']);
+        if ($assoc === false || $assoc['type'] === 'fk_shop') {
+            return $defaultAlias;
+        }
+
+        return 'multi_shop_' . $definition['table'] . '.';
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context;
 
 use Behat\Gherkin\Node\TableNode;
+use Db;
+use ObjectModel;
 use PHPUnit\Framework\Assert;
 use RuntimeException;
 use Symfony\Component\DomCrawler\Crawler;
@@ -23,11 +25,49 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
     protected $lastOutput;
 
     /**
-     * @When /^I use Webservice with key "(.*)" to list "(.+)"$/
+     * @When /^I use Webservice with key "(.*)" to list "([^"]+)"$/
      */
     public function whenRequestList(string $webserviceKey, string $endpoint): void
     {
         $this->lastOutput = $this->whenRequest($webserviceKey, 'GET', $endpoint);
+    }
+
+    /**
+     * @When /^I use Webservice with key "(.*)" to list "(.+)" filtered by "(.+)" with value "(.+)"$/
+     */
+    public function whenRequestFilteredList(string $webserviceKey, string $endpoint, string $field, string $value): void
+    {
+        $_GET['filter'] = [$field => $value];
+        // date_add and date_upd only become filterable when the date feature is asked for.
+        $_GET['date'] = 1;
+
+        try {
+            $this->lastOutput = $this->whenRequest($webserviceKey, 'GET', $endpoint);
+        } finally {
+            unset($_GET['filter'], $_GET['date']);
+        }
+    }
+
+    /**
+     * A shop scoped field is stored twice, so the two tables can hold different values for the same
+     * row. This sets them apart on purpose, which is what tells a filter on the base table from a
+     * filter on the shop table.
+     *
+     * @Given /^I set "(.+)" of (.+) (\d+) to "(.+)" in the base table and "(.+)" in the shop table$/
+     */
+    public function givenDivergentShopScopedValue(
+        string $column,
+        string $className,
+        int $id,
+        string $baseValue,
+        string $shopValue
+    ): void {
+        $definition = ObjectModel::getDefinition($className);
+        $primary = $definition['primary'];
+        $db = Db::getInstance();
+
+        $db->update($definition['table'], [$column => $baseValue], $primary . ' = ' . $id, 0, true);
+        $db->update($definition['table'] . '_shop', [$column => $shopValue], $primary . ' = ' . $id, 0, true);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/products.feature
@@ -1,0 +1,38 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s webservice --tags webservice-endpoints-products
+@restore-all-tables-before-feature
+@webservice-endpoints-products
+Feature: Webservice product listing
+  PrestaShop exposes products over the webservice
+  As a webservice consumer
+  I must be able to filter a listing on the same value the listing reports
+
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    And I restore tables "webservice_account,webservice_account_shop,webservice_permission"
+    And shop configuration for "PS_WEBSERVICE" is set to 1
+    And I add a new webservice key with specified properties:
+      | key              | ENABLEDENABLEDENABLEDENABLEDENAB |
+      | description      | Enabled key                      |
+      | is_enabled       | 1                                |
+      | shop_association | shop1                            |
+    And I edit webservice key "ENABLEDENABLEDENABLEDENABLEDENAB" with specified properties:
+      | description    | Enabled key with Permissions |
+      | permission_GET | products                     |
+
+  # A shop scoped field lives in both `product` and `product_shop`. The listing joins the shop table
+  # and reports its value, so a filter has to be qualified with the same table or it answers about a
+  # different column. The two values below are set apart to tell the two tables from each other.
+  Scenario: Filtering a shop scoped field matches the value the listing reports
+    Given I set "date_upd" of Product 1 to "2001-01-01 00:00:00" in the base table and "2038-01-01 00:00:00" in the shop table
+    When I use Webservice with key "ENABLEDENABLEDENABLEDENABLEDENAB" to list "products" filtered by "date_upd" with value "2038-01-01 00:00:00"
+    Then I should get 1 item of type "product"
+
+  Scenario: Filtering a shop scoped field does not match the value only the base table holds
+    Given I set "date_upd" of Product 1 to "2001-01-01 00:00:00" in the base table and "2038-01-01 00:00:00" in the shop table
+    When I use Webservice with key "ENABLEDENABLEDENABLEDENABLEDENAB" to list "products" filtered by "date_upd" with value "2001-01-01 00:00:00"
+    Then I should get 0 items of type "product"
+
+  # The non shop scoped fields must keep being filtered on the base table.
+  Scenario: Filtering a field that is not shop scoped still works
+    When I use Webservice with key "ENABLEDENABLEDENABLEDENABLEDENAB" to list "products" filtered by "id" with value "1"
+    Then I should get 1 item of type "product"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A shop scoped field is stored twice: in the base table and in the shop table. `ObjectModel::getWebserviceObjectList()` joins the shop table as `multi_shop_<table>` and the listing reports its value, but `WebserviceRequest` qualifies every filter with `main.` (or the resource's `tableAlias`), so a filter compares a different column from the one the response returns. On products, `filter[date_upd]` therefore matches `ps_product.date_upd` while the response shows `ps_product_shop.date_upd`. A filter now resolves its alias from the field: shop scoped fields of a multishop association are qualified with the shop table, everything else keeps the previous alias.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s webservice --tags webservice-endpoints-products`. The scenarios set `date_upd` of product 1 apart in the two tables, then filter on each value. Before this change the filter on the value the listing reports returns nothing, and the filter on the value only the base table holds wrongly returns the product; the third scenario pins that a field which is not shop scoped keeps being filtered on the base table. Reverting only `classes/webservice/WebserviceRequest.php` gives `Failed asserting that 0 matches expected 1` and `Failed asserting that 1 matches expected 0`, with the whole webservice suite at 14 scenarios / 130 steps green with the fix.
| UI Tests          | Not applicable, webservice query building only - no front office or back office surface is touched.
| Fixed issue or discussion?     | Fixes #42263
| Related PRs       |
| Sponsor company   |

### Why the alias has to depend on the field

`getWebserviceObjectList()` only adds the join for a non `fk_shop` association:

```php
if ($assoc['type'] !== 'fk_shop') {
    $multi_shop_join = ' LEFT JOIN `' . _DB_PREFIX_ . $this->def['table'] . '_' . $assoc['type'] . '`
                            AS `multi_shop_' . $this->def['table'] . '` ...
```

so the same condition decides where a filter belongs. `Product::$definition` marks `date_upd`, `date_add`, `active` and `price` with `'shop' => true`; `id_product` and `reference` are not marked and stay on `main`.

Measured routing after the change:

```
date_upd     -> multi_shop_product.
date_add     -> multi_shop_product.
active       -> multi_shop_product.
price        -> multi_shop_product.
id_product   -> main.
reference    -> main.
```

A resource with no `className`, or one declaring its own `tableAlias`, is left exactly as before.

### About the test steps

Filtering a listing had no step definition, so `WebserviceEndpointFeatureContext` gains one, plus a step that sets a shop scoped column apart in the two tables - which is what distinguishes a filter on one table from a filter on the other. The date feature (`date=1`) is set by the filtering step because `date_add` and `date_upd` only become filterable when it is asked for; without it the filter is rejected and a scenario would pass for the wrong reason. The existing list step's regex was narrowed from `"(.+)"` to `"([^"]+)"` so it stops swallowing the longer sentence.
