### PR TITLE
Preserve the scalar type of an extra property default value in the CQRS layer

### DIFF
--- a/src/Adapter/ExtraProperty/QueryHandler/GetExtraPropertyDefinitionForEditingHandler.php
+++ b/src/Adapter/ExtraProperty/QueryHandler/GetExtraPropertyDefinitionForEditingHandler.php
@@ -53,7 +53,7 @@ final class GetExtraPropertyDefinitionForEditingHandler implements GetExtraPrope
             sqlIndex: $definition->getSqlIndex(),
             nullable: $definition->isNullable(),
             size: $definition->getSize(),
-            defaultValue: null !== $definition->getDefaultValue() ? (string) $definition->getDefaultValue() : null,
+            defaultValue: $definition->getDefaultValue(),
             enumValues: $definition->getEnumValues(),
             displayFront: $definition->isDisplayFront(),
             required: $definition->isRequired(),

--- a/src/Core/Domain/ExtraProperty/Command/AddExtraPropertyDefinitionCommand.php
+++ b/src/Core/Domain/ExtraProperty/Command/AddExtraPropertyDefinitionCommand.php
@@ -33,7 +33,7 @@ class AddExtraPropertyDefinitionCommand
      * @param bool $required Whether the field is marked required in the BO form and in the Admin API (OpenAPI) schema
      * @param bool $nullable Whether the storage column allows NULL
      * @param int|null $size Varchar size for string type (null → 255)
-     * @param string|null $defaultValue SQL DEFAULT clause value
+     * @param scalar|null $defaultValue SQL DEFAULT clause value (kept as its scalar type to match ExtraPropertyDefinition)
      * @param list<string>|null $enumValues Allowed values for CHOICE type
      * @param string|null $labelWording i18n wording for the BO label (required when associated_forms or associated_grids)
      * @param string|null $labelDomain Translation domain for the label
@@ -56,7 +56,7 @@ class AddExtraPropertyDefinitionCommand
         protected readonly bool $required = false,
         protected readonly bool $nullable = true,
         protected readonly ?int $size = null,
-        protected readonly ?string $defaultValue = null,
+        protected readonly int|float|string|bool|null $defaultValue = null,
         protected readonly ?array $enumValues = null,
         protected readonly ?string $labelWording = null,
         protected readonly ?string $labelDomain = null,
@@ -116,7 +116,7 @@ class AddExtraPropertyDefinitionCommand
         return $this->size;
     }
 
-    public function getDefaultValue(): ?string
+    public function getDefaultValue(): int|float|string|bool|null
     {
         return $this->defaultValue;
     }

--- a/src/Core/Domain/ExtraProperty/QueryResult/EditableExtraPropertyDefinition.php
+++ b/src/Core/Domain/ExtraProperty/QueryResult/EditableExtraPropertyDefinition.php
@@ -34,7 +34,7 @@ class EditableExtraPropertyDefinition
      * @param ExtraPropertySqlIndex $sqlIndex
      * @param bool $nullable
      * @param int|null $size Varchar size for string fields
-     * @param string|null $defaultValue
+     * @param scalar|null $defaultValue Kept as its scalar type to match ExtraPropertyDefinition
      * @param list<string>|null $enumValues Allowed values for CHOICE type
      * @param bool $displayFront
      * @param bool $required
@@ -59,7 +59,7 @@ class EditableExtraPropertyDefinition
         protected readonly ExtraPropertySqlIndex $sqlIndex,
         protected readonly bool $nullable,
         protected readonly ?int $size,
-        protected readonly ?string $defaultValue,
+        protected readonly int|float|string|bool|null $defaultValue,
         protected readonly ?array $enumValues,
         protected readonly bool $displayFront,
         protected readonly bool $required,
@@ -124,7 +124,7 @@ class EditableExtraPropertyDefinition
         return $this->size;
     }
 
