### PR TITLE
Resolve a product reference that is made of digits

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7950,8 +7950,12 @@ class ProductCore extends ObjectModel
         foreach ((is_array($ids_or_refs) ? $ids_or_refs : [$ids_or_refs]) as $id_or_ref) {
             if (is_numeric($id_or_ref)) {
                 $ids[] = (int) $id_or_ref;
-            } elseif (is_string($id_or_ref)) {
-                $refs[] = '\'' . pSQL($id_or_ref) . '\'';
+            }
+            // A value made of digits is ambiguous: it can be an identifier or a reference that
+            // happens to be numeric. The caller cannot tell them apart, so both are looked up,
+            // otherwise a numeric reference matches nothing at all.
+            if (is_string($id_or_ref) || is_numeric($id_or_ref)) {
+                $refs[] = '\'' . pSQL((string) $id_or_ref) . '\'';
             }
         }
 

--- a/tests/Integration/Classes/Product/ProductIdsOrRefsTest.php
+++ b/tests/Integration/Classes/Product/ProductIdsOrRefsTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+
+/**
+ * `getExistingIdsFromIdsOrRefs()` accepts identifiers or references, and CSV import resolves
+ * accessories through it. A reference made of digits used to be read as an identifier only, so a
+ * catalogue that numbers its references could not import accessories at all.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/10824
+ */
+class ProductIdsOrRefsTest extends TestCase
+{
+    private const NUMERIC_REFERENCE = '9876543';
+    private const TEXTUAL_REFERENCE = 'REF-CONTROL-1';
+
+    private int $productId;
+
+    private string $originalReference;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->productId = (int) Db::getInstance()->getValue(
+            'SELECT id_product FROM ' . _DB_PREFIX_ . 'product ORDER BY id_product DESC'
+        );
+        $this->originalReference = (string) Db::getInstance()->getValue(
+            'SELECT reference FROM ' . _DB_PREFIX_ . 'product WHERE id_product = ' . $this->productId
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Db::getInstance()->update(
+            'product',
+            ['reference' => pSQL($this->originalReference)],
+            'id_product = ' . $this->productId
+        );
+
+        parent::tearDown();
+    }
+
+    public function testAReferenceMadeOfDigitsResolvesToItsProduct(): void
+    {
+        $this->giveTheProductTheReference(self::NUMERIC_REFERENCE);
+
+        // Nothing must own that identifier, otherwise the lookup could succeed for the wrong reason.
+        $this->assertFalse((bool) Db::getInstance()->getValue(
+            'SELECT id_product FROM ' . _DB_PREFIX_ . 'product WHERE id_product = ' . (int) self::NUMERIC_REFERENCE
+        ));
+
+        $this->assertContains($this->productId, (array) Product::getExistingIdsFromIdsOrRefs(self::NUMERIC_REFERENCE));
+    }
+
+    public function testATextualReferenceStillResolves(): void
+    {
+        $this->giveTheProductTheReference(self::TEXTUAL_REFERENCE);
+
+        $this->assertContains($this->productId, (array) Product::getExistingIdsFromIdsOrRefs(self::TEXTUAL_REFERENCE));
+    }
+
+    public function testAnIdentifierStillResolves(): void
+    {
+        $this->assertContains($this->productId, (array) Product::getExistingIdsFromIdsOrRefs((string) $this->productId));
+    }
+
+    private function giveTheProductTheReference(string $reference): void
+    {
+        Db::getInstance()->update(
+            'product',
+            ['reference' => pSQL($reference)],
+            'id_product = ' . $this->productId
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Product::getExistingIdsFromIdsOrRefs()` accepts identifiers or references, and CSV import resolves accessories through it. A value made of digits was treated as an identifier and never as a reference, so a catalogue whose references are numeric could not import accessories at all. Such a value is now looked up as both.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. The change is covered by the integration test added here, `ProductIdsOrRefsTest`, on reference resolution; a campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #10824
| Related PRs       |
| Sponsor company   |

### How to test

Give a product a reference made of digits, `9876543` for instance, and make sure no product carries that identifier. Then:

```php
Product::getExistingIdsFromIdsOrRefs('9876543');
```

Measured on a 9.2 shop before the change:

```
product 19 given the numeric reference '9876543'
does a product with id 9876543 exist? no
getExistingIdsFromIdsOrRefs('9876543') = []
control, textual reference 'REF-CONTROL-1' = [19]
```

The textual reference resolves, the numeric one finds nothing, which is why the accessories column of a CSV import is silently ignored for those catalogues. After the change the numeric reference returns the product, and the two controls are unaffected.

### The change

```php
if (is_numeric($id_or_ref)) {
    $ids[] = (int) $id_or_ref;
}
if (is_string($id_or_ref) || is_numeric($id_or_ref)) {
    $refs[] = '\'' . pSQL((string) $id_or_ref) . '\'';
}
```

The `elseif` made the two mutually exclusive, but a value made of digits is genuinely ambiguous and the caller cannot say which it meant. The query already combines the two lists with `OR`, so adding the value to both is enough, and a value that matches an identifier keeps matching it exactly as before.

@artur-tkaczyk-invisiblefarm pointed at this method in the report, and it is unchanged since.

### Tests

`tests/Integration/Classes/Product/ProductIdsOrRefsTest.php` covers the three cases: a reference made of digits, a textual reference and a plain identifier. It also asserts that no product owns the numeric value as an identifier, so the lookup cannot pass for the wrong reason.

```
Tests: 3, Assertions: 4   OK
```

Restoring the `elseif` fails only the first one:

```
Failed asserting that an array contains 20.
```

`tests/Integration/Classes` stays green at 181 tests.

