### PR TITLE
Count orders without the joins that only supply columns

### DIFF
--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -96,7 +96,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
      */
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        $qb = $this->getBaseQueryBuilder($searchCriteria->getFilters());
+        $qb = $this->getBaseQueryBuilder($searchCriteria->getFilters(), true);
         $qb = $this->applyNewCustomerFilter($qb, $searchCriteria->getFilters());
         $qb->select('count(o.id_order)');
 
@@ -108,13 +108,11 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
      *
      * @return QueryBuilder
      */
-    private function getBaseQueryBuilder(array $filters)
+    private function getBaseQueryBuilder(array $filters, bool $forCounting = false)
     {
         $qb = $this->connection
             ->createQueryBuilder()
             ->from($this->dbPrefix . 'orders', 'o')
-            ->leftJoin('o', $this->dbPrefix . 'customer', 'cu', 'o.id_customer = cu.id_customer')
-            ->leftJoin('o', $this->dbPrefix . 'currency', 'cur', 'o.id_currency = cur.id_currency')
             ->innerJoin('o', $this->dbPrefix . 'address', 'a', 'o.id_address_delivery = a.id_address')
             ->innerJoin('a', $this->dbPrefix . 'country', 'c', 'a.id_country = c.id_country')
             ->innerJoin(
@@ -123,18 +121,34 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
                 'cl',
                 'c.id_country = cl.id_country AND cl.id_lang = :context_lang_id'
             )
-            ->leftJoin('o', $this->dbPrefix . 'order_state', 'os', 'o.current_state = os.id_order_state')
-            ->leftJoin(
-                'os',
-                $this->dbPrefix . 'order_state_lang',
-                'osl',
-                'os.id_order_state = osl.id_order_state AND osl.id_lang = :context_lang_id'
-            )
-            ->leftJoin('o', $this->dbPrefix . 'shop', 's', 'o.id_shop = s.id_shop')
             ->andWhere('o.`id_shop` IN (:context_shop_ids)')
             ->setParameter('context_lang_id', $this->contextLangId, PDO::PARAM_INT)
             ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY)
         ;
