### PR TITLE
Count the products a customer bought even when they are the gifted one

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1273,8 +1273,7 @@ class CartRuleCore extends ObjectModel
 								FROM `' . _DB_PREFIX_ . 'cart_product` cp
 								LEFT JOIN `' . _DB_PREFIX_ . 'category_product` catp ON cp.id_product = catp.id_product
 								WHERE cp.`id_cart` = ' . (int) $cart->id . '
-								AND cp.`id_product` IN (' . implode(',', array_map('intval', $eligible_products_list)) . ')
-								AND cp.`id_product` <> ' . (int) $this->gift_product);
+								AND cp.`id_product` IN (' . implode(',', array_map('intval', $eligible_products_list)) . ')');
                                 $count_matching_products = 0;
                                 $matching_products_list = [];
                                 foreach ($cart_categories as $cart_category) {
@@ -1285,6 +1284,14 @@ class CartRuleCore extends ObjectModel
                                          */
                                         && !in_array($cart_category['id_product'] . '-' . $cart_category['id_product_attribute'], $matching_products_list)) {
                                         $count_matching_products += $cart_category['quantity'];
+                                        // The free unit itself must not pay for the rule that granted it, but the
+                                        // ones the customer bought have to count, even when they are the same product.
+                                        if (
+                                            $alreadyInCart
+                                            && $this->gift_product == $cart_category['id_product']
+                                            && $this->gift_product_attribute == $cart_category['id_product_attribute']) {
+                                            --$count_matching_products;
+                                        }
                                         $matching_products_list[] = $cart_category['id_product'] . '-' . $cart_category['id_product_attribute'];
                                     }
                                 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A cart rule that gives a product away and restricts on a category excluded that product from its own count, so a customer who bought the gifted product qualified for nothing. Buy four shirts and get a free Dominik works with four Daniel in the cart and fails with four Dominik. The units the customer paid for are now counted, and only the free one is discounted, which is what the other two restriction types already do.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39501
| Related PRs       |
| Sponsor company   |

### How to test

Follow the steps of the report: a rule requiring four products of a category, giving one of those products away. Put four of the gifted product in a cart.

Measured on a 9.2 shop, running the same scenario twice, once with the gift being another product of the category and once with the gift being the product in the cart:

```
customer buys 4 x product 1, rule restricts on its CATEGORY

before
  gift is a DIFFERENT product  -> rule applied to cart: YES | units in cart: 4
  gift is the SAME product     -> rule applied to cart: no  | units in cart: 4

after
  gift is a DIFFERENT product  -> rule applied to cart: YES | units in cart: 4
  gift is the SAME product     -> rule applied to cart: YES | units in cart: 5
```

Five units in the last line is the four the customer bought plus the free one. The first line is the control: it behaves exactly as before, so shops that gift a different product see no change.

### The cause

The category branch removed the gifted product from the query outright:

```sql
AND cp.`id_product` <> ' . (int) $this->gift_product
```

so a cart holding only that product counted zero and never reached the required quantity. The `products` and `combinations` branches of the same method do not do that. They count everything and take one unit back once the rule is in the cart:

```php
if ($alreadyInCart && $this->gift_product == $cart_product['id_product']) {
    --$count_matching_products;
}
```

This applies the same treatment to categories, so the free unit still does not pay for the rule that granted it while the purchased ones do.

### On the missing test

I tried three ways to cover this in `tests/Integration` and none of them can fail, so I am not shipping a green test that guards nothing. What I found, in case it saves someone the same hour:

- Building the cart with `Cart::updateQty()` auto applies the rule, so `checkValidity()` then answers `This voucher is already in your cart` rather than judging the restriction.
- Writing the cart line directly avoids that, but the rule still validates in that fixture with and without this change.
- Asserting `checkProductRestrictionsFromCart()` directly, which is the method this changes, also passes both ways, so the category branch is not being reached in that database at all.

The same fixture on a real 9.2 shop reproduces immediately and shows the before and after above, which is what the reproduction section documents. If you know where a cart rule with a product rule group does get evaluated in the test suite, point me at it and I will add the case there.

