### PR TITLE
Keep prices out of the payload when the customer may not see them

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -1041,6 +1041,42 @@ class ProductLazyArray extends AbstractLazyArray
      * @param ProductPresentationSettings $settings
      * @param array $product
      */
+    /**
+     * Everything addPriceInformation() computes from a price. Emptied as a set rather than one by one,
+     * so a partial list cannot leak a value through one of the tax or discount variants.
+     */
+    private const HIDDEN_WHEN_PRICES_ARE_HIDDEN = [
+        'discount_amount',
+        'discount_amount_tax_excluded',
+        'discount_amount_tax_included',
+        'discount_amount_to_display',
+        'discount_amount_to_display_tax_excluded',
+        'discount_amount_to_display_tax_included',
+        'discount_percentage',
+        'discount_percentage_absolute',
+        'discount_to_display',
+        'discount_to_display_tax_excluded',
+        'discount_to_display_tax_included',
+        'discount_type',
+        'price',
+        'price_amount',
+        'price_amount_tax_excluded',
+        'price_amount_tax_included',
+        'price_tax_excluded',
+        'price_tax_included',
+        'reduction',
+        'reduction_tax_excluded',
+        'reduction_tax_included',
+        'regular_price',
+        'regular_price_amount',
+        'regular_price_amount_tax_excluded',
+        'regular_price_amount_tax_included',
+        'regular_price_tax_excluded',
+        'regular_price_tax_included',
+        'unit_price',
+        'unit_price_full',
+    ];
+
     protected function addPriceInformation(
         ProductPresentationSettings $settings,
         array $product,
@@ -1187,6 +1223,18 @@ class ProductLazyArray extends AbstractLazyArray
             $this->product['nopackprice'] = null;
             $this->product['nopackprice_to_display'] = null;
         }
