### PR TITLE
Give the shipped languages a PDF font that can encode their alphabet

### DIFF
--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -68,6 +68,12 @@ class PDFGeneratorCore extends TCPDF
         'tw' => 'cid0cs',
         'th' => 'freeserif',
         'hy' => 'freeserif',
+        // Shipped languages whose alphabet the default font cannot encode: it is a core font,
+        // limited to cp1252, so anything outside it comes out as a question mark.
+        'hu' => 'dejavusans',
+        'bs' => 'dejavusans',
+        'hi' => 'freeserif',
+        'bn' => 'freeserif',
     ];
 
     /**

--- a/tests/Unit/Classes/pdf/PDFGeneratorFontTest.php
+++ b/tests/Unit/Classes/pdf/PDFGeneratorFontTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\pdf;
+
+use PDFGeneratorCore;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+
+/**
+ * The invoice font is picked from the language iso code alone. Languages with no entry fall back
+ * to a core font, which is limited to cp1252, so their alphabet comes out as question marks.
+ */
+class PDFGeneratorFontTest extends TestCase
+{
+    private const FONT_DIR = _PS_ROOT_DIR_ . '/vendor/tecnickcom/tcpdf/fonts/';
+
+    /**
+     * One characteristic letter per language, so a failure names the character that would break.
+     *
+     * @dataProvider getShippedLanguagesWithACharacterOutsideCp1252
+     */
+    public function testAShippedLanguageIsMappedToAFontThatCanEncodeIt(string $isoCode, int $codePoint): void
+    {
+        $font = $this->getFontForLang($isoCode);
+
+        $this->assertNotSame(
+            PDFGeneratorCore::DEFAULT_FONT,
+            $font,
+            sprintf('"%s" falls back to the core font, which cannot encode U+%04X', $isoCode, $codePoint)
+        );
+        $this->assertTrue(
+            $this->fontCovers($font, $codePoint),
+            sprintf('"%s" is mapped to "%s", which has no glyph for U+%04X', $isoCode, $font, $codePoint)
+        );
+    }
+
+    public function getShippedLanguagesWithACharacterOutsideCp1252(): array
+    {
+        return [
+            'Hungarian o double acute' => ['hu', 0x0151],
+            'Bosnian c caron' => ['bs', 0x010D],
+            'Hindi devanagari a' => ['hi', 0x0905],
+            'Bengali a' => ['bn', 0x0985],
+            'Russian a' => ['ru', 0x0410],
+            'Japanese hiragana a' => ['ja', 0x3042],
+            'Turkish g breve' => ['tr', 0x011F],
+            'Romanian s comma' => ['ro', 0x0219],
+        ];
+    }
+
+    private function getFontForLang(string $isoCode): string
+    {
+        $generator = (new ReflectionClass(PDFGeneratorCore::class))->newInstanceWithoutConstructor();
+        $map = (new ReflectionProperty(PDFGeneratorCore::class, 'font_by_lang'))->getValue($generator);
+
+        return $map[$isoCode] ?? PDFGeneratorCore::DEFAULT_FONT;
+    }
+
+    private function fontCovers(string $font, int $codePoint): bool
+    {
+        $definition = self::FONT_DIR . $font . '.php';
+        if (!file_exists($definition)) {
+            $this->fail(sprintf('No TCPDF definition file for font "%s"', $font));
+        }
+
+        $cw = null;
+        include $definition;
+
+        return is_array($cw) && array_key_exists($codePoint, $cw);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The PDF font is chosen from the language iso code, and a language with no entry falls back to a core font limited to cp1252. Four shipped languages have no entry and an alphabet cp1252 cannot represent, so their invoices come out as question marks. They now point at fonts that already ship with TCPDF.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #9817
| Related PRs       | #42113
| Sponsor company   |

### How to test

Install Hungarian, generate an order invoice, and look at any word carrying `ő` or `ű`. Before this change those letters print as question marks, after it they print. Same for Bosnian `č`, and for Hindi and Bengali, whose scripts were entirely unrenderable.

### The measurement

`PDFGenerator::setFontForLang()` looks the iso code up in `font_by_lang` and otherwise uses `DEFAULT_FONT`, which is `helvetica`, a TCPDF *core* font, so its coverage is cp1252 and nothing more. Of the 46 iso codes under `install-dev/langs/`, 26 have an entry and 20 do not. Taking one characteristic letter per unmapped language and round-tripping it through cp1252:

```
helvetica (cp1252) CANNOT render the alphabet of:
  bn অ U+0985
  bs č U+010D
  hi अ U+0905
  hu ő U+0151

helvetica is fine for: br ã, da ø, de ü, es ñ, et š, fi ä, fr é, id a,
                       it à, mx ñ, nl ë, no æ, pt ç, qc é, sq, sv å
```

So the other sixteen are genuinely unaffected and are left alone: this adds four entries, it does not change the font of any invoice that renders correctly today.

Checking which bundled fonts carry those glyphs, over all 34 TCPDF font definitions:

```
hu ő U+0151     covered by: dejavusans, freeserif, freesans, cid0*, ...
bs č U+010D     covered by: dejavusans, freeserif, freesans, cid0*, ...
hi अ U+0905    covered by: freeserif, freesans, cid0*
bn অ U+0985    covered by: freeserif, freesans, cid0*
```

`dejavusans` is already the map's most used font and `freeserif` already serves bg, ru, uk, mk, el, th and hy, so no new asset is needed.

### What this does not fix

Two further cases from the thread remain open, and neither is a mapping problem:

- **The ruble sign.** U+20BD is in **none** of the 34 fonts bundled with TCPDF, so `₽` cannot be drawn whatever the language. That needs a font that has it, not a different entry in this map.
- **Mixed scripts in one document.** The font is selected once per document from the language, so Japanese typed into a customization field still fails on an invoice rendered in, say, French. Fixing that means per-run font fallback rather than one font per document.

Both are worth their own issues; this PR deliberately covers only the part that is a plain missing mapping.

### Tests

`tests/Unit/Classes/pdf/PDFGeneratorFontTest.php` resolves the font for a language and asserts it is not the core fallback and that the chosen font has a glyph for a characteristic letter. Eight languages, the four fixed plus ru, ja, tr and ro as controls.

```
Tests: 8, Assertions: 16   OK
```

Removing the four entries fails exactly those four, with the character named:

```
"hu" falls back to the core font, which cannot encode U+0151
"bs" falls back to the core font, which cannot encode U+010D
"hi" falls back to the core font, which cannot encode U+0905
"bn" falls back to the core font, which cannot encode U+0985
```

`tests/Unit/Classes` stays green at 609 tests. php-cs-fixer `Fixed 0 of 2`, PHPStan `[OK] No errors`.

