### PR TITLE
Mention on the carrier page that a zone is inactive

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProvider.php
@@ -18,6 +18,7 @@ use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryResult\CarrierRangesCollectio
 use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryResult\EditableCarrier;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\ShippingMethod;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CarrierFormDataProvider implements FormDataProviderInterface
 {
@@ -28,6 +29,7 @@ class CarrierFormDataProvider implements FormDataProviderInterface
         private readonly ConfigurationInterface $configuration,
         private readonly ZoneByIdChoiceProvider $zonesChoiceProvider,
         private readonly GroupDataProvider $groupDataProvider,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -121,6 +123,9 @@ class CarrierFormDataProvider implements FormDataProviderInterface
         // We retrieve zones to get the correct zone name
         $zones = $this->zonesChoiceProvider->getChoices([]);
         $zones = array_flip($zones);
+        // A zone keeps its ranges once it is disabled, so it stays on this page. Asking for the
+        // active ones separately is what tells the two apart, the choices carry no such flag.
+        $activeZones = array_flip($this->zonesChoiceProvider->getChoices(['active' => true]));
 
         // We choose the right symbol for the range in function of the ShippingMethod
         switch ($carrier->getShippingMethod()) {
@@ -149,11 +154,26 @@ class CarrierFormDataProvider implements FormDataProviderInterface
 
             $ranges[] = [
                 'zoneId' => $zone->getZoneId(),
-                'zoneName' => $zones[$zone->getZoneId()] ?? $zone->getZoneId(),
+                'zoneName' => $this->getZoneLabel($zones, $activeZones, $zone->getZoneId()),
                 'ranges' => $zoneRanges,
             ];
         }
 
         return $ranges;
+    }
+
+    /**
+     * @param array<int, string> $zones
+     * @param array<int, string> $activeZones
+     */
+    private function getZoneLabel(array $zones, array $activeZones, int $zoneId): string
+    {
+        $zoneName = (string) ($zones[$zoneId] ?? $zoneId);
+
+        if (!isset($activeZones[$zoneId])) {
+            $zoneName .= ' (' . $this->translator->trans('Inactive', [], 'Admin.Global') . ')';
+        }
+
+        return $zoneName;
     }
 }

--- a/tests/Integration/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderZoneTest.php
+++ b/tests/Integration/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderZoneTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Form\IdentifiableObject\DataProvider;
+
+use Cache;
+use Db;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CarrierFormDataProvider;
+use Tests\Integration\PrestaShopBundle\Form\FormListenerTestCase;
+
+/**
+ * A zone keeps the ranges of a carrier once it is disabled, so it stays listed on the carrier page.
+ * Nothing on the row said so, which left no way to tell why the carrier is not offered there.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/37171
+ */
+class CarrierFormDataProviderZoneTest extends FormListenerTestCase
+{
+    private const CARRIER_ID = 2;
+
+    private int $zoneId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopId(1);
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+
+        $this->zoneId = (int) Db::getInstance()->getValue(
+            'SELECT id_zone FROM ' . _DB_PREFIX_ . 'delivery WHERE id_carrier = ' . self::CARRIER_ID . ' AND id_zone > 0'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setZoneActive(true);
+
+        parent::tearDown();
+    }
+
+    public function testAnActiveZoneIsNamedAsItIs(): void
+    {
+        $this->setZoneActive(true);
+
+        $this->assertStringNotContainsString('(', $this->zoneLabel());
+    }
+
+    public function testADisabledZoneSaysSoOnItsRow(): void
+    {
+        $activeLabel = $this->zoneLabel();
+
+        $this->setZoneActive(false);
+
+        $this->assertSame($activeLabel . ' (Inactive)', $this->zoneLabel());
+    }
+
+    private function zoneLabel(): string
+    {
+        /** @var CarrierFormDataProvider $dataProvider */
+        $dataProvider = self::getContainer()->get(CarrierFormDataProvider::class);
+        $data = $dataProvider->getData(self::CARRIER_ID);
+
+        foreach ($data['shipping_settings']['ranges_costs'] as $zone) {
+            if ((int) $zone['zoneId'] === $this->zoneId) {
+                return $zone['zoneName'];
+            }
+        }
+
+        $this->fail(sprintf('Zone %d is not listed for carrier %d.', $this->zoneId, self::CARRIER_ID));
+    }
+
+    private function setZoneActive(bool $active): void
+    {
+        Db::getInstance()->update('zone', ['active' => (int) $active], 'id_zone = ' . $this->zoneId);
+        Cache::clean('*');
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderTest.php
@@ -19,6 +19,7 @@ use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryResult\CarrierRangesCollectio
 use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryResult\EditableCarrier;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\OutOfRangeBehavior;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CarrierFormDataProvider;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CarrierFormDataProviderTest extends TestCase
 {
@@ -107,7 +108,8 @@ class CarrierFormDataProviderTest extends TestCase
             $currencyDataProvider,
             $configuration,
             $zonesChoiceProvider,
-            $groupDataProvider
+            $groupDataProvider,
+            $this->createMock(TranslatorInterface::class)
         );
         $formData = $formDataProvider->getData(42);
         $this->assertEquals([
@@ -175,7 +177,8 @@ class CarrierFormDataProviderTest extends TestCase
             $this->createMock(CurrencyDataProviderInterface::class),
             $this->createMock(ConfigurationInterface::class),
             $this->createMock(ZoneByIdChoiceProvider::class),
-            $groupDataProvider
+            $groupDataProvider,
+            $this->createMock(TranslatorInterface::class)
         );
         $this->assertEquals([
             'general_settings' => [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A zone keeps the ranges of a carrier once it is disabled, so it stays listed in `Shipping locations and costs`, but nothing on the row says it is inactive. The merchant sees prices for a zone the carrier is never offered for. The row now carries the mention, reusing the `Inactive` wording the customer page already uses.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37171
| Related PRs       |
| Sponsor company   |

### How to test

Disable a zone in International, Locations, Zones, then edit a carrier that has ranges for it and open `Shipping locations and costs`. Before this change the zone is listed exactly like the active ones, after it its name is followed by `(Inactive)`.

The list is built from `ZoneByIdChoiceProvider::getChoices([])`, whose default is `active => false`, so it returns every zone with no flag to tell them apart. Asking the same provider for the active ones is what makes the difference visible:

```php
$zones = array_flip($this->zonesChoiceProvider->getChoices([]));
$activeZones = array_flip($this->zonesChoiceProvider->getChoices(['active' => true]));
```

`tests/Integration/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderZoneTest.php` toggles a zone used by a carrier and reads the label back from the data provider:

```
Tests: 2, Assertions: 2   OK
```

Restoring the previous line turns the second one red on `Failed asserting that two strings are identical`. The zone is put back to active in `tearDown()`, so the suite is repeatable.

### On the wording

`Inactive` already exists in `Admin.Global`, used on the customer view, so no new string is introduced and the parentheses are added by the code. The label is composed in the data provider because that is where the range label with its currency or weight symbol is already composed.

