### PR TITLE
Stop reading the controller type off a missing controller

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -984,7 +984,7 @@ class CategoryCore extends ObjectModel
             return false;
         }
 
-        $front = in_array($context->controller->controller_type, ['front', 'modulefront']);
+        $front = in_array($context->controller?->controller_type, ['front', 'modulefront']);
         $idSupplier = (int) Tools::getValue('id_supplier');
 
         /* Return only the number of products */

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -361,7 +361,7 @@ class ManufacturerCore extends ObjectModel
         }
 
         $front = true;
-        if (!in_array($context->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array($context->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 
@@ -500,7 +500,7 @@ class ManufacturerCore extends ObjectModel
     {
         $context = Context::getContext();
         $front = true;
-        if (!in_array($context->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array($context->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1605,7 +1605,7 @@ class ProductCore extends ObjectModel
         }
 
         $front = true;
-        if (!in_array($context->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array($context->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 
@@ -1663,7 +1663,7 @@ class ProductCore extends ObjectModel
         }
 
         $front = true;
-        if (!in_array($context->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array($context->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 
@@ -2762,7 +2762,7 @@ class ProductCore extends ObjectModel
         }
 
         $front = true;
-        if (!in_array($context->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array($context->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 
@@ -2932,7 +2932,7 @@ class ProductCore extends ObjectModel
         }
 
         $front = true;
-        if (!in_array($context->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array($context->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 
@@ -3075,7 +3075,7 @@ class ProductCore extends ObjectModel
         }
 
         $front = true;
-        if (!in_array($context->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array($context->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -264,7 +264,7 @@ class SupplierCore extends ObjectModel
     ) {
         $context = Context::getContext();
         $front = true;
-        if (!in_array($context->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array($context->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 
@@ -399,7 +399,7 @@ class SupplierCore extends ObjectModel
     {
         $context = Context::getContext();
         $front = true;
-        if (!in_array($context->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array($context->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -868,7 +868,7 @@ class OrderDetailCore extends ObjectModel
         }
 
         $front = true;
-        if (!in_array(Context::getContext()->controller->controller_type, ['front', 'modulefront'])) {
+        if (!in_array(Context::getContext()->controller?->controller_type, ['front', 'modulefront'])) {
             $front = false;
         }
 

--- a/tests/Integration/Classes/ControllerTypeGuardTest.php
+++ b/tests/Integration/Classes/ControllerTypeGuardTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Context;
+use Manufacturer;
+use PHPUnit\Framework\TestCase;
+use Supplier;
+
+/**
+ * The context has no controller when the code runs outside a request, which is the case for the Admin
+ * API, a console command or a script. Listing methods read the controller's type to decide whether they
+ * are serving the front office, and reading it off a null controller raises "Attempt to read property
+ * controller_type on null" on every call.
+ */
+class ControllerTypeGuardTest extends TestCase
+{
+    /**
+     * @var mixed
+     */
+    private $previousController;
+
+    /**
+     * @var array<int, string>
+     */
+    private array $warnings = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->previousController = Context::getContext()->controller;
+        Context::getContext()->controller = null;
+
+        $this->warnings = [];
+        set_error_handler(function (int $errno, string $message): bool {
+            $this->warnings[] = $message;
+
+            return true;
+        }, E_WARNING);
+    }
+
+    protected function tearDown(): void
+    {
+        restore_error_handler();
+        Context::getContext()->controller = $this->previousController;
+
+        parent::tearDown();
+    }
+
+    public function testManufacturerListsProductsWithoutAControllerInContext(): void
+    {
+        $products = (new Manufacturer(1))->getProductsLite((int) Configuration::get('PS_LANG_DEFAULT'));
+
+        $this->assertSame([], $this->warnings);
+        $this->assertIsIterable($products);
+    }
+
+    public function testSupplierListsProductsWithoutAControllerInContext(): void
+    {
+        $products = Supplier::getProducts(1, (int) Configuration::get('PS_LANG_DEFAULT'), 1, 10);
+
+        $this->assertSame([], $this->warnings);
+        $this->assertIsIterable($products);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Listing methods decide whether they serve the front office by reading `$context->controller->controller_type`, without checking that a controller is set. The context has none when the code runs outside a request - the Admin API, a console command, a script - so every such call raises `Attempt to read property "controller_type" on null`. The value read is `null`, which is not in the allowed list, so the branch taken is already the correct one and only the warning is wrong. This reads the property through the null safe operator, which core already does in four other places.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Will be added when a runner slot frees up.
| Fixed issue or discussion?     | Fixes #39469
| Related PRs       |
| Sponsor company   |

### How to test

```php
Context::getContext()->controller = null;
(new Manufacturer(1))->getProductsLite((int) Configuration::get('PS_LANG_DEFAULT'));
```

On `9.2.x` that prints `Warning: Attempt to read property "controller_type" on null` and returns the products anyway. With this change the warning is gone and the same products come back.

`tests/Integration/Classes/ControllerTypeGuardTest.php` covers it for `Manufacturer` and `Supplier` by collecting `E_WARNING` through a temporary error handler and asserting none was raised. Reverting the two classes to `9.2.x` and rerunning gives `Failed asserting that two arrays are identical` on both tests, so they are tied to the change.

### Not only Manufacturer

The report came from the Admin API hitting `Manufacturer::getProductsLite()`, but the same expression is written in eleven places:

| file | lines |
|---|---|
| `classes/Product.php` | 1608, 1666, 2765, 2935, 3078 |
| `classes/Manufacturer.php` | 364, 503 |
| `classes/Supplier.php` | 267, 402 |
| `classes/Category.php` | 987 |
| `classes/order/OrderDetail.php` | 871 |

Fixing only the reported one would leave the same warning behind every other listing an API resource or a command touches, so all eleven are changed the same way.

Core already guards this elsewhere, which is why the fix follows the existing intent rather than introducing a convention: `classes/Context.php` line 301 uses `?? null`, `classes/order/Order.php` line 282 wraps it in `is_object()`, and `classes/Product.php` line 6319 and `classes/ImageManager.php` line 109 use `isset()`. Those four are left untouched.

Behaviour is identical in both directions: with a controller the expression is unchanged, and without one it evaluates to `null` exactly as before, so `$front` stays `false`.
