### PR TITLE
fixed: TypeError when editing a product with null isbn/upc/ean13/mpn/reference

### DIFF
--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -375,11 +375,11 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
     private function getDetails(Product $product): ProductDetails
     {
         return new ProductDetails(
-            $product->isbn,
-            $product->upc,
-            $product->ean13,
-            $product->mpn,
-            $product->reference
+            (string) $product->isbn,
+            (string) $product->upc,
+            (string) $product->ean13,
+            (string) $product->mpn,
+            (string) $product->reference
         );
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `GetProductForEditingHandler::getDetails()` passes `Product` fields directly to the `ProductDetails` constructor, whose parameters are all typed as non-nullable `string`. `ps_product.isbn`, `upc`, `ean13`, `mpn` and `reference` are nullable columns, so any product with one of these fields set to `NULL` (data import, partial webservice update, or legacy data carried over from an older PrestaShop version) makes the product editing page in the admin panel crash with `ProductDetails::__construct(): Argument #1 ($isbn) must be of type string, null given`. We hit this in production on a store migrated from an older PrestaShop install where several products had `isbn`/`upc`/`ean13`/`mpn` set to `NULL`. The fix casts each value to `(string)` before passing it to `ProductDetails`, consistent with how other private methods in the same class already handle nullable `Product` fields (e.g. `getOptions()` casts `condition`, `getPricesInformation()` casts `unity`).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set `isbn` (or `upc`/`ean13`/`mpn`) to `NULL` on any product row directly in the database, then open that product for editing in the back office (Catalog > Products > edit). Before this fix: 500 error (`TypeError`). After: page loads normally and the field shows as empty.
| UI Tests          | N/A - single-line defensive cast, no UI behavior change to cover; verified manually against a live product with a NULL field as described above.
| Fixed issue or discussion?     | Related to #33371
| Related PRs       | #41868 (equivalent fix already proposed for product combinations, not yet merged)
| Sponsor company   | bwlab