### PR TITLE
Round the refund form's unit price only when the order rounds per item

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -148,7 +148,8 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
 
             // if rounding type is set to "per item" we must round the unit price now, otherwise values won't match
             // the totals in the order summary
-            if ((int) $order->round_type === Order::ROUND_ITEM) {
+            $roundsPerItem = (int) $order->round_type === Order::ROUND_ITEM;
+            if ($roundsPerItem) {
                 $unitPrice = (new DecimalNumber((string) $unitPrice))->round($precision, $this->getNumberRoundMode());
             }
 
@@ -229,8 +230,8 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 $totalPriceFormatted,
                 $product['current_stock'],
                 $imagePath,
-                (new DecimalNumber((string) $product['unit_price_tax_excl']))->round($precision, $this->getNumberRoundMode()),
-                (new DecimalNumber((string) $product['unit_price_tax_incl']))->round($precision, $this->getNumberRoundMode()),
+                $this->roundUnitPriceIfNeeded((string) $product['unit_price_tax_excl'], $roundsPerItem, $precision),
+                $this->roundUnitPriceIfNeeded((string) $product['unit_price_tax_incl'], $roundsPerItem, $precision),
                 (string) $product['tax_rate'],
                 $this->locale->formatPrice($product['amount_refunded'], $currency->iso_code),
                 $product['product_quantity_refunded'] + $product['product_quantity_return'],
@@ -264,6 +265,22 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
     /**
      * @param array $pack_item
      */
+    /**
+     * These two are handed to the refund form, which multiplies them by a quantity. Rounding them when
+     * the order does not round per item makes that product miss the stored line total by a cent or more,
+     * so the same condition the displayed unit price uses applies here.
+     */
+    private function roundUnitPriceIfNeeded(string $unitPrice, bool $roundsPerItem, int $precision): string
+    {
+        // The column is decimal(20,6), so the stored value arrives with trailing zeros; DecimalNumber
+        // normalises them away without touching the value itself.
+        if (!$roundsPerItem) {
+            return (string) new DecimalNumber($unitPrice);
+        }
+
+        return (string) (new DecimalNumber($unitPrice))->round($precision, $this->getNumberRoundMode());
+    }
+
     private function setProductImageInformation(&$pack_item): void
     {
         if (isset($pack_item['id_product_attribute']) && $pack_item['id_product_attribute']) {

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
@@ -50,7 +50,7 @@ Feature: In BO, get right display prices for products and totals, depending on t
       | total_price_tax_incl        | 755.04 |
     Then product "Test Product With Odd Tax" in order "bo_order1" has following prices for viewing in BO:
       | unit_price_tax_excl_raw     | 7.8    |
-      | unit_price_tax_incl_raw     | 9.44   |
+      | unit_price_tax_incl_raw     | 9.438   |
       | unit_price                  | $9.44  |
       | total_price                 | $755.04 |
 
@@ -110,6 +110,6 @@ Feature: In BO, get right display prices for products and totals, depending on t
       | total_price_tax_incl        | 755.04 |
     Then product "Test Product With Odd Tax" in order "bo_order1" has following prices for viewing in BO:
       | unit_price_tax_excl_raw     | 7.8    |
-      | unit_price_tax_incl_raw     | 9.44   |
+      | unit_price_tax_incl_raw     | 9.438   |
       | unit_price                  | $9.44  |
       | total_price                 | $755.04 |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The partial refund form multiplies a unit price by the quantity, and the price it is given is rounded, so on quantities above one the suggested refund misses the line total by a cent or more - 27.04 x 3 = 81.12 where the order says 81.13. The same handler already knows when rounding a unit price is correct: it rounds the *displayed* price only when the order rounds per item, because that is the one mode where the totals are built that way. The values handed to the form did not follow that condition. They do now.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order` - the whole suite is green, 260 scenarios. `order_rounding_type.feature` covers the three rounding modes; the per line and per cart total scenarios now expect the unit price they actually store. Manually: on an order whose rounding type is per line or per cart total, with a product priced so its taxed unit price is not a round cent, start a partial refund for a quantity above 1 and compare the suggested amount with the line total.
| UI Tests          | Not applicable, back office view model only.
| Fixed issue or discussion?     | Fixes #38629
| Related PRs       | #42296 fixes the other reported defect of the same form, which is a different code path.
| Sponsor company   |

### The two rules in one method

`GetOrderProductsForViewingHandler` rounds the displayed unit price under a condition:

```php
// if rounding type is set to "per item" we must round the unit price now, otherwise values won't match
// the totals in the order summary
if ((int) $order->round_type === Order::ROUND_ITEM) {
    $unitPrice = (new DecimalNumber((string) $unitPrice))->round($precision, $this->getNumberRoundMode());
}
```

and then rounded the values the form reads without one:

```php
(new DecimalNumber((string) $product['unit_price_tax_excl']))->round($precision, $this->getNumberRoundMode()),
(new DecimalNumber((string) $product['unit_price_tax_incl']))->round($precision, $this->getNumberRoundMode()),
```

Those two feed `data-product-price-tax-incl` / `data-product-price-tax-excl`, which `order-product-cancel.ts` multiplies by the quantity. The comment above the first block is the reason the second one is wrong: outside per item rounding, the totals are not built from a rounded unit price, so multiplying one does not reproduce them.

### The two changed expectations

`order_rounding_type.feature` asserted `unit_price_tax_incl_raw | 9.44` in all three modes. The per item scenario keeps it - rounding is right there. The per line and per cart total scenarios now expect `9.438`, which is what `unit_price_tax_incl` holds in the same table three lines above, and those same scenarios already assert `total_price | $755.04` while `9.44 x 80` is `755.20`. The assertions were encoding the defect.

The displayed `unit_price | $9.44` and `total_price | $755.04` are untouched: they come from a separate variable and are formatted for display, which is where rounding belongs.

Trailing zeros are normalised through `DecimalNumber` rather than returned raw, since the column is `decimal(20,6)` and would otherwise hand the form `7.800000`.
