### PR TITLE
Say which bound a carrier range includes

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
@@ -95,7 +95,7 @@ export default class CarrierFormManager {
       const $rangeNameHidden = $rangeRow.find(CarrierFormMap.rangeNameInput);
       const from = $rangeRow.find(CarrierFormMap.rangeFromInput).val();
       const to = $rangeRow.find(CarrierFormMap.rangeToInput).val();
-      const rangeName = `${from}${this.currentShippingSymbol} - ${to}${this.currentShippingSymbol}`;
+      const rangeName = this.formatRangeName(from, to);
       $rangeName.text(rangeName);
       $rangeNameHidden.val(rangeName);
     });
@@ -236,13 +236,21 @@ export default class CarrierFormManager {
     });
   }
 
+  /**
+   * A range covers its lower bound and stops before its upper one, so the operators are spelled out.
+   * Keep in sync with CarrierFormDataProvider, which renders the same label on first load.
+   */
+  private formatRangeName(from: unknown, to: unknown): string {
+    return `>= ${from}${this.currentShippingSymbol} - < ${to}${this.currentShippingSymbol}`;
+  }
+
   private prepareRangePrototype(rangePrototype: string, index: number, range: Range): JQuery {
     // We prepare the range prototype by replacing the range index, and setting the range values
     const $rPrototype = $(rangePrototype.replace(/__range__/g, index.toString()));
     $rPrototype.find(CarrierFormMap.rangeFromInput).val(range.from || '0');
     $rPrototype.find(CarrierFormMap.rangeToInput).val(range.to || '0');
     $rPrototype.find(CarrierFormMap.rangeNamePreview)
-      .text(`${range.from}${this.currentShippingSymbol} - ${range.to}${this.currentShippingSymbol}`);
+      .text(this.formatRangeName(range.from, range.to));
 
     // We return the prototype well formed
     return $rPrototype;

--- a/src/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProvider.php
@@ -140,7 +140,16 @@ class CarrierFormDataProvider implements FormDataProviderInterface
             $zoneRanges = [];
             foreach ($zone->getRanges() as $range) {
                 $zoneRanges[] = [
-                    'range' => $range->getFrom()->__toString() . $rangeSymbol . ' - ' . $range->getTo()->__toString() . $rangeSymbol,
+                    // The bounds are inclusive on the left and exclusive on the right, which a
+                    // plain dash does not say: with "0 - 4" and "4 - 10" nothing tells which row a
+                    // cart of exactly 4 falls into. Keep in sync with carrier-form-manager.ts.
+                    'range' => sprintf(
+                        '>= %s%s - < %s%s',
+                        $range->getFrom()->__toString(),
+                        $rangeSymbol,
+                        $range->getTo()->__toString(),
+                        $rangeSymbol
+                    ),
                     'from' => $range->getFrom(),
                     'to' => $range->getTo(),
                     'price' => $range->getPrice()->__toString(),

--- a/tests/Integration/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderRangeLabelTest.php
+++ b/tests/Integration/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderRangeLabelTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Form\IdentifiableObject\DataProvider;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CarrierFormDataProvider;
+use Tests\Integration\PrestaShopBundle\Form\FormListenerTestCase;
+
+/**
+ * A range covers its lower bound and stops before the upper one. Labelling two consecutive rows
+ * "0 - 4" and "4 - 10" leaves the merchant with no way to know what a cart of exactly 4 pays.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/37180
+ */
+class CarrierFormDataProviderRangeLabelTest extends FormListenerTestCase
+{
+    private const CARRIER_ID = 2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopId(1);
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+    }
+
+    public function testEveryRangeStatesWhichBoundItIncludes(): void
+    {
+        $labels = $this->rangeLabels();
+
+        $this->assertNotEmpty($labels, 'The fixture carrier is expected to have ranges.');
+
+        foreach ($labels as $label) {
+            $this->assertMatchesRegularExpression('/^>= .+ - < .+$/', $label);
+        }
+    }
+
+    public function testBothBoundsAreStillShown(): void
+    {
+        foreach ($this->rangeLabels() as $label) {
+            // Nothing is lost compared to the plain dash: a value remains on each side.
+            [$lowerBound, $upperBound] = explode(' - < ', $label);
+
+            $this->assertMatchesRegularExpression('/\d/', $lowerBound);
+            $this->assertMatchesRegularExpression('/\d/', $upperBound);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function rangeLabels(): array
+    {
+        /** @var CarrierFormDataProvider $dataProvider */
+        $dataProvider = self::getContainer()->get(CarrierFormDataProvider::class);
+        $data = $dataProvider->getData(self::CARRIER_ID);
+
+        $labels = [];
+        foreach ($data['shipping_settings']['ranges_costs'] as $zone) {
+            foreach ($zone['ranges'] as $range) {
+                $labels[] = $range['range'];
+            }
+        }
+
+        return $labels;
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderTest.php
@@ -140,14 +140,14 @@ class CarrierFormDataProviderTest extends TestCase
                 ],
                 'ranges_costs' => [
                     ['zoneId' => 1, 'zoneName' => 'Zone A', 'ranges' => [
-                        ['range' => '0kg - 10kg', 'from' => '0', 'to' => '10', 'price' => '10'],
-                        ['range' => '10kg - 20kg', 'from' => '10', 'to' => '20', 'price' => '11'],
-                        ['range' => '20kg - 25kg', 'from' => '20', 'to' => '25', 'price' => '12'],
+                        ['range' => '>= 0kg - < 10kg', 'from' => '0', 'to' => '10', 'price' => '10'],
+                        ['range' => '>= 10kg - < 20kg', 'from' => '10', 'to' => '20', 'price' => '11'],
+                        ['range' => '>= 20kg - < 25kg', 'from' => '20', 'to' => '25', 'price' => '12'],
                     ]],
                     ['zoneId' => 2, 'zoneName' => 'Zone B', 'ranges' => [
-                        ['range' => '0kg - 10kg', 'from' => '0', 'to' => '10', 'price' => '20'],
-                        ['range' => '10kg - 20kg', 'from' => '10', 'to' => '20', 'price' => '21'],
-                        ['range' => '20kg - 25kg', 'from' => '20', 'to' => '25', 'price' => '22'],
+                        ['range' => '>= 0kg - < 10kg', 'from' => '0', 'to' => '10', 'price' => '20'],
+                        ['range' => '>= 10kg - < 20kg', 'from' => '10', 'to' => '20', 'price' => '21'],
+                        ['range' => '>= 20kg - < 25kg', 'from' => '20', 'to' => '25', 'price' => '22'],
                     ]],
                 ],
             ],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A range covers its lower bound and stops before the upper one, but the label is a plain dash, so two consecutive rows read `0€ - 4€` and `4€ - 10€` and nothing says which one a cart of exactly 4€ falls into. The operators the legacy carrier wizard used are put back into the label.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37180
| Related PRs       |
| Sponsor company   |

### How to test

Edit a carrier with several ranges and open `Shipping locations and costs`. Each row now reads `>= 0€ - < 4€` instead of `0€ - 4€`, and switching between `Based on the order's total price` and `Based on the order's total weight` keeps the same shape with the other unit.

### Why two files

The label is produced in two places that had drifted apart in wording only by accident: `CarrierFormDataProvider` renders it on first load, and `carrier-form-manager.ts` rewrites it whenever the shipping method changes or a range is added. Changing one alone would make the label differ before and after any interaction, so both are updated, and the TypeScript side now builds it in a single private method instead of repeating the template literal twice.

`tests/Integration/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderRangeLabelTest.php` reads the labels back from the data provider and checks both that every row states its operators and that neither bound disappeared:

```
Tests: 2, Assertions: 7   OK
```

That test covers the PHP side only. The two implementations are kept in step by a comment in each file and by nothing else, so editing the TypeScript formatter alone would not fail anything. A spec for it would go next to the existing ones under `admin-dev/themes/new-theme/tests/`, say so if you want it in the same PR.

Restoring the previous line turns it red on the real value of the fixture carrier:

```
Failed asserting that '0kg - 10000kg' matches PCRE pattern "/^>= .+ - < .+$/".
```

### On the wording

`>= x - < y` keeps both bounds, uses the operators the previous page already showed in its two range rows, and needs no new translation since it is punctuation only. If you would rather have something else, for instance the lower bound alone since the ranges are contiguous, say so and I will rework it.

