### PR TITLE
Use shared team-guard action for prestashop-sa workflow gates

### DIFF
--- a/.github/workflows/create-build-branch.yml
+++ b/.github/workflows/create-build-branch.yml
@@ -17,38 +17,13 @@ jobs:
   check-membership:
     name: Check team membership
     runs-on: ubuntu-latest
-    env:
-      TEAM_SLUG: prestashop-sa
     steps:
-      - name: Verify actor belongs to ${{ env.TEAM_SLUG }}
-        env:
-          TOKEN: ${{ secrets.JARVIS_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::JARVIS_TOKEN secret is empty. Configure a token with read:org scope before running this workflow."
-            exit 1
-          fi
-
-          API_URL="https://api.github.com/orgs/PrestaShop/teams/${TEAM_SLUG}/memberships/${ACTOR}"
-          echo "Checking membership: ${API_URL}"
-
-          RESPONSE=$(curl -s -w "\n%{http_code}" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "$API_URL")
-          STATUS=$(echo "$RESPONSE" | tail -1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-
-          if [ "$STATUS" = "200" ]; then
-            ROLE=$(echo "$BODY" | jq -r '.role // "unknown"')
-            STATE=$(echo "$BODY" | jq -r '.state // "unknown"')
-            echo "✅ ${ACTOR} is a member of ${TEAM_SLUG} (role=${ROLE}, state=${STATE})." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::error::${ACTOR} is not a member of ${TEAM_SLUG} (HTTP ${STATUS}). Only members of this team can create a build branch."
-            echo "⛔ ${ACTOR} is not a member of ${TEAM_SLUG} (HTTP ${STATUS})." >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
+      - name: Verify actor belongs to prestashop-sa
+        uses: PrestaShop/.github/.github/actions/team-guard@master
+        with:
+          team_slug: prestashop-sa
+          org: PrestaShop
+          token: ${{ secrets.JARVIS_TOKEN }}
 
   create-build-branch:
     name: Create Build Branch

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -45,42 +45,18 @@ concurrency:
 
 jobs:
   # 1) Gate: only members of the prestashop-sa team may run this.
-  #    Copied verbatim from create-build-branch.yml.
+  #    The org is hardcoded because this workflow also runs on mirrors/forks,
+  #    where the repository owner is not the PrestaShop organization.
   check-membership:
     name: Check team membership
     runs-on: ubuntu-latest
-    env:
-      TEAM_SLUG: prestashop-sa
     steps:
-      - name: Verify actor belongs to ${{ env.TEAM_SLUG }}
-        env:
-          TOKEN: ${{ secrets.JARVIS_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::JARVIS_TOKEN secret is empty. Configure a token with read:org scope before running this workflow."
-            exit 1
-          fi
-
-          API_URL="https://api.github.com/orgs/PrestaShop/teams/${TEAM_SLUG}/memberships/${ACTOR}"
-          echo "Checking membership: ${API_URL}"
-
-          RESPONSE=$(curl -s -w "\n%{http_code}" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "$API_URL")
-          STATUS=$(echo "$RESPONSE" | tail -1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-
-          if [ "$STATUS" = "200" ]; then
-            ROLE=$(echo "$BODY" | jq -r '.role // "unknown"')
-            STATE=$(echo "$BODY" | jq -r '.state // "unknown"')
-            echo "✅ ${ACTOR} is a member of ${TEAM_SLUG} (role=${ROLE}, state=${STATE})." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::error::${ACTOR} is not a member of ${TEAM_SLUG} (HTTP ${STATUS}). Only members of this team can run this sync."
-            echo "⛔ ${ACTOR} is not a member of ${TEAM_SLUG} (HTTP ${STATUS})." >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
+      - name: Verify actor belongs to prestashop-sa
+        uses: PrestaShop/.github/.github/actions/team-guard@master
+        with:
+          team_slug: prestashop-sa
+          org: PrestaShop
+          token: ${{ secrets.JARVIS_TOKEN }}
 
   # 2) Sync: bare-clone upstream, then force-push the working branches and
   #    all tags into the repository this workflow runs on. Never deletes

--- a/.github/workflows/version-branch-bootstrap.yml
+++ b/.github/workflows/version-branch-bootstrap.yml
@@ -30,42 +30,16 @@ concurrency:
 
 jobs:
   # 1) Gate: only members of the prestashop-sa team may run this.
-  #    Copied verbatim from create-build-branch.yml.
   check-membership:
     name: Check team membership
     runs-on: ubuntu-latest
-    env:
-      TEAM_SLUG: prestashop-sa
     steps:
-      - name: Verify actor belongs to ${{ env.TEAM_SLUG }}
-        env:
-          TOKEN: ${{ secrets.JARVIS_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::JARVIS_TOKEN secret is empty. Configure a token with read:org scope before running this workflow."
-            exit 1
-          fi
-
-          API_URL="https://api.github.com/orgs/PrestaShop/teams/${TEAM_SLUG}/memberships/${ACTOR}"
-          echo "Checking membership: ${API_URL}"
-
-          RESPONSE=$(curl -s -w "\n%{http_code}" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "$API_URL")
-          STATUS=$(echo "$RESPONSE" | tail -1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-
-          if [ "$STATUS" = "200" ]; then
-            ROLE=$(echo "$BODY" | jq -r '.role // "unknown"')
-            STATE=$(echo "$BODY" | jq -r '.state // "unknown"')
-            echo "✅ ${ACTOR} is a member of ${TEAM_SLUG} (role=${ROLE}, state=${STATE})." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::error::${ACTOR} is not a member of ${TEAM_SLUG} (HTTP ${STATUS}). Only members of this team can run version-branch bootstrap."
-            echo "⛔ ${ACTOR} is not a member of ${TEAM_SLUG} (HTTP ${STATUS})." >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
+      - name: Verify actor belongs to prestashop-sa
+        uses: PrestaShop/.github/.github/actions/team-guard@master
+        with:
+          team_slug: prestashop-sa
+          org: PrestaShop
+          token: ${{ secrets.JARVIS_TOKEN }}
 
   # 2) Derive version_branch / new_version / release_type from Version.php on develop.
   derive:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The `create-build-branch`, `sync-from-upstream` and `version-branch-bootstrap` workflows each carried the same copy-pasted inline curl check to restrict manual dispatch to members of the **prestashop-sa** team. This PR replaces the three copies with the shared `team-guard` composite action introduced in PrestaShop/.github#52, so the guard policy is defined once for all repositories. The `org` input is passed explicitly because `sync-from-upstream` also runs on mirrors/forks, where the repository owner is not the PrestaShop organization. Small hardening: only `state=active` memberships pass — a pending team invitation no longer counts as membership.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | After PrestaShop/.github#52 is merged: dispatch any of the three workflows as a prestashop-sa member — the `Check team membership` job passes and the workflow proceeds as before. As a non-member, the job fails and all dependent jobs are skipped.
| UI Tests          | Not applicable — CI workflow change only.
| Fixed issue or discussion?     | ~
| Related PRs       | PrestaShop/.github#52 (must be merged first), PrestaShop/docker#483
| Sponsor company   | ~

⚠️ **Merge order**: PrestaShop/.github#52 must land first — the workflows reference `PrestaShop/.github/.github/actions/team-guard@master`. Until then, dispatching one of these workflows would fail at the guard step (scheduled/automatic behavior is unaffected: all three are dispatch-only).