### PR TITLE
Translate the low stock alert email subject

### DIFF
--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -304,7 +304,12 @@ class StockManager
                 Mail::Send(
                     $idLang,
                     'productoutofstock',
-                    Mail::l('Product out of stock', $idLang),
+                    $context->getTranslator()->trans(
+                        'Product out of stock',
+                        [],
+                        'Emails.Subject',
+                        $context->language->locale
+                    ),
                     $templateVars,
                     $employee->email,
                     null,

--- a/tests/Integration/Core/Stock/StockManagerTest.php
+++ b/tests/Integration/Core/Stock/StockManagerTest.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Stock;
 
+use Configuration;
+use Context;
+use Mail;
 use PHPUnit\Framework\MockObject\MockObject;
 use PrestaShop\PrestaShop\Adapter\Product\PackItemsManager;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
@@ -16,8 +19,11 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
 use PrestaShop\PrestaShop\Core\Foundation\IoC\Container;
 use PrestaShop\PrestaShop\Core\Stock\StockManager;
 use Product;
+use ReflectionMethod;
+use ReflectionProperty;
 use StockAvailable;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StockManagerTest extends KernelTestCase
 {
@@ -361,6 +367,47 @@ class StockManagerTest extends KernelTestCase
                 'expected' => [2, 14, 2],
             ],
         ];
+    }
+
+    public function testLowStockAlertSubjectIsTakenFromTheEmailsSubjectCatalogue(): void
+    {
+        // The fake configuration bound in setUp() is only meant for the pack tests
+        ServiceLocator::setServiceContainerInstance($this->savedContainer);
+
+        $context = Context::getContext();
+        $locale = $context->language->locale;
+
+        $translated = [];
+        $translator = $this->createMock(TranslatorInterface::class);
+        // Context::getTranslator() replaces the translator unless it already carries the
+        // context locale, so the double has to answer that question the same way
+        $translator->method('getLocale')->willReturn($locale);
+        $translator->method('trans')->willReturnCallback(
+            function (string $id, array $parameters = [], ?string $domain = null, ?string $translatorLocale = null) use (&$translated) {
+                $translated[] = [$id, $domain, $translatorLocale];
+
+                return $id;
+            }
+        );
+
+        $translatorProperty = new ReflectionProperty(Context::class, 'translator');
+        $translatorProperty->setAccessible(true);
+        $previousTranslator = $translatorProperty->getValue($context);
+        $translatorProperty->setValue($context, $translator);
+
+        $previousMailMethod = Configuration::get('PS_MAIL_METHOD');
+        Configuration::updateValue('PS_MAIL_METHOD', Mail::METHOD_DISABLE);
+
+        try {
+            $sendLowStockAlert = new ReflectionMethod(StockManager::class, 'sendLowStockAlert');
+            $sendLowStockAlert->setAccessible(true);
+            $sendLowStockAlert->invoke(new StockManager(), new Product(1), 0, 0);
+        } finally {
+            Configuration::updateValue('PS_MAIL_METHOD', $previousMailMethod);
+            $translatorProperty->setValue($context, $previousTranslator);
+        }
+
+        $this->assertContains(['Product out of stock', 'Emails.Subject', $locale], $translated);
     }
 }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The low stock alert sent to employees built its subject with `Mail::l()`, the pre-1.7 mechanism that reads `mails/<iso>/lang.php`. PrestaShop 9 ships no such file, so the call always returned the untranslated English source. The subject now goes through the translator in the `Emails.Subject` domain, like every other core email.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42325
| Related PRs       |
| Sponsor company   |

### How to test

Install a second language, set a low stock threshold on a product, and drop its quantity to that threshold. Before this change the employee email is titled "Product out of stock" whatever the shop language; after it, it follows the language.

Measured on a 9.2 shop with French installed:

```
Mail::l("Product out of stock", 1 /* en */) = [Product out of stock]
Mail::l("Product out of stock", 2 /* fr */) = [Product out of stock]
lang.php fr exists = false

Emails.Subject  fr-FR => [Produit en rupture de stock]
```

`Mail::l()` returns the source string untouched when `mails/<iso>/lang.php` is missing, which it always is on 9.x, so the shipped translation in `translations/fr-FR/EmailsSubject.fr-FR.xlf` and any merchant override in Improve > International > Translations never reached this email.

### The change

```php
$context->getTranslator()->trans(
    'Product out of stock',
    [],
    'Emails.Subject',
    $context->language->locale
),
```

This is the idiom already used by `PrestaShopLogger::sendByMail()`, `OrderCarrier::sendInTransitEmail()`, `Customer::sendWelcomeEmail()` and the other 23 `Emails.Subject` call sites. `$idLang` passed to `Mail::Send()` is `$context->language->id`, so the subject and the body template stay on the same language as before.

This was the last `Mail::l()` call in the code base. The method itself is untouched, it stays available for third party modules.

Note that the email body was never affected: `Mail::Send()` is given `__DIR__ . '/mails/'` here, a directory that does not exist, but `Mail::getTemplateBasePath()` rebuilds the path from theme, parent theme, then root, and only reads the caller's string to detect a module name. So the body has always resolved to `mails/<iso>/productoutofstock.html`. Left as is to keep the diff to the reported defect.

### Tests

One case added to `tests/Integration/Core/Stock/StockManagerTest.php`. It swaps the context translator for a double, invokes `sendLowStockAlert()` and asserts the subject was requested from the `Emails.Subject` domain for the context locale.

```
Tests: 20, Assertions: 58   OK
```

Restoring `Mail::l('Product out of stock', $idLang)` fails it:

```
Failed asserting that an array contains Array &0 [
    0 => 'Product out of stock',
    1 => 'Emails.Subject',
    2 => 'en-US',
].
```

php-cs-fixer reports `Fixed 0 of 2 files`, PHPStan `[OK] No errors`.

