### PR TITLE
Fix Cyrillic soft signs in friendly URLs

### DIFF
--- a/src/Core/Util/String/StringModifier.php
+++ b/src/Core/Util/String/StringModifier.php
@@ -105,6 +105,9 @@ final class StringModifier implements StringModifierInterface
         if ($allow_accented_chars) {
             $return_str = preg_replace('/[^a-zA-Z0-9\s\'\:\/\[\]\-\p{L}]/u', '', $return_str);
         } else {
+            // ICU transliterates the Cyrillic soft sign as an apostrophe, which
+            // the URL sanitizer then treats as a word separator.
+            $return_str = str_replace('ь', '', $return_str);
             $return_str = $this->replaceAccentedChars($return_str);
             $return_str = preg_replace('/[^a-zA-Z0-9\s\'\:\/\[\]\-]/', '', $return_str);
         }

--- a/tests/Unit/Core/Util/String/StringModifierTest.php
+++ b/tests/Unit/Core/Util/String/StringModifierTest.php
@@ -164,6 +164,9 @@ class StringModifierTest extends TestCase
         yield ['Some text 123 !@#$%^&*()_+-={}[]|:;"<>,.?/', 'some-text-123-', false];
         yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-aeiou', false];
         yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-áéíóú', true];
+        yield 'Cyrillic soft signs do not split transliterated words' => ['Нейтральный очиститель', 'nejtralnyj-ocistitel', false];
+        yield 'Cyrillic soft signs remain when accented characters are allowed' => ['Нейтральный очиститель', 'нейтральный-очиститель', true];
+        yield 'Regular apostrophes remain word separators' => ["O'Connor", 'o-connor', false];
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Prevents Cyrillic soft signs from creating artificial word separators in generated friendly URLs. ICU transliterates `ь` as an apostrophe, and the URL sanitizer subsequently converts that apostrophe to a hyphen. The soft sign is now removed before transliteration, while regular apostrophes and accented-character URLs keep their existing behavior.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `php ./vendor/bin/phpunit tests/Unit/Core/Util/String/StringModifierTest.php`. Verify that `Нейтральный очиститель` becomes `nejtralnyj-ocistitel` instead of `nejtral-nyj-ocistitel` when accented characters are disabled. The added tests also verify that Cyrillic is preserved when accented characters are enabled and that `O'Connor` still becomes `o-connor`.
| UI Tests          | Not needed; this change is covered by a focused unit test.
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | N/A

## Root cause

`Any-Latin; Latin-ASCII` transliterates the Cyrillic soft sign to an ASCII apostrophe. `str2url()` then treats the apostrophe as a separator, inserting a hyphen inside the word.

## Validation

- Added regression coverage for Cyrillic soft signs.
- Preserved accented-character URLs.
- Preserved the existing handling of regular apostrophes.
- Verified all three cases against PHP's ICU transliterator.
