### PR TITLE
Order confirmation email ignores the order state's "Attach invoice PDF to email" setting

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -659,7 +659,7 @@ abstract class PaymentModuleCore extends Module
                 $orderLanguage = new Language((int) $order->id_lang);
 
                 // Join PDF invoice
-                if ((int) Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
+                if ((int) Configuration::get('PS_INVOICE') && $order_status->pdf_invoice && $order->invoice_number) {
                     $currentLanguage = $this->context->language;
                     $this->context->language = $orderLanguage;
                     $this->context->getTranslator()->setLocale($orderLanguage->locale);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Order confirmation email ignores the order state's "Attach invoice PDF to email" setting
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Reproduce the following steps here : #42370 
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/32451314403
| Fixed issue or discussion?     | Fixes #42370 
| Related PRs       | /
| Sponsor company   | Agence Off
