### PR TITLE
Add a regression test for translations saved on a non core theme

### DIFF
--- a/tests/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
@@ -9,16 +9,32 @@ declare(strict_types=1);
 namespace Tests\Integration\PrestaShopBundle\Controller\Api;
 
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShopBundle\Entity\Translation;
 use Tests\Integration\Utility\LoginTrait;
 
 class TranslationControllerTest extends ApiTestCase
 {
     use LoginTrait;
 
+    private const NON_CORE_THEME = 'fakeThemeForTranslations';
+    private const NON_CORE_THEME_DOMAIN = 'ShopThemeActions';
+    private const NON_CORE_THEME_MESSAGE = 'Refresh';
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->loginUser(self::$client);
+    }
+
+    protected function tearDown(): void
+    {
+        self::getContainer()->get('doctrine')->getManager()
+            ->createQuery('DELETE FROM ' . Translation::class . ' t WHERE t.theme = :theme')
+            ->setParameter('theme', self::NON_CORE_THEME)
+            ->execute()
+        ;
+
+        parent::tearDown();
     }
 
     /**
@@ -153,6 +169,42 @@ class TranslationControllerTest extends ApiTestCase
     public function testItShouldReturnValidResponseWhenRequestingTranslationsEdition(array $params): void
     {
         $this->assertOkResponseOnTranslationEdition($params);
+    }
+
+    /**
+     * An edited translation is stored under the theme it was edited for, and the database lookup is
+     * scoped to that same theme. Serving the catalogue of a theme that is not a core one through the
+     * core domain provider queries `theme IS NULL` instead, so the value that was just saved is never
+     * read back.
+     */
+    public function testItReadsBackATranslationSavedForANonCoreTheme(): void
+    {
+        $edited = 'Translated for a non core theme';
+
+        $this->assertOkResponseOnTranslationEdition([
+            'locale' => 'en-US',
+            'domain' => self::NON_CORE_THEME_DOMAIN,
+            'default' => self::NON_CORE_THEME_MESSAGE,
+            'edited' => $edited,
+            'theme' => self::NON_CORE_THEME,
+        ]);
+
+        self::$client->request('GET', $this->router->generate('api_translation_domain_catalog', [
+            'locale' => 'en-US',
+            'domain' => self::NON_CORE_THEME_DOMAIN,
+            'theme' => self::NON_CORE_THEME,
+        ]));
+        $catalogue = $this->assertResponseBodyValidJson(200)['data'];
+
+        $this->assertSame(
+            self::NON_CORE_THEME,
+            $catalogue['info']['theme'],
+            'A theme that is not a core one must be served by the theme provider.'
+        );
+
+        $messages = array_column($catalogue['data'], 'user', 'default');
+        $this->assertArrayHasKey(self::NON_CORE_THEME_MESSAGE, $messages);
+        $this->assertSame($edited, $messages[self::NON_CORE_THEME_MESSAGE]);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `listDomainTranslationAction()` chose the translation provider with an inverted test until 9.1.2, so a theme that is not a core one was served by `CoreDomainProviderDefinition`. Because the database lookup is scoped to the theme, a value edited for a custom theme was written under that theme name and then read back with `theme IS NULL`, and the back office showed the untranslated default again after a reload. #41193 corrected the condition with a one character change and no test, and nothing in `tests/` asserts which provider a theme name maps to. This adds that coverage.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31349944237 - 3 campaigns ended with one failing test each, none of them reachable from this diff, detail below. Re-run: https://github.com/boo-code/ga.tests.ui.pr/actions/runs/31354103600
| Fixed issue or discussion?     | Fixes #41562
| Related PRs       | Follow up of #41193
| Sponsor company   |

### How to test

```
vendor/bin/phpunit -c tests/Integration/phpunit.xml \
  --filter testItReadsBackATranslationSavedForANonCoreTheme \
  tests/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
```

The test edits a message of `fakeThemeForTranslations`, the non core theme fixture already used by the theme catalogue tests, through `api_translation_value_edit`, then reads the same domain back through `api_translation_domain_catalog` and asserts both that the catalogue was served by the theme provider and that the saved value is the one returned.

Green on `9.2.x`:

```
Tests: 17, Assertions: 47
```

Restoring the pre-9.1.2 condition in `src/PrestaShopBundle/Controller/Api/TranslationController.php` line 80:

```php
&& in_array($theme, Theme::CORE_THEMES)
```

turns it red on the provider assertion, which is the defect the issue described:

```
Failed asserting that null is identical to 'fakeThemeForTranslations'.
```

The row written by the test is removed in `tearDown()`, so the suite is repeatable.


### About the UI run

The campaign reported three failures out of more than two thousand tests, one per campaign:

```
functional:BO:international:03-04   174 passing, 1 failing
  BO - International - Translation : Modify translation
    Case 2 - Front office translations with classic theme
      AssertionError: expected 'Popular Products' to include 'translate'

functional:BO:catalog:01-02         651 passing, 1 failing
  Catalog - Products : Multistore, should create shop
      waitForSelector: Timeout 10000ms exceeded.

functional:BO:catalog:07-08        1254 passing, 1 failing
  Stocks - Movements, bulk edit quantity by setting input value
```

This pull request adds one test file and changes no production code, so none of these paths can be reached from it. The same campaign was green on another 9.2.x pull request six hours earlier, 46 of 46 jobs. A second run is in flight to tell a flaky environment apart from something real on the branch, and I will report what it says rather than assume.