+
+        /*
+         * A shop that hides prices from this customer must not hand them over either. Templates stop
+         * rendering them, but the presented product is also serialised straight to JSON by the search
+         * and product listing endpoints, so every value computed above would still reach the browser.
+         */
+        if (!$this->shouldShowPrice($settings, $this->product)) {
+            $this->product['has_discount'] = false;
+            foreach (self::HIDDEN_WHEN_PRICES_ARE_HIDDEN as $field) {
+                $this->product[$field] = null;
+            }
+        }
     }
 
     /**
@@ -1196,7 +1244,7 @@ class ProductLazyArray extends AbstractLazyArray
     public function getRoundedDisplayPrice()
     {
         return Tools::ps_round(
-            $this->product['price_amount'],
+            (float) $this->product['price_amount'],
             Context::getContext()->currency->precision
         );
     }

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -164,6 +164,56 @@ class ProductLazyArrayTest extends TestCase
         $this->assertNotNull($productLazyArray);
     }
 
+    public function testPricesAreEmptiedWhenTheyMustNotBeShown(): void
+    {
+        $this->setDefaultConfiguration();
+        $this->mockProductPresentationSettings->method('shouldShowPrice')->willReturn(false);
+
+        $productLazyArray = new ProductLazyArray(
+            $this->mockProductPresentationSettings,
+            $this->baseProduct,
+            $this->mockLanguage,
+            $this->mockImageRetriever,
+            $this->mockLink,
+            $this->mockPriceFormatter,
+            $this->mockProductColorsRetriever,
+            $this->mockTranslatorInterface,
+            $this->mockHookManager,
+            $this->mockConfiguration
+        );
+
+        foreach (['price', 'price_amount', 'regular_price', 'regular_price_amount',
+            'price_tax_included', 'price_tax_excluded', 'unit_price'] as $field) {
+            $this->assertNull($productLazyArray[$field], sprintf('"%s" still carries a price', $field));
+        }
+        $this->assertFalse($productLazyArray['has_discount']);
+    }
+
+    public function testPricesAreKeptWhenTheyMayBeShown(): void
+    {
+        $this->setDefaultConfiguration();
+        $this->mockProductPresentationSettings->method('shouldShowPrice')->willReturn(true);
+
+        $productLazyArray = new ProductLazyArray(
+            $this->mockProductPresentationSettings,
+            // the per-product flag is the other half of the gate, baseProduct leaves it unset
+            array_merge($this->baseProduct, ['show_price' => 1]),
+            $this->mockLanguage,
+            $this->mockImageRetriever,
+            $this->mockLink,
+            $this->mockPriceFormatter,
+            $this->mockProductColorsRetriever,
+            $this->mockTranslatorInterface,
+            $this->mockHookManager,
+            $this->mockConfiguration
+        );
+
+        // the formatted strings run through the mocked PriceFormatter, so assert on the raw amounts
+        $this->assertNotNull($productLazyArray['price_amount']);
+        $this->assertNotNull($productLazyArray['regular_price_amount']);
+        $this->assertNotNull($productLazyArray['price_amount_tax_included']);
+    }
+
     /**
      * @param array $product
      * @param string $availabilityMessage


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When a customer group is set to "Show prices: No", the templates stop rendering prices but the presented product still carries them, and the search and listing endpoints serialise that product straight to JSON. The price fields are now emptied at the point they are computed, so they never leave the server.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #13354
| Related PRs       |
| Sponsor company   |

### How to test

Set the Visitor group to "Show prices: No" under Customer Settings > Groups, then POST to the search controller the way the search bar does and read the JSON.

Measured on a 9.2 shop, same request both times:

```
BEFORE, group show_prices = 0
  name                   = 'Customizable mug'
  price                  = '€16.68'
  price_amount           = 16.68
  regular_price          = '€16.68'
  regular_price_amount   = 16.68

WITH FIX, group show_prices = 0
  name                   = 'Customizable mug'
  price                  = None
  price_amount           = None
  regular_price          = None
  regular_price_amount   = None
  unit_price             = None
  has_discount           = False
```

With the group left at "Show prices: Yes" nothing changes, the values are computed and returned exactly as before.

### Why it happened

`ProductLazyArray::addPriceInformation()` fills roughly thirty price-derived fields unconditionally. The `shouldShowPrice()` gate exists and is consulted, but only for decisions like which flags to render and whether the add-to-cart button is enabled, never for the values themselves. That is invisible while a template is doing the rendering, since the template simply does not print them, and it becomes visible the moment the same presented product is serialised, which is what the search bar's autocomplete does through the `search` controller.

### The change

At the end of `addPriceInformation()`, when the gate says prices must not be shown, the computed set is emptied:

```php
if (!$this->shouldShowPrice($settings, $this->product)) {
    $this->product['has_discount'] = false;
    foreach (self::HIDDEN_WHEN_PRICES_ARE_HIDDEN as $field) {
        $this->product[$field] = null;
    }
}
```

The field list is a constant rather than a handful of assignments, because a partial list is the failure mode here: leaving out one of the tax-included, tax-excluded or discount variants would keep leaking the same number under a different key.

`getRoundedDisplayPrice()` reads `price_amount` and is the only accessor that consumes one of these after they are set, so it now casts before rounding.

Nothing changes for a shop that shows prices, which is the default: `shouldShowPrice()` is `showPrices && (!catalog_mode || catalog_mode_with_prices)`, so the new branch is only reached by shops that deliberately hide prices, whether through a group or through catalogue mode.

### Tests

Two cases in the existing `tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php`: prices emptied when the gate is closed, and still present when it is open.

```
Tests: 45, Assertions: 71   OK
```

Removing the new branch fails the first, naming the field:

```
"price_amount" still carries a price
```

The second case is a control and earned its place twice while writing it: the gate is `$settings->shouldShowPrice() && (bool) $product['show_price']`, so the fixture needed the per-product flag, and the formatted strings run through the mocked `PriceFormatter`, so it asserts on the raw amounts rather than on `price`.

php-cs-fixer clean, PHPStan `[OK] No errors`, `tests/Integration/Adapter/Presenter` green.

