### PR TITLE
Exclude products given away as a gift from the cheapest product discount

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1601,7 +1601,7 @@ class CartRuleCore extends ObjectModel
             // Discount (%) on the cheapest product
             if ((float) $this->reduction_percent && $this->reduction_product == -1) {
                 // First search for cheapest product
-                $cheapestProduct = $this->getCheapestProduct($all_products, $package_products, $use_tax);
+                $cheapestProduct = $this->getCheapestProduct($all_products, $package_products, $use_tax, $context->cart);
                 if ($cheapestProduct) {
                     $cheapestProductPrice = $use_tax ? $cheapestProduct['price_with_reduction'] : $cheapestProduct['price_with_reduction_without_tax'];
                     // For product level discount, the percent discount is applied on all targeted products
@@ -1669,7 +1669,7 @@ class CartRuleCore extends ObjectModel
                 if (self::isDiscountFeatureFlagEnabled() && $this->getType() === DiscountType::PRODUCT_LEVEL && ($this->reduction_product == -1 || $this->reduction_product == -2)) {
                     // Find matching products
                     if ($this->reduction_product == -1) {
-                        $cheapestProduct = $this->getCheapestProduct($all_products, $package_products, $use_tax);
+                        $cheapestProduct = $this->getCheapestProduct($all_products, $package_products, $use_tax, $context->cart);
                         $selectedProducts = $cheapestProduct ? [$cheapestProduct] : [];
                     } else {
                         $selectedProducts = $this->getProductsMatchingSelection($package_products, $context->cart);
@@ -1839,11 +1839,29 @@ class CartRuleCore extends ObjectModel
         return $reduction_value;
     }
 
-    protected function getCheapestProduct(array $allProducts, array $packageProducts, bool $useTax): ?array
+    protected function getCheapestProduct(array $allProducts, array $packageProducts, bool $useTax, ?Cart $cart = null): ?array
     {
+        // A product given away by another cart rule costs the customer nothing, so it must not be picked
+        // as the cheapest one. Its row still carries the catalog price, which the price test below cannot
+        // see, so the given away quantity is resolved from the gift rules applied to the cart. A line is
+        // only skipped when every unit of it is a gift, so a product the customer also paid for stays
+        // eligible.
+        $giftedQuantities = [];
+        if ($cart !== null) {
+            foreach ($cart->getCartRules(CartRule::FILTER_ACTION_GIFT, false) as $giftRule) {
+                $giftKey = (int) $giftRule['gift_product'] . '-' . (int) $giftRule['gift_product_attribute'];
+                $giftedQuantities[$giftKey] = ($giftedQuantities[$giftKey] ?? 0) + 1;
+            }
+        }
+
         $minPrice = false;
         $cheapestProduct = null;
         foreach ($allProducts as $product) {
+            $giftKey = (int) $product['id_product'] . '-' . (int) ($product['id_product_attribute'] ?? 0);
+            if (($giftedQuantities[$giftKey] ?? 0) >= (int) $product['cart_quantity']) {
+                continue;
+            }
+
             $price = $useTax ? $product['price_with_reduction'] : $product['price_with_reduction_without_tax'];
             if ($price > 0 && ($minPrice === false || $minPrice > $price) && (($this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
                 $minPrice = $price;

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -355,13 +355,42 @@ class CartRuleCalculator
         return $concernedRows;
     }
 
+    /**
+     * @return array<string, int> given away quantity, keyed by "id_product-id_product_attribute"
+     */
+    protected function getGiftedQuantities(): array
+    {
+        // Read through getCartRules() and not by iterating the collection: CartRuleCollection is a
+        // stateful Iterator with a single cursor, so iterating it here while applyCartRules() is already
+        // iterating it would move that cursor and silently drop the rules that come after the current one.
+        $giftedQuantities = [];
+        foreach ($this->cartRules->getCartRules() as $cartRuleData) {
+            $cartRule = $cartRuleData->getCartRule();
+            if (!(int) $cartRule->gift_product) {
+                continue;
+            }
+            $giftKey = (int) $cartRule->gift_product . '-' . (int) $cartRule->gift_product_attribute;
+            $giftedQuantities[$giftKey] = ($giftedQuantities[$giftKey] ?? 0) + 1;
+        }
+
+        return $giftedQuantities;
+    }
+
     protected function getCheapestCartRow(CartRuleData $cartRuleData): ?CartRow
     {
         /** @var CartRow|null $cartRowCheapest */
         $cartRowCheapest = null;
         $cartRule = $cartRuleData->getCartRule();
+        $giftedQuantities = $this->getGiftedQuantities();
         foreach ($this->cartRows as $cartRow) {
             $product = $cartRow->getRowData();
+            // A row the customer does not pay for cannot be the cheapest one it is offered as a gift by
+            // another rule. Only skip it when every unit is a gift, so a product also bought stays eligible.
+            $giftKey = (int) $product['id_product'] . '-' . (int) $product['id_product_attribute'];
+            if (($giftedQuantities[$giftKey] ?? 0) >= (int) $product['cart_quantity']) {
+                continue;
+            }
+
             if (
                 (
                     ($cartRule->reduction_exclude_special && !$product['reduction_applies'])

--- a/src/Core/Cart/CartRuleCollection.php
+++ b/src/Core/Cart/CartRuleCollection.php
@@ -22,6 +22,17 @@ class CartRuleCollection implements Iterator
         $this->cartRules[] = $cartRule;
     }
 
+    /**
+     * Read the rules without moving the iterator cursor, so a caller can look at the collection while
+     * something else is iterating it.
+     *
+     * @return CartRuleData[]
+     */
+    public function getCartRules(): array
+    {
+        return $this->cartRules;
+    }
+
     public function rewind(): void
     {
         $this->iteratorPosition = 0;

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/cheapest_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/cheapest_product.feature
@@ -77,3 +77,25 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to cheape
     # The cheapest product is applied only once on one of the cheapest products
     # (2 * 32.388) + (2 * 9.812 / 2) + (9.812 / 2) + 31.188 + 7
     Then my cart total should be 127.494 tax included
+
+  @restore-cart-rules-after-scenario
+  Scenario: 50% cartRule on cheapest product must ignore a product offered as a gift
+    Given there is a product in the catalog named "giftproduct" with a price of 5.0 and 1000 items in stock
+    And there is a cart rule "cartrule30" with following properties:
+      | name[en-US]                  | cartrule30  |
+      | priority                     | 30          |
+      | free_shipping                | false       |
+      | code                         | foo30       |
+      | gift_product                 | giftproduct |
+      | apply_to_discounted_products | true        |
+    And I add 1 items of product "product2" in my cart
+    And my cart total should be 39.388 tax included
+    When I apply the voucher code "foo30"
+    # the gift is free, so the total does not move
+    Then my cart total should be 39.388 tax included
+    When I apply the voucher code "foo10"
+    # The cheapest product the customer actually pays for is product2, not the 5.0 gift,
+    # so the discount is 32.388 / 2 and not 5.0 / 2.
+    Then I should have a voucher named "foo10" with 16.194 of discount
+    # 32.388 + 5.0 gift + 7 shipping - 5.0 gift discount - 16.194
+    And my cart total should be 23.194 tax included


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A cart rule giving a percentage off the cheapest product applies it to a product the customer was given for free by another rule. The cheapest product selection compares raw row prices, and a gift row still carries the catalog price because the free part is expressed as a separate cart rule reduction rather than a zero line price. A gift is usually a cheap item, so it wins the comparison and the customer gets a discount on something they were not paying for. This skips a row when every unit of it is given away by a gift rule, in both places that select the cheapest product.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38078
| Related PRs       |
| Sponsor company   |

### How to test

`tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/cheapest_product.feature` gains a scenario: a 5.00 product offered as a gift by one rule, a 32.388 product bought by the customer, and a rule giving 50% on the cheapest product. Run it with `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags fo-cart-rule-cheapest-product`.

Without the change the second rule stores `value_real` 2.50, which is half the gift, and the scenario fails with `Failed asserting that 16.194 matches expected 2.5`. With it the discount is 16.194 and the cart total is 23.194.

Suites: `-s cart` 243 scenarios / 3552 steps, `-s order` 260 scenarios / 7343 steps, both green.

### Two selection sites

The cheapest product is chosen in two places, feeding different numbers, so both need it:

- `CartRuleCalculator::getCheapestCartRow()` drives the cart total.
- `CartRule::getCheapestProduct()` drives the value stored in `cart_cart_rule.value_real`, which is what the voucher line shows.

Fixing only one leaves the cart total and the displayed voucher amount disagreeing.

A row is skipped only when the given away quantity covers its whole `cart_quantity`, so a product the customer also bought units of stays eligible. The legacy method already tried to express this intent with its `$price > 0` test; that test cannot work here because the gift row's price is not zero.

### Note on CartRuleCollection

`getCheapestCartRow()` runs while `CartRuleCalculator::applyCartRules()` is iterating `$this->cartRules`, and `CartRuleCollection` implements `Iterator` with a single shared cursor. Reading the gift rules by iterating that same instance moves the cursor and makes the outer loop stop early, silently dropping every rule after the current one. This adds `CartRuleCollection::getCartRules()`, which returns the rules without touching the cursor, and uses it. Worth knowing for any other code that needs to look at the collection mid-iteration.

