### PR TITLE
Index new CMS pages by default

### DIFF
--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -19,8 +19,8 @@ class CMSCore extends ObjectModel
     public $link_rewrite;
     public $id_cms_category;
     public $position;
-    public $indexation;
-    public $active;
+    public $indexation = true;
+    public $active = true;
 
     /**
      * @see ObjectModel::$definition

--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -20,7 +20,7 @@ class CMSCore extends ObjectModel
     public $id_cms_category;
     public $position;
     public $indexation = true;
-    public $active = true;
+    public $active;
 
     /**
      * @see ObjectModel::$definition

--- a/src/Core/Form/IdentifiableObject/DataProvider/CmsPageFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CmsPageFormDataProvider.php
@@ -70,8 +70,8 @@ class CmsPageFormDataProvider implements FormDataProviderInterface
         return [
             'page_category_id' => CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID,
             'shop_association' => $this->contextShopIds,
-            'is_indexed_for_search' => false,
-            'is_displayed' => false,
+            'is_indexed_for_search' => true,
+            'is_displayed' => true,
         ];
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/CmsPageFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CmsPageFormDataProvider.php
@@ -71,7 +71,7 @@ class CmsPageFormDataProvider implements FormDataProviderInterface
             'page_category_id' => CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID,
             'shop_association' => $this->contextShopIds,
             'is_indexed_for_search' => true,
-            'is_displayed' => true,
+            'is_displayed' => false,
         ];
     }
 }


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------- |
| Branch?           | 9.2.x |
| Description?      | New CMS pages are indexed for search by default. Their display status remains disabled by default. |
| Type?             | improvement |
| Category?         | BO |
| BC breaks?        | no |
| Deprecations?     | no |
| How to test?      | In the back office, go to Design > Pages and start creating a CMS page. Verify that the search indexation switch is enabled by default and the displayed switch remains disabled. |
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/34340591209
| Fixed issue or discussion? | |
| Related PRs       | |
| Sponsor company   | TRENDO s.r.o. |

## Description

The CMS page creation form currently initializes search indexation as disabled, while the CMS ObjectModel provides no explicit default for indexation. Enabling search indexation by default avoids requiring merchants to enable this switch manually for each new page.

This change enables search indexation in the CMS ObjectModel and the default form data. New pages remain disabled by default so merchants can review them before publication. Existing CMS pages and the edit form remain unchanged.
