### PR TITLE
Refacto : Use the default theme and optimize

### DIFF
--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -639,15 +639,7 @@ class AdminShopControllerCore extends AdminController
             ];
         }
 
-        if (!$obj->theme_name) {
-            $themes = (new ThemeManagerBuilder($this->context, Db::getInstance()))
-                ->buildRepository()
-                ->getList();
-            $theme = array_pop($themes);
-            $theme_name = $theme->getName();
-        } else {
-            $theme_name = $obj->theme_name;
-        }
+        $theme_name = $obj->theme_name ?: $this->context->shop->theme_name;
 
         $this->fields_value = [
             'id_shop_group' => (


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When creating a new shop in a multistore context, PrestaShop selected the last theme returned by the theme repository. This could result in an unrelated theme being checked by default. This PR now selects the theme used by default. It also removes an unnecessary second loading of the theme repository.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test | See below
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @Touxten 

## How to test

### Prerequisites

1. Enable the multistore feature.
2. Install at least two themes.
3. Make sure the current shop uses a theme that is not the last theme returned in the theme list.

### Before this PR

1. Go to **Advanced Parameters > Multistore**.
2. Select a shop context.
3. Click **Add new shop**.
4. Check the theme selected by default.
5. The selected theme may be different from the default theme

### After this PR

1. Go to **Advanced Parameters > Multistore**.
2. Select a shop context.
3. Click **Add new shop**.
4. Check the theme selected by default.
5. The theme used by default should be selected.


