### PR TITLE
Escape the currency symbol and weight unit written into the carrier wizard script

### DIFF
--- a/admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl
@@ -17,8 +17,8 @@
 	var enableAllSteps = {if $enableAllSteps|intval == 1}true{else}false{/if};
 	var need_to_validate = '{l s='Please validate the last range before creating a new one.' js=1 d='Admin.Shipping.Notification'}';
 	var delete_range_confirm = '{l s='Are you sure to delete this range ?' js=1 d='Admin.Shipping.Notification'}';
-	var currency_sign = '{$currency_sign}';
-	var PS_WEIGHT_UNIT = '{$PS_WEIGHT_UNIT}';
+	var currency_sign = '{$currency_sign|addslashes}';
+	var PS_WEIGHT_UNIT = '{$PS_WEIGHT_UNIT|addslashes}';
 	var invalid_range = '{l s='This range is not valid' js=1 d='Admin.Shipping.Notification'}';
 	var overlapping_range = '{l s='Ranges are overlapping' js=1 d='Admin.Shipping.Notification'}';
 	var range_is_overlapping = '{l s='Ranges are overlapping' js=1 d='Admin.Shipping.Notification'}';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The carrier wizard writes the currency symbol and the weight unit straight into a JavaScript string literal. Both are merchant editable, so a symbol containing an apostrophe, such as the Uzbek `so'm`, closes the literal and the whole inline script stops parsing, which takes every behaviour of the wizard down with it. The neighbouring values in the same block already pass through `addslashes`, this applies it to the two that were missed.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36870
| Related PRs       |
| Sponsor company   |

### How to test

Set a currency symbol that contains an apostrophe, `so'm`, and open the carrier wizard. Before this change the browser console reports a syntax error and the wizard stops responding, after it the wizard behaves normally and the symbol is displayed as entered.

The templates of the back office are rendered with `escape_html` left at its default, since it is only turned on for the front office in `config/smartyfront.config.inc.php`, so the value reaches the literal unchanged. Rendering that block with the same settings and checking the result:

```
--- before ---
var currency_sign = 'so'm';
var PS_WEIGHT_UNIT = 'kg';
--- after ---
var currency_sign = 'so\'m';
var PS_WEIGHT_UNIT = 'kg';

node --check before.js -> exit=1  SyntaxError: Unexpected identifier 'm'
node --check after.js  -> exit=0
```

### Scope

`PS_WEIGHT_UNIT` is included because it comes from `Configuration` and is just as editable, so it carries the same defect. The four other values in the same block, two labels and two urls, already use `addslashes`, and `multistore_enable` is a boolean, so they are left alone.

The migrated carriers pages under `src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Carriers/` never put the currency symbol into a script, so they were not affected and are unchanged. The legacy wizard is still reachable when the `carrier` feature flag is turned off, which is why it is worth fixing rather than leaving to the migration.

There is no unit test harness for the legacy admin Smarty templates, so the reproduction above is the verification.

