### PR TITLE
Say why a carrier range is refused when it ends before it starts

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
@@ -35,6 +35,13 @@
         >
           {{ $t('modal.negativeRangeAlert') }}
         </div>
+        <div
+          class="alert alert-danger"
+          v-if="invalidRangeAlert"
+          role="alert"
+        >
+          {{ $t('modal.invalidRangeAlert') }}
+        </div>
         <div class="table-container">
           <table class="table table-carrier-ranges-modal">
             <thead>
@@ -127,6 +134,8 @@
     refreshKey: number, // force the refresh of the table by incrementing this key
     errors: boolean, // define if there are errors in the ranges
     overlappingAlert: boolean, // define if there are overlapping ranges (and display an alert)
+    negativeRangeAlert: boolean, // define if a bound is negative (and display an alert)
+    invalidRangeAlert: boolean, // define if a range ends before it starts (and display an alert)
     symbol: string, // define the current symbol used in function of the shipping method
   }
 
@@ -142,6 +151,7 @@
         errors: false,
         overlappingAlert: false,
         negativeRangeAlert: false,
+        invalidRangeAlert: false,
         symbol: '',
       };
     },
@@ -179,6 +189,7 @@
         this.errors = false;
         this.overlappingAlert = false;
         this.negativeRangeAlert = false;
+        this.invalidRangeAlert = false;
       },
       closeModal() {
         // We remove the class to allow scrolling
@@ -214,6 +225,7 @@
         this.errors = false;
         this.overlappingAlert = false;
         this.negativeRangeAlert = false;
+        this.invalidRangeAlert = false;
         // We remove the error class from all inputs already in error
         table.querySelectorAll('input.is-invalid').forEach((input) => {
           input.classList.remove('is-invalid');
@@ -263,6 +275,7 @@
                 input.classList.add('is-invalid');
               });
             this.errors = true;
+            this.invalidRangeAlert = true;
           }
 
           saveMax = range.to;

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CarrierRangesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CarrierRangesType.php
@@ -47,6 +47,7 @@ class CarrierRangesType extends TranslatorAwareType
                         'modal.col.action' => $this->trans('Action', 'Admin.Shipping.Feature'),
                         'modal.overlappingAlert' => $this->trans('Make sure there are no overlapping ranges. Remember, the minimum is part of the range, but the maximum isn\'t. So, the upper limit of a range is the lower limit of the next range.', 'Admin.Shipping.Feature'),
                         'modal.negativeRangeAlert' => $this->trans('You can not add a negative range', 'Admin.Shipping.Feature'),
+                        'modal.invalidRangeAlert' => $this->trans('This range is not valid', 'Admin.Shipping.Notification'),
                     ]),
                 ],
             ])

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierRangesModalTranslationsTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierRangesModalTranslationsTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Tests\Integration\PrestaShopBundle\Form\FormListenerTestCase;
+
+/**
+ * The ranges modal receives its wording through the `data-translations` attribute of the button that
+ * opens it. A message the component asks for but the form does not send renders as nothing at all,
+ * which is how the invalid range case ended up silent.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/37182
+ */
+class CarrierRangesModalTranslationsTest extends FormListenerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopId(1);
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+    }
+
+    /**
+     * @dataProvider getAlertsTheModalCanRaise
+     */
+    public function testTheModalIsGivenAMessageForEveryAlertItCanRaise(string $translationKey): void
+    {
+        $translations = $this->modalTranslations();
+
+        $this->assertArrayHasKey($translationKey, $translations);
+        $this->assertNotSame('', trim($translations[$translationKey]));
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public function getAlertsTheModalCanRaise(): array
+    {
+        return [
+            ['modal.overlappingAlert'],
+            ['modal.negativeRangeAlert'],
+            ['modal.invalidRangeAlert'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function modalTranslations(): array
+    {
+        $form = self::getContainer()
+            ->get('prestashop.core.form.identifiable_object.builder.carrier_form_builder')
+            ->getForm();
+
+        $attributes = $form->get('shipping_settings')->get('ranges')->get('show_modal')
+            ->getConfig()->getOption('attr');
+
+        return json_decode($attributes['data-translations'], true, 512, JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | In the ranges modal, a range whose maximum is below its minimum turns the field red and refuses to apply, but says nothing. The two other rejections, overlapping and negative, each raise an alert, this one sets the error flag and no message. It now raises the alert the report asks for, reusing the wording the previous carrier wizard already used.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37182
| Related PRs       |
| Sponsor company   |

### How to test

Edit a carrier, open `Manage ranges`, set a minimum of 5 and a maximum of 3, then apply. Before this change the maximum turns red and nothing explains why, after it the modal shows `This range is not valid`.

### On the case in the report

The exact steps of the report, minimum 1 and maximum -1, no longer reproduce: `bf9cce23282 chore(carrier): prevent negative range` added the negative check on 2024-10-28, eleven days after the report, and that branch does raise its own alert. What remains, and what this fixes, is the sibling case with two non negative bounds, which reaches a different branch:

```js
if (range.to !== null && range.from !== null && range.to <= range.from) {
  table.querySelectorAll(`tr[data-row="${index}"] input.form-to`)
    .forEach((input) => { input.classList.add('is-invalid'); });
  this.errors = true;   // no alert was set here
}
```

### On the wording and the test

`This range is not valid` is the exact message the report expects and it already exists in `Admin.Shipping.Notification`, used by the legacy carrier wizard, so nothing new needs translating.

The modal takes its wording from the `data-translations` attribute of the button that opens it, so a message the component asks for but the form does not send renders as an empty alert. `tests/Integration/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierRangesModalTranslationsTest.php` asserts that every alert the component can raise has a non empty message:

```
Tests: 3, Assertions: 6   OK
```

Removing the new entry turns it red with `Failed asserting that an array has the key 'modal.invalidRangeAlert'`.

The branch itself is inside a single file Vue component and the specs under `admin-dev/themes/new-theme/tests/` all import plain modules, none mounts a component, so that half is covered by the manual reproduction above rather than by a spec.

### Also in the diff

`negativeRangeAlert` was returned by `data()` without being declared in the component's state type. It is declared now, next to the one this change adds.

