### PR TITLE
Stop the back office cart view from attaching automatic cart rules

### DIFF
--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -7,6 +7,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Cart\QueryHandler;
 
 use Cart;
+use CartRule;
 use Context;
 use Currency;
 use Customer;
@@ -269,7 +270,9 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
      */
     private function getCartRulesForView(Cart $cart)
     {
-        $cartRules = $cart->getCartRules();
+        // Viewing a cart must not change it: the default of getCartRules() auto adds every automatic
+        // rule that is valid today, which rewrites what an already ordered cart appears to have cost.
+        $cartRules = $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false);
         $cartRulesView = [];
 
         $cartCurrency = new Currency($cart->id_currency);

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -43,6 +43,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\MinimalQuantityException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForOrderCreation;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation;
 use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\CartRuleValidityException;
@@ -1313,6 +1314,24 @@ class CartFeatureContext extends AbstractDomainFeatureContext
         }
 
         $this->assertLastErrorIs(CartNotFoundException::class);
+    }
+
+    /**
+     * @When I view the current cart in the back office
+     */
+    public function viewCurrentCartInBackOffice(): void
+    {
+        $this->getQueryBus()->handle(new GetCartForViewing((int) Context::getContext()->cart->id));
+    }
+
+    /**
+     * @Then the current cart should have :count cart rules
+     */
+    public function currentCartShouldHaveCartRules(int $count): void
+    {
+        $cart = new Cart((int) Context::getContext()->cart->id);
+
+        Assert::assertCount($count, $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/cart_view.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/cart_view.feature
@@ -1,0 +1,39 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-view
+@restore-all-tables-before-feature
+@cart-view
+Feature: View a cart in the back office
+  As an employee
+  I must be able to view a cart without changing what it contains
+
+  Background:
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    And I add new zone "zone1" with following properties:
+      | name    | zone1 |
+      | enabled | true  |
+    And there is a country named "country1" and iso code "FR" in zone "zone1"
+    And there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
+    And there is an address named "address1" with postcode "1" in state "state1"
+    And there is a customer named "customer1" whose email is "fake@prestashop.com"
+    And address "address1" is associated to customer "customer1"
+    And I create carrier "carrier1" with specified properties:
+      | name  | carrier 1 |
+      | zones | zone1     |
+    And I set ranges for carrier "carrier1" with specified properties for all shops:
+      | id_zone | range_from | range_to | range_price |
+      | zone1   | 0          | 10000    | 5.0         |
+
+  # An automatic cart rule has no code and is valid from before the order was placed. Viewing an
+  # already ordered cart used to attach it, so the cart then showed a total the customer never paid.
+  Scenario: Viewing an ordered cart does not attach an automatic cart rule created afterwards
+    Given I have an empty default cart
+    And email sending is disabled
+    And I am logged in as "customer1"
+    And I add 1 items of product "product1" in my cart
+    And I select address "address1" in my cart
+    And I select carrier "carrier1" in my cart
+    And I validate my cart using payment module fake
+    And there is a cart rule "autorule1" with following properties:
+      | name[en-US]         | autorule1 |
+      | discount_percentage | 10        |
+    When I view the current cart in the back office
+    Then the current cart should have 0 cart rules


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Opening a cart in the back office writes to it. `GetCartForViewingHandler::getCartRulesForView()` calls `Cart::getCartRules()`, whose `$autoAdd` parameter defaults to `true`, so rendering the voucher list runs `CartRule::autoAddToCart()` and inserts every automatic cart rule that is valid today into `cart_cart_rule` - including for a cart that was converted to an order months ago. From then on the cart is displayed with a discount the customer never got, while the order keeps its own stored totals, which is the mismatch in the report. The row is persisted, so it does not go away on reload and it affects every later viewer. A view must not change what it shows, so this passes `$autoAdd = false`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | [46/46 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31482154018) on `df243a2b` (detected 9.2.0, target `9.2.x`). Three campaigns failed on the first attempt and passed on a re-run of the same commit: `BO:orders:01-create-orders`, `BO:catalog:01-02`, `BO:advanced-parameters:07-10`. The first of those failed identically on an unrelated PR run in the same slot, so it is not this diff.
| Fixed issue or discussion?     | Fixes #38075
| Related PRs       |
| Sponsor company   |

### How to test

`tests/Integration/Behaviour/Features/Scenario/Cart/cart_view.feature` places an order from a cart, then creates an automatic cart rule (no code, valid from before the order), views the cart through `GetCartForViewing`, and asserts the cart still has no cart rule. Run it with `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-view`. Without the change it fails with `Failed asserting that actual size 1 matches expected size 0`. The whole suite stays green: `-s cart` gives 243 scenarios, 3556 steps.

Reproduced by hand on a 9.2.x shop before writing the fix, on an order dated before the rule:

| | order `total_paid` | cart total before viewing | cart total after viewing | `cart_cart_rule` rows |
|---|---|---|---|---|
| 9.2.x | 14.90 | 12.90 | 11.61 | 1 added |
| with this change | 14.90 | 12.90 | 12.90 | none |

The 1.29 difference is the 10% rule applied to a cart that had already been paid for.

### Why here and not in autoAddToCart

Guarding `CartRule::autoAddToCart()` against carts that already have an order would look like the more general fix, but it would break back office order editing: `OrderAmountUpdater` calls `CartRule::autoAddToCart(null, true)` deliberately, on the cart of an existing order, and its own comment says the call is required so that newly created automatic rules are assigned. Editing an order is a write and may legitimately change the cart's rules; rendering the cart view is not. The read path is where the wrong assumption is, and `OrderAmountUpdater` already reads with `getCartRules(CartRule::FILTER_ACTION_ALL, false, true)`, so this aligns the view with the convention already used elsewhere.

Side effect worth noting: a live, not yet ordered cart opened in the back office is no longer modified either. It previously gained automatic rules simply because an employee looked at it, which changed the customer's cart behind their back.
