### PR TITLE
Fix 9843 category groups multistore

### DIFF
--- a/classes/Group.php
+++ b/classes/Group.php
@@ -417,14 +417,20 @@ class GroupCore extends ObjectModel
         return self::$groups[$id_group];
     }
 
-    public static function getAllGroupIds(): array
+    public static function getAllGroupIds($filterByShop = false): array
     {
         $query = new DbQuery();
+
         $query
-            ->select('g.`id_group`')
+            ->select('DISTINCT g.`id_group`')
             ->from('group', 'g')
             ->orderby('g.`id_group` ASC')
         ;
+
+        if ($filterByShop) {
+            $query->join(Shop::addSqlAssociation('group', 'g'));
+        }
+
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
 
         return array_column($result, 'id_group');

--- a/src/Adapter/Group/GroupDataProvider.php
+++ b/src/Adapter/Group/GroupDataProvider.php
@@ -38,8 +38,8 @@ class GroupDataProvider
         return Group::getCurrent();
     }
 
-    public function getAllGroupIds(): array
+    public function getAllGroupIds($filterByShop = false): array
     {
-        return Group::getAllGroupIds();
+        return Group::getAllGroupIds($filterByShop);
     }
 }

--- a/src/Core/Form/ChoiceProvider/GroupByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/GroupByIdChoiceProvider.php
@@ -26,15 +26,23 @@ final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
     private $langId;
 
     /**
+     * @var bool whether choices must be restricted to the groups of the current shop context
+     */
+    private $filterByShop;
+
+    /**
      * @param GroupDataProvider $groupDataProvider
      * @param int $langId
+     * @param bool $filterByShop
      */
     public function __construct(
         GroupDataProvider $groupDataProvider,
-        $langId
+        $langId,
+        bool $filterByShop = false
     ) {
         $this->groupDataProvider = $groupDataProvider;
         $this->langId = $langId;
+        $this->filterByShop = $filterByShop;
     }
 
     /**
@@ -43,7 +51,7 @@ final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
     public function getChoices()
     {
         return FormChoiceFormatter::formatFormChoices(
-            $this->groupDataProvider->getGroups($this->langId),
+            $this->groupDataProvider->getGroups($this->langId, $this->filterByShop),
             'id_group',
             'name',
             false

--- a/src/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandler.php
@@ -6,10 +6,13 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\AddCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\EditableCategory;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\RedirectOption;
 
@@ -29,7 +32,8 @@ final class CategoryFormDataHandler implements FormDataHandlerInterface
      * @param CommandBusInterface $commandBus
      */
     public function __construct(
-        CommandBusInterface $commandBus
+        CommandBusInterface $commandBus,
+        private readonly GroupDataProvider $groupDataProvider,
     ) {
         $this->commandBus = $commandBus;
     }
