### PR TITLE
Describe how the default image of a combination is actually chosen

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
@@ -47,7 +47,7 @@ class CombinationImagesChoiceType extends TranslatorAwareType
             ->setAllowedTypes('product_id', 'int')
             ->setDefaults([
                 'label' => $this->trans('Images', 'Admin.Global'),
-                'label_subtitle' => $this->trans('You can specify which images should be displayed when customer selects this combination. If you don\'t select any image, all will be displayed. The default image of the combination will be the first one selected from the list.', 'Admin.Catalog.Feature'),
+                'label_subtitle' => $this->trans('You can specify which images should be displayed when customer selects this combination. If you don\'t select any image, all will be displayed. The default image of the combination is the selected image that comes first in the product\'s image order.', 'Admin.Catalog.Feature'),
                 'choice_attr' => function (string $choice, string $key): array {
                     return ['data-image-url' => $key];
                 },

--- a/tests/Integration/Classes/Product/CombinationImagesOrderTest.php
+++ b/tests/Integration/Classes/Product/CombinationImagesOrderTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+
+/**
+ * The help text of the combination image selector used to promise that the default image would be
+ * the first one selected. `ps_product_attribute_image` holds only the two identifiers that form its
+ * primary key, so a selection order is never stored, and `Product::getCombinationImages()` orders by
+ * the position of the image within the product.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/38415
+ */
+class CombinationImagesOrderTest extends TestCase
+{
+    private int $productId;
+
+    private int $combinationId;
+
+    private int $firstPositionImageId;
+
+    private int $secondPositionImageId;
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $backup = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $product = Db::getInstance()->getRow(
+            'SELECT i.id_product, MIN(i.position) AS first_position
+             FROM ' . _DB_PREFIX_ . 'image i
+             INNER JOIN ' . _DB_PREFIX_ . 'product_attribute pa ON pa.id_product = i.id_product
+             GROUP BY i.id_product HAVING COUNT(DISTINCT i.id_image) >= 2'
+        );
+
+        if (!$product) {
+            $this->markTestSkipped('No product with two images and a combination to exercise the ordering with.');
+        }
+
+        $this->productId = (int) $product['id_product'];
+        $this->combinationId = (int) Db::getInstance()->getValue(
+            'SELECT id_product_attribute FROM ' . _DB_PREFIX_ . 'product_attribute WHERE id_product = ' . $this->productId
+        );
+
+        $images = Db::getInstance()->executeS(
+            'SELECT id_image FROM ' . _DB_PREFIX_ . 'image WHERE id_product = ' . $this->productId . ' ORDER BY position'
+        );
+        $this->firstPositionImageId = (int) $images[0]['id_image'];
+        $this->secondPositionImageId = (int) $images[1]['id_image'];
+
+        $this->backup = Db::getInstance()->executeS(
+            'SELECT * FROM ' . _DB_PREFIX_ . 'product_attribute_image WHERE id_product_attribute = ' . $this->combinationId
+        ) ?: [];
+
+        Db::getInstance()->delete('product_attribute_image', 'id_product_attribute = ' . $this->combinationId);
+        // Inserted back to front on purpose: if the order followed the selection, the image sitting
+        // second in the product would come out first.
+        Db::getInstance()->insert('product_attribute_image', [
+            'id_product_attribute' => $this->combinationId,
+            'id_image' => $this->secondPositionImageId,
+        ]);
+        Db::getInstance()->insert('product_attribute_image', [
+            'id_product_attribute' => $this->combinationId,
+            'id_image' => $this->firstPositionImageId,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Db::getInstance()->delete('product_attribute_image', 'id_product_attribute = ' . $this->combinationId);
+        foreach ($this->backup as $row) {
+            Db::getInstance()->insert('product_attribute_image', $row, false, true, Db::INSERT_IGNORE);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testTheDefaultImageFollowsTheProductOrderNotTheSelectionOrder(): void
+    {
+        $images = (new Product($this->productId))->getCombinationImages((int) Configuration::get('PS_LANG_DEFAULT'));
+
+        $this->assertIsArray($images);
+        $this->assertArrayHasKey($this->combinationId, $images);
+
+        $this->assertSame(
+            $this->firstPositionImageId,
+            (int) $images[$this->combinationId][0]['id_image'],
+            'The first image offered for the combination must be the one that comes first in the product.'
+        );
+    }
+
+    public function testTheSelectionCarriesNoOrderOfItsOwn(): void
+    {
+        $columns = array_column(
+            Db::getInstance()->executeS('SHOW COLUMNS FROM ' . _DB_PREFIX_ . 'product_attribute_image') ?: [],
+            'Field'
+        );
+
+        // Nothing here could record which image was picked first.
+        $this->assertSame(['id_product_attribute', 'id_image'], $columns);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The help text of the combination image selector promises that the default image will be the first one selected from the list. Nothing records a selection order, so that never happens: the images offered for a combination are ordered by their position within the product. The sentence now says what the code does.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38415
| Related PRs       |
| Sponsor company   |

### Why the promise cannot hold

`ps_product_attribute_image` stores the two identifiers that make up its primary key and nothing else:

```
id_product_attribute  int unsigned  PRI
id_image              int unsigned  PRI
```

There is no column that could carry which image was picked first, which is the point @devexplora made in the report. `Product::getCombinationImages()` then reads them back ordered by the position of the image inside the product:

```sql
... WHERE i.`id_product` = X AND il.`id_lang` = Y ORDER by i.`position`
```

and `ProductController` takes the first row of that list as the image of the combination. So the default is the selected image that comes first in the product's own image order, whatever order the merchant clicked them in.

### The change

```
- The default image of the combination will be the first one selected from the list.
+ The default image of the combination is the selected image that comes first in the product's image order.
```

Only the source string is touched, the catalogues under `translations/` are left to the usual synchronisation.

### Tests

`tests/Integration/Classes/Product/CombinationImagesOrderTest.php` attaches two images of the same product to one combination, inserting the one that sits **second** in the product first, and checks that `getCombinationImages()` still returns the one that sits first. If the order followed the selection the assertion would fail. A second case asserts the table has only its two key columns, which is what makes a selection order impossible to store in the first place.

```
Tests: 2, Assertions: 4   OK
```

The previous rows of the combination are restored in `tearDown()`.

### The other reading

The alternative would be to make the behaviour match the sentence, which needs a column on that table to carry either a cover flag or an order, plus a migration. That is a feature rather than a correction, so this fixes the text. If a maintainer would rather have the behaviour, say so and I will rework it.

