### PR TITLE
Allow an already invalid object to be soft deleted

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -957,7 +957,17 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
         /* @phpstan-ignore-next-line */
         $this->deleted = true;
 
-        return $this->update();
+        // Only the flag is written. An object whose other fields are already invalid, an address
+        // left behind by an import or an older version for instance, can then still be soft deleted
+        // instead of being impossible to remove or to correct.
+        $previousFieldsToUpdate = $this->getFieldsToUpdate();
+        $this->setFieldsToUpdate(['deleted' => true]);
+
+        try {
+            return $this->update();
+        } finally {
+            $this->setFieldsToUpdate($previousFieldsToUpdate);
+        }
     }
 
     /**
@@ -1001,7 +1011,10 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
                 continue;
             }
 
-            if (is_array($this->update_fields) && empty($this->update_fields[$field]) && isset($this->def['fields'][$field]['shop']) && $this->def['fields'][$field]['shop']) {
+            // A field that is not in the update list is not written by formatFields(), so validating
+            // it rejects an update over data it never touches. validateFieldsLang() already skips on
+            // the update list alone, this is the same rule for the other fields.
+            if (is_array($this->update_fields) && empty($this->update_fields[$field])) {
                 continue;
             }
 

--- a/tests/Integration/Classes/SoftDeleteInvalidObjectTest.php
+++ b/tests/Integration/Classes/SoftDeleteInvalidObjectTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Address;
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use PrestaShopException;
+
+/**
+ * An address left behind by an import, an old version or a checkout module can hold a value that no
+ * longer passes validation. Editing it in the back office soft deletes the previous row, and that
+ * used to validate the whole object, so the merchant could neither correct the address nor remove
+ * it.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/37917
+ */
+class SoftDeleteInvalidObjectTest extends TestCase
+{
+    private const FAULTY_PHONE = 'not a phone <<>>';
+
+    private int $addressId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $address = new Address();
+        $address->id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $address->alias = 'Soft delete fixture';
+        $address->lastname = 'Doe';
+        $address->firstname = 'John';
+        $address->address1 = '1 street';
+        $address->city = 'City';
+        $address->add();
+
+        $this->addressId = (int) $address->id;
+
+        // Straight to the column: the point is an object that is already stored in an invalid state.
+        Db::getInstance()->update('address', ['phone' => self::FAULTY_PHONE], 'id_address = ' . $this->addressId);
+    }
+
+    protected function tearDown(): void
+    {
+        Db::getInstance()->delete('address', 'id_address = ' . $this->addressId);
+
+        parent::tearDown();
+    }
+
+    public function testTheFixtureIsInvalidToBeginWith(): void
+    {
+        $address = new Address($this->addressId);
+
+        $this->assertFalse($address->validateFields(false));
+    }
+
+    public function testAnInvalidObjectCanStillBeSoftDeleted(): void
+    {
+        $address = new Address($this->addressId);
+
+        try {
+            $address->softDelete();
+        } catch (PrestaShopException $e) {
+            $this->fail('Soft deleting an invalid object must not be blocked: ' . $e->getMessage());
+        }
+
+        $this->assertSame('1', (string) Db::getInstance()->getValue(
+            'SELECT deleted FROM ' . _DB_PREFIX_ . 'address WHERE id_address = ' . $this->addressId
+        ));
+    }
+
+    public function testSoftDeletingLeavesTheOtherColumnsAlone(): void
+    {
+        (new Address($this->addressId))->softDelete();
+
+        $this->assertSame(self::FAULTY_PHONE, (string) Db::getInstance()->getValue(
+            'SELECT phone FROM ' . _DB_PREFIX_ . 'address WHERE id_address = ' . $this->addressId
+        ));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | An address that is already stored in an invalid state, left by an import, an older version or a checkout module, cannot be corrected in the back office. Saving an address used by an order soft deletes the previous row, `softDelete()` goes through `update()`, and `update()` validates every field of an object whose data is exactly what is wrong. The merchant can then neither fix the address nor remove it. Soft deleting now writes only the flag, and validation no longer covers fields that are not being written.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37917
| Related PRs       |
| Sponsor company   |

### How to test

Put an address into an invalid state without going through the model, which is what an import does:

```sql
UPDATE ps_address SET phone = 'not a phone <<>>' WHERE id_address = 1;
```

```php
(new Address(1))->softDelete();
```

Measured on 9.2.x before the change:

```
validateFields(die=false) = false
softDelete(): PrestaShopException -> Property Address->phone is not valid
deleted flag in db = 0
```

After it the call returns, the row carries `deleted = 1`, and `phone` is untouched.

### The two halves

`softDelete()` now declares that only the flag is written:

```php
$previousFieldsToUpdate = $this->getFieldsToUpdate();
$this->setFieldsToUpdate(['deleted' => true]);

try {
    return $this->update();
} finally {
    $this->setFieldsToUpdate($previousFieldsToUpdate);
}
```

That alone is not enough, because `validateFields()` honoured the update list only for shop scoped fields:

```php
if (is_array($this->update_fields) && empty($this->update_fields[$field]) && isset($this->def['fields'][$field]['shop']) && $this->def['fields'][$field]['shop']) {
```

Its two siblings do not make that distinction. `formatFields()` skips every field absent from the update list, so those columns are never written, and `validateFieldsLang()` skips on the update list alone. The condition is now the same in all three, so a partial update is validated over the fields it actually writes.

Both halves are needed: reverting either one turns the test red.

### Scope of the second half

Eight call sites use partial updates, the widest being `AbstractObjectModelRepository::partialUpdate()`, which most CQRS handlers go through. The change means such an update is no longer rejected because of a field it does not touch, which is the same reasoning as the report: a stored value that is already invalid should not block a write that leaves it alone.

Verified against the suites that exercise this: `tests/Integration/Classes` 181 tests, `tests/Integration/Adapter` 169 tests, `ObjectModelTest` including its partial update cases 12 tests, all green. `tests/Integration/ApiPlatform` reports 26 errors and 4 failures both with and without this change on my environment, so those are unrelated to it.

