### PR TITLE
Keep the invoice number when the webservice changes an order status

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -233,10 +233,6 @@ class OrderCore extends ObjectModel
             'id_lang' => ['xlink_resource' => 'languages'],
             'id_customer' => ['xlink_resource' => 'customers'],
             'id_carrier' => ['xlink_resource' => 'carriers'],
-            'current_state' => [
-                'xlink_resource' => 'order_states',
-                'setter' => 'setWsCurrentState',
-            ],
             'module' => ['required' => true],
             'invoice_number' => [],
             'invoice_date' => [],
@@ -250,6 +246,16 @@ class OrderCore extends ObjectModel
                 'setter' => 'setWsShippingNumber',
             ],
             'note' => [],
+            /*
+             * Must stay last. Its setter runs the whole status change, which generates the invoice
+             * and writes invoice_number and invoice_date on the order. WebserviceRequest walks these
+             * fields in order and assigns null to every one the request left out, so anything listed
+             * after this would undo what the status change just produced.
+             */
+            'current_state' => [
+                'xlink_resource' => 'order_states',
+                'setter' => 'setWsCurrentState',
+            ],
         ],
         'associations' => [
             'order_rows' => ['resource' => 'order_row', 'setter' => false, 'virtual_entity' => true,

--- a/tests/Unit/Classes/order/OrderWebserviceFieldOrderTest.php
+++ b/tests/Unit/Classes/order/OrderWebserviceFieldOrderTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\order;
+
+use Order;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+
+/**
+ * WebserviceRequest assigns null to every declared field the request left out, walking them in
+ * declaration order. The status change generates the invoice, so it has to run after the fields it
+ * fills, or the save that follows writes those nulls over them.
+ */
+class OrderWebserviceFieldOrderTest extends TestCase
+{
+    private const FILLED_BY_THE_STATUS_CHANGE = [
+        'invoice_number',
+        'invoice_date',
+        'delivery_number',
+        'delivery_date',
+    ];
+
+    public function testTheStatusChangeIsDeclaredAfterEveryFieldItFills(): void
+    {
+        $fields = array_keys($this->getWebserviceFields());
+        $statusPosition = array_search('current_state', $fields, true);
+
+        $this->assertNotFalse($statusPosition, 'current_state is no longer a webservice field');
+
+        foreach (self::FILLED_BY_THE_STATUS_CHANGE as $field) {
+            $position = array_search($field, $fields, true);
+            $this->assertNotFalse($position, sprintf('"%s" is no longer a webservice field', $field));
+            $this->assertLessThan(
+                $statusPosition,
+                $position,
+                sprintf('"%s" is declared after current_state, so a status change would null it', $field)
+            );
+        }
+    }
+
+    private function getWebserviceFields(): array
+    {
+        $property = new ReflectionProperty(Order::class, 'webserviceParameters');
+        $property->setAccessible(true);
+
+        return $property->getValue((new ReflectionClass(Order::class))->newInstanceWithoutConstructor())['fields'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Changing an order status through the webservice generated the invoice but left `invoice_number` and `invoice_date` empty on the order, so the back office kept offering "no invoice" while the document existed. The status field is declared before the fields its own setter fills, and the webservice nulls every declared field a request leaves out, so the save that follows wrote those nulls back over them.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #10157
| Related PRs       |
| Sponsor company   |

### How to test

PUT an order through the webservice with `current_state` set to a status that generates an invoice. Before this change the order keeps `invoice_number` at `0` and shows the "no invoice" button while the document is listed under Documents; after it the number and date are on the order, as they already were when the same change is made from the back office.

### Why it happened

`WebserviceRequest::executeEntityPut()` walks `webserviceParameters['fields']` in declaration order and, for anything the request did not send, assigns null:

```php
} elseif ((!isset($fieldProperties['required']) || !$fieldProperties['required']) && property_exists($object, $sqlId)) {
    $object->$sqlId = null;
}
```

`current_state` was declared eighth, before `invoice_number` and `invoice_date`. Its setter runs the entire status change, `setWsCurrentState()` to `setCurrentState()` to `OrderHistory::changeIdOrderState()`, which generates the invoice and re-reads the number and date onto the object. Those two fields are then reached by the same loop, nulled, and the `update()` the webservice performs afterwards writes the nulls. A client that echoes back the order it just read hits the same thing, since the value it read was the pre-change `0`.

Moving the declaration after those fields is enough, and the comment on it says why so it does not drift back.

### The measurement

Both orders run against the same order on a 9.2 shop, inside a transaction that was rolled back, replaying what the webservice loop does:

```
current_state first (today)      -> invoice_number=0    invoice_date=0000-00-00 00:00:00
current_state last (proposed)    -> invoice_number=10   invoice_date=2026-08-10 09:02:03
```

The `10` is a real number out of the shop's invoice sequence, so the document is genuinely issued in both runs. Only the order row differs, which is exactly what the report describes.

### Tests

`tests/Unit/Classes/order/OrderWebserviceFieldOrderTest.php` asserts `current_state` is declared after each of `invoice_number`, `invoice_date`, `delivery_number` and `delivery_date`.

```
Tests: 1, Assertions: 9   OK
```

With the declaration back where it was:

```
"invoice_number" is declared after current_state, so a status change would null it
```

`tests/Unit/Classes` stays green at 602 tests. php-cs-fixer `Fixed 0 of 2`, PHPStan `[OK] No errors`.

### One thing this does not change

`invoice_number` and the three fields beside it stay writable through the webservice. Marking them read-only with `'setter' => false` would make the webservice reject any request that carries them, which is the common client pattern of reading an order and putting it back, so it would break integrations to fix a narrower problem than the one reported here.

