### PR TITLE
Let the back office choose the tax basis of an order discount amount

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -115,9 +115,8 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
         if ($command->getCartRuleType() === OrderDiscountType::DISCOUNT_PERCENT) {
             $cartRuleObj->reduction_percent = (float) (string) $command->getDiscountValue();
         } elseif ($command->getCartRuleType() === OrderDiscountType::DISCOUNT_AMOUNT) {
-            $discountValueTaxIncluded = (float) (string) $command->getDiscountValue();
-            $cartRuleObj->reduction_amount = $discountValueTaxIncluded;
-            $cartRuleObj->reduction_tax = true;
+            $cartRuleObj->reduction_amount = (float) (string) $command->getDiscountValue();
+            $cartRuleObj->reduction_tax = $command->isValueTaxIncluded();
         } elseif ($command->getCartRuleType() === OrderDiscountType::FREE_SHIPPING) {
             $cartRuleObj->free_shipping = true;
         }

--- a/src/Core/Domain/Order/Command/AddCartRuleToOrderCommand.php
+++ b/src/Core/Domain/Order/Command/AddCartRuleToOrderCommand.php
@@ -49,12 +49,18 @@ class AddCartRuleToOrderCommand
      * @param string|null $value
      * @param int|null $orderInvoiceId
      */
+    /**
+     * @var bool
+     */
+    private $valueTaxIncluded;
+
     public function __construct(
         int $orderId,
         string $cartRuleName,
         string $cartRuleType,
         ?string $value,
-        $orderInvoiceId = null
+        $orderInvoiceId = null,
+        bool $valueTaxIncluded = true
     ) {
         $this->assertCartRuleNameIsNotEmpty($cartRuleName);
         $this->assertCartRuleTypeAndValueCombination($cartRuleType, $value);
@@ -64,6 +70,16 @@ class AddCartRuleToOrderCommand
         $this->cartRuleType = $cartRuleType;
         $this->value = null !== $value ? new DecimalNumber($value) : null;
         $this->orderInvoiceId = $orderInvoiceId ? new OrderInvoiceId($orderInvoiceId) : null;
+        $this->valueTaxIncluded = $valueTaxIncluded;
+    }
+
+    /**
+     * Whether the amount was stated with tax. A shop pricing a group tax excluded needs to give a net
+     * figure, and the amount alone does not say which of the two it is.
+     */
+    public function isValueTaxIncluded(): bool
+    {
+        return $this->valueTaxIncluded;
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1526,7 +1526,8 @@ class OrderController extends PrestaShopAdminController
                             $data['name'],
                             $data['type'],
                             $data['value'] ?? null,
-                            empty($data['invoice_id']) ? null : (int) $data['invoice_id']
+                            empty($data['invoice_id']) ? null : (int) $data['invoice_id'],
+                            !isset($data['value_tax_included']) || (bool) $data['value_tax_included']
                         )
                     );
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/AddOrderCartRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/AddOrderCartRuleType.php
@@ -88,6 +88,15 @@ class AddOrderCartRuleType extends AbstractType
                     'message' => $this->trans('Discount value must be a number', [], 'Admin.Notifications.Error'),
                 ]),
             ])
+            ->add('value_tax_included', ChoiceType::class, [
+                'choices' => [
+                    $this->trans('Tax included', [], 'Admin.Global') => 1,
+                    $this->trans('Tax excluded', [], 'Admin.Global') => 0,
+                ],
+                'data' => 1,
+                'required' => false,
+                'placeholder' => false,
+            ])
             ->add('invoice_id', ChoiceType::class, [
                 'choices' => $invoices,
                 'required' => false,

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
@@ -45,9 +45,11 @@
                     </div>
                     {{ form_widget(addOrderCartRuleForm.value) }}
                   </div>
-                  <small class="text-muted js-cart-rule-value-help d-none">
-                    {{ 'This value must include taxes.'|trans({}, 'Admin.Orderscustomers.Notification') }}
-                  </small>
+                  <div class="js-cart-rule-value-help d-none mt-1">
+                    {{ form_widget(addOrderCartRuleForm.value_tax_included, {attr: {
+                      'aria-label': 'Tax'|trans({}, 'Admin.Global'),
+                    }}) }}
+                  </div>
                 </div>
               </div>
             </div>

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1309,7 +1309,9 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                 $orderId,
                 $data['name'],
                 $data['type'],
-                $data['value'] ?? null
+                $data['value'] ?? null,
+                null,
+                !isset($data['tax_included']) || (bool) $data['tax_included']
             ));
         } catch (InvalidCartRuleDiscountValueException $e) {
             $this->setLastException($e);

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
@@ -53,6 +53,19 @@ Feature: Add discounts to order from Back Office (BO)
     And order "bo_order1" should have 1 cart rule
     And order "bo_order1" should have a cart rule with name "<<"
 
+  Scenario: Add tax excluded amount type discount to order which has no invoices
+    Given order "bo_order1" does not have any invoices
+    When I add discount to order "bo_order1" with following details:
+      | name         | discount fpf |
+      | type         | amount       |
+      | value        | 5.50         |
+      | tax_included | 0            |
+    Then order "bo_order1" should have following details:
+      | total_discounts_tax_excl | 5.5   |
+      | total_discounts_tax_incl | 5.83  |
+      | total_paid_tax_excl      | 25.3  |
+      | total_paid_tax_incl      | 26.82 |
+
   Scenario: Add amount type discount to order which has no invoices
     Given order "bo_order1" does not have any invoices
     When I add discount to order "bo_order1" with following details:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The back office discount modal always stored an amount discount as tax included: `AddCartRuleToOrderHandler` hardcoded `reduction_tax = true`, and the modal showed a fixed "This value must include taxes." hint. A merchant selling to a tax-excluded customer group types the net amount that was agreed with the customer, but the order is discounted by that amount interpreted as gross, so the customer receives less than agreed. This PR replaces the fixed hint with a Tax included / Tax excluded selector next to the value field and passes the choice through the command to the cart rule.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31334995912 - 46 of 46 jobs green
| Fixed issue or discussion?     | Fixes #38759
| Related PRs       |
| Sponsor company   |

The selector defaults to Tax included and the new `AddCartRuleToOrderCommand` parameter is optional with the same default, so a shop that does nothing keeps the current behaviour and existing callers are unaffected.

### How to test

1. BO > Customers > Groups: set a group's price display method to Tax excluded, and put a customer in that group (or enable B2B mode).
2. Open an order of that customer, click Add a new discount, choose Type = Amount.
3. Where the modal used to print "This value must include taxes.", there is now a Tax included / Tax excluded selector.
4. Enter 5.50 with Tax excluded: the order's discount tax excluded is 5.50. Enter 5.50 with Tax included: 5.50 is the gross amount, which is what 9.2.x does today.

Automated coverage: `vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags add-discounts-to-order` - 11 scenarios, 211 steps. The new scenario `Add tax excluded amount type discount to order which has no invoices` asserts 5.50 tax excluded; reverting the handler line makes it fail with `expected 5.5 instead of 5.190000`, the other 10 stay green.

### Alternative considered

Deriving the basis from the customer group (`Group::getPriceDisplayMethod()`) instead of asking. It needs no UI, but it silently changes the meaning of the value field for every existing tax-excluded group, and it is wrong whenever the agreed discount is a gross amount for a net-priced customer. It also broke 4 existing scenarios in `add_cart_rule_to_order.feature`, whose totals encode the current interpretation. An explicit per-discount choice is BC-safe and covers both cases. If you would rather have the selector preselected from the customer group instead of always defaulting to Tax included, say so and I will add that on top.
