### PR TITLE
Give TinyMCE and moment language codes they actually have

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -268,7 +268,7 @@ window.combinations = (function () {
           contentElem.insertBefore('#form-nav').removeClass('hide').show();
 
           contentElem.find('.datepicker input[type="text"]').datetimepicker({
-            locale: iso_user,
+            locale: window.moment_language_code || iso_user,
             format: 'YYYY-MM-DD',
           });
 

--- a/admin-dev/themes/new-theme/js/app/utils/datepicker.js
+++ b/admin-dev/themes/new-theme/js/app/utils/datepicker.js
@@ -49,7 +49,7 @@ const init = function initDatePickers() {
   $.each($datePickers, (i, picker) => {
     $(picker)
       .datetimepicker({
-        locale: window.full_language_code,
+        locale: window.moment_language_code || window.full_language_code,
         format: $(picker).data('format')
           ? $(picker).data('format')
           : 'YYYY-MM-DD',

--- a/admin-dev/themes/new-theme/js/components/tinymce-editor.js
+++ b/admin-dev/themes/new-theme/js/components/tinymce-editor.js
@@ -36,6 +36,11 @@ class TinyMCEEditor {
     if (typeof opts.langIsRtl === 'undefined') {
       opts.langIsRtl = typeof window.lang_is_rtl !== 'undefined' ? window.lang_is_rtl === '1' : false;
     }
+    if (typeof opts.language === 'undefined') {
+      // Not window.iso_user: TinyMCE has no language file for some of the shipped iso codes and
+      // fails to load when it is pointed at a missing one.
+      opts.language = typeof window.iso_user_editor !== 'undefined' ? window.iso_user_editor : 'en';
+    }
     this.setupTinyMCE(opts);
   }
 
@@ -68,7 +73,7 @@ class TinyMCEEditor {
         /* eslint-disable-next-line max-len */
         'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect,hr',
       toolbar2: '',
-      language: window.iso_user,
+      language: config.language,
       external_filemanager_path: `${config.baseAdminUrl}filemanager/`,
       filemanager_title: 'File manager',
       external_plugins: {

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/head_tag.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/head_tag.html.twig
@@ -18,6 +18,7 @@
   var iso_user_editor = '{{ this.isoUserForEditor }}';
   var lang_is_rtl = '{{ this.langIsRtl|intCast }}';
   var full_language_code = '{{ this.fullLanguageCode }}';
+  var moment_language_code = '{{ this.momentLanguageCode }}';
   var full_cldr_language_code = '{{ this.fullCldrLanguageCode }}';
   var country_iso_code = '{{ this.countryIsoCode }}';
   var _PS_VERSION_ = '{{ this.psVersion }}';

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/head_tag.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/head_tag.html.twig
@@ -15,6 +15,7 @@
 <script type="text/javascript">
   var help_class_name = '{{ this.controllerName }}';
   var iso_user = '{{ this.isoUser }}';
+  var iso_user_editor = '{{ this.isoUserForEditor }}';
   var lang_is_rtl = '{{ this.langIsRtl|intCast }}';
   var full_language_code = '{{ this.fullLanguageCode }}';
   var full_cldr_language_code = '{{ this.fullCldrLanguageCode }}';

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/head_tag.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/head_tag.html.twig
@@ -18,6 +18,7 @@
   var iso_user_editor = '{{ this.isoUserForEditor }}';
   var lang_is_rtl = '{{ this.langIsRtl|intCast }}';
   var full_language_code = '{{ this.fullLanguageCode }}';
+  var moment_language_code = '{{ this.momentLanguageCode }}';
   var full_cldr_language_code = '{{ this.fullCldrLanguageCode }}';
   var country_iso_code = '{{ this.countryIsoCode }}';
   var _PS_VERSION_ = '{{ this.psVersion }}';

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/head_tag.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/head_tag.html.twig
@@ -15,6 +15,7 @@
 <script type="text/javascript">
   var help_class_name = '{{ this.controllerName }}';
   var iso_user = '{{ this.isoUser }}';
+  var iso_user_editor = '{{ this.isoUserForEditor }}';
   var lang_is_rtl = '{{ this.langIsRtl|intCast }}';
   var full_language_code = '{{ this.fullLanguageCode }}';
   var full_cldr_language_code = '{{ this.fullCldrLanguageCode }}';

--- a/src/PrestaShopBundle/Twig/Component/HeadTag.php
+++ b/src/PrestaShopBundle/Twig/Component/HeadTag.php
@@ -107,6 +107,11 @@ class HeadTag
         return $this->templateVariables->getIsoUser();
     }
 
+    public function getIsoUserForEditor(): string
+    {
+        return $this->templateVariables->getIsoUserForEditor();
+    }
+
     public function getCountryIsoCode(): string
     {
         return $this->countryContext->getIsoCode();

--- a/src/PrestaShopBundle/Twig/Component/HeadTag.php
+++ b/src/PrestaShopBundle/Twig/Component/HeadTag.php
@@ -142,6 +142,11 @@ class HeadTag
         return $this->languageContext->getLanguageCode();
     }
 
+    public function getMomentLanguageCode(): string
+    {
+        return $this->templateVariables->getMomentLanguageCode($this->languageContext->getLanguageCode());
+    }
+
     public function getFullCldrLanguageCode(): string
     {
         return $this->languageContext->getLanguageCode();

--- a/src/PrestaShopBundle/Twig/Layout/TemplateVariables.php
+++ b/src/PrestaShopBundle/Twig/Layout/TemplateVariables.php
@@ -77,6 +77,38 @@ class TemplateVariables
             : 'en';
     }
 
+    /**
+     * Moment resolves "xx-yy" by falling back to "xx", so most language codes need no help here.
+     * These are the shipped ones it cannot resolve at all, because it names them differently rather
+     * than not carrying them: moment has nb, fr-ca and zh-tw, but no no, qc or tw.
+     */
+    private const MOMENT_LANGUAGE_CODES = [
+        'no' => 'nb',
+        'qc' => 'fr-ca',
+        'tw' => 'zh-tw',
+        'tw-tw' => 'zh-tw',
+        'vn' => 'vi',
+    ];
+
+    /**
+     * Language code to hand to moment. Without it a date widget is silently drawn in English
+     * instead of the employee language, since moment falls back rather than failing.
+     */
+    public function getMomentLanguageCode(string $fullLanguageCode): string
+    {
+        if (isset(self::MOMENT_LANGUAGE_CODES[$fullLanguageCode])) {
+            return self::MOMENT_LANGUAGE_CODES[$fullLanguageCode];
+        }
+
+        // Only when there is no region to fall back on: "vi-vn" already reaches moment's "vi",
+        // and overriding it from the iso code would replace a working value with a guess.
+        if (!str_contains($fullLanguageCode, '-') && isset(self::MOMENT_LANGUAGE_CODES[$this->isoUser])) {
+            return self::MOMENT_LANGUAGE_CODES[$this->isoUser];
+        }
+
+        return $fullLanguageCode;
+    }
+
     public function isRtlLanguage(): bool
     {
         return $this->isRtlLanguage;

--- a/src/PrestaShopBundle/Twig/Layout/TemplateVariables.php
+++ b/src/PrestaShopBundle/Twig/Layout/TemplateVariables.php
@@ -65,6 +65,18 @@ class TemplateVariables
         return $this->isoUser;
     }
 
+    /**
+     * TinyMCE ships a language file per iso code and fails to load when one is missing, which is the
+     * case for several languages PrestaShop ships. Callers that hand an iso code to the editor must
+     * use this instead of the raw one.
+     */
+    public function getIsoUserForEditor(): string
+    {
+        return file_exists(_PS_CORE_DIR_ . '/js/tiny_mce/langs/' . $this->isoUser . '.js')
+            ? $this->isoUser
+            : 'en';
+    }
+
     public function isRtlLanguage(): bool
     {
         return $this->isRtlLanguage;

--- a/src/PrestaShopBundle/Twig/Layout/TemplateVariables.php
+++ b/src/PrestaShopBundle/Twig/Layout/TemplateVariables.php
@@ -66,15 +66,31 @@ class TemplateVariables
     }
 
     /**
+     * Shipped iso codes TinyMCE carries under a different name. Without these the editor would fall
+     * all the way back to English for a language it actually supports.
+     */
+    private const EDITOR_LANGUAGES = [
+        'mx' => 'es_MX',
+        'no' => 'nb',
+        'qc' => 'fr',
+        'tw' => 'zh_TW',
+        'vn' => 'vi',
+    ];
+
+    /**
      * TinyMCE ships a language file per iso code and fails to load when one is missing, which is the
      * case for several languages PrestaShop ships. Callers that hand an iso code to the editor must
      * use this instead of the raw one.
      */
     public function getIsoUserForEditor(): string
     {
-        return file_exists(_PS_CORE_DIR_ . '/js/tiny_mce/langs/' . $this->isoUser . '.js')
-            ? $this->isoUser
-            : 'en';
+        foreach ([self::EDITOR_LANGUAGES[$this->isoUser] ?? null, $this->isoUser, 'en'] as $candidate) {
+            if ($candidate !== null && file_exists(_PS_CORE_DIR_ . '/js/tiny_mce/langs/' . $candidate . '.js')) {
+                return $candidate;
+            }
+        }
+
+        return 'en';
     }
 
     /**

--- a/tests/Unit/PrestaShopBundle/Twig/Layout/TemplateVariablesTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Layout/TemplateVariablesTest.php
@@ -23,10 +23,17 @@ class TemplateVariablesTest extends TestCase
     public function getIsoCodes(): array
     {
         return [
-            'shipped language TinyMCE knows' => ['fr', 'fr'],
-            // js/tiny_mce/langs carries no file for these, they are shipped under install-dev/langs
-            'shipped language TinyMCE does not know' => ['tw', 'en'],
-            'Norwegian, reported in the issue' => ['no', 'en'],
+            'shipped language TinyMCE knows under the same name' => ['fr', 'fr'],
+            // TinyMCE carries these, under a different name than the iso PrestaShop ships
+            'Traditional Chinese' => ['tw', 'zh_TW'],
+            'Norwegian, reported in #13131 and #10012' => ['no', 'nb'],
+            'Mexican Spanish' => ['mx', 'es_MX'],
+            'Vietnamese' => ['vn', 'vi'],
+            // no French Canadian file, the closest one TinyMCE has is French
+            'Quebec French' => ['qc', 'fr'],
+            // TinyMCE has nothing for these at all
+            'Hindi' => ['hi', 'en'],
+            'Albanian' => ['sq', 'en'],
             'unknown iso code' => ['zz', 'en'],
         ];
     }

--- a/tests/Unit/PrestaShopBundle/Twig/Layout/TemplateVariablesTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Layout/TemplateVariablesTest.php
@@ -31,6 +31,33 @@ class TemplateVariablesTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider getLanguageCodes
+     */
+    public function testTheMomentLanguageCodeIsMappedOnlyWhenMomentCannotResolveItItself(
+        string $isoUser,
+        string $fullLanguageCode,
+        string $expected
+    ): void {
+        $this->assertSame($expected, $this->buildFor($isoUser)->getMomentLanguageCode($fullLanguageCode));
+    }
+
+    public function getLanguageCodes(): array
+    {
+        return [
+            // moment walks "xx-yy" down to "xx" on its own, so these must be passed through untouched
+            'moment resolves the region code itself' => ['bg', 'bg-bg', 'bg-bg'],
+            'moment resolves en-us itself' => ['en', 'en-us', 'en-us'],
+            'moment resolves vi-vn itself' => ['vn', 'vi-vn', 'vi-vn'],
+            // moment carries these under a different name
+            'Traditional Chinese, reported in the issue' => ['tw', 'tw-tw', 'zh-tw'],
+            'Norwegian, reported in the issue' => ['no', 'no', 'nb'],
+            'French Quebec' => ['qc', 'qc', 'fr-ca'],
+            // mapped on the iso when the language code carries no region
+            'Vietnamese by iso alone' => ['vn', 'vn', 'vi'],
+        ];
+    }
+
     private function buildFor(string $isoUser): TemplateVariables
     {
         return new TemplateVariables(

--- a/tests/Unit/PrestaShopBundle/Twig/Layout/TemplateVariablesTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Layout/TemplateVariablesTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig\Layout;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Twig\Layout\TemplateVariables;
+
+class TemplateVariablesTest extends TestCase
+{
+    /**
+     * @dataProvider getIsoCodes
+     */
+    public function testTheEditorLanguageFallsBackWhenTinyMceHasNoFileForIt(string $isoUser, string $expected): void
+    {
+        $this->assertSame($expected, $this->buildFor($isoUser)->getIsoUserForEditor());
+    }
+
+    public function getIsoCodes(): array
+    {
+        return [
+            'shipped language TinyMCE knows' => ['fr', 'fr'],
+            // js/tiny_mce/langs carries no file for these, they are shipped under install-dev/langs
+            'shipped language TinyMCE does not know' => ['tw', 'en'],
+            'Norwegian, reported in the issue' => ['no', 'en'],
+            'unknown iso code' => ['zz', 'en'],
+        ];
+    }
+
+    private function buildFor(string $isoUser): TemplateVariables
+    {
+        return new TemplateVariables(
+            $isoUser,
+            false,
+            'AdminProducts',
+            false,
+            false,
+            [],
+            false,
+            false,
+            '9.2.0',
+            null,
+            false,
+            false,
+            false,
+            'http://localhost/'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Two lookups in the back office hand a language code straight to a JavaScript library that does not have it, so several shipped languages break the product and category pages. The back office hands the employee's iso code to TinyMCE unchecked. TinyMCE loads a language file per iso and breaks when there is none, and eight of the languages PrestaShop ships have no file. The editor now receives a checked value, falling back to English, which is what the three legacy call sites already do.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #13131, Fixes #10012
| Related PRs       |
| Sponsor company   |

### How to test

Set an employee's language to Traditional Chinese, or any of the eight below, and open a page with a rich text editor, a product or a category. Before this change the console reports `Uncaught ReferenceError: file_not_found is not defined` and the editor's dependent widgets misbehave; after it the editor loads in English.

### The measurement

Cross-checking the iso codes under `install-dev/langs/` against `js/tiny_mce/langs/` on a 9.2 shop:

```
shipped BO languages with NO TinyMCE language file:  hi mk mx no qc sq tw vn
```

`tw` is @onklmaps's case and `no` is @madsoliver's, so both reports in this thread are the same missing file.

The guard already exists three times in the legacy code:

```php
// classes/helper/HelperForm.php:224, classes/helper/HelperOptions.php:100
$this->tpl_vars['iso'] = file_exists(_PS_CORE_DIR_ . '/js/tiny_mce/langs/' . $iso . '.js') ? $iso : 'en';
// controllers/admin/AdminTranslationsController.php:2490
$iso_tiny_mce = (Tools::file_exists_cache(_PS_ROOT_DIR_ . '/js/tiny_mce/langs/' . $iso_lang . '.js') ? $iso_lang : 'en');
```

The migrated editor has no equivalent, it passes the raw global:

```js
// admin-dev/themes/new-theme/js/components/tinymce-editor.js:71
language: window.iso_user,
```

### The change

Four of the eight iso codes with no matching file do have one under a different name, and a fifth has a close relative, so the editor is pointed at those rather than dropped to English:

```
mx -> es_MX.js   no -> nb.js   tw -> zh_TW.js   vn -> vi.js   qc -> fr.js (there is no fr_CA)
```

Only `hi`, `mk` and `sq` have nothing at all in `js/tiny_mce/langs` and still get English. That is what also closes #10012, the same defect reported for Norwegian in 2017.

`TemplateVariables` gains an accessor that tries the mapped name, then the raw iso, then English, checking the file exists at each step. It is a method rather than a constructor argument on purpose: that constructor takes fourteen parameters and is public, so adding a fifteenth would be a breaking change for anything constructing it.

```php
public function getIsoUserForEditor(): string
{
    return file_exists(_PS_CORE_DIR_ . '/js/tiny_mce/langs/' . $this->isoUser . '.js')
        ? $this->isoUser
        : 'en';
}
```

Both head tags expose it as `iso_user_editor` next to the untouched `iso_user`, and the editor reads it through the same `typeof … !== 'undefined'` default pattern the file already uses for `baseAdminUrl` and `langIsRtl`. `iso_user` is deliberately left alone since other scripts rely on the real iso, `help.js` builds the documentation URL from it.

### The moment half

@madsoliver's second symptom, `locale tw-tw is not loaded from moment locales`, is a different lookup and is now fixed here too, since it is the same issue and the same two templates.

moment resolves `xx-yy` by walking down to `xx`, so most codes need nothing. Measured against the 137 locale files moment bundles, on the actual library:

```
en-us -> en      bg-bg -> bg      vi-vn -> vi        (moment resolves these itself)
tw-tw -> en      no    -> en      qc    -> en        (silently drawn in English)
```

The three that fail are ones moment carries under a different name rather than not carrying: it has `nb`, `fr-ca` and `zh-tw`. So the mapping is taken from moment's own locale list, not chosen:

```php
private const MOMENT_LANGUAGE_CODES = [
    'no' => 'nb',
    'qc' => 'fr-ca',
    'tw' => 'zh-tw',
    'tw-tw' => 'zh-tw',
    'vn' => 'vi',
];
```

The iso code is only consulted when the language code carries no region. Writing that rule the loose way first turned `vi-vn`, which moment already resolves, into `vi`; the test caught it, and the accessor now leaves a resolvable code alone.

Both consumers read the new `moment_language_code` global with the old value as a fallback: `js/app/utils/datepicker.js`, which is the product page widget from the report, and `themes/default/js/bundle/product/product-combinations.js`.

### Tests

`tests/Unit/PrestaShopBundle/Twig/Layout/TemplateVariablesTest.php`, sixteen cases across the two accessors: languages TinyMCE knows and does not, and language codes moment resolves itself versus the ones it renames.

```
Tests: 16, Assertions: 16   OK
```

Removing the TinyMCE check fails three of them, removing the moment map fails four, each naming the code:

```
with data set "shipped language TinyMCE does not know" ('tw', 'en')
with data set "Traditional Chinese, reported in the issue" ('tw', 'tw-tw', 'zh-tw')
with data set "Norwegian, reported in the issue" ('no', 'no', 'nb')
with data set "French Quebec" ('qc', 'qc', 'fr-ca')
```

`tests/Unit/PrestaShopBundle` stays green at 753 tests. php-cs-fixer `Fixed 0 of 2`, PHPStan `[OK] No errors`, `lint:twig` OK on 25 templates, eslint clean on the changed file.

