### PR TITLE
Report an unreachable memcache server instead of a fatal error

### DIFF
--- a/src/Adapter/Cache/MemcacheServerManager.php
+++ b/src/Adapter/Cache/MemcacheServerManager.php
@@ -72,6 +72,13 @@ class MemcacheServerManager
             return is_array($version) && false === in_array('255.255.255', $version, true);
         }
 
+        // Both cache classes guard their own instantiation the same way. Without it, a shop that has
+        // neither extension answers the back office test and add requests with "Class Memcache not
+        // found" and a 500, instead of reporting that the server cannot be reached.
+        if (!class_exists('Memcache') || !extension_loaded('memcache')) {
+            return false;
+        }
+
         $memcache = new Memcache();
 
         return true === $memcache->connect($serverIp, (int) $serverPort);

--- a/tests/Unit/Adapter/Cache/MemcacheServerManagerTest.php
+++ b/tests/Unit/Adapter/Cache/MemcacheServerManagerTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Cache;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Cache\MemcacheServerManager;
+
+class MemcacheServerManagerTest extends TestCase
+{
+    /**
+     * The back office calls this when testing a server and before adding one. On a shop without any
+     * memcache extension it used to instantiate a class that does not exist, so both requests answered
+     * with a 500 instead of reporting an unreachable server.
+     */
+    public function testConfigurationReportsFailureInsteadOfCrashingWithoutExtension(): void
+    {
+        $manager = new MemcacheServerManager($this->createMock(Connection::class), 'ps_');
+
+        // Port 1 is refused immediately, so no connection attempt hangs.
+        $result = $manager->testConfiguration('127.0.0.1', 1);
+
+        if (extension_loaded('memcached') || extension_loaded('memcache')) {
+            // With an extension present the outcome depends on what answers on that port, so only the
+            // absence of a fatal error can be asserted.
+            $this->assertIsBool($result);
+
+            return;
+        }
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On a shop with neither the `memcached` nor the `memcache` PHP extension, Performance > Add server and Test server both answer with a 500. `MemcacheServerManager::testConfiguration()` falls back to `new Memcache()` without checking that the class exists, so it raises `Error: Class "Memcache" not found`. Both back office actions go through that method, which is why both buttons fail. `CacheMemcache` and `CacheMemcached` already guard their own instantiation with `class_exists() && extension_loaded()`; this applies the same guard, so the request reports that the server cannot be reached instead of crashing.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38204
| Related PRs       |
| Sponsor company   |

### How to test

On a PHP build without `memcached` and without `memcache`, go to Configure > Advanced Parameters > Performance, fill in any server IP and port, and press Test server, then Add server. Before this change both requests return 500 and the browser console shows the failed POST to `/configure/advanced/performance/memcache/servers` and GET to `/memcache/servers/test` from the report. After it they return 400 with "The Memcached server cannot be added.".

Automated: `tests/Unit/Adapter/Cache/MemcacheServerManagerTest.php` calls `testConfiguration()` on a port that refuses immediately. Run it with `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Adapter/Cache/MemcacheServerManagerTest.php`. Without the change it errors with `Error: Class "Memcache" not found`; with it the method returns false. When an extension is present the test only asserts that no fatal occurs, since the result then depends on what answers on that port.

### Scope

Only the unguarded fallback is touched. The `memcached` branch above it already checks `extension_loaded()`, and `classes/cache/CacheMemcache.php` and `classes/cache/CacheMemcached.php` already carry the same `class_exists() && extension_loaded()` guard, so this aligns the one place that was missing it rather than introducing a new pattern.

The back office still offers the memcache section on a shop that cannot use it. Hiding it is a separate user interface decision and is not part of this fix, which is limited to removing the fatal.

Credit to @ChillCode, who diagnosed the missing extension as the cause on the issue and proposed the same guard in #40041, which was closed unmerged while targeting the removed `9.0.x` branch.

