### PR TITLE
Follow the quantity when a partial refund amount was never edited

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-cancel.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-cancel.ts
@@ -120,26 +120,19 @@ export default class OrderProductCancel {
 
       if (productQuantity <= 0) {
         $productAmount.val(0);
+        $productAmount.removeData('suggestedAmount');
         this.updateVoucherRefund();
 
         return;
       }
-      const priceFieldName = this.isTaxIncluded ? 'productPriceTaxIncl' : 'productPriceTaxExcl';
-      const productUnitPrice = parseFloat($productQuantityInput.data(priceFieldName));
-      const amountRefundable = parseFloat($productQuantityInput.data('amountRefundable'));
-      const guessedAmount = productUnitPrice * productQuantity < amountRefundable
-        ? productUnitPrice * productQuantity
-        : amountRefundable;
-      const amountValue = parseFloat(<string>$productAmount.val());
 
       if (this.useAmountInputs) {
         this.updateAmountInput($productQuantityInput);
+      } else {
+        this.suggestAmount($productQuantityInput, $productAmount, productQuantity);
       }
 
-      if ($productAmount.val() === '' || amountValue === 0 || amountValue > guessedAmount) {
-        $productAmount.val(guessedAmount);
-        this.updateVoucherRefund();
-      }
+      this.updateVoucherRefund();
     });
 
     $(document).on('change', OrderViewPageMap.cancelProduct.inputs.amount, () => {
@@ -169,10 +162,21 @@ export default class OrderProductCancel {
 
     if (productQuantity <= 0) {
       $productAmount.val(0);
+      $productAmount.removeData('suggestedAmount');
 
       return;
     }
 
+    this.suggestAmount($productQuantityInput, $productAmount, productQuantity);
+  }
+
+  /*
+   * The amount follows the quantity unless the merchant typed a figure of their own, which is why the
+   * suggestion is remembered: an untouched field still holds the last suggestion, so it can be replaced,
+   * while anything else is left alone. Comparing against the suggestion rather than only replacing a
+   * value that is too high is what lets the amount grow again when the quantity is raised back up.
+   */
+  private suggestAmount($productQuantityInput: JQuery, $productAmount: JQuery, productQuantity: number): void {
     const priceFieldName = this.isTaxIncluded ? 'productPriceTaxIncl' : 'productPriceTaxExcl';
     const productUnitPrice = parseFloat($productQuantityInput.data(priceFieldName));
     const amountRefundable = parseFloat($productQuantityInput.data('amountRefundable'));
@@ -180,9 +184,12 @@ export default class OrderProductCancel {
       ? productUnitPrice * productQuantity
       : amountRefundable;
     const amountValue = parseFloat(<string>$productAmount.val());
+    const previousSuggestion = parseFloat($productAmount.data('suggestedAmount'));
+    const isUntouched = !Number.isNaN(previousSuggestion) && amountValue === previousSuggestion;
 
-    if ($productAmount.val() === '' || amountValue === 0 || amountValue > guessedAmount) {
+    if ($productAmount.val() === '' || amountValue === 0 || isUntouched || amountValue > guessedAmount) {
       $productAmount.val(guessedAmount);
+      $productAmount.data('suggestedAmount', guessedAmount);
     }
   }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On a partial refund, lowering the quantity updates the amount but raising it back does not, so the merchant is left refunding less than the quantity says. The amount is only replaced when it is empty, zero, or **higher** than the newly computed one - a one way test, so going 3 -> 2 -> 3 leaves the amount from 2. The field now also follows the quantity when it still holds the figure the page suggested, which is how an untouched field is told apart from one the merchant typed into.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open an order with a product whose quantity is 3 or more, start a partial refund, set the quantity to 3, then to 2, then back to 3. Before: the amount stays at the figure for 2. After: it follows each change. Then type an amount of your own and change the quantity again - the typed figure is kept, which is what the original test was protecting.
| UI Tests          | Not applicable, back office form behaviour only.
| Fixed issue or discussion?     | Fixes #38630
| Related PRs       | #38629 is the other half of the same form and is a different defect - see the note below.
| Sponsor company   |

### The one way test

```js
if ($productAmount.val() === '' || amountValue === 0 || amountValue > guessedAmount) {
  $productAmount.val(guessedAmount);
}
```

`amountValue > guessedAmount` only fires when the new figure is smaller, which is why lowering the quantity works and raising it does not. Replacing unconditionally would throw away an amount the merchant typed, which is what that test exists to prevent - so the suggestion is remembered on the field instead, and a value still equal to it counts as untouched.

The same block existed twice, in the quantity handler and in `updateAmountInput()`, and only one of the two ran depending on `useAmountInputs`. They are now one method, so the rule cannot drift between them.

### Not fixed here: #38629

While reading this form I checked the neighbouring report, and it is a separate defect with a separate cause. The template feeds the script `product.unitPriceTaxInclRaw`, but that value is not raw - it is rounded where the view model is built:

```php
(new DecimalNumber((string) $product['unit_price_tax_incl']))->round($precision, $this->getNumberRoundMode()),
```

so the script multiplies an already rounded unit price and lands a cent away on quantities above one. That belongs in `GetOrderProductsForViewingHandler`, not in this file, and changing what that field carries touches every other consumer of it, so it is left out of this change deliberately.
