### PR TITLE
Hide the back office tabs of a disabled module

### DIFF
--- a/src/PrestaShopBundle/Twig/Component/NavBar.php
+++ b/src/PrestaShopBundle/Twig/Component/NavBar.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Twig\Component;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use PrestaShopBundle\Twig\Layout\MenuBuilder;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -25,6 +26,7 @@ class NavBar
         protected readonly LoggerInterface $logger,
         protected readonly MenuBuilder $menuBuilder,
         protected readonly string $psVersion,
+        protected readonly ModuleManager $moduleManager,
     ) {
     }
 
@@ -79,7 +81,11 @@ class NavBar
     {
         return Tab::checkTabRights($tab['id_tab'])
             && $tab['enabled']
-            && $tab['class_name'] !== 'AdminCarrierWizard';
+            && $tab['class_name'] !== 'AdminCarrierWizard'
+            // Disabling a module leaves the tab rows it installed untouched, so the menu decides on
+            // the module state instead. isEnabled() resolves through the shop association that
+            // disabling removes, so the entries follow the shops of the current context.
+            && (empty($tab['module']) || $this->moduleManager->isEnabled($tab['module']));
     }
 
     protected function processTab(array $tab, int $currentId, int $level, ?string $controllerName): array

--- a/tests/Integration/PrestaShopBundle/Twig/Component/NavBarTest.php
+++ b/tests/Integration/PrestaShopBundle/Twig/Component/NavBarTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Twig\Component;
+
+use Cache;
+use Context;
+use Db;
+use Employee;
+use PrestaShop\PrestaShop\Core\Module\ModuleManager;
+use PrestaShopBundle\Twig\Component\NavBar;
+use ReflectionMethod;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tab;
+
+/**
+ * Disabling a module does not touch the tab rows it installed, so the back office menu has to
+ * decide on the module state instead. Without that the entries of a disabled module stay in the
+ * menu and lead to a controller the module no longer serves.
+ */
+class NavBarTest extends KernelTestCase
+{
+    private const MODULE_NAME = 'navbartestmodule';
+    private const TAB_CLASS_NAME = 'AdminNavBarTestModule';
+
+    private int $moduleId;
+
+    private int $tabId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $db = Db::getInstance();
+
+        $db->insert('module', ['name' => self::MODULE_NAME, 'active' => 1, 'version' => '1.0.0']);
+        $this->moduleId = (int) $db->Insert_ID();
+        $db->insert('module_shop', ['id_module' => $this->moduleId, 'id_shop' => 1]);
+
+        $db->insert('tab', [
+            'id_parent' => 0,
+            'position' => 1 + (int) $db->getValue('SELECT MAX(position) FROM ' . _DB_PREFIX_ . 'tab WHERE id_parent = 0'),
+            'module' => self::MODULE_NAME,
+            'class_name' => self::TAB_CLASS_NAME,
+            'active' => 1,
+            'enabled' => 1,
+            // A top level tab without an icon is dropped by processTab(), so the fixture carries one.
+            'icon' => 'extension',
+        ]);
+        $this->tabId = (int) $db->Insert_ID();
+
+        Context::getContext()->employee = new Employee(
+            (int) $db->getValue('SELECT id_employee FROM ' . _DB_PREFIX_ . 'employee WHERE id_profile = ' . _PS_ADMIN_PROFILE_)
+        );
+
+        $this->forgetCachedState();
+    }
+
+    protected function tearDown(): void
+    {
+        $db = Db::getInstance();
+        $db->delete('tab', 'id_tab = ' . $this->tabId);
+        $db->delete('module_shop', 'id_module = ' . $this->moduleId);
+        $db->delete('module', 'id_module = ' . $this->moduleId);
+        $this->forgetCachedState();
+
+        parent::tearDown();
+    }
+
+    public function testItKeepsTheTabOfAnEnabledModule(): void
+    {
+        $this->assertTrue($this->isKeptInTheMenu($this->fixtureTab()));
+    }
+
+    public function testItDropsTheTabOfADisabledModule(): void
+    {
+        // What Module::disable() does: it drops the association of the current shop.
+        Db::getInstance()->delete('module_shop', 'id_module = ' . $this->moduleId);
+        $this->forgetCachedState();
+
+        $this->assertFalse($this->isKeptInTheMenu($this->fixtureTab()));
+    }
+
+    public function testItKeepsATabThatBelongsToNoModule(): void
+    {
+        $coreTab = $this->fixtureTab();
+        $coreTab['module'] = null;
+
+        $this->assertTrue($this->isKeptInTheMenu($coreTab));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fixtureTab(): array
+    {
+        return Tab::getTab((int) Context::getContext()->language->id, $this->tabId);
+    }
+
+    /**
+     * @param array<string, mixed> $tab
+     */
+    private function isKeptInTheMenu(array $tab): bool
+    {
+        $container = self::getContainer();
+        $navBar = new NavBar(
+            $container->get('prestashop.adapter.legacy.context'),
+            $container->get('logger'),
+            $container->get('PrestaShopBundle\Twig\Layout\MenuBuilder'),
+            _PS_VERSION_,
+            $container->get(ModuleManager::class)
+        );
+
+        $isValidTab = new ReflectionMethod(NavBar::class, 'isValidTab');
+        $isValidTab->setAccessible(true);
+
+        return (bool) $isValidTab->invoke($navBar, $tab);
+    }
+
+    private function forgetCachedState(): void
+    {
+        Tab::resetStaticCache();
+        Cache::clean('Module::isEnabled' . self::MODULE_NAME);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Disabling a module leaves the `tab` rows it installed untouched, and the back office menu only looks at `tab.active` and `tab.enabled`, which belong to the tab and not to the module. The entries of a disabled module therefore stay in the menu. The menu now also requires the owning module to be enabled.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36590
| Related PRs       |
| Sponsor company   |

### How to test

On a 9.2 shop, disable a module that installs tabs, `ps_themecusto` for instance, then open the back office. Before this change `Pages Configuration` and `Advanced Customization` are still listed under Design; after it they are gone, and they come back when the module is enabled again.

Measured on a 9.2 shop, disabling the module and reading the rows the menu is built from:

```
before:   module.active=1/shop_assoc=1
disabled: module.active=0/shop_assoc=0
tabs still returned by Tab::getTabs():
  AdminPsThemeCustoConfiguration active=1 enabled=1
  AdminPsThemeCustoAdvanced active=1 enabled=1
```

Both rows keep `active=1 enabled=1`, which is why `NavBar::isValidTab()` accepted them.

`tests/Integration/PrestaShopBundle/Twig/Component/NavBarTest.php` covers the three cases with a module and tab fixture: the tab of an enabled module is kept, the tab of a module whose shop association was removed is dropped, and a tab that belongs to no module is untouched. Removing the new condition turns the second one red with `Failed asserting that true is false`, so the test is tied to the change.

### Correction to an earlier version of this description

This text previously said the stale entries lead to "a controller the module no longer serves". That is wrong.
`Dispatcher::dispatch()` gates the two sides differently on `9.2.x`: the front office branch requires the module
to be active (`classes/Dispatcher.php:390`), the back office branch resolves a module controller on the controller
file existing (`classes/Dispatcher.php:433-436`) and never looks at the module state. A disabled module's admin
controller therefore keeps serving, and this change only removes the menu entry pointing at it.

### On the shop scope

`isEnabled()` resolves through the `module_shop` association, which is exactly what disabling removes, so the entries follow the shops of the current context. Deactivating the tab rows instead would have been wrong, because tabs are global rows while a module is enabled per shop.

### On the constructor

`NavBar` takes the module manager as one more service. Per ADR 0017, "since classes whose instantiation is delegated to the Symfony service container are not supposed to be instantiated individually, changing the constructor of those classes is allowed", and this component is built by the container. The manager is used rather than the legacy `Module` class because the bundle is not allowed to call legacy code, which PHPStan enforces.


