### PR TITLE
BO: fix price tax included on multistore with different tax rule

### DIFF
--- a/src/Core/Grid/Query/ProductQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductQueryBuilder.php
@@ -80,7 +80,6 @@ class ProductQueryBuilder extends AbstractDoctrineQueryBuilder
             ->addSelect('cl.`name` AS `category`')
             ->addSelect('img_shop.`id_image`')
             ->addSelect('img_lang.legend')
-            ->addSelect('p.`id_tax_rules_group`')
         ;
 
         // When ecotax is enabled the real final price is the sum of price and ecotax so we fetch an extra alias column that is used for sorting

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/MultiShopProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/MultiShopProductControllerTest.php
@@ -42,29 +42,48 @@ class MultiShopProductControllerTest extends GridControllerTestCase
     protected const DEFAULT_SHOP_GROUP = 'Default';
     protected const SHARED_STOCK_SHOP_GROUP = 'Shared stock Group';
 
+    protected const ALL_SHOP_TAX_RULES_GROUPS = [
+        self::DEFAULT_SHOP_NAME => [
+            'id_tax_rules_group' => 1,
+        ],
+        self::INDEPENDENT_SHOP_NAME => [
+            'id_tax_rules_group' => 2,
+        ],
+        self::SHARED_SHOP_NAME => [
+            'id_tax_rules_group' => 3,
+        ],
+        self::SECOND_SHARED_SHOP_NAME => [
+            'id_tax_rules_group' => 4,
+        ],
+    ];
+
     protected const ALL_SHOPS_PRODUCT_DATA = [
         self::DEFAULT_SHOP_NAME => [
             'name' => 'All shops Product - Default',
             'reference' => 'product-all-shops',
             'price_tax_excluded' => '$51.00',
+            'price_tax_included' => '$53.04',
             'quantity' => 51,
         ],
         self::INDEPENDENT_SHOP_NAME => [
             'name' => 'All shops Product - independent shop',
             'reference' => 'product-all-shops',
             'price_tax_excluded' => '$69.00',
+            'price_tax_included' => '$69.00',
             'quantity' => 69,
         ],
         self::SHARED_SHOP_NAME => [
             'name' => 'All shops Product - Shared stock',
             'reference' => 'product-all-shops',
             'price_tax_excluded' => '$13.00',
+            'price_tax_included' => '$13.86',
             'quantity' => 21,
         ],
         self::SECOND_SHARED_SHOP_NAME => [
             'name' => 'All shops Product - Second shared stock',
             'reference' => 'product-all-shops',
             'price_tax_excluded' => '$14.00',
+            'price_tax_included' => '$14.84',
             'quantity' => 21,
         ],
     ];
@@ -566,6 +585,7 @@ class MultiShopProductControllerTest extends GridControllerTestCase
                 ->setLocalizedNames([static::DEFAULT_LANG_ID => $shopProductData['name']])
                 ->setReference($shopProductData['reference'])
                 ->setPrice(str_replace('$', '', $shopProductData['price_tax_excluded']))
+                ->setTaxRulesGroupId(static::ALL_SHOP_TAX_RULES_GROUPS[$shopName]['id_tax_rules_group'])
             ;
             $commandBus->handle($updateCommand);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Add an integration test for the product grid in multishop context to ensure two products with different shop-specific tax rules display correct tax-included prices.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `php vendor/bin/phpunit tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/MultiShopProductControllerTest.php` and verify the test passes. You can also open BO > Catalog > Products, switch shop context (default/independent), and check that tax-included prices match the expected tax rules for each shop.
| UI Tests          | Not run (not applicable).
| Fixed issue or discussion?     | #36539 
| Related PRs       | #40777 
| Sponsor company   | N/A