### PR TITLE
Describe what the customization picture size setting actually does

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
@@ -151,7 +151,7 @@ class ImageSettingsType extends TranslatorAwareType
             ])
             ->add('picture-max-width', IntegerType::class, [
                 'label' => $this->trans('Product picture width', 'Admin.Design.Feature'),
-                'help' => $this->trans('Width of product customization pictures that customers can upload (in pixels).', 'Admin.Design.Help'),
+                'help' => $this->trans('Width of the box a customization picture is fitted into when its thumbnail is generated (in pixels). The uploaded file itself is stored at its original size.', 'Admin.Design.Help'),
                 'attr' => [
                     'min' => 0,
                 ],
@@ -164,7 +164,7 @@ class ImageSettingsType extends TranslatorAwareType
             ])
             ->add('picture-max-height', IntegerType::class, [
                 'label' => $this->trans('Product picture height', 'Admin.Design.Feature'),
-                'help' => $this->trans('Height of product customization pictures that customers can upload (in pixels).', 'Admin.Design.Help'),
+                'help' => $this->trans('Height of the box a customization picture is fitted into when its thumbnail is generated (in pixels). The uploaded file itself is stored at its original size.', 'Admin.Design.Help'),
                 'attr' => [
                     'min' => 0,
                 ],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The help text under Design > Image settings > Product picture width/height says those values limit what a customer may upload. They do not. They are the size of the thumbnail generated from the uploaded picture; the upload itself is accepted at any resolution and stored untouched. The text now describes the actual behaviour.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #9787
| Related PRs       | #39374
| Sponsor company   |

### The measurement behind the wording

Set Product picture width/height to 64 and upload a 1920x1080 picture on a customizable product. Measured on 9.2:

```
source            = 1920x1080
BO setting        = 64x64
validateUpload    = false          (no error is raised)
stored original   = 1920x1080      (what /upload serves as medium and large)
stored _small     = 64x64          (thumbnail)
```

Sampling the thumbnail shows the ratio is kept and the picture is letterboxed into the box, it is not stretched:

```
top-centre     rgb(255,255,255)
centre         rgb(200, 30, 30)
bottom-centre  rgb(255,255,255)
left-centre    rgb(200, 30, 30)
```

(the source is a solid `rgb(200,30,30)` 16:9 rectangle, so white bands top and bottom mean a fitted, ratio-preserving resize)

So the two settings describe a rendering box, not an upload limit. The old text promised the opposite, which is the first thing #9787 reports.

### Scope

Only the two help strings change. This does not add dimension validation, and does not touch `ProductController::pictureUpload()` — see the comment on #9787 for why the enforcement half is a separate decision, and #39374 for an implementation of it.

`translations/default/*.xlf` is deliberately untouched: those catalogues are regenerated by maintainers ("Update default catalog"), and the `trans-unit` ids are md5 hashes of the source, so a hand edit would leave stale ids.

