### PR TITLE
Fix Carts page performance regression on connections query

### DIFF
--- a/src/Core/Grid/Query/CartQueryBuilder.php
+++ b/src/Core/Grid/Query/CartQueryBuilder.php
@@ -115,7 +115,7 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
             ->createQueryBuilder()
             ->select('DISTINCT co.`id_guest`')
             ->from($this->dbPrefix . 'connections', 'co')
-            ->where('TIME_TO_SEC(TIMEDIFF(\'' . pSQL(date('Y-m-d H:i:00', time())) . '\', `date_add`)) < ' . self::CUSTOMER_ONLINE_TIME);
+            ->where('co.`date_add` > DATE_SUB(\'' . pSQL(date('Y-m-d H:i:00', time())) . '\', INTERVAL ' . self::CUSTOMER_ONLINE_TIME . ' SECOND)');
 
         $qb = $this->connection
             ->createQueryBuilder()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x 
| Description?      | Fix a performance regression in the Back Office Carts page query.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Open the Back Office Carts page on a shop with a large `connections` table and verify that the page loads correctly. Compare the query execution plan before and after the change to verify that the `date_add` index can be used. 
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/32577351949
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42399
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/31729
| Sponsor company   | Codencode snc

---

## Description

This PR fixes a performance regression affecting the Back Office **Orders > Carts** page when the `connections` table contains a large number of rows.

The query used to determine whether a customer is online currently contains the following condition:

```sql
TIME_TO_SEC(TIMEDIFF(current_date, date_add)) < 1800
```

Applying functions to `connections.date_add` prevents MySQL/MariaDB from efficiently using the existing `date_add` index. As a result, the database may have to evaluate the expression for a large number of rows in `connections`, which can make the Carts page extremely slow and eventually result in a gateway or PHP timeout.

This PR rewrites the condition so that `date_add` is directly compared with the calculated threshold:

```sql
date_add > DATE_SUB(current_date, INTERVAL 1800 SECOND)
```

The behavior remains unchanged: a customer is still considered online when the latest connection is less than 30 minutes old. However, the new condition allows the database optimizer to use the index on `connections.date_add`.

## Previous fix and regression

This issue had already been identified in #31727.

It was fixed by #31729, **"Use index for connections.date_add"**, which replaced the same `TIME_TO_SEC(TIMEDIFF(..., date_add))` pattern with an index-friendly comparison.

The previous PR documented a significant performance improvement on large `connections` tables, reducing the Carts page loading time from minutes to around 0.5 seconds while preserving the same behavior.

The issue was later reintroduced when the Carts page was migrated to the new Grid implementation.

Commit `bb02ea8` (**"Add grid and query builder for Carts page"**) introduced `src/Core/Grid/Query/CartQueryBuilder.php` and restored the previous condition:

```php
->where('TIME_TO_SEC(TIMEDIFF(..., `date_add`)) < ' . self::CUSTOMER_ONLINE_TIME);
```

Therefore, this PR restores the optimization previously implemented by #31729 in the current `CartQueryBuilder`.
