### PR TITLE
Move the admin folder across devices instead of failing the install

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -50,6 +50,7 @@ use PrestashopInstallerException;
 use PrestaShopLoggerInterface;
 use Psr\Log\LogLevel;
 use PSRLoggerAdapter;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
@@ -1228,12 +1229,25 @@ class Install extends AbstractInstall
             );
             $adminFolder = $randomizedAdminFolderName;
 
-            // rename folder
-            if (@rename(_PS_ROOT_DIR_ . '/admin/', _PS_ROOT_DIR_ . '/' . $randomizedAdminFolderName)) {
+            /*
+             * Rename the folder through the filesystem component rather than rename() directly: the two
+             * paths are not guaranteed to sit on the same device, and rename() answers EXDEV there instead
+             * of moving anything. That happens on an ordinary Docker install where /var/www/html/admin comes
+             * from the image while its parent is a mount. The component falls back to a copy and a delete in
+             * that case, and reports why when even that fails - rename() was called with @, so the reason
+             * used to be discarded and the merchant was left with a message naming only the target folder.
+             */
+            try {
+                (new Filesystem())->rename(_PS_ROOT_DIR_ . '/admin/', _PS_ROOT_DIR_ . '/' . $randomizedAdminFolderName);
                 $successLogMessage = sprintf('The admin folder was renamed into %s', $randomizedAdminFolderName);
                 $this->getLogger()->logInfo($successLogMessage);
                 $this->clearCache();
-            } else {
+            } catch (IOException $e) {
+                $this->getLogger()->logError(sprintf(
+                    'The admin folder could not be renamed into %s: %s',
+                    $randomizedAdminFolderName,
+                    $e->getMessage()
+                ));
                 $this->setError($this->translator->trans('The admin folder could not be renamed into %folderName%', ['%folderName%' => $randomizedAdminFolderName], 'Install'));
 
                 return false;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The installer renames `admin/` to a randomized name with `rename()`, which only moves a directory within one filesystem. When the two paths sit on different devices it answers `EXDEV` and moves nothing, which is an ordinary Docker layout: `/var/www/html/admin` comes from the image while its parent is a mount. The install then stops at the last step. The call was made with `@`, so the reason was discarded and the merchant got a message naming only the target folder - the reporter had to patch the file to find out why. This routes the rename through `Symfony\Component\Filesystem`, which already falls back to a copy and a delete when `rename()` cannot cross the boundary, and reports the underlying reason when even that fails.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install into a layout where `admin/` and its parent are on different devices - the reporter's compose file in #42289 does it by leaving `/var/www/html` unmounted. Before: the installer stops at about 90% with "The admin folder could not be renamed into adminXXXX" and no reason anywhere. After: the folder is moved and the install completes; if it still cannot be moved, the install log now carries the actual filesystem error. The mechanism, measured on two real devices (see below), is `rename()` false with `Invalid cross-device link` against `Filesystem::rename()` succeeding.
| UI Tests          | Not applicable, installer file system handling only.
| Fixed issue or discussion?     | Fixes #42289
| Related PRs       |
| Sponsor company   |

### The measurement

Run in a container where `/tmp` and `/var/www/html` are genuinely separate devices (61 and 66307):

```
1) rename() -> false ; error: rename(/tmp/xdev_src,/var/www/html/var/xdev_dst): Invalid cross-device link
   did the target appear? NO
2) Filesystem::rename() -> succeeded
   target present? YES ; contents: hello
   source removed? YES
```

The first line is the error #42289 reports, and the second is the behaviour this change adopts.

### Why the component rather than a hand written fallback

`Filesystem::rename()` already carries it, citing the same PHP bug:

```php
if (!self::box('rename', $origin, $target)) {
    if (is_dir($origin)) {
        // See https://bugs.php.net/54097 & https://php.net/rename#113943
        $this->mirror($origin, $target, null, ['override' => $overwrite, 'delete' => $overwrite]);
        $this->remove($origin);

        return;
    }
    throw new IOException(...);
}
```

The component was already imported in this file and is used a few lines further down, so this adds no
dependency. The copy only happens on the path that is broken today; a rename that already works is
untouched.

### About the message

The user facing string is left exactly as it is, so no translation key changes. The reason is added to
the install log instead, which is what was missing: `@rename()` threw the cause away, and that is why
the report had to instrument the file to recover it.

### No automated test

`PrestaShopBundle\Install\Install::finalize()` runs inside a full installation and has no test harness -
there are no tests for this class in the tree. Standing one up for a filesystem call seemed out of
proportion, so the deterministic before/after above is the evidence instead. The fallback itself is
covered by the Symfony component's own tests.
