### PR TITLE
Record the payment of an order that reaches a paid status without an invoice

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -281,31 +281,18 @@ class OrderHistoryCore extends ObjectModel
             }
 
             $invoices = $order->getInvoicesCollection();
-            foreach ($invoices as $invoice) {
-                /** @var OrderInvoice $invoice */
-                $rest_paid = $invoice->getRestPaid();
-                if ($rest_paid > 0) {
-                    $payment = new OrderPayment();
-                    $payment->order_reference = Tools::substr($order->reference, 0, 9);
-                    $payment->id_currency = $order->id_currency;
-                    $payment->amount = $rest_paid;
-                    $payment->payment_method = isset($payment_method) && $payment_method instanceof Module ? $payment_method->displayName : null;
-                    $payment->conversion_rate = $order->conversion_rate;
-                    $payment->save();
 
-                    // Update total_paid_real value for backward compatibility reasons
-                    $order->total_paid_real += $rest_paid;
-                    $order->save();
-
-                    Db::getInstance()->insert(
-                        'order_invoice_payment',
-                        [
-                            'id_order_invoice' => (int) $invoice->id,
-                            'id_order_payment' => (int) $payment->id,
-                            'id_order' => (int) $order->id,
-                        ]
-                    );
+            if ($invoices->count() > 0) {
+                foreach ($invoices as $invoice) {
+                    /** @var OrderInvoice $invoice */
+                    $rest_paid = $invoice->getRestPaid();
+                    $this->recordPayment($order, $rest_paid, $payment_method ?? null, $invoice);
                 }
+            } else {
+                // A status can mark an order as paid without invoicing it, and a shop that has
+                // delegated invoicing to another system never issues one at all. The payment still
+                // belongs to the order, so what is left to pay is read from the order itself.
+                $this->recordPayment($order, $order->total_paid - $order->getTotalPaid(), $payment_method ?? null, null);
             }
         }
 
@@ -332,6 +319,46 @@ class OrderHistoryCore extends ObjectModel
         );
 
         ShopUrl::resetMainDomainCache();
