### PR TITLE
Read the cart quantity once per product and cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -250,6 +250,10 @@ class CartCore extends ObjectModel
         if (isset(self::$_totalWeight[$this->id])) {
             unset(self::$_totalWeight[$this->id]);
         }
+        // WHY: pricing memoises how many units of a product this cart holds, and that count is what
+        // quantity-based specific prices are matched against. It has to be dropped with the rest of the
+        // product-related caches, or a price read after the cart changed still sees the old quantity.
+        Cache::clean('Product::getPriceStatic_*-' . (int) $this->id);
         $this->_products = null;
         $this->_products_with_separated_gifts = null;
     }
@@ -4867,6 +4871,11 @@ class CartCore extends ObjectModel
 
     public function deleteAssociations()
     {
+        // WHY: this drops the cart's rows without going through update(), so it is the one product
+        // write that the reset in update()/updateQty()/deleteProduct() does not already cover.
+        // setWsCartRows() calls it and then inserts the replacements in the same request.
+        $this->resetProductRelatedStaticCache();
+
         return Db::getInstance()->execute('
                 DELETE FROM `' . _DB_PREFIX_ . 'cart_product`
                 WHERE `id_cart` = ' . (int) $this->id) !== false;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3443,8 +3443,11 @@ class ProductCore extends ObjectModel
 
         $cart_quantity = 0;
         if ((int) $id_cart) {
+            // The value cached here is the quantity of this product in this cart, which does not depend
+            // on the quantity being priced. Comparing the two re-ran the query for nearly every call -
+            // and `!=` binds tighter than `=`, so the assignment stored a boolean rather than the count.
             $cache_id = 'Product::getPriceStatic_' . (int) $id_product . '-' . (int) $id_cart;
-            if (!Cache::isStored($cache_id) || ($cart_quantity = Cache::retrieve($cache_id) != (int) $quantity)) {
+            if (!Cache::isStored($cache_id)) {
                 $sql = 'SELECT SUM(`quantity`)
                 FROM `' . _DB_PREFIX_ . 'cart_product`
                 WHERE `id_product` = ' . (int) $id_product . '
@@ -3452,7 +3455,7 @@ class ProductCore extends ObjectModel
                 $cart_quantity = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
                 Cache::store($cache_id, $cart_quantity);
             } else {
-                $cart_quantity = Cache::retrieve($cache_id);
+                $cart_quantity = (int) Cache::retrieve($cache_id);
             }
         }
 

--- a/tests/Integration/Classes/ProductCartQuantityCacheTest.php
+++ b/tests/Integration/Classes/ProductCartQuantityCacheTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Cache;
+use Db;
+use DbPDO;
+use PHPUnit\Framework\TestCase;
+use Product;
+
+/**
+ * Pricing a product reads how many of it the cart holds. That total is the same whatever quantity is
+ * being priced, so it is looked up once per cart and product; a cart holding several combinations of
+ * one product used to repeat the query for every row.
+ */
+class ProductCartQuantityCacheTest extends TestCase
+{
+    private int $cartQuantityQueries = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $realDb = Db::getInstance();
+        $spy = $this->getMockBuilder(DbPDO::class)
+            ->setConstructorArgs([_DB_SERVER_, _DB_USER_, _DB_PASSWD_, _DB_NAME_, true])
+            ->onlyMethods(['getValue'])
+            ->getMock();
+
+        $spy->method('getValue')->willReturnCallback(
+            function ($sql, $useCache = true) use ($realDb) {
+                if (str_contains((string) $sql, 'cart_product')) {
+                    ++$this->cartQuantityQueries;
+                }
+
+                return $realDb->getValue($sql, $useCache);
+            }
+        );
+
+        Db::setInstanceForTesting($spy);
+        Cache::clean('Product::getPriceStatic_*');
+    }
+
+    protected function tearDown(): void
+    {
+        Db::deleteTestingInstance();
+        Cache::clean('Product::getPriceStatic_*');
+
+        parent::tearDown();
+    }
+
+    public function testItReadsTheCartQuantityOncePerProductAndCart(): void
+    {
+        $idCart = (int) Db::getInstance()->getValue('SELECT id_cart FROM ' . _DB_PREFIX_ . 'cart ORDER BY id_cart DESC');
+        $idProduct = (int) Db::getInstance()->getValue('SELECT id_product FROM ' . _DB_PREFIX_ . 'product');
+        $this->cartQuantityQueries = 0;
+
+        // Several quantities, as a cart holding several combinations of one product produces.
+        foreach ([1, 2, 3, 4, 5] as $quantity) {
+            Product::getPriceStatic($idProduct, true, null, 6, null, false, true, $quantity, false, null, $idCart, 0);
+        }
+
+        $this->assertSame(1, $this->cartQuantityQueries);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Pricing a product looks up how many of it the cart already holds. That total does not depend on the quantity being priced, but the cache guard compared the two, so the query ran again for almost every call. A cart holding several combinations of one product prices one row per combination and repeats the query for each, which is the flood of `SELECT SUM(quantity) FROM cart_product` in the report. The same line also has a precedence bug: `!=` binds tighter than `=`, so the assignment stored a boolean instead of the count.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38255
| Related PRs       |
| Sponsor company   |

### The line

```php
if (!Cache::isStored($cache_id) || ($cart_quantity = Cache::retrieve($cache_id) != (int) $quantity)) {
```

`$cache_id` is `Product::getPriceStatic_<id_product>-<id_cart>`, so the cached value is the quantity of that product in that cart. `$quantity` is the quantity being priced for one row. Comparing them re-runs the query whenever they differ, which is nearly always once a cart holds more than one of anything.

And because `!=` binds tighter than `=`, `$cart_quantity` receives the result of the comparison:

```php
$cached = 7; $quantity = 3;
$cart_quantity = $cached != $quantity;   // true, not 7
```

The value is overwritten by the query that follows, so this is invisible in output - but it shows the condition was not written as intended.

### Measurement

Counting the statement through `performance_schema`, pricing one product 20 times with different quantities against the same cart:

```
9.2.x         20 queries on cart_product
this change    1 query
```

Pricing the same quantity 20 times already produced one query before this change, which is why the report sees the flood only with several combinations of one product.

### Test

`tests/Integration/Classes/ProductCartQuantityCacheTest.php` counts the statement through a `Db` spy and asserts one lookup for five different quantities. On the current code it fails with `5 is identical to 1`.

The cache is `Cache::$local`, a static array cleared at the end of the request, so this changes nothing across requests. Within a request the value was already served from that cache whenever the two numbers happened to be equal, so nothing new is trusted here that was not trusted before.


### Why a `Cart.php` hunk is in a pricing PR

Memoising the per-cart quantity means it now has to be invalidated, and the `!=` bug it replaces had been
acting as an accidental refresh. `Cart::resetProductRelatedStaticCache()` is where the cart-mutation paths
already converge — `update()`, `updateQty()` and `deleteProduct()` all call it — so the new
`Cache::clean('Product::getPriceStatic_*-<id_cart>')` goes there.

Enumerating the writers mattered: six sites write `cart_product`, and that hook only covered four.
`setWsCartRows()` (webservice row replacement) reaches them through `deleteAssociations()` without ever
calling `update()`, so a webservice PUT followed by a price read in the same request would still have gone
stale. `deleteAssociations()` therefore resets too. `delete()` is deliberately left alone: the cart is gone,
so the per-cart key cannot be read again.

Covered by `Features/Scenario/Cart/Product/add_combination.feature:48` — reverting the `Cart.php` hunk alone
fails that scenario on line 61 (`Expects 19.324, got 24.324`) and passes with it.