-    public function getDefaultValue(): ?string
+    public function getDefaultValue(): int|float|string|bool|null
     {
         return $this->defaultValue;
     }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ExtraPropertyDefinitionFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ExtraPropertyDefinitionFormDataProvider.php
@@ -58,7 +58,7 @@ final class ExtraPropertyDefinitionFormDataProvider implements FormDataProviderI
                 'sql_index' => $definition->getSqlIndex()->value,
                 'nullable' => $definition->isNullable(),
                 'size' => $definition->getSize(),
-                'default_value' => $definition->getDefaultValue(),
+                'default_value' => null !== $definition->getDefaultValue() ? (string) $definition->getDefaultValue() : null,
                 'enum_values' => null !== $definition->getEnumValues() ? implode("\n", $definition->getEnumValues()) : null,
             ],
             'visibility' => [

--- a/tests/Unit/Core/Domain/ExtraProperty/Command/AddExtraPropertyDefinitionCommandTest.php
+++ b/tests/Unit/Core/Domain/ExtraProperty/Command/AddExtraPropertyDefinitionCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\ExtraProperty\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Command\AddExtraPropertyDefinitionCommand;
+
+/**
+ * The command carries the DEFAULT clause value down to ExtraPropertyDefinition, whose
+ * $defaultValue is typed int|float|string|bool|null. The command must accept and preserve
+ * the same scalar types instead of coercing everything to string, so a non-string default
+ * (e.g. an int coming from the Admin API JSON payload) keeps its type through the CQRS layer.
+ */
+class AddExtraPropertyDefinitionCommandTest extends TestCase
+{
+    /**
+     * @dataProvider defaultValueProvider
+     */
+    public function testItPreservesTheScalarTypeOfTheDefaultValue(int|float|string|bool|null $defaultValue): void
+    {
+        $command = new AddExtraPropertyDefinitionCommand(
+            entityName: 'product',
+            propertyName: 'internal_code',
+            defaultValue: $defaultValue,
+        );
+
+        $this->assertSame($defaultValue, $command->getDefaultValue());
+    }
+
+    /**
+     * @return iterable<string, array{int|float|string|bool|null}>
+     */
+    public static function defaultValueProvider(): iterable
+    {
+        yield 'int' => [42];
+        yield 'float' => [3.5];
+        yield 'bool true' => [true];
+        yield 'bool false' => [false];
+        yield 'string' => ['some-default'];
+        yield 'null' => [null];
+    }
+}

--- a/tests/Unit/Core/Domain/ExtraProperty/QueryResult/EditableExtraPropertyDefinitionTest.php
+++ b/tests/Unit/Core/Domain/ExtraProperty/QueryResult/EditableExtraPropertyDefinitionTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\ExtraProperty\QueryResult;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\QueryResult\EditableExtraPropertyDefinition;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyScope;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertySqlIndex;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyType;
+
+/**
+ * The edit DTO mirrors ExtraPropertyDefinition, whose $defaultValue is int|float|string|bool|null.
+ * It must keep that scalar type instead of narrowing it to string, so the value read back from an
+ * INT/BOOL/FLOAT column is not silently stringified before the form layer decides how to render it.
+ */
+class EditableExtraPropertyDefinitionTest extends TestCase
+{
+    /**
+     * @dataProvider defaultValueProvider
+     */
+    public function testItPreservesTheScalarTypeOfTheDefaultValue(int|float|string|bool|null $defaultValue): void
+    {
+        $definition = $this->makeDefinition($defaultValue);
+
+        $this->assertSame($defaultValue, $definition->getDefaultValue());
+    }
+
+    /**
+     * @return iterable<string, array{int|float|string|bool|null}>
+     */
+    public static function defaultValueProvider(): iterable
+    {
+        yield 'int' => [42];
+        yield 'float' => [3.5];
+        yield 'bool true' => [true];
+        yield 'bool false' => [false];
+        yield 'string' => ['some-default'];
+        yield 'null' => [null];
+    }
+
+    private function makeDefinition(int|float|string|bool|null $defaultValue): EditableExtraPropertyDefinition
+    {
+        return new EditableExtraPropertyDefinition(
+            id: 1,
+            entityName: 'product',
+            moduleName: null,
+            propertyName: 'internal_code',
+            fieldType: ExtraPropertyType::INT,
+            fieldScope: ExtraPropertyScope::COMMON,
+            sqlIndex: ExtraPropertySqlIndex::NONE,
+            nullable: true,
+            size: null,
+            defaultValue: $defaultValue,
+            enumValues: null,
+            displayFront: false,
+            required: false,
+            labelWording: null,
+            labelDomain: null,
+            descriptionWording: null,
+            descriptionDomain: null,
+            constraints: null,
+            formType: null,
+            formOptions: null,
+            associatedForms: null,
+            associatedGrids: null,
+            associatedApis: null,
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" below. Unit tests only — no DB/UI surface changed.
| UI Tests          | N/A — no UI behaviour changed; covered by unit tests.
| Fixed issue or discussion?     | Fixes #41829
| Related PRs       | None.
| Sponsor company   | N/A

### Description

`ExtraPropertyDefinition` types its `$defaultValue` as `int|float|string|bool|null` (docblock `@param scalar|null`), and the repository already casts the raw DB string back to that declared type via `ExtraPropertyValueCaster::castFromDb()`. But the CQRS layer narrowed the same value to `?string`:

- `AddExtraPropertyDefinitionCommand::$defaultValue` was `?string`, so a non-string scalar passed programmatically (e.g. an integer default coming from the Admin API JSON payload) raised a `TypeError` under `declare(strict_types=1)`.
- `EditableExtraPropertyDefinition::$defaultValue` was `?string`, and `GetExtraPropertyDefinitionForEditingHandler` forced a `(string)` cast when building it — losing the scalar type carried by the entity.

This PR aligns the CQRS layer with the entity:

- Widen `$defaultValue` (constructor param + getter) to `int|float|string|bool|null` in `AddExtraPropertyDefinitionCommand` and `EditableExtraPropertyDefinition`.
- Drop the lossy `(string)` cast in `GetExtraPropertyDefinitionForEditingHandler` so the edit DTO carries the real scalar.
- Move that `(string)` cast to `ExtraPropertyDefinitionFormDataProvider`, where the back-office `TextType` field needs a string for display. **The rendered form value is therefore unchanged** — the cast simply happens at the form boundary instead of inside the query handler.

No BC break: string defaults continue to work everywhere (string is part of the widened union), and the only in-repo command caller (the BO form data handler) still passes a string.

### How to test

Unit tests cover the type-preservation contract on both CQRS classes:

```
vendor/bin/phpunit -c tests/Unit/phpunit.xml \
  tests/Unit/Core/Domain/ExtraProperty/Command/AddExtraPropertyDefinitionCommandTest.php \
  tests/Unit/Core/Domain/ExtraProperty/QueryResult/EditableExtraPropertyDefinitionTest.php
```

Each test constructs the class with `int`, `float`, `bool`, `string` and `null` defaults and asserts (`assertSame`) that the getter returns the same typed value.

### Test verification (RED → GREEN)

**RED** — new tests on `develop` (before the production change): the `int`/`float`/`bool` data sets fail because the constructor still declares `?string`:

```
TypeError: AddExtraPropertyDefinitionCommand::__construct(): Argument #10 ($defaultValue)
must be of type ?string, int given
TypeError: EditableExtraPropertyDefinition::__construct(): Argument #10 ($defaultValue)
must be of type ?string, float given
...
Tests: 12, Assertions: 4, Errors: 8.
```

**GREEN** — after widening the types (full ExtraProperty unit suites, includes the 12 new cases):

```
PHPUnit 10.5.63
Tests: 491, Assertions: 1356.
OK
```

`php-cs-fixer` (dry-run) and `phpstan` on the changed files both report no errors.
