### PR TITLE
Keep module overrides while another shop still uses the module

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1177,9 +1177,6 @@ abstract class ModuleCore implements ModuleInterface
         Hook::exec('actionModuleDisable', ['module' => $this]);
 
         $result = true;
-        if (!Configuration::get('PS_DISABLE_MODULE_OVERRIDES') && $this->getOverrides() != null) {
-            $result &= $this->uninstallOverrides();
-        }
 
         // Disable module for all shops or contextual shops
         $whereIdShop = $force_all ? '' : ' AND `id_shop` IN(' . implode(', ', Shop::getContextListShopID()) . ')';
@@ -1188,6 +1185,13 @@ abstract class ModuleCore implements ModuleInterface
         // if module has no more shop associations, set module.active = 0
         if (!$this->hasShopAssociations()) {
             $result &= Db::getInstance()->update('module', ['active' => 0], 'id_module = ' . (int) $this->id);
+
+            // Overrides are files and there is one copy of them for the whole installation, so they can
+            // only go once no shop runs the module any more. Removing them while another shop still has
+            // it enabled takes that shop's behaviour away with it.
+            if (!Configuration::get('PS_DISABLE_MODULE_OVERRIDES') && $this->getOverrides() != null) {
+                $result &= $this->uninstallOverrides();
+            }
         }
 
         return (bool) $result;

--- a/tests/Integration/Classes/ModuleDisableOverridesTest.php
+++ b/tests/Integration/Classes/ModuleDisableOverridesTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Db;
+use Module;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Overrides are files: one copy serves the whole installation. Disabling a module on one shop of a
+ * multistore used to delete them anyway, which removed the behaviour from every other shop still
+ * running that module.
+ */
+class ModuleDisableOverridesTest extends TestCase
+{
+    private int $moduleId;
+
+    /**
+     * @var array<int, array{id_shop: string}>
+     */
+    private array $originalAssociations = [];
+
+    private string $originalActive = '1';
+
+    private const OTHER_SHOP_ID = 999;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->moduleId = (int) Db::getInstance()->getValue('SELECT id_module FROM ' . _DB_PREFIX_ . 'module');
+
+        if (!$this->moduleId) {
+            $this->markTestSkipped('No module installed to exercise disable() with.');
+        }
+
+        $this->originalAssociations = Db::getInstance()->executeS(
+            'SELECT * FROM ' . _DB_PREFIX_ . 'module_shop WHERE id_module = ' . $this->moduleId
+        ) ?: [];
+        $this->originalActive = (string) Db::getInstance()->getValue(
+            'SELECT active FROM ' . _DB_PREFIX_ . 'module WHERE id_module = ' . $this->moduleId
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        // disable() deletes rows, so the module is put back exactly as it was found.
+        Db::getInstance()->delete('module_shop', 'id_module = ' . $this->moduleId);
+        foreach ($this->originalAssociations as $association) {
+            Db::getInstance()->insert('module_shop', $association, false, true, Db::INSERT_IGNORE);
+        }
+        Db::getInstance()->update('module', ['active' => (int) $this->originalActive], 'id_module = ' . $this->moduleId);
+
+        parent::tearDown();
+    }
+
+    private function moduleWithOverrides(): Module&MockObject
+    {
+        $module = $this->getMockBuilder(Module::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getOverrides', 'uninstallOverrides'])
+            ->getMock();
+        $module->id = $this->moduleId;
+        $module->method('getOverrides')->willReturn(['SomeOverriddenClass']);
+
+        return $module;
+    }
+
+    public function testItKeepsOverridesWhileAnotherShopStillUsesTheModule(): void
+    {
+        Db::getInstance()->insert(
+            'module_shop',
+            ['id_module' => $this->moduleId, 'id_shop' => self::OTHER_SHOP_ID],
+            false,
+            true,
+            Db::INSERT_IGNORE
+        );
+
+        $module = $this->moduleWithOverrides();
+        $module->expects($this->never())->method('uninstallOverrides');
+
+        $module->disable();
+
+        $this->assertTrue(
+            $module->hasShopAssociations(),
+            'The association of the other shop must survive a contextual disable'
+        );
+    }
+
+    public function testItRemovesOverridesOnceNoShopUsesTheModule(): void
+    {
+        $module = $this->moduleWithOverrides();
+        $module->expects($this->once())->method('uninstallOverrides')->willReturn(true);
+
+        $module->disable(true);
+
+        $this->assertFalse($module->hasShopAssociations());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Disabling a module removes its override files before looking at which shops still use it, so on a multistore, turning a module off for one shop deletes overrides that every other shop is still running. This moves the removal behind the check the method already performs, so the files go once no shop has the module enabled any more.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38508
| Related PRs       |
| Sponsor company   |

### The order of operations

`Module::disable()` did this:

```php
if (!Configuration::get('PS_DISABLE_MODULE_OVERRIDES') && $this->getOverrides() != null) {
    $result &= $this->uninstallOverrides();
}

$whereIdShop = $force_all ? '' : ' AND `id_shop` IN(' . implode(', ', Shop::getContextListShopID()) . ')';
$result &= Db::getInstance()->delete('module_shop', ...);

if (!$this->hasShopAssociations()) {
    $result &= Db::getInstance()->update('module', ['active' => 0], ...);
}
```

The override removal ran unconditionally, while the shop association delete honoured the context. The method already knows when the module is gone everywhere - that is the `hasShopAssociations()` check it uses to clear `active` - so the removal now sits inside it.

There is one copy of the override files for the whole installation, which is why they cannot follow a per shop decision.

### How to test

On a multistore with a module that ships overrides, enabled on two shops: disable it on the first shop. Before this change `override/` loses the files and the second shop loses the behaviour; after it, the files stay and the second shop is untouched. Disabling it on the last shop, or from the module page which disables everywhere, still removes them.

`tests/Integration/Classes/ModuleDisableOverridesTest.php` asserts both directions and restores the module's associations and `active` flag afterwards. On the current code the first case fails with `ModuleCore::uninstallOverrides() was not expected to be called`.

### Points b and c of the report

Point c, that disabling on a single shop is impractical, is this same cause and is covered. Point b, that enabling re-creates overrides that are already present, is in `installOverrides()` and is left alone here so this stays reviewable on its own.