@@ -52,6 +56,23 @@ final class CategoryFormDataHandler implements FormDataHandlerInterface
      */
     public function update($categoryId, array $data)
     {
+        /** @var EditableCategory $editableCategory */
+        $editableCategory = $this->commandBus->handle(
+            new GetCategoryForEditing((int) $categoryId)
+        );
+
+        $contextGroupIds = $this->groupDataProvider->getAllGroupIds(true);
+
+        $outOfContextGroupIds = array_diff(
+            $editableCategory->getGroupAssociationIds(),
+            $contextGroupIds
+        );
+
+        $data['group_association'] = array_values(array_unique(array_merge(
+            $data['group_association'],
+            $outOfContextGroupIds
+        )));
+
         $command = $this->createEditCategoryCommand((int) $categoryId, $data);
 
         $this->commandBus->handle($command);

--- a/src/Core/Form/IdentifiableObject/DataProvider/CategoryFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CategoryFormDataProvider.php
@@ -90,7 +90,7 @@ final class CategoryFormDataProvider implements FormDataProviderInterface
      */
     public function getDefaultData()
     {
-        $allGroupIds = $this->groupDataProvider->getAllGroupIds();
+        $allGroupIds = $this->groupDataProvider->getAllGroupIds(true);
 
         return [
             'id_parent' => $this->shopContext->getCategoryId(),

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -32,7 +32,7 @@ services:
       $contextLanguageId: '@=service("prestashop.adapter.legacy.context").getContext().language.id'
       $contextCountryId: '@=service("prestashop.adapter.legacy.context").getContext().country.id'
       $employeeIsoCode: '@=service("prestashop.adapter.legacy.context").getEmployeeLanguageIso()'
-      $customerGroupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
+      $customerGroupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id_shop_filtered").getChoices()'
       $isSingleShopContext: '@=service("prestashop.adapter.shop.context").isShopContext()'
       $categoryDataProvider: '@prestashop.adapter.data_provider.category'
       $ecoTaxGroupId: "@=service('prestashop.adapter.legacy.configuration').getInt('PS_ECOTAX_TAX_RULES_GROUP_ID')"

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -145,7 +145,7 @@ services:
     arguments:
       $paymentModules: '@=service("prestashop.adapter.module.payment_module_provider").getPaymentModuleList()'
       $countryChoices: '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
-      $groupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
+      $groupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id_shop_filtered").getChoices()'
       $carrierChoices: '@=service("prestashop.core.form.choice_provider.carrier_by_reference_id").getChoices()'
       $countryDataProvider: '@prestashop.adapter.data_provider.country'
 

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -47,6 +47,13 @@ services:
     arguments:
       - '@prestashop.adapter.data_provider.group'
 
+  # Same provider but restricted to the customer groups of the current shop context (e.g. payment restrictions)
+  prestashop.core.form.choice_provider.group_by_id_shop_filtered:
+    class: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider
+    arguments:
+      $groupDataProvider: '@prestashop.adapter.data_provider.group'
+      $filterByShop: true
+
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CarrierByReferenceChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.carrier'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -44,8 +44,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CategoryFormDataHandler'
     arguments:
       - '@prestashop.core.command_bus'
-      - '@prestashop.adapter.image.uploader.category_cover_image_uploader'
-      - '@prestashop.adapter.image.uploader.category_thumbnail_image_uploader'
+      - '@prestashop.adapter.data_provider.group'
 
   prestashop.core.form.identifiable_object.data_handler.root_category_form_data_handler:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\RootCategoryFormDataHandler'

--- a/tests/UI/campaigns/functional/BO/10_payment/02_preferences/03_groupRestrictionsMultistore.ts
+++ b/tests/UI/campaigns/functional/BO/10_payment/02_preferences/03_groupRestrictionsMultistore.ts
@@ -1,0 +1,329 @@
+import testContext from '@utils/testContext';
+import setMultiStoreStatus from '@commonTests/BO/advancedParameters/multistore';
+import {expect} from 'chai';
+
+import {
+  boCustomerGroupsPage,
+  boCustomerGroupsCreatePage,
+  boCustomerSettingsPage,
+  boDashboardPage,
+  boLoginPage,
+  boMultistorePage,
+  boMultistoreShopPage,
+  boMultistoreShopCreatePage,
+  boMultistoreShopUrlCreatePage,
+  boPaymentPreferencesPage,
+  type BrowserContext,
+  FakerGroup,
+  FakerShop,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_payment_preferences_groupRestrictionsMultistore';
+
+/*
+Issue #9858: In a multishop context, the "Payment > Preferences" group restrictions table must only list the
+customer groups of the currently selected shop, not the groups of every shop.
+
+Scenario:
+- Enable multistore and create a second shop
+- Create a customer group while the second shop is the active context (so the group belongs to that shop only)
+- Check that the group is listed in the group restrictions table when the second shop is selected
+- Check that the group is NOT listed when the default shop is selected (regression of #9858)
+ */
+describe('BO - Payment - Preferences : Group restrictions are filtered by shop', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+  let shopID: number = 0;
+  let groupsInNewShop: string[] = [];
+
+  const createShopData: FakerShop = new FakerShop({name: 'newShop', shopGroup: 'Default', categoryRoot: 'Home'});
+  const groupData: FakerGroup = new FakerGroup();
+
+  // Pre-condition: Enable multistore
+  setMultiStoreStatus(true, `${baseContext}_preTest`);
+
+  // before and after functions
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  describe('Create a second shop', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
+    it('should go to \'Advanced Parameters > Multistore\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToMultiStorePage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.multistoreLink,
+      );
+      await boMultistorePage.closeSfToolBar(page);
+
+      const pageTitle = await boMultistorePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistorePage.pageTitle);
+    });
+
+    it('should go to add new shop page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewShopPage', baseContext);
+
+      await boMultistorePage.goToNewShopPage(page);
+
+      const pageTitle = await boMultistoreShopCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistoreShopCreatePage.pageTitleCreate);
+    });
+
+    it('should create shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createShop', baseContext);
+
+      const textResult = await boMultistoreShopCreatePage.setShop(page, createShopData);
+      expect(textResult).to.contains(boMultistorePage.successfulCreationMessage);
+    });
+
+    it('should get the id of the new shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'getShopID', baseContext);
+
+      const numberOfShops = await boMultistoreShopPage.getNumberOfElementInGrid(page);
+      expect(numberOfShops).to.be.above(0);
+
+      shopID = parseInt(await boMultistoreShopPage.getTextColumn(page, 1, 'id_shop'), 10);
+    });
+
+    it('should go to add URL', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToAddURL', baseContext);
+
+      await boMultistoreShopPage.filterTable(page, 'a!name', createShopData.name);
+      await boMultistoreShopPage.goToSetURL(page, 1);
+
+      const pageTitle = await boMultistoreShopUrlCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistoreShopUrlCreatePage.pageTitleCreate);
+    });
+
+    it('should set URL', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addURL', baseContext);
+
+      const textResult = await boMultistoreShopUrlCreatePage.setVirtualUrl(page, createShopData.name);
+      expect(textResult).to.contains(boMultistoreShopUrlCreatePage.successfulCreationMessage);
+    });
+  });
+
+  describe('Create a customer group that belongs to the new shop only', async () => {
+    it('should select the new shop in the multistore header', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'selectNewShop', baseContext);
+
+      await boMultistoreShopUrlCreatePage.clickOnMultiStoreHeader(page);
+      await boMultistoreShopUrlCreatePage.chooseShop(page, 2);
+
+      const shopName = await boMultistoreShopUrlCreatePage.getShopName(page);
+      expect(shopName).to.eq(createShopData.name);
+    });
+
+    it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPage', baseContext);
+
+      await boMultistoreShopUrlCreatePage.goToSubMenu(
+        page,
+        boDashboardPage.shopParametersParentLink,
+        boDashboardPage.customerSettingsLink,
+      );
+      await boCustomerSettingsPage.closeSfToolBar(page);
+
+      const pageTitle = await boCustomerSettingsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerSettingsPage.pageTitle);
+    });
+
+    it('should go to \'Groups\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToGroupsPage', baseContext);
+
+      await boCustomerSettingsPage.goToGroupsPage(page);
+
+      const pageTitle = await boCustomerGroupsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsPage.pageTitle);
+    });
+
+    it('should go to add new group page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewGroup', baseContext);
+
+      await boCustomerGroupsPage.goToNewGroupPage(page);
+
+      const pageTitle = await boCustomerGroupsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsCreatePage.pageTitleCreate);
+    });
+
+    it('should create the group', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createGroup', baseContext);
+
+      const textResult = await boCustomerGroupsCreatePage.createEditGroup(page, groupData);
+      expect(textResult).to.contains(boCustomerGroupsPage.successfulCreationMessage);
+    });
+  });
+
+  describe('Check that the group restrictions table is filtered by shop', async () => {
+    it('should go to \'Payment > Preferences\' page (new shop selected)', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToPreferencesPageNewShop', baseContext);
+
+      await boCustomerGroupsPage.goToSubMenu(
+        page,
+        boCustomerGroupsPage.paymentParentLink,
+        boCustomerGroupsPage.preferencesLink,
+      );
+
+      const pageTitle = await boPaymentPreferencesPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boPaymentPreferencesPage.pageTitle);
+    });
+
+    it('should check that the created group is listed for the new shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkGroupVisibleNewShop', baseContext);
+
+      groupsInNewShop = await boPaymentPreferencesPage.getGroupRestrictionNames(page);
+      expect(groupsInNewShop).to.include(groupData.name);
+    });
+
+    it('should select the default shop in the multistore header', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'selectDefaultShop', baseContext);
+
+      await boPaymentPreferencesPage.clickOnMultiStoreHeader(page);
+      await boPaymentPreferencesPage.chooseShop(page, 1);
+
+      const shopName = await boPaymentPreferencesPage.getShopName(page);
+      expect(shopName).to.eq(global.INSTALL.SHOP_NAME);
+    });
+
+    it('should go to \'Payment > Preferences\' page (default shop selected)', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToPreferencesPageDefaultShop', baseContext);
+
+      await boPaymentPreferencesPage.goToSubMenu(
+        page,
+        boPaymentPreferencesPage.paymentParentLink,
+        boPaymentPreferencesPage.preferencesLink,
+      );
+
+      const pageTitle = await boPaymentPreferencesPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boPaymentPreferencesPage.pageTitle);
+    });
+
+    it('should check that the created group is NOT listed for the default shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkGroupHiddenDefaultShop', baseContext);
+
+      const groupsInDefaultShop = await boPaymentPreferencesPage.getGroupRestrictionNames(page);
+      // The group belongs to the new shop only, so it must not appear in the default shop context (issue #9858)
+      expect(groupsInDefaultShop).to.not.include(groupData.name);
+      // Sanity check: the default shop still has its own groups, but fewer than the new shop
+      expect(groupsInDefaultShop.length).to.be.above(0);
+      expect(groupsInDefaultShop.length).to.be.below(groupsInNewShop.length);
+    });
+  });
+
+  describe('Delete the created group', async () => {
+    it('should select the new shop in the multistore header', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'selectNewShopToDelete', baseContext);
+
+      await boPaymentPreferencesPage.clickOnMultiStoreHeader(page);
+      await boPaymentPreferencesPage.chooseShop(page, 2);
+
+      const shopName = await boPaymentPreferencesPage.getShopName(page);
+      expect(shopName).to.eq(createShopData.name);
+    });
+
+    it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPageToDelete', baseContext);
+
+      await boPaymentPreferencesPage.goToSubMenu(
+        page,
+        boDashboardPage.shopParametersParentLink,
+        boDashboardPage.customerSettingsLink,
+      );
+
+      const pageTitle = await boCustomerSettingsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerSettingsPage.pageTitle);
+    });
+
+    it('should go to \'Groups\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToGroupsPageToDelete', baseContext);
+
+      await boCustomerSettingsPage.goToGroupsPage(page);
+
+      const pageTitle = await boCustomerGroupsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomerGroupsPage.pageTitle);
+    });
+
+    it('should filter the list by the created group name', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterToDelete', baseContext);
+
+      await boCustomerGroupsPage.resetFilter(page);
+      await boCustomerGroupsPage.filterTable(page, 'input', 'b!name', groupData.name);
+
+      const textColumn = await boCustomerGroupsPage.getTextColumn(page, 1, 'b!name');
+      expect(textColumn).to.contains(groupData.name);
+    });
+
+    it('should delete the group', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteGroup', baseContext);
+
+      const textResult = await boCustomerGroupsPage.deleteGroup(page, 1);
+      expect(textResult).to.contains(boCustomerGroupsPage.successfulDeleteMessage);
+    });
+  });
+
+  describe('Delete the created shop', async () => {
+    it('should select the default shop in the multistore header', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'selectDefaultShopBeforeDeleteShop', baseContext);
+
+      await boCustomerGroupsPage.clickOnMultiStoreHeader(page);
+      await boCustomerGroupsPage.chooseShop(page, 1);
+
+      const shopName = await boCustomerGroupsPage.getShopName(page);
+      expect(shopName).to.eq(global.INSTALL.SHOP_NAME);
+    });
+
+    it('should go to \'Advanced Parameters > Multistore\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToMultiStorePage', baseContext);
+
+      await boCustomerGroupsPage.goToSubMenu(
+        page,
+        boDashboardPage.advancedParametersLink,
+        boDashboardPage.multistoreLink,
+      );
+      await boMultistorePage.closeSfToolBar(page);
+
+      const pageTitle = await boMultistorePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boMultistorePage.pageTitle);
+    });
+
+    it('should go to the created shop page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCreatedShopPage', baseContext);
+
+      await boMultistorePage.goToShopPage(page, shopID);
+
+      const pageTitle = await boMultistoreShopPage.getPageTitle(page);
+      expect(pageTitle).to.contains(createShopData.name);
+    });
+
+    it('should delete the shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteShop', baseContext);
+
+      await boMultistoreShopPage.filterTable(page, 'a!name', createShopData.name);
+
+      const textResult = await boMultistoreShopPage.deleteShop(page, 1);
+      expect(textResult).to.contains(boMultistoreShopPage.successfulDeleteMessage);
+    });
+  });
+
+  // Post-condition: Disable multistore
+  setMultiStoreStatus(false, `${baseContext}_postTest`);
+});