+    }
+
+    /**
+     * Record what is still owed as a payment on the order.
+     *
+     * @param OrderCore $order
+     * @param float $restPaid amount left to pay, either on the invoice or on the order
+     * @param Module|null $paymentMethod
+     * @param OrderInvoice|null $invoice invoice the payment settles, null when the order has none
+     */
+    private function recordPayment($order, $restPaid, $paymentMethod, $invoice)
+    {
+        if ($restPaid <= 0) {
+            return;
+        }
+
+        $payment = new OrderPayment();
+        $payment->order_reference = Tools::substr($order->reference, 0, 9);
+        $payment->id_currency = $order->id_currency;
+        $payment->amount = $restPaid;
+        $payment->payment_method = $paymentMethod instanceof Module ? $paymentMethod->displayName : null;
+        $payment->conversion_rate = $order->conversion_rate;
+        $payment->save();
+
+        // Update total_paid_real value for backward compatibility reasons
+        $order->total_paid_real += $restPaid;
+        $order->save();
+
+        // The table ties a payment to the invoice it settles, so there is nothing to write when the
+        // order was never invoiced.
+        if ($invoice !== null) {
+            Db::getInstance()->insert(
+                'order_invoice_payment',
+                [
+                    'id_order_invoice' => (int) $invoice->id,
+                    'id_order_payment' => (int) $payment->id,
+                    'id_order' => (int) $order->id,
+                ]
+            );
+        }
     }
 
     /**

--- a/tests/Integration/Classes/Order/OrderHistoryPaymentTest.php
+++ b/tests/Integration/Classes/Order/OrderHistoryPaymentTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Configuration;
+use Context;
+use Currency;
+use Db;
+use Employee;
+use Language;
+use Order;
+use OrderHistory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The payment used to be created inside a loop over the order's invoices, so an order reaching a
+ * paid status without ever being invoiced recorded nothing at all. A status can carry `paid` without
+ * carrying `invoice`, which is what a shop that delegates invoicing to another system does.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/38103
+ */
+class OrderHistoryPaymentTest extends TestCase
+{
+    private int $orderId;
+
+    private int $paidStateId;
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $historyBackup = [];
+
+    private string $stateInvoiceFlag;
+
+    private string $currentState;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $context = Context::getContext();
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->employee = new Employee((int) Db::getInstance()->getValue(
+            'SELECT id_employee FROM ' . _DB_PREFIX_ . 'employee WHERE id_profile = ' . _PS_ADMIN_PROFILE_
+        ));
+
+        $this->paidStateId = (int) Configuration::get('PS_OS_PAYMENT');
+        $this->orderId = (int) Db::getInstance()->getValue(
+            'SELECT o.id_order FROM ' . _DB_PREFIX_ . 'orders o
+             LEFT JOIN ' . _DB_PREFIX_ . 'order_invoice oi ON oi.id_order = o.id_order
+             WHERE oi.id_order IS NULL AND o.total_paid > 0 ORDER BY o.id_order'
+        );
+
+        $this->stateInvoiceFlag = (string) Db::getInstance()->getValue(
+            'SELECT invoice FROM ' . _DB_PREFIX_ . 'order_state WHERE id_order_state = ' . $this->paidStateId
+        );
+        $this->currentState = (string) Db::getInstance()->getValue(
+            'SELECT current_state FROM ' . _DB_PREFIX_ . 'orders WHERE id_order = ' . $this->orderId
+        );
+        $this->historyBackup = Db::getInstance()->executeS(
+            'SELECT * FROM ' . _DB_PREFIX_ . 'order_history WHERE id_order = ' . $this->orderId
+        ) ?: [];
+
+        // The paid status no longer issues an invoice, the shop invoices elsewhere.
+        Db::getInstance()->update('order_state', ['invoice' => 0], 'id_order_state = ' . $this->paidStateId);
+    }
+
+    protected function tearDown(): void
+    {
+        $reference = (string) Db::getInstance()->getValue(
+            'SELECT reference FROM ' . _DB_PREFIX_ . 'orders WHERE id_order = ' . $this->orderId
+        );
+
+        Db::getInstance()->update('order_state', ['invoice' => (int) $this->stateInvoiceFlag], 'id_order_state = ' . $this->paidStateId);
+        Db::getInstance()->delete('order_payment', 'order_reference = "' . pSQL($reference) . '"');
+        Db::getInstance()->delete('order_invoice_payment', 'id_order = ' . $this->orderId);
+        Db::getInstance()->delete('order_history', 'id_order = ' . $this->orderId);
+        foreach ($this->historyBackup as $row) {
+            Db::getInstance()->insert('order_history', $row, false, true, Db::INSERT_IGNORE);
+        }
+        Db::getInstance()->update(
+            'orders',
+            ['current_state' => (int) $this->currentState, 'total_paid_real' => 0],
+            'id_order = ' . $this->orderId
+        );
+
+        parent::tearDown();
+    }
+
+    public function testAnOrderPaidWithoutAnInvoiceStillRecordsItsPayment(): void
+    {
+        $order = new Order($this->orderId);
+
+        $this->assertCount(0, $order->getInvoicesCollection(), 'The fixture order must start without an invoice.');
+        $this->assertSame(0, $this->countPayments($order->reference));
+
+        $this->moveToPaidStatus();
+
+        $this->assertSame(1, $this->countPayments($order->reference));
+        $this->assertEqualsWithDelta(
+            (float) $order->total_paid,
+            (float) Db::getInstance()->getValue(
+                'SELECT amount FROM ' . _DB_PREFIX_ . 'order_payment WHERE order_reference = "' . pSQL($order->reference) . '"'
+            ),
+            0.01
+        );
+    }
+
+    public function testTheOrderIsReportedAsPaidForReal(): void
+    {
+        $order = new Order($this->orderId);
+
+        $this->moveToPaidStatus();
+
+        $this->assertEqualsWithDelta(
+            (float) $order->total_paid,
+            (float) Db::getInstance()->getValue(
+                'SELECT total_paid_real FROM ' . _DB_PREFIX_ . 'orders WHERE id_order = ' . $this->orderId
+            ),
+            0.01
+        );
+    }
+
+    public function testNoInvoiceLinkIsWrittenWhenThereIsNoInvoice(): void
+    {
+        $this->moveToPaidStatus();
+
+        $this->assertSame(0, (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'order_invoice_payment WHERE id_order = ' . $this->orderId
+        ));
+    }
+
+    private function moveToPaidStatus(): void
+    {
+        $history = new OrderHistory();
+        $history->id_order = $this->orderId;
+        $history->changeIdOrderState($this->paidStateId, $this->orderId);
+        $history->add();
+    }
+
+    private function countPayments(string $reference): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'order_payment WHERE order_reference = "' . pSQL($reference) . '"'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The payment of a paid order is created inside a loop over the order's invoices, so an order that reaches a paid status without ever being invoiced records no payment at all and keeps `total_paid_real` at zero. A status can carry `paid` without carrying `invoice`, which is what a shop that delegates invoicing to another system configures, and then the order reads as paid with nothing behind it. The payment is now recorded against the order when there is no invoice to attach it to.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38103
| Related PRs       | #38105 and #38159 by @Jeremie-Kiwik propose the same behaviour on `develop` and `8.2.x`
| Sponsor company   |

### How to test

Uncheck the **invoice** flag of a paid status in Orders, Statuses, then move an order that has no invoice to it.

Measured on a 9.2 shop before the change:

```
order moved to a paid status whose invoice flag is off
  invoices        = 0
  order_payment   = 0
  total_paid_real = 0.000000 (order total 169.900000)
```

After it the order carries one payment for the amount due and `total_paid_real` matches the total.

### Why not the invoicing setting

@Jeremie-Kiwik reached the same behaviour in #38105 by branching on `Configuration::get('PS_INVOICE')`. That covers the shop wide setting but not the case that is reachable from the back office in two clicks, and the two are independent. Measured on the same shop with the setting left enabled and only the status flag turned off:

```
PS_INVOICE=1, status invoice flag=0
  invoices        = 0
  order_payment   = 0
  total_paid_real = 0.000000
```

`Order::setInvoice()` runs only when the new status carries the invoice flag, so what decides whether there is an invoice to attach the payment to is the collection itself. This branches on that instead, which covers both configurations and leaves every invoicing shop on exactly the path it is on today.

The link row is also skipped when there is no invoice, rather than written with `id_order_invoice = 0`, since `order_invoice_payment` exists to tie a payment to the invoice it settles.

### Tests

`tests/Integration/Classes/Order/OrderHistoryPaymentTest.php` moves an uninvoiced order to a paid status whose invoice flag is off, and checks the three things that were wrong: a payment exists, its amount is the order total, `total_paid_real` matches, and no orphan link row is written. The status flag, the order and its history are restored in `tearDown()`.

```
Tests: 3, Assertions: 6   OK
```

Removing the new branch turns two of them red on the values from the reproduction above:

```
Failed asserting that 0 is identical to 1.
Failed asserting that 0.0 matches expected 61.8.
```

`tests/Integration/Classes` stays green at 181 tests.

