### PR TITLE
Refuse a required field answered with spaces only

### DIFF
--- a/classes/form/AbstractForm.php
+++ b/classes/form/AbstractForm.php
@@ -132,7 +132,13 @@ abstract class AbstractFormCore implements FormInterface
     {
         foreach ($this->formFields as $field) {
             if ($field->isRequired()) {
-                if (!$field->getValue()) {
+                $value = $field->getValue();
+                // A value made only of spaces is not an answer, and PHP considers such a string
+                // truthy, so it used to satisfy the requirement. Comparing the trimmed value also
+                // keeps "0" acceptable, which the previous truthiness test rejected.
+                $isEmpty = is_array($value) ? empty($value) : '' === trim((string) $value);
+
+                if ($isEmpty) {
                     $field->addError(
                         $this->constraintTranslator->translate('required')
                     );

--- a/tests/Unit/Classes/form/AbstractFormTest.php
+++ b/tests/Unit/Classes/form/AbstractFormTest.php
@@ -67,6 +67,26 @@ class AbstractFormTest extends TestCase
                     'field' => ['The %1$s field is too long (%2$d chars max).'],
                 ],
             ],
+            // Required field filled with spaces only
+            [
+                ['field' => (new FormField())->setName('field')->setRequired(true)],
+                ['field' => '   '],
+                false,
+                [
+                    '' => [],
+                    'field' => ['Required field'],
+                ],
+            ],
+            // Required field answered with a zero, which is an answer
+            [
+                ['field' => (new FormField())->setName('field')->setRequired(true)],
+                ['field' => '0'],
+                true,
+                [
+                    '' => [],
+                    'field' => [],
+                ],
+            ],
             // Not Required field but empty
             [
                 ['field' => (new FormField())->setName('field')->setRequired(false)],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A required field of a front office form was satisfied by a single space. The check tested the raw value for truthiness, and a string of spaces is truthy in PHP, so an address could be saved with a phone number of `" "`. The trimmed value is compared instead, which also stops rejecting a legitimate answer of `0`.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #9871
| Related PRs       |
| Sponsor company   |

### How to test

Follow the steps of the report: make `phone` a required field in Customers, Addresses, then add an address from the customer account with a single space as the phone number. Before this change it saves, after it the field is reported as required.

Nothing else catches it either. `Validate::isPhoneNumber()` accepts whitespace, measured on a 9.2 shop:

```
isPhoneNumber(" ")          = true
isPhoneNumber("")           = true
isPhoneNumber("   ")        = true
isPhoneNumber("0612345678") = true
```

so the form check is the only gate for this.

### The change

```php
$value = $field->getValue();
$isEmpty = is_array($value) ? empty($value) : '' === trim((string) $value);

if ($isEmpty) {
```

`!$field->getValue()` was already catching an empty string, since that is falsy, but not a string of spaces. Arrays keep the previous behaviour, an empty one still counts as missing.

### One behaviour change beyond the report

The previous test also treated `"0"` as missing, because it is falsy, so a required field answered with a zero was refused. The trimmed comparison accepts it. That looks like the intended meaning of "required", but it is a change, so it is called out here and covered by its own case in the test.

### Tests

Two cases added to the existing `tests/Unit/Classes/form/AbstractFormTest.php` data provider, one for a field filled with spaces and one for a field answered with `0`:

```
Tests: 8, Assertions: 16   OK
```

Restoring the previous condition fails exactly those two:

```
Failed asserting that true matches expected false.
Failed asserting that false matches expected true.
```

`tests/Unit/Classes` stays green at 603 tests, and the checkout integration tests at 4.

