### PR TITLE
Keep resource names when rendering the API listing as JSON

### DIFF
--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -145,7 +145,11 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
     public function overrideContent($content)
     {
         array_walk($this->content, function (&$item) {
-            $item = array_filter($item);
+            // Rendering the API listing appends each resource name as a plain string, so only the
+            // entity arrays can be filtered here.
+            if (is_array($item)) {
+                $item = array_filter($item);
+            }
         });
         $content = json_encode($this->content, JSON_UNESCAPED_UNICODE);
 

--- a/tests/Unit/Classes/Webservice/WebserviceOutputJSONTest.php
+++ b/tests/Unit/Classes/Webservice/WebserviceOutputJSONTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Webservice;
+
+use PHPUnit\Framework\TestCase;
+use WebserviceOutputJSON;
+
+class WebserviceOutputJSONTest extends TestCase
+{
+    /**
+     * Listing the API root appends each resource name to the content as a plain string, while entities
+     * are appended as arrays. Filtering the content used to assume every entry was an array, so asking
+     * for the listing in JSON ended in "array_filter(): Argument #1 must be of type array, string given".
+     *
+     * This is the only test in this file on purpose: renderNodeHeader() keeps its "am I rendering the
+     * API listing" flag in a static local, so a second test would inherit it and no longer describe a
+     * fresh renderer.
+     */
+    public function testItRendersTheApiListingOfResourceNames(): void
+    {
+        $renderer = new WebserviceOutputJSON();
+        $renderer->renderNodeHeader('api', []);
+        $renderer->renderNodeHeader('customers', []);
+        $renderer->renderNodeHeader('orders', []);
+
+        $this->assertSame('["customers","orders"]', $renderer->overrideContent(''));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Asking the Webservice for the list of resources in JSON ends in a fatal. `WebserviceOutputJSON::renderNodeHeader()` appends each resource name to the content as a plain string while entities are appended as arrays, and `overrideContent()` then runs `array_filter()` over every entry, which raises `array_filter(): Argument #1 ($array) must be of type array, string given`. This filters only the entries that are arrays, so the resource names survive and the listing renders.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | [46/46 campaigns pass](https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31482156362) on `42a8cac5` (detected 9.2.0, target `9.2.x`). `BO:orders:01-create-orders` failed on the first attempt and passed on a re-run of the same commit; it failed identically on an unrelated PR run in the same slot, so it is not this diff.
| Fixed issue or discussion?     | Fixes #34794
| Related PRs       |
| Sponsor company   |

### How to test

```php
$renderer = new WebserviceOutputJSON();
$renderer->renderNodeHeader('api', []);
$renderer->renderNodeHeader('customers', []);
$renderer->renderNodeHeader('orders', []);
$renderer->overrideContent('');
```

On `9.2.x` that throws `TypeError: array_filter(): Argument #1 ($array) must be of type array, string given`. With this change it returns `["customers","orders"]`. Through the Webservice the same path is `GET /api?output_format=JSON`, which is where the report hit it.

`tests/Unit/Classes/Webservice/WebserviceOutputJSONTest.php` covers it. Reverting the class to `9.2.x` and rerunning the test produces that TypeError.

### Note on the test file

There is a single test in it deliberately. `renderNodeHeader()` remembers whether it is rendering the API listing in a `static` local, so a second test in the same file would inherit that flag and stop describing a fresh renderer. I hit exactly that while writing this and dropped the second case rather than encode the leaked state as if it were expected behaviour.

Entities are unaffected: entries that are arrays go through `array_filter()` exactly as before, so the empty values it exists to drop are still dropped.
