### PR TITLE
Keep the attached file when an import does not carry it

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1824,12 +1824,20 @@ class AdminImportControllerCore extends AdminController
                     StockAvailable::setProductOutOfStock((int) $product->id, (int) $product->out_of_stock);
                 }
 
-                if ($product_download_id = ProductDownload::getIdFromIdProduct((int) $product->id)) {
+                // The column mapping decides which keys reach $info, so an import that does not carry the
+                // file columns must leave an existing attachment alone instead of deleting the row and
+                // the file with it. A product that is no longer virtual still has its download removed.
+                $importsDownloadData = isset($info['file_url']);
+                $isVirtual = $product->getType() == Product::PTYPE_VIRTUAL;
+
+                if (($importsDownloadData || !$isVirtual)
+                    && ($product_download_id = ProductDownload::getIdFromIdProduct((int) $product->id))
+                ) {
                     $product_download = new ProductDownload($product_download_id);
                     $product_download->delete(true);
                 }
 
-                if ($product->getType() == Product::PTYPE_VIRTUAL) {
+                if ($isVirtual && $importsDownloadData) {
                     $product_download = new ProductDownload();
                     $product_download->filename = ProductDownload::getNewFilename();
                     Tools::copy($info['file_url'], _PS_DOWNLOAD_DIR_ . $product_download->filename);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Importing products deletes the attached file of every virtual product it touches, even when the import does not carry the file columns. `AdminImportController::productImportOne()` removes the `ProductDownload` row unconditionally, with `delete(true)` so the file goes too, and only recreates it from `$info`. A CSV that updates a price or a name and does not map `file_url` therefore wipes the download. This ties both halves to whether the import actually carries that data.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #35526
| Related PRs       |
| Sponsor company   |

### How to test

1. Create a virtual product with an associated file and note the row in `ps_product_download` and the file in `/download/`.
2. Import a CSV that matches it by ID or reference and maps only, say, ID and price - no `file_url`, `nb_downloadable`, `date_expiration` or `nb_days_accessible`.
3. Before this change the row is gone and the file is deleted from `/download/`. After it, both are untouched and the price is updated.

### Why isset($info['file_url']) is the right signal

`$info` is built by `getMaskedRow()`, which only fills the keys present in the column mapping, and `productImportOne()` does not run `setDefaultValues()`, which has no entry for the download columns anyway. So the key exists exactly when the merchant mapped that column:

```
mapping without file_url   keys: id,name          isset($info['file_url']) = false
mapping with file_url      keys: id,name,file_url isset($info['file_url']) = true
```

### What stays the same

- An import that maps `file_url` behaves exactly as before: the old download is removed and recreated from the row, so clearing or replacing a file still works.
- A product that is not virtual still has any leftover download removed, which is why the delete keeps running in that case.
- Only a virtual product whose file columns were not mapped changes, which is the reported case.

