### PR TITLE
Tools::clearCompile: absorb Smarty concurrent-cleanup UnexpectedValueException

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3068,7 +3068,18 @@ exit;
             return null;
         }
 
-        $ret = $smarty->clearCompiledTemplate();
+        try {
+            $ret = $smarty->clearCompiledTemplate();
+        } catch (UnexpectedValueException $e) {
+            // Smarty iterates the compile directory with RecursiveIteratorIterator
+            // without CATCH_GET_CHILD; a subdirectory removed by another process
+            // (concurrent request, cron, deploy) between the parent enumeration
+            // and the descent makes getChildren() throw UnexpectedValueException.
+            // Absorb it: any module _clearCache() call bubbling this exception
+            // can crash unrelated critical paths (payment webhooks, order
+            // validation…) — see PrestaShop/ps_crossselling.
+            $ret = null;
+        }
 
         Hook::exec('actionClearCompileCache');
 


### PR DESCRIPTION
# Title
Tools::clearCompile: absorb Smarty concurrent-cleanup UnexpectedValueException

# Body

| Question              | Answer  |
|-----------------------|---------|
| Branch?               | develop |
| Bug fix?              | yes     |
| New feature?          | no      |
| Deprecations?         | no      |
| License?              | AFL 3.0 |
| Category?             | CO      |
| Type?                 | bug fix |
| How to test?          | see below |

## Problem

`Tools::clearCompile()` delegates directly to `$smarty->clearCompiledTemplate()`
with no exception guard. Smarty iterates the compile directory with
`RecursiveIteratorIterator` **without** the `CATCH_GET_CHILD` flag. If a
subdirectory is removed by another process (concurrent PHP request, cron,
deploy, external cache purge) between the parent enumeration and the
`getChildren()` descent, `UnexpectedValueException` bubbles up.

Every `Module::_clearCache()` in the ecosystem goes through this method, so a
race in Smarty can crash payment webhooks, order validation, or any critical
flow that indirectly clears the cache.

## Real-world impact

Observed in production (PS 1.7.8, Smarty 3.1.48). The core `ps_crossselling`
module clears its cache on every order status update via
`hookActionOrderStatusPostUpdate`. A Mollie payment webhook (preorder
finalisation) hit the race and returned HTTP 400:

```
UnexpectedValueException :
  RecursiveDirectoryIterator::__construct(/…/var/cache/prod/smarty/compile/13/68):
  failed to open dir: No such file or directory
  at vendor/smarty/smarty/libs/sysplugins/smarty_internal_method_clearcompiledtemplate.php:76

#4 classes/Tools.php(3408): Smarty_Internal_Data->__call()
#5 classes/Tools.php(3422): ToolsCore::clearCompile()
#6 classes/module/Module.php(2591): ToolsCore::clearSmartyCache()
#7 modules/ps_crossselling/ps_crossselling.php(115): ModuleCore->_clearCache()
#9 classes/Hook.php(970): Ps_Crossselling->hookActionOrderStatusPostUpdate()
#13 classes/order/OrderHistory.php(434): Hook::exec()
#14 classes/PaymentModule.php(580): OrderHistoryCore->changeIdOrderState()
```

Consequence: `PS_OS_PAYMENT` was never posted, the customer's preorder stayed
stuck in the reminder batch, and the order had to be repaired by hand.

## Fix

Wrap `$smarty->clearCompiledTemplate()` in `try/catch (UnexpectedValueException)`.
Missing files are cleaned on the next call — this matches the compile cache's
existing lazy-cleanup contract (it always rebuilds on demand).

Diff is 5 net lines (plus a short explanatory comment).

## Why here rather than only upstream Smarty

The root fix is in Smarty (`CATCH_GET_CHILD` on `RecursiveIteratorIterator`)
— opened as smarty-php/smarty#1207. But:

1. PrestaShop pins Smarty via `composer.lock`; a Smarty release takes months
   to reach production.
2. The contract "clearing the cache must not take down a payment webhook"
   belongs to PrestaShop, not to a third-party dependency.
3. The patch is trivial with no functional side-effect.

## How to test

Reproduce the race in a unit test or manually:

```php
mkdir(_PS_CACHE_DIR_ . 'smarty/compile/x/y', 0777, true);
$smarty = Context::getContext()->smarty;
register_shutdown_function(fn() => exec('rm -rf ' . _PS_CACHE_DIR_ . 'smarty/compile/x/y'));
Tools::clearCompile($smarty); // must not throw
```

Before this patch, the call throws `UnexpectedValueException` under
concurrent cleanup; after it, the call returns `null` cleanly.

