### PR TITLE
Reject a negative shipping cost on the carrier page

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
@@ -44,6 +44,11 @@ class CostsRangeType extends TranslatorAwareType
             ->add('price', MoneyWithSuffixType::class, [
                 'label' => $this->trans('Price (VAT excl.)', 'Admin.Shipping.Feature'),
                 'empty_data' => '0.0', // string instead number needed for DecimalNumber.php validation
+                'constraints' => [
+                    new PositiveOrZero([
+                        'message' => 'The value must be a positive number.',
+                    ]),
+                ],
             ]);
     }
 

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeTypeTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier\Type;
+
+use PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier\Type\CostsRangeType;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Validation;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * A negative shipping cost is accepted by the database and then applied to the cart, where it
+ * behaves as a discount. The range bounds were already guarded, the price is guarded here too.
+ */
+class CostsRangeTypeTest extends TypeTestCase
+{
+    protected function getExtensions(): array
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        return [
+            new PreloadedExtension([new CostsRangeType($translator, [])], []),
+            new ValidatorExtension(Validation::createValidator()),
+        ];
+    }
+
+    /**
+     * @dataProvider getAcceptedPrices
+     */
+    public function testItAcceptsAPriceThatIsPositiveOrZero(string $price): void
+    {
+        $this->assertTrue($this->submitPrice($price)->isValid());
+    }
+
+    /**
+     * @dataProvider getRejectedPrices
+     */
+    public function testItRejectsANegativePrice(string $price): void
+    {
+        $form = $this->submitPrice($price);
+
+        $this->assertFalse($form->isValid());
+        $this->assertCount(1, $form->get('price')->getErrors());
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public function getAcceptedPrices(): array
+    {
+        return [['0'], ['0.00'], ['5'], ['12.34']];
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public function getRejectedPrices(): array
+    {
+        return [['-5'], ['-0.01'], ['-12.34']];
+    }
+
+    private function submitPrice(string $price): \Symfony\Component\Form\FormInterface
+    {
+        $form = $this->factory->create(CostsRangeType::class);
+        $form->submit([
+            'from' => '0',
+            'to' => '10',
+            'price' => $price,
+        ]);
+
+        return $form;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The carrier page accepts a negative shipping cost without a word, and the value reaches the cart where it behaves as a discount. The two range bounds of the same row are already guarded with `PositiveOrZero`, the price was the one field left without a constraint. This applies the same one to it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37153
| Related PRs       |
| Sponsor company   |

### How to test

Go to Shipping, Carriers, edit a carrier and open Shipping locations and costs. Enter `-5` as the price of a range and save. Before this change the carrier is saved and the front office offers the shipping method at a negative cost, after it the field is refused with the same message the range bounds already use.

The field sat alone without a constraint next to two that had one:

```php
->add('from', HiddenType::class, [
    'constraints' => [new PositiveOrZero([...])],
])
->add('to', HiddenType::class, [
    'constraints' => [new PositiveOrZero([...])],
])
->add('price', MoneyWithSuffixType::class, [
    'label' => $this->trans('Price (VAT excl.)', 'Admin.Shipping.Feature'),
    'empty_data' => '0.0',
]);
```

`tests/Unit/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeTypeTest.php` submits the row through the form and covers both directions, `0`, `0.00`, `5` and `12.34` accepted, `-5`, `-0.01` and `-12.34` refused with one error on the price field:

```
Tests: 7, Assertions: 10   OK
```

Removing the constraint again turns exactly the three negative cases red:

```
Tests: 7, Assertions: 7, Failures: 3
Failed asserting that true is false.
```

### Scope

The check is placed on the form because that is where the two neighbouring fields are checked and because the form is the only place user supplied prices enter, `CarrierRangePrice` is built from arrays in two internal call sites only. Nothing in the carrier form tree disables validation, so the constraint applies to every row of every zone.

