### PR TITLE
Add language ID to actionMailAlterMessageBeforeSend hook

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -632,6 +632,7 @@ class MailCore extends ObjectModel
             // Hook to alter Symfony Mailer before sending mail
             Hook::exec('actionMailAlterMessageBeforeSend', [
                 'message' => &$email,
+                'id_lang' => (int) $idLang,
             ]);
 
             // Create new message and DKIM sign it, if enabled and all data for signature are provided


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Adds the current language ID as `id_lang` to the parameters passed to the `actionMailAlterMessageBeforeSend` hook. This allows modules altering the final Symfony Mailer message to reliably determine the email language. (Real use case scenario - I needed to change a logo in mails depending on mail language.)
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Register a module on `actionMailAlterMessageBeforeSend`, send an email in a known language, and verify that the hook receives the corresponding integer `id_lang` alongside `message`.
| UI Tests          | Not needed; this change only adds a parameter to an existing hook.
| Fixed issue or discussion? | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.