### PR TITLE
Apply a logo saved for a shop group to every shop of that group

### DIFF
--- a/src/Adapter/Shop/CommandHandler/UploadLogosHandler.php
+++ b/src/Adapter/Shop/CommandHandler/UploadLogosHandler.php
@@ -6,6 +6,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Shop\CommandHandler;
 
+use Configuration as ConfigurationLegacy;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Exception\FileUploadException;
@@ -16,6 +17,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Shop\LogoUploader;
 use PrestaShopException;
+use Shop;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
@@ -95,6 +97,7 @@ final class UploadLogosHandler implements UploadLogosHandlerInterface
         $this->setUploadedFileToBeCompatibleWithLegacyUploader(ShopLogoSettings::HEADER_LOGO_FILE_NAME, $uploadedFile);
 
         $this->logoUploader->updateHeader();
+        $this->dropShopOverridesOfGroupContext(['PS_LOGO', 'SHOP_LOGO_HEIGHT', 'SHOP_LOGO_WIDTH']);
     }
 
     /**
@@ -105,6 +108,7 @@ final class UploadLogosHandler implements UploadLogosHandlerInterface
         $this->setUploadedFileToBeCompatibleWithLegacyUploader(ShopLogoSettings::MAIL_LOGO_FILE_NAME, $uploadedFile);
 
         $this->logoUploader->updateMail();
+        $this->dropShopOverridesOfGroupContext(['PS_LOGO_MAIL']);
     }
 
     /**
@@ -115,6 +119,7 @@ final class UploadLogosHandler implements UploadLogosHandlerInterface
         $this->setUploadedFileToBeCompatibleWithLegacyUploader(ShopLogoSettings::INVOICE_LOGO_FILE_NAME, $uploadedHeaderLogo);
 
         $this->logoUploader->updateInvoice();
+        $this->dropShopOverridesOfGroupContext(['PS_LOGO_INVOICE']);
     }
 
     /**
@@ -125,6 +130,31 @@ final class UploadLogosHandler implements UploadLogosHandlerInterface
         $this->setUploadedFileToBeCompatibleWithLegacyUploader(ShopLogoSettings::FAVICON_FILE_NAME, $uploadedHeaderLogo);
 
         $this->logoUploader->updateFavicon();
+    }
+
+    /**
+     * A logo saved from a group context belongs to every shop of that group. The value is stored on the
+     * group, but a value stored earlier for one of those shops individually keeps taking precedence over
+     * it, so the new logo appears only on the shops that never had one of their own. Dropping those
+     * leaves the group value as the one they all read.
+     *
+     * The favicon is deliberately left out: updateFavicon() names the file after the shop and stores it
+     * per shop on purpose.
+     *
+     * @param string[] $configurationKeys
+     */
+    private function dropShopOverridesOfGroupContext(array $configurationKeys): void
+    {
+        if (!Shop::isFeatureActive() || Shop::getContext() !== Shop::CONTEXT_GROUP) {
+            return;
+        }
+
+        $idShopGroup = (int) Shop::getContextShopGroupID();
+        foreach (Shop::getShops(false, $idShopGroup, true) as $idShop) {
+            foreach ($configurationKeys as $configurationKey) {
+                ConfigurationLegacy::deleteFromGivenContext($configurationKey, $idShopGroup, (int) $idShop);
+            }
+        }
     }
 
     /**

--- a/tests/Integration/Adapter/Shop/CommandHandler/UploadLogosHandlerTest.php
+++ b/tests/Integration/Adapter/Shop/CommandHandler/UploadLogosHandlerTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Shop\CommandHandler;
+
+use Configuration;
+use PrestaShop\PrestaShop\Adapter\Shop\CommandHandler\UploadLogosHandler;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Command\UploadLogosCommand;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShop\PrestaShop\Core\Shop\LogoUploader;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class UploadLogosHandlerTest extends KernelTestCase
+{
+    private const KEY = 'PS_LOGO_MAIL';
+    private const GROUP_VALUE = 'logo_mail-group.jpg';
+
+    /**
+     * @var int
+     */
+    private $secondShopId;
+
+    /**
+     * @var string
+     */
+    private $imagePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        Configuration::updateGlobalValue('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+        Shop::setContext(Shop::CONTEXT_ALL);
+
+        $shop = new Shop();
+        $shop->name = 'UploadLogosHandlerTest shop';
+        $shop->id_category = 2;
+        $shop->id_shop_group = 1;
+        $shop->active = true;
+        $shop->add();
+        $this->secondShopId = (int) $shop->id;
+
+        Shop::resetContext();
+        Shop::resetStaticCache();
+        Configuration::loadConfiguration();
+
+        $this->imagePath = sys_get_temp_dir() . '/upload-logos-handler-test.jpg';
+        imagejpeg(imagecreatetruecolor(10, 10), $this->imagePath);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Shop($this->secondShopId))->delete();
+        Configuration::deleteByName(self::KEY);
+        Shop::resetContext();
+        Shop::resetStaticCache();
+        Configuration::loadConfiguration();
+        @unlink($this->imagePath);
+
+        parent::tearDown();
+    }
+
+    /**
+     * A logo saved from a group context is meant for the whole group, but a value stored earlier for one
+     * of its shops keeps taking precedence, so the change reaches only the shops that never had one of
+     * their own.
+     */
+    public function testAGroupContextUploadReachesTheShopsThatHaveTheirOwnLogo(): void
+    {
+        $this->givenEachShopHasItsOwnLogo();
+        $this->givenTheGroupLogoIs(self::GROUP_VALUE);
+
+        Shop::setContext(Shop::CONTEXT_GROUP, 1);
+        Configuration::loadConfiguration();
+        $this->buildHandler()->handle($this->mailLogoCommand());
+
+        foreach ([1, $this->secondShopId] as $idShop) {
+            Shop::setContext(Shop::CONTEXT_SHOP, $idShop);
+            Configuration::loadConfiguration();
+            $this->assertSame(
+                self::GROUP_VALUE,
+                Configuration::get(self::KEY),
+                sprintf('Shop %d should read the logo saved for its group.', $idShop)
+            );
+        }
+    }
+
+    /**
+     * Outside a group context each shop keeps the logo set for it.
+     */
+    public function testAShopContextUploadLeavesTheOtherShopsAlone(): void
+    {
+        $this->givenEachShopHasItsOwnLogo();
+
+        Shop::setContext(Shop::CONTEXT_SHOP, 1);
+        Configuration::loadConfiguration();
+        $this->buildHandler()->handle($this->mailLogoCommand());
+
+        Shop::setContext(Shop::CONTEXT_SHOP, $this->secondShopId);
+        Configuration::loadConfiguration();
+        $this->assertSame('own-logo-' . $this->secondShopId . '.jpg', Configuration::get(self::KEY));
+    }
+
+    private function givenEachShopHasItsOwnLogo(): void
+    {
+        foreach ([1, $this->secondShopId] as $idShop) {
+            Shop::setContext(Shop::CONTEXT_SHOP, $idShop);
+            Configuration::loadConfiguration();
+            Configuration::updateValue(self::KEY, 'own-logo-' . $idShop . '.jpg');
+        }
+    }
+
+    private function givenTheGroupLogoIs(string $value): void
+    {
+        Shop::setContext(Shop::CONTEXT_GROUP, 1);
+        Configuration::loadConfiguration();
+        Configuration::updateValue(self::KEY, $value);
+    }
+
+    private function mailLogoCommand(): UploadLogosCommand
+    {
+        $command = new UploadLogosCommand();
+        $command->setUploadedMailLogo(new UploadedFile($this->imagePath, 'logo_mail.jpg', 'image/jpeg', null, true));
+
+        return $command;
+    }
+
+    private function buildHandler(): UploadLogosHandler
+    {
+        return new UploadLogosHandler(
+            $this->createMock(ConfigurationInterface::class),
+            $this->createMock(LogoUploader::class),
+            $this->createMock(HookDispatcherInterface::class)
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Changing the header, mail or invoice logo from a group context applies to some shops of the group and not others. A logo saved there is stored on the group, but a value stored earlier for one of its shops individually keeps taking precedence, so the new logo appears only on the shops that never had one of their own. The upload now drops those per shop values for the shops of the group, leaving the group one as what they all read.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable multistore, add a second shop to the default group, set a logo on each shop separately, then switch the context to the group and upload a new mail or header logo. Before: the shops that had their own logo keep it. After: both follow the group. `vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Adapter/Shop/CommandHandler/UploadLogosHandlerTest.php` covers both directions; reverting only `UploadLogosHandler.php` fails the group case with `Shop 1 should read the logo saved for its group` while the shop-context case stays green.
| UI Tests          | Not applicable, multistore configuration scoping only.
| Fixed issue or discussion?     | Fixes #38706
| Related PRs       |
| Sponsor company   |

### What the storage looks like

Measured on a 9.2 install with two shops in group 1, saving in the group context:

```
before:  [group=1 shop=1 own-logo-1]  [group=1 shop=2 own-logo-2]
after:   [group=1 shop=1 own-logo-1]  [group=1 shop=2 own-logo-2]  [group=1 shop=NULL group-logo]
reads:   shop 1 -> own-logo-1         shop 2 -> own-logo-2
```

The group row is written, and neither shop reads it. `Configuration::sqlRestriction()` explains why - a group scoped write only ever addresses the group row:

```
sqlRestriction(1, null) =  AND id_shop_group = 1 AND (id_shop IS NULL OR id_shop = 0)
```

so the per shop rows are untouched and keep shadowing it. The report describes this as "only applies to shop 1", which is the same thing seen from an install where shop 1 had no logo of its own and inherited the group value while the other shop did.

### Why the handler and not the uploader

The first version of this lived in `Core\Shop\LogoUploader`, next to the write. PHPStan rejected it - `Namespace Shop is forbidden, No legacy calls inside the prestashop bundle` - which is the correct answer: resolving the shops of a group is a legacy call and belongs in the adapter layer. `UploadLogosHandler` already sits there, already knows which logos were uploaded, and needs no new dependency.

`Configuration::deleteFromGivenContext()` is used rather than `ConfigurationInterface::remove()`, which deletes every row of the key regardless of scope.

### The favicon is deliberately left out

`LogoUploader::updateFavicon()` names the file after the shop and stores it per shop on purpose, so a group context save should not flatten it.
