### PR TITLE
Refactor getRemoteAddr to use Symfony Request

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -9,6 +9,7 @@ use PHPSQLParser\PHPSQLParser;
 use PrestaShop\PrestaShop\Adapter\ContainerFinder;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
+use PrestaShop\PrestaShop\Core\Exception\ContainerNotFoundException;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem as PsFileSystem;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
@@ -390,45 +391,30 @@ class ToolsCore
     }
 
     /**
-     * Get the server variable REMOTE_ADDR, or the client IP from HTTP_X_FORWARDED_FOR (when using proxy).
-     *
-     * Parses the XFF chain from right-to-left to prevent IP spoofing (CWE-290 / CWE-348):
-     * the rightmost entries are appended by trusted proxy infrastructure and cannot be forged
-     * by the client. The leftmost entry is entirely client-controlled and must never be trusted.
+     * Get the client IP from Symfony Request including trusted proxies.
      *
      * @return string $remote_addr ip of client
      */
     public static function getRemoteAddr()
     {
-        if (function_exists('apache_request_headers')) {
-            $headers = apache_request_headers();
-        } else {
-            $headers = $_SERVER;
+        if (self::$request instanceof Request) {
+            return self::$request->getClientIp();
         }
 
-        if (array_key_exists('X-Forwarded-For', $headers)) {
-            $_SERVER['HTTP_X_FORWARDED_FOR'] = $headers['X-Forwarded-For'];
-        }
-
-        if (!empty($_SERVER['HTTP_X_FORWARDED_FOR']) && (!isset($_SERVER['REMOTE_ADDR'])
-            || preg_match('/^127\..*/i', trim($_SERVER['REMOTE_ADDR'])) || preg_match('/^172\.(1[6-9]|2\d|30|31)\..*/i', trim($_SERVER['REMOTE_ADDR']))
-            || preg_match('/^192\.168\.*/i', trim($_SERVER['REMOTE_ADDR'])) || preg_match('/^10\..*/i', trim($_SERVER['REMOTE_ADDR'])))) {
-            // CWE-348: Traverse right-to-left — the rightmost entries are appended by trusted
-            // proxy infrastructure and cannot be forged by the client. Return the first
-            // non-private, non-reserved IP to prevent XFF header spoofing (CWE-290).
-            $ips = array_map('trim', explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']));
-            foreach (array_reverse($ips) as $ip) {
-                if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false) {
-                    return $ip;
-                }
+        try {
+            $context = Context::getContext();
+            $containerFinder = new ContainerFinder($context);
+            $container = $containerFinder->getContainer();
+            if (null === $context->container) {
+                $context->container = $container;
             }
-
-            // All entries are private/reserved (internal proxy chain) — return the rightmost
-            // which is at minimum the last hop and not client-controlled.
-            return end($ips);
+            self::$request = $container->get('request_stack')->getCurrentRequest()
+            ?? Request::createFromGlobals();
+        } catch (ContainerNotFoundException $e) {
+            self::$request = Request::createFromGlobals();
         }
 
-        return $_SERVER['REMOTE_ADDR'];
+        return self::$request->getClientIp();
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Following security fix https://github.com/PrestaShop/PrestaShop/security/advisories/GHSA-2cr4-vw9p-pjvf I propose this refactoring to use Symfony Request object instead of a custom method.
| Type?             | refacto
| Category?         | FO 
| BC breaks?        | yes
| Deprecations?     |no
| How to test?      | Call Tools::getRemoteAddr(); in a module or anyway and control the IP of the client.
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | NC
| Related PRs       | NC
| Sponsor company  | @202ecommerce