### PR TITLE
Let the caller name the author of a stock movement

### DIFF
--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -400,6 +400,19 @@ class StockManager
                     $stockMvt->setEmployeeLastname($employee->lastname);
                 }
 
+                // A caller running without an employee in the context - a console command, a cron - can
+                // name the author itself through the same array that already carries id_order and
+                // id_stock_mvt_reason, instead of the movement being recorded against nobody.
+                if (isset($params['id_employee'])) {
+                    $stockMvt->setIdEmployee((int) $params['id_employee']);
+                }
+                if (isset($params['employee_firstname'])) {
+                    $stockMvt->setEmployeeFirstname((string) $params['employee_firstname']);
+                }
+                if (isset($params['employee_lastname'])) {
+                    $stockMvt->setEmployeeLastname((string) $params['employee_lastname']);
+                }
+
                 return $stockMvt;
             }
         }

--- a/tests/Integration/Core/Stock/StockMovementAuthorTest.php
+++ b/tests/Integration/Core/Stock/StockMovementAuthorTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Stock;
+
+use Context;
+use Db;
+use PrestaShop\PrestaShop\Core\Stock\StockManager;
+use Product;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class StockMovementAuthorTest extends KernelTestCase
+{
+    private int $productId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+        // The movement is written through the Symfony container, which StockManager reads from the
+        // global kernel.
+        $GLOBALS['kernel'] = self::$kernel;
+
+        $this->productId = (int) Db::getInstance()->getValue(
+            'SELECT id_product FROM ' . _DB_PREFIX_ . 'stock_available WHERE id_product_attribute = 0'
+        );
+    }
+
+    /**
+     * A cron or a console command has no employee in the context, so without this the movement is
+     * recorded against employee 0 with no name and the caller cannot say who performed it.
+     */
+    public function testItRecordsTheAuthorGivenByTheCaller(): void
+    {
+        $previousEmployee = Context::getContext()->employee;
+        Context::getContext()->employee = null;
+
+        try {
+            (new StockManager())->updateQuantity(
+                new Product($this->productId),
+                0,
+                1,
+                null,
+                true,
+                [
+                    'id_employee' => 7,
+                    'employee_firstname' => 'Import',
+                    'employee_lastname' => 'Script',
+                ]
+            );
+        } finally {
+            Context::getContext()->employee = $previousEmployee;
+        }
+
+        $movement = Db::getInstance()->getRow(
+            'SELECT id_employee, employee_firstname, employee_lastname
+             FROM ' . _DB_PREFIX_ . 'stock_mvt ORDER BY id_stock_mvt DESC'
+        );
+
+        $this->assertSame('7', (string) $movement['id_employee']);
+        $this->assertSame('Import', $movement['employee_firstname']);
+        $this->assertSame('Script', $movement['employee_lastname']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `StockManager::updateQuantity()` takes a `$params` array and passes it on to the movement it writes, but only `id_order` and `id_stock_mvt_reason` are read from it. The author is taken from the context employee alone, so a console command or a cron - which has none - records every movement against employee `0` with no name, and the `id_employee`, `employee_firstname` and `employee_lastname` keys a caller supplies are silently dropped. This reads them, so a caller without an employee can say who performed the movement.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38799
| Related PRs       |
| Sponsor company   |

### How to test

```php
Context::getContext()->employee = null;
(new StockManager())->updateQuantity($product, 0, 1, null, true, [
    'id_stock_mvt_reason' => $reasonId,
    'id_employee' => 7,
    'employee_firstname' => 'Import',
    'employee_lastname' => 'Script',
]);
```

Then read the last row of `stock_mvt`. On `9.2.x` it holds `id_employee 0` and two empty names; with this change it holds `7`, `Import` and `Script`.

`tests/Integration/Core/Stock/StockManagerTest.php` covers it, and fails on the current code.

### On the other half of the report

The movement not being written at all does not reproduce on `9.2.x`. Running the same call from a script, with no employee in the context, writes the row in both cases tested - with an explicit shop id and with `null`:

```
before 0  after 1     id_shop = 1
before 1  after 2     id_shop = null
```

`saveMovement()` does return early when `SymfonyContainer::getInstance()` is null, but a front controller request has the kernel available through the `$kernel` global set in `index.php`, so a cron controller reaches the repository. What was missing in the reported output is the author, which is what this changes.

### Precedence

An explicit value in `$params` wins over the context employee, since a caller that names an author is being deliberate. Nothing passes these keys today, precisely because they were ignored, so no existing behaviour changes.