+
+        // Counting rows does not need the joins above that only supply columns to display: each of them
+        // is a LEFT JOIN matching at most one row, so it cannot add or remove an order. They are still
+        // added when a filter reads from them, and always for the list itself.
+        if (!$forCounting || isset($filters['company']) || isset($filters['customer'])) {
+            $qb->leftJoin('o', $this->dbPrefix . 'customer', 'cu', 'o.id_customer = cu.id_customer');
+        }
+
+        if (!$forCounting || isset($filters['osname'])) {
+            $qb->leftJoin('o', $this->dbPrefix . 'order_state', 'os', 'o.current_state = os.id_order_state');
+        }
+
+        if (!$forCounting) {
+            $qb
+                ->leftJoin('o', $this->dbPrefix . 'currency', 'cur', 'o.id_currency = cur.id_currency')
+                ->leftJoin(
+                    'os',
+                    $this->dbPrefix . 'order_state_lang',
+                    'osl',
+                    'os.id_order_state = osl.id_order_state AND osl.id_lang = :context_lang_id'
+                )
+                ->leftJoin('o', $this->dbPrefix . 'shop', 's', 'o.id_shop = s.id_shop')
+            ;
+        }
 
         $strictComparisonFilters = [
             'id_order' => 'o.id_order',

--- a/tests/Integration/Core/Grid/Query/OrderQueryBuilderTest.php
+++ b/tests/Integration/Core/Grid/Query/OrderQueryBuilderTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Grid\Query;
+
+use PrestaShop\PrestaShop\Core\Grid\Query\OrderQueryBuilder;
+use PrestaShop\PrestaShop\Core\Search\Filters\OrderFilters;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The count query only needs the joins that can exclude an order. The rest are LEFT joins matching at
+ * most one row each, so they cannot change the count, and on a large orders table they cost real time.
+ */
+class OrderQueryBuilderTest extends KernelTestCase
+{
+    private function buildQueryBuilder(): OrderQueryBuilder
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        return new OrderQueryBuilder(
+            $container->get('doctrine.dbal.default_connection'),
+            _DB_PREFIX_,
+            $container->get('prestashop.core.query.doctrine_search_criteria_applicator'),
+            1,
+            [1]
+        );
+    }
+
+    private function countSql(array $filters): string
+    {
+        return $this->buildQueryBuilder()->getCountQueryBuilder(new OrderFilters([
+            'limit' => 10,
+            'offset' => 0,
+            'orderBy' => 'id_order',
+            'sortOrder' => 'asc',
+            'filters' => $filters,
+        ]))->getSQL();
+    }
+
+    public function testItCountsWithoutTheJoinsThatOnlySupplyColumns(): void
+    {
+        $sql = $this->countSql([]);
+
+        // These can exclude an order, so they decide the count.
+        $this->assertStringContainsString(_DB_PREFIX_ . 'address', $sql);
+        $this->assertStringContainsString(_DB_PREFIX_ . 'country', $sql);
+
+        $this->assertStringNotContainsString(_DB_PREFIX_ . 'currency', $sql);
+        $this->assertStringNotContainsString(_DB_PREFIX_ . 'shop s', $sql);
+        $this->assertStringNotContainsString(_DB_PREFIX_ . 'order_state_lang', $sql);
+        $this->assertStringNotContainsString(_DB_PREFIX_ . 'customer', $sql);
+    }
+
+    /**
+     * @dataProvider provideFiltersNeedingAJoin
+     */
+    public function testItKeepsTheJoinAFilterReadsFrom(array $filters, string $expectedTable): void
+    {
+        $this->assertStringContainsString(_DB_PREFIX_ . $expectedTable, $this->countSql($filters));
+    }
+
+    public function provideFiltersNeedingAJoin(): iterable
+    {
+        yield 'order state' => [['osname' => 2], 'order_state'];
+        yield 'customer name' => [['customer' => 'doe'], 'customer'];
+        yield 'company' => [['company' => 'acme'], 'customer'];
+    }
+
+    /**
+     * @dataProvider provideFilters
+     */
+    public function testItRunsForEveryFilter(array $filters): void
+    {
+        $count = $this->buildQueryBuilder()->getCountQueryBuilder(new OrderFilters([
+            'limit' => 10,
+            'offset' => 0,
+            'orderBy' => 'id_order',
+            'sortOrder' => 'asc',
+            'filters' => $filters,
+        ]))->executeQuery()->fetchOne();
+
+        $this->assertIsNumeric($count);
+    }
+
+    public function provideFilters(): iterable
+    {
+        yield 'none' => [[]];
+        yield 'order state' => [['osname' => 2]];
+        yield 'customer' => [['customer' => 'doe']];
+        yield 'company' => [['company' => 'acme']];
+        yield 'reference' => [['reference' => 'ABC']];
+        yield 'new customer' => [['new' => 1]];
+        yield 'country' => [['country_name' => 1]];
+        yield 'date' => [['date_add' => ['from' => '2000-01-01']]];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The Orders grid counts rows with the same query it uses to display them, so the count joins customer, currency, order state, order state language and shop even though none of those can change the number of matching orders: each is a LEFT JOIN matching at most one row. On a large orders table that count dominates the page. This keeps the joins that can exclude an order, plus any join a filter reads from, and drops the rest when counting.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #35728
| Related PRs       |
| Sponsor company   |

### Measurement

On a shop seeded to 114 688 orders, MySQL 8.4, `SQL_NO_CACHE`, comparing the count query as it is built today with the one this produces:

```
with every join      0.160 s
joins that count     0.013 s
```

Both return 114 688. The reporter's shop has 180 000 orders, so the gap there is larger.

### Correctness

The joins that are dropped are all LEFT joins on a primary key, so they match at most one row and cannot add or remove an order. The three INNER joins stay, because they can exclude one: an order whose delivery address, country or country translation is missing is not counted today and still is not.

Filters are the reason it is not simply "drop them all": `osname` reads `os.`, and `customer` and `company` read `cu.`, so those joins are added back when the filter is present. `currency`, `shop` and `order_state_lang` are never read by a filter.

Verified by running the count for every filter the builder supports and comparing against the query built the old way:

```
no filter    old 22  new 22    order state  old 13  new 13
customer     old  0  new  0    company      old  0  new  0
reference    old  1  new  1    new customer old  1  new  1
country      old  0  new  0    date         old 22  new 22
```

`tests/Integration/Core/Grid/Query/OrderQueryBuilderTest.php` covers both halves: the tables that must not appear when nothing is filtered, the ones that must come back per filter, and that every filter still produces a runnable query. Reverting the builder makes it fail on `ps_currency` still being joined.

### Note

The list query itself is untouched, so the grid still shows the same columns. Only `getCountQueryBuilder()` takes the reduced set.

