### PR TITLE
Stop advertising the preselected carrier choices as mandatory

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsType.php
@@ -104,6 +104,10 @@ class ShippingLocationsAndCostsType extends TranslatorAwareType
                 'default_empty_data' => ShippingMethod::BY_PRICE,
                 'expanded' => true,
                 'multiple' => false,
+                // One choice is always selected, so the field is never something the merchant has
+                // to fill in. `placeholder` is pinned because Symfony adds an empty one otherwise.
+                'required' => false,
+                'placeholder' => false,
                 'attr' => [
                     'data-units' => json_encode([
                         ShippingMethod::BY_PRICE => $this->currencyDataProvider->getDefaultCurrencySymbol(),
@@ -118,6 +122,8 @@ class ShippingLocationsAndCostsType extends TranslatorAwareType
                     $this->trans('Disable carrier', 'Admin.Shipping.Feature') => OutOfRangeBehavior::DISABLED,
                 ],
                 'default_empty_data' => OutOfRangeBehavior::USE_HIGHEST_RANGE,
+                'required' => false,
+                'placeholder' => false,
             ])
             ->add('ranges', CarrierRangesType::class, [
                 'required' => false,

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsRequiredTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsRequiredTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\Form\FormConfigInterface;
+use Tests\Integration\PrestaShopBundle\Form\FormListenerTestCase;
+
+/**
+ * Both choices always carry a selected value, so the merchant has nothing to fill in and the
+ * required marker on their label is misleading. Turning `required` off makes Symfony add an empty
+ * choice unless `placeholder` is pinned, which is what the second assertion of each case guards.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/37178
+ */
+class ShippingLocationsAndCostsRequiredTest extends FormListenerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopId(1);
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+    }
+
+    /**
+     * @dataProvider getPreselectedFields
+     */
+    public function testAPreselectedChoiceIsNotAdvertisedAsMandatory(string $fieldName): void
+    {
+        $this->assertFalse($this->fieldConfig($fieldName)->getOption('required'));
+    }
+
+    /**
+     * @dataProvider getPreselectedFields
+     */
+    public function testTurningTheMarkerOffDoesNotAddAnEmptyChoice(string $fieldName): void
+    {
+        $config = $this->fieldConfig($fieldName);
+
+        // Symfony defaults `placeholder` to an empty entry as soon as `required` is false, and
+        // normalises an explicit `false` to null, which is the "no empty entry" state.
+        $this->assertNull($config->getOption('placeholder'));
+        $this->assertCount(2, $config->getOption('choices'));
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public function getPreselectedFields(): array
+    {
+        return [['shipping_method'], ['range_behavior']];
+    }
+
+    private function fieldConfig(string $fieldName): FormConfigInterface
+    {
+        $form = self::getContainer()
+            ->get('prestashop.core.form.identifiable_object.builder.carrier_form_builder')
+            ->getForm();
+
+        return $form->get('shipping_settings')->get($fieldName)->getConfig();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Shipping costs` and `Out of range behavior` are marked with the required asterisk although both always carry a selected value, so there is nothing for the merchant to fill in. Both are plain choices that were left without a `required` option, which Symfony defaults to true. The two switches next to them already declare it false.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37178
| Related PRs       |
| Sponsor company   |

### How to test

Go to Shipping, Carriers, add a carrier and open the `Shipping locations and costs` tab. Before this change `Shipping costs` and `Out of range behavior` carry the required marker, after it they do not, and their choices are unchanged, still preselected on `Based on the order's total price` and `Apply the cost of the highest defined range`.

### Why the placeholder is pinned as well

Turning the marker off is not enough on its own. Symfony gives `placeholder` an empty entry as soon as `required` is false, which would add a `None` radio to the expanded `Shipping costs` group and an empty option to the `Out of range behavior` select. Pinning `placeholder` to false normalises it back to null, which is the "no empty entry" state.

`tests/Integration/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsRequiredTest.php` builds the real carrier form from the container and covers both halves for both fields:

```
Tests: 4, Assertions: 6   OK
```

Dropping `required => false` again fails the first two, and dropping only the `placeholder` pin fails the other two with exactly the entries described above:

```
Failed asserting that 'None' is null.
Failed asserting that '' is null.
```

