### PR TITLE
Refuse an over long carrier name in the form instead of failing in the adapter

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\File;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Url;
@@ -27,6 +28,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class GeneralSettings extends TranslatorAwareType
 {
     private const MAX_IMAGE_SIZE_IN_BYTES = 8 * 1000000;
+
+    // Mirrors the size of the `name` column of the Carrier ObjectModel.
+    private const MAX_NAME_LENGTH = 64;
 
     public function __construct(
         TranslatorInterface $translator,
@@ -51,6 +55,16 @@ class GeneralSettings extends TranslatorAwareType
                 'constraints' => [
                     new CleanHtml([
                         'message' => $this->trans('%s is invalid.', 'Admin.Notifications.Error'),
+                    ]),
+                    // Without this the name reaches the ObjectModel, whose column is 64 characters,
+                    // and comes back as a CarrierConstraintException the form cannot attach anywhere.
+                    new Length([
+                        'max' => self::MAX_NAME_LENGTH,
+                        'maxMessage' => $this->trans(
+                            'This field cannot be longer than %limit% characters.',
+                            'Admin.Notifications.Error',
+                            ['%limit%' => self::MAX_NAME_LENGTH]
+                        ),
                     ]),
                 ],
             ])

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierNameConstraintTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierNameConstraintTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Tests\Integration\PrestaShopBundle\Form\FormListenerTestCase;
+
+/**
+ * The `name` column of the carrier is 64 characters, and the adapter turns an over long value into
+ * a CarrierConstraintException. The controller catches it and shows a generic failure with no field
+ * attached, so the form has to refuse the value first.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/37183
+ */
+class CarrierNameConstraintTest extends FormListenerTestCase
+{
+    private const MAX_NAME_LENGTH = 64;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopId(1);
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+    }
+
+    public function testItAcceptsANameOfTheMaximumLength(): void
+    {
+        $this->assertCount(0, $this->submitName(str_repeat('a', self::MAX_NAME_LENGTH))->getErrors());
+    }
+
+    public function testItRefusesANameLongerThanTheColumn(): void
+    {
+        $errors = $this->submitName(str_repeat('a', self::MAX_NAME_LENGTH + 1))->getErrors();
+
+        $this->assertCount(1, $errors);
+        $this->assertInstanceOf(Length::class, $errors[0]->getCause()->getConstraint());
+    }
+
+    private function submitName(string $name): FormInterface
+    {
+        $form = self::getContainer()
+            ->get('prestashop.core.form.identifiable_object.builder.carrier_form_builder')
+            ->getForm();
+
+        // Only the name is submitted, every other field keeps the data the builder provided.
+        $form->submit(['general_settings' => ['name' => $name]], false);
+
+        return $form->get('general_settings')->get('name');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A carrier name longer than the 64 characters of its column is accepted by the form, and only the adapter refuses it, by throwing `CarrierConstraintException`. The controller catches it and turns it into a generic failure with no field attached, which is the raw exception text the report shows instead of an error on the input. The form now refuses the value itself, the way the other fields of the same card already do.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37183
| Related PRs       |
| Sponsor company   |

### How to test

Go to Shipping, Carriers, add a carrier and type a name longer than 64 characters. Before this change saving fails with a generic error naming `CarrierConstraintException`, after it the field itself reports that it cannot be longer than 64 characters, like the grade, the tracking url and the group access already do.

The chain is: `CarrierValidator::validateObjectModelProperty($carrier, 'name', CarrierConstraintException::class, ...)` calls `ObjectModel::validateField()`, which enforces the `size` of 64 declared in `classes/Carrier.php`. `CarrierConstraintException` is not in the controller's `getErrorMessages()` map, so it falls through to the generic message.

`tests/Integration/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierNameConstraintTest.php` builds the real carrier form from the container and submits only the name, so nothing is mocked. A name of exactly 64 characters is accepted, one of 65 carries a single `Length` violation:

```
Tests: 2, Assertions: 3   OK
```

Removing the constraint again turns the second one red with `Failed asserting that actual size 0 matches expected size 1`.

### Scope

The limit is declared as a constant next to the existing image size one and mirrors the column, so the two stay together. Only the length is added, the character rule of `Validate::isCarrierName` is left as it is, since the report is about the length and `CleanHtml` already covers the markup case.

