### PR TITLE
Notify modules when the webservice writes a stock quantity

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -89,7 +89,30 @@ class StockAvailableCore extends ObjectModel
      */
     public function updateWs()
     {
-        return $this->update();
+        // The webservice writes this row directly, which bypasses setQuantity() and therefore the
+        // notification it sends, so modules watching stock never hear about a change made this way.
+        $previousQuantity = (int) Db::getInstance()->getValue(
+            'SELECT `quantity`
+            FROM `' . _DB_PREFIX_ . 'stock_available`
+            WHERE `id_stock_available` = ' . (int) $this->id
+        );
+
+        if (!$this->update()) {
+            return false;
+        }
+
+        Hook::exec(
+            'actionUpdateQuantity',
+            [
+                'id_product' => (int) $this->id_product,
+                'id_product_attribute' => (int) $this->id_product_attribute,
+                'quantity' => (int) $this->quantity,
+                'delta_quantity' => (int) $this->quantity - $previousQuantity,
+                'id_shop' => (int) $this->id_shop,
+            ]
+        );
+
+        return true;
     }
 
     public static function getStockAvailableIdByProductId($id_product, $id_product_attribute = null, $id_shop = null)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Writing a quantity through the `stock_availables` webservice resource updated the row without firing `actionUpdateQuantity`, so modules that watch stock never learned about it. The webservice write path now sends the same notification `setQuantity()` does.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #13006
| Related PRs       |
| Sponsor company   |

### Why the notification was missing

`actionUpdateQuantity` is sent by `StockAvailable::setQuantity()`. The webservice does not go through it: `$definition['objectMethods']['update'] => 'updateWs'`, and `updateWs()` was `return $this->update();`, a plain `ObjectModel` write. `postSave()` runs afterwards but returns immediately for a row with no combination:

```php
public function postSave()
{
    // If there are no combinations, we can just consider it finished
    if ($this->id_product_attribute == 0) {
        return true;
    }
```

which is the case @michjoh identified in the report. For a combination row `postSave()` does reach `setQuantity()`, but with `id_product_attribute = 0`, so the notification describes the recomputed parent total and never the combination that actually changed.

### How to test

Measured on 9.2 by temporarily recording every `Hook::exec()` dispatch, then calling `updateWs()` on the stock row of a product without combinations:

```
BASE 9.2.x: updateWs() on stock row 16 (simple product row)
  hooks dispatched matching "quantity":  (none)

WITH FIX:   updateWs() on stock row 16, quantity 1200 -> 1205
  hooks dispatched matching "quantity":  1 actionUpdateQuantity
```

The instrument was a one-line probe in `Hook::exec()` on my local shop, removed afterwards; it is not part of this change.

### The change

`updateWs()` reads the stored quantity first so it can report a delta, performs the write, and sends the same payload `setQuantity()` sends:

```php
Hook::exec(
    'actionUpdateQuantity',
    [
        'id_product' => (int) $this->id_product,
        'id_product_attribute' => (int) $this->id_product_attribute,
        'quantity' => (int) $this->quantity,
        'delta_quantity' => (int) $this->quantity - $previousQuantity,
        'id_shop' => (int) $this->id_shop,
    ]
);
```

`delta_quantity` matters to listeners: `ps_emailalerts::hookActionUpdateQuantity()` returns early on a delta of `0`, so sending the key with a real value keeps webservice writes consistent with every other path.

This deliberately does not touch `postSave()`. Firing there would double up on the normal path, because `setQuantity()` itself calls `update()`, which calls `postSave()`. Putting it on the webservice boundary keeps exactly one notification per write and leaves every other caller untouched. A combination written through the webservice now produces two, one for the combination and one for the recomputed parent, which is correct since two rows change.

### On tests

No automated test is included, and I would rather say why than add one that cannot fail. Legacy `Hook::exec()` does not route through `HookDispatcher`, so `HookDispatcherTest`'s `addListener()` approach cannot observe it, and there is no other hook spy in the suite. A test that asserts only the row write would stay green with the fix reverted, which makes it a false guard. If you want coverage here, the workable shape is a fixture module under `tests/Resources/modules/` registered on `actionUpdateQuantity` that records the call; say the word and I will add it.

