### PR TITLE
Add fallback_repository input to Generate Changelog PR workflow

### DIFF
--- a/.github/workflows/generate-changelog-pr.yml
+++ b/.github/workflows/generate-changelog-pr.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         default: ''
+      fallback_repository:
+        description: 'Fallback repository (owner/repo) used to resolve PRs not found in this repository (useful when running on a private mirror). Ignored when it matches the current repository.'
+        required: false
+        type: string
+        default: 'PrestaShop/PrestaShop'
 
 permissions:
   contents: write
@@ -59,6 +64,7 @@ jobs:
           echo target_ref: ${{ inputs.target_ref || inputs.base_branch }}
           echo next_version: ${{ inputs.next_version }}
           echo release_date: ${{ inputs.release_date }}
+          echo fallback_repository: ${{ inputs.fallback_repository }}
 
       - name: Generate changelog
         id: changelog
@@ -66,6 +72,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
           repository: ${{ github.repository }}
+          fallback_repository: ${{ inputs.fallback_repository }}
           previous_ref: ${{ inputs.previous_ref }}
           target_ref: ${{ inputs.target_ref || inputs.base_branch }}
           next_version: ${{ inputs.next_version }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add an optional `fallback_repository` input to the `Generate Changelog PR` workflow, passed through to the shared `generate-changelog` action (see related PR). When the workflow runs on a private mirror of this repository, the merge commits synced from this repository reference PR numbers that do not exist in the mirror, and the changelog generation failed with `Could not fetch PR #...`. With the fallback configured, those PRs are resolved in this repository instead. The input defaults to `PrestaShop/PrestaShop`: when the workflow runs on this repository the fallback equals the current repository and is ignored, so behavior here is unchanged.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On this repository, dispatch the workflow as usual: the fallback equals the current repository, the action ignores it and the result is identical to before. On a private mirror, dispatch the workflow with the default value: PR numbers referencing this repository are resolved here, and the mirror address never appears in the generated changelog.
| UI Tests          | N/A
| Fixed issue or discussion? | N/A
| Related PRs       | https://github.com/PrestaShop/.github/pull/49 (must be merged first)
| Sponsor company   | N/A
