### PR TITLE
Fix #42395: Prevent template variables from being overwritten

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -540,26 +540,29 @@ class FrontControllerCore extends Controller
             ]
         );
 
-        $templateVars = [
-            'cart' => $this->cart_presenter->present($cart, true),
-            'currency' => $this->getTemplateVarCurrency(),
-            'customer' => $this->getTemplateVarCustomer(),
-            'country' => $this->objectPresenter->present($this->context->country),
-            'language' => $this->objectPresenter->present($this->context->language),
-            'page' => $this->getTemplateVarPage(),
-            'shop' => $this->getTemplateVarShop(),
-            'core_js_public_path' => $this->getCoreJsPublicPath(),
-            'urls' => $this->getTemplateVarUrls(),
-            'configuration' => $this->getTemplateVarConfiguration(),
-            'field_required' => $this->context->customer->validateFieldsRequiredDatabase(),
-            'breadcrumb' => $this->getBreadcrumb(),
-            'structured_data' => $this->getStructuredData(),
-            'link' => $this->context->link,
-            'time' => time(),
-            'static_token' => Tools::getToken(false),
-            'token' => Tools::getToken(),
-            'debug' => _PS_MODE_DEV_,
-        ];
+        $templateVars = array_merge(
+            [
+                'cart' => $this->cart_presenter->present($cart, true),
+                'currency' => $this->getTemplateVarCurrency(),
+                'customer' => $this->getTemplateVarCustomer(),
+                'country' => $this->objectPresenter->present($this->context->country),
+                'language' => $this->objectPresenter->present($this->context->language),
+                'page' => $this->getTemplateVarPage(),
+                'shop' => $this->getTemplateVarShop(),
+                'core_js_public_path' => $this->getCoreJsPublicPath(),
+                'urls' => $this->getTemplateVarUrls(),
+                'configuration' => $this->getTemplateVarConfiguration(),
+                'field_required' => $this->context->customer->validateFieldsRequiredDatabase(),
+                'breadcrumb' => $this->getBreadcrumb(),
+                'structured_data' => $this->getStructuredData(),
+                'link' => $this->context->link,
+                'time' => time(),
+                'static_token' => Tools::getToken(false),
+                'token' => Tools::getToken(),
+                'debug' => _PS_MODE_DEV_,
+            ],
+            $templateVars
+        );
 
         // An array [module_name => module_output] will be returned
         $modulesVariables = Hook::exec(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | This PR fixes a regression affecting the `actionFrontControllerSetVariablesBefore` and `action{ControllerName}SetVariablesBefore` hooks.<br/>Variables added to `$templateVars` through these hooks were lost because `$templateVars` was completely reassigned afterwards in `FrontController::assignGeneralPurposeVariables()`.<br/>The fix preserves the variables already defined by the hooks while still assigning the default Front Office template variables.
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the [issueactionfrontcontrollersetvariablesbefore.zip](https://github.com/user-attachments/files/31308081/issueactionfrontcontrollersetvariablesbefore.zip) test module.<br/>2. Go to the Front Office.<br/>3. Check the footer.<br/>4. Before this fix, `Variable not set` is displayed.<br/>5. After this fix, the expected value `value` is displayed.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/32488608208
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42395
| Related PRs       | 
| Sponsor company   | Codencode snc