--- a/tests/Unit/Core/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php
+++ b/tests/Unit/Core/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\ChoiceProvider;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider;
+
+class GroupByIdChoiceProviderTest extends TestCase
+{
+    private const LANG_ID = 1;
+
+    /**
+     * @var array<int, array<string, int|string>>
+     */
+    private $groups = [
+        ['id_group' => 1, 'name' => 'Visitor'],
+        ['id_group' => 2, 'name' => 'Guest'],
+        ['id_group' => 3, 'name' => 'Customer'],
+    ];
+
+    public function testItProvidesAllGroupsWithoutShopFilteringByDefault(): void
+    {
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider
+            ->expects($this->once())
+            ->method('getGroups')
+            ->with(self::LANG_ID, false)
+            ->willReturn($this->groups);
+
+        $choiceProvider = new GroupByIdChoiceProvider($groupDataProvider, self::LANG_ID);
+
+        $this->assertSame(
+            ['Visitor' => 1, 'Guest' => 2, 'Customer' => 3],
+            $choiceProvider->getChoices()
+        );
+    }
+
+    public function testItFiltersGroupsByCurrentShopWhenEnabled(): void
+    {
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider
+            ->expects($this->once())
+            ->method('getGroups')
+            ->with(self::LANG_ID, true)
+            ->willReturn($this->groups);
+
+        $choiceProvider = new GroupByIdChoiceProvider($groupDataProvider, self::LANG_ID, true);
+
+        $this->assertSame(
+            ['Visitor' => 1, 'Guest' => 2, 'Customer' => 3],
+            $choiceProvider->getChoices()
+        );
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandlerTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandlerTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\DataHandler;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\EditableCategory;
+use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\RedirectType;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CategoryFormDataHandler;
+
+class CategoryFormDataHandlerTest extends TestCase
+{
+    public function testUpdatePreservesGroupsOutsideCurrentShopContext(): void
+    {
+        $categoryId = 42;
+
+        // Groups 1, 2 and 3 belong to the current shop context.
+        $contextGroupIds = [1, 2, 3];
+
+        // Groups 8 and 9 are already associated with the category,
+        // but belong to another shop and are therefore hidden from this form.
+        $currentCategoryGroupIds = [1, 2, 3, 8, 9];
+
+        // The user deliberately deselects group 2 in the current shop.
+        $submittedGroupIds = [1, 3];
+
+        $editableCategory = $this->createMock(EditableCategory::class);
+        $editableCategory
+            ->expects($this->once())
+            ->method('getGroupAssociationIds')
+            ->willReturn($currentCategoryGroupIds);
+
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider
+            ->expects($this->once())
+            ->method('getAllGroupIds')
+            ->with(true)
+            ->willReturn($contextGroupIds);
+
+        $editCommand = null;
+
+        $commandBus = $this->createMock(CommandBusInterface::class);
+        $commandBus
+            ->expects($this->exactly(2))
+            ->method('handle')
+            ->willReturnCallback(
+                function ($command) use (&$editCommand, $editableCategory) {
+                    if ($command instanceof GetCategoryForEditing) {
+                        return $editableCategory;
+                    }
+
+                    if ($command instanceof EditCategoryCommand) {
+                        $editCommand = $command;
+                    }
+
+                    return null;
+                }
+            );
+
+        $dataHandler = new CategoryFormDataHandler(
+            $commandBus,
+            $groupDataProvider
+        );
+
+        $dataHandler->update(
+            $categoryId,
+            $this->createCategoryFormData($submittedGroupIds)
+        );
+
+        $this->assertInstanceOf(EditCategoryCommand::class, $editCommand);
+
+        // Group 2 was visible in the current context and intentionally unchecked,
+        // so it must be removed. Groups 8 and 9 were outside the current context
+        // and must be preserved.
+        $this->assertSame(
+            [1, 3, 8, 9],
+            $editCommand->getAssociatedGroupIds()
+        );
+    }
+
+    public function testUpdateDoesNotRestoreDeselectedGroupsFromCurrentContext(): void
+    {
+        $categoryId = 42;
+
+        $editableCategory = $this->createMock(EditableCategory::class);
+        $editableCategory
+            ->expects($this->once())
+            ->method('getGroupAssociationIds')
+            ->willReturn([1, 2, 3]);
+
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider
+            ->expects($this->once())
+            ->method('getAllGroupIds')
+            ->with(true)
+            ->willReturn([1, 2, 3]);
+
+        $editCommand = null;
+
+        $commandBus = $this->createMock(CommandBusInterface::class);
+        $commandBus
+            ->expects($this->exactly(2))
+            ->method('handle')
+            ->willReturnCallback(
+                function ($command) use (&$editCommand, $editableCategory) {
+                    if ($command instanceof GetCategoryForEditing) {
+                        return $editableCategory;
+                    }
+
+                    if ($command instanceof EditCategoryCommand) {
+                        $editCommand = $command;
+                    }
+
+                    return null;
+                }
+            );
+
+        $dataHandler = new CategoryFormDataHandler(
+            $commandBus,
+            $groupDataProvider
+        );
+
+        $dataHandler->update(
+            $categoryId,
+            $this->createCategoryFormData([1, 3])
+        );
+
+        $this->assertInstanceOf(EditCategoryCommand::class, $editCommand);
+
+        $this->assertSame(
+            [1, 3],
+            $editCommand->getAssociatedGroupIds()
+        );
+    }
+
+    /**
+     * @param int[] $groupIds
+     */
+    private function createCategoryFormData(array $groupIds): array
+    {
+        return [
+            'active' => true,
+            'link_rewrite' => [1 => 'test-category'],
+            'name' => [1 => 'Test category'],
+            'id_parent' => 2,
+            'description' => [1 => 'Description'],
+            'additional_description' => [1 => 'Additional description'],
+            'meta_title' => [1 => 'Meta title'],
+            'meta_description' => [1 => 'Meta description'],
+            'group_association' => $groupIds,
+            'cover_image' => null,
+            'thumbnail_image' => null,
+            'redirect_option' => [
+                'type' => RedirectType::TYPE_NOT_FOUND,
+                'target' => null,
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CategoryFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CategoryFormDataProviderTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\DataProvider;
+
+use Link;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+use PrestaShop\PrestaShop\Adapter\Shop\Url\CategoryProvider;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CategoryFormDataProvider;
+use Symfony\Component\Routing\Router;
+
+class CategoryFormDataProviderTest extends TestCase
+{
+    public function testDefaultDataUsesGroupsFilteredByCurrentShopContext(): void
+    {
+        $groupIds = [1, 2, 3];
+        $categoryId = 2;
+        $associatedShopIds = [1];
+        $seoPreviewUrl = 'https://example.test/category/{friendly-url}';
+
+        $queryBus = $this->createMock(CommandBusInterface::class);
+
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider
+            ->expects($this->once())
+            ->method('getAllGroupIds')
+            ->with(true)
+            ->willReturn($groupIds);
+
+        $link = $this->createMock(Link::class);
+        $link
+            ->expects($this->once())
+            ->method('getCategoryLink')
+            ->with(0, '{friendly-url}')
+            ->willReturn($seoPreviewUrl);
+
+        $categoryProvider = new CategoryProvider($link);
+
+        $router = $this->createMock(Router::class);
+
+        $shopContext = $this->createMock(ShopContext::class);
+        $shopContext
+            ->expects($this->once())
+            ->method('getCategoryId')
+            ->willReturn($categoryId);
+        $shopContext
+            ->expects($this->once())
+            ->method('getAssociatedShopIds')
+            ->willReturn($associatedShopIds);
+
+        $dataProvider = new CategoryFormDataProvider(
+            $queryBus,
+            $groupDataProvider,
+            $categoryProvider,
+            $router,
+            $shopContext
+        );
+
+        $this->assertSame(
+            [
+                'id_parent' => $categoryId,
+                'group_association' => $groupIds,
+                'shop_association' => $associatedShopIds,
+                'active' => true,
+                'seo_preview' => $seoPreviewUrl,
+            ],
+            $dataProvider->getDefaultData()
+        );
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | ⚠️ This PR depends on #41606 and must be reviewed/merged after it, as it reuses the shop-filtered group choice provider introduced there.<br/><br/>This PR fixes customer group handling for categories in a multistore context.<br><br>When creating or editing a category from a specific shop context, customer groups belonging exclusively to other shops were still displayed. Filtering the available groups also introduced a potential regression when editing shared categories, because hidden out-of-context group associations could be removed on save.<br><br>This PR:<br>- Uses the shop-filtered customer group choice provider for category forms.<br>- Filters default group associations according to the current shop context when creating a category.<br>- Preserves existing group associations that belong to other shop contexts when editing a category.<br>- Allows groups visible in the current context to still be selected or unselected normally.<br>- Updates `CategoryFormDataHandler` service dependencies by removing unused category image uploader arguments and injecting the required `GroupDataProvider`.<br>- Adds unit tests covering category default group filtering and preservation of out-of-context group associations.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | 1. Enable multistore and create two shops.<br>2. Create a customer group associated only with Shop 2.<br>3. Switch to Shop 1.<br>4. Go to **Catalog > Categories > Add new category**.<br>5. Verify that the Shop 2-only customer group is not displayed.<br>6. Create a category associated with both shops and with customer groups belonging to both shop contexts.<br>7. Edit the category from Shop 1 and save it.<br>8. Verify that:<br>- groups belonging only to Shop 2 are not displayed in Shop 1;<br>- their existing category associations are preserved after saving;<br>- groups belonging to Shop 1 can still be selected or unselected normally.
| UI Tests          | https://github.com/Codencode/ga.tests.ui.pr/actions/runs/31970835377
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/9843
| Related PRs       | #41606
| Sponsor company   | Codencode snc