### PR TITLE
Make the CMS pages back link climb one level instead of jumping to the root

### DIFF
--- a/src/Core/CMS/CmsPageViewDataProvider.php
+++ b/src/Core/CMS/CmsPageViewDataProvider.php
@@ -9,6 +9,7 @@ namespace PrestaShop\PrestaShop\Core\CMS;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageCategoriesForBreadcrumb;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageParentCategoryIdForRedirection;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\QueryResult\Breadcrumb;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
 
@@ -39,8 +40,32 @@ final class CmsPageViewDataProvider implements CmsPageViewDataProviderInterface
     {
         return [
             'root_category_id' => CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID,
+            'parent_category_id' => $this->getParentCategoryId((int) $cmsCategoryParentId),
             'breadcrumb_tree' => $this->getBreadcrumbTree($cmsCategoryParentId),
         ];
+    }
+
+    /**
+     * Gets the category one level above the one being listed, so that "Back to list" climbs the tree
+     * instead of jumping to the root. Falls back to the root when there is nothing above.
+     *
+     * @param int $cmsCategoryId
+     *
+     * @return int
+     */
+    private function getParentCategoryId($cmsCategoryId)
+    {
+        if (CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID === $cmsCategoryId) {
+            return CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID;
+        }
+
+        try {
+            return $this->queryBus->handle(
+                new GetCmsPageParentCategoryIdForRedirection($cmsCategoryId)
+            )->getValue();
+        } catch (CmsPageCategoryException) {
+            return CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID;
+        }
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/listing_panel_footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/listing_panel_footer.html.twig
@@ -3,8 +3,13 @@
  # docs/licenses/LICENSE.txt file that was distributed with this source code.
  #}
 
+{% set params = {} %}
+{% if cmsPageView.parent_category_id != cmsPageView.root_category_id %}
+  {% set params = {id_cms_category: cmsPageView.parent_category_id} %}
+{% endif %}
+
 <div class="card-footer">
-  <a href="{{ path('admin_cms_pages_index') }}" class="btn btn-outline-secondary back-to-list-link">
+  <a href="{{ path('admin_cms_pages_index', params) }}" class="btn btn-outline-secondary back-to-list-link">
     <i class="material-icons rtl-flip">arrow_back</i>
     {{ 'Back to list'|trans({}, 'Admin.Actions') }}
   </a>

--- a/tests/Unit/Core/CMS/CmsPageViewDataProviderTest.php
+++ b/tests/Unit/Core/CMS/CmsPageViewDataProviderTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\CMS;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\CMS\CmsPageViewDataProvider;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageCategoriesForBreadcrumb;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageParentCategoryIdForRedirection;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\QueryResult\Breadcrumb;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
+
+class CmsPageViewDataProviderTest extends TestCase
+{
+    private const ROOT_ID = CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID;
+    private const CHILD_ID = 5;
+    private const PARENT_ID = 3;
+
+    public function testItReportsTheCategoryOneLevelAboveTheOneBeingListed(): void
+    {
+        $provider = new CmsPageViewDataProvider($this->mockQueryBus());
+
+        $view = $provider->getView(self::CHILD_ID);
+
+        $this->assertSame(self::PARENT_ID, $view['parent_category_id']);
+        $this->assertSame(self::ROOT_ID, $view['root_category_id']);
+    }
+
+    public function testItStaysOnTheRootWhenTheRootIsBeingListed(): void
+    {
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        // The root has nothing above it, so the parent must not even be looked up
+        $queryBus->method('handle')->willReturnCallback(
+            function ($query) {
+                $this->assertNotInstanceOf(GetCmsPageParentCategoryIdForRedirection::class, $query);
+
+                return new Breadcrumb([]);
+            }
+        );
+
+        $view = (new CmsPageViewDataProvider($queryBus))->getView(self::ROOT_ID);
+
+        $this->assertSame(self::ROOT_ID, $view['parent_category_id']);
+    }
+
+    public function testItFallsBackToTheRootWhenTheLevelAboveCannotBeResolved(): void
+    {
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        // The breadcrumb still answers, only the parent lookup fails: a listing that can be
+        // drawn must not lose its back link over it
+        $queryBus->method('handle')->willReturnCallback(
+            function ($query) {
+                if ($query instanceof GetCmsPageParentCategoryIdForRedirection) {
+                    throw new CmsPageCategoryException('parent is unreachable');
+                }
+
+                return new Breadcrumb([]);
+            }
+        );
+
+        $view = (new CmsPageViewDataProvider($queryBus))->getView(self::CHILD_ID);
+
+        $this->assertSame(self::ROOT_ID, $view['parent_category_id']);
+    }
+
+    private function mockQueryBus(): CommandBusInterface
+    {
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        $queryBus->method('handle')->willReturnCallback(
+            function ($query) {
+                if ($query instanceof GetCmsPageParentCategoryIdForRedirection) {
+                    return new CmsPageCategoryId(self::PARENT_ID);
+                }
+
+                if ($query instanceof GetCmsPageCategoriesForBreadcrumb) {
+                    return new Breadcrumb([]);
+                }
+
+                $this->fail('Unexpected query ' . get_class($query));
+            }
+        );
+
+        return $queryBus;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On Design > Pages, "Back to list" inside a page category always returned to the root category instead of the category one level up. The catalog categories listing, which uses the same widget, already climbs to the parent. The CMS listing now does the same.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. The change is covered by the unit test added here, `CmsPageViewDataProviderTest`, on the parent category exposed to the view; a campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #10399
| Related PRs       |
| Sponsor company   |

### How to test

Create nested page categories, Home > A > B, open B, and click "Back to list" at the bottom of the categories panel. Before this change you land on Home, after it you land on A. From a first-level category you still land on Home, since that is the level above.

### Why the CMS page was the odd one

The same footer exists on Sell > Catalog > Categories, and it already climbs:

```twig
{% if currentCategoryView.id_parent %}
  {% set params = {id_category: currentCategoryView.id_parent} %}
{% endif %}
```

The CMS copy had no parameters at all, so `admin_cms_pages_index` fell back to the root:

```twig
<a href="{{ path('admin_cms_pages_index') }}" class="btn btn-outline-secondary back-to-list-link">
```

`CmsPageViewDataProvider::getView()` exposed `root_category_id` and `breadcrumb_tree` but nothing for the level above, so the template had nothing to link to. It now also returns `parent_category_id`, resolved through the existing `GetCmsPageParentCategoryIdForRedirection` query that the controller already uses for its post-action redirects, and falling back to the root when there is nothing above or the lookup fails.

On cost, since this moves that query from once per action to once per listing render: its handler is a single `new CMSCategory($id)` followed by reading `id_parent`, so one indexed row plus its lang row, and it already runs on every create, edit, delete and toggle redirect on this page. Deriving the parent from `breadcrumb_tree` instead would avoid it, but `Breadcrumb` is `IteratorAggregate` only, so that would mean iterating the chain in Twig for no measurable gain.

### On the rest of #10399

The original 2018 report was about filters and pagination bouncing back to the CMS root. That part no longer reproduces: `CmsPageController::searchAction()` passes `['id_cms_category']` to `buildSearchResponse()`, so the category survives a filter. What remained was the navigation expectation stated later in the thread, "it should redirect us to Category Parent not the Home category", which is what this fixes.

### Tests

`tests/Unit/Core/CMS/CmsPageViewDataProviderTest.php`, three cases: a nested category reports the level above, the root reports itself without dispatching the parent query at all, and a failing parent lookup degrades to the root rather than taking the listing down.

```
Tests: 12, Assertions: 20   OK      (tests/Unit/Core/CMS + tests/Unit/Core/Domain/CmsPageCategory)
```

That third case is worth a note. Forcing it showed the fallback only covers the back link: an id the value object refuses, `0` for instance, still aborts `getView()` from the breadcrumb query underneath. That is the documented `@throws CmsPageCategoryException` behaviour of the method and is unchanged here, so the test pins what this PR actually guarantees rather than implying more.

Pinning `parent_category_id` back to the root fails the first case:

```
Failed asserting that 1 is identical to 3.
```

`lint:twig` OK on all 11 CMS templates, php-cs-fixer `Fixed 0 of 2`, PHPStan `[OK] No errors`.

