### PR TITLE
Fix: Carrier price ranges always display EUR symbol regardless of shop's default currency

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
@@ -9,15 +9,25 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier\Type;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\PositiveOrZero;
+use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
 use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CostsRangeType extends TranslatorAwareType
 {
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        private readonly CurrencyDataProviderInterface $currencyDataProvider
+    ) {
+        parent::__construct($translator, $locales);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -44,6 +54,7 @@ class CostsRangeType extends TranslatorAwareType
             ->add('price', MoneyWithSuffixType::class, [
                 'label' => $this->trans('Price (VAT excl.)', 'Admin.Shipping.Feature'),
                 'empty_data' => '0.0', // string instead number needed for DecimalNumber.php validation
+                'currency' => $this->currencyDataProvider->getDefaultCurrencyIsoCode(),
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier\Type;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\PositiveOrZero;
-use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
 use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -23,7 +22,7 @@ class CostsRangeType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        private readonly CurrencyDataProviderInterface $currencyDataProvider
+       private readonly string $defaultCurrencyIsoCode,
     ) {
         parent::__construct($translator, $locales);
     }
@@ -54,7 +53,7 @@ class CostsRangeType extends TranslatorAwareType
             ->add('price', MoneyWithSuffixType::class, [
                 'label' => $this->trans('Price (VAT excl.)', 'Admin.Shipping.Feature'),
                 'empty_data' => '0.0', // string instead number needed for DecimalNumber.php validation
-                'currency' => $this->currencyDataProvider->getDefaultCurrencyIsoCode(),
+                'currency' => $this->defaultCurrencyIsoCode,
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
@@ -22,7 +22,7 @@ class CostsRangeType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-       private readonly string $defaultCurrencyIsoCode,
+        private readonly string $defaultCurrencyIsoCode,
     ) {
         parent::__construct($translator, $locales);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.2.x
| Description?      | Fixes the currency displayed in carrier shipping cost fields.<br/>`CostsRangeType` uses `MoneyWithSuffixType` without specifying the `currency` option, causing Symfony to fall back to EUR.<br/>This PR injects `CurrencyDataProviderInterface` into `CostsRangeType` and passes the shop's default currency ISO code to `MoneyWithSuffixType`.<br/>As a result, the carrier cost fields now display the correct currency according to the shop configuration.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Configure a shop with a default currency different from EUR, for example SEK.<br/>2. Go to **Shipping > Carriers**.<br/>3. Edit a carrier.<br/>4. Open the **Shipping locations and costs** step.<br/>5. Select **According to total price** as the billing method.<br/>6. Check the shipping cost fields.<br/>7. Confirm that the displayed currency corresponds to the shop's default currency instead of EUR.
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/32701113772
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42401
| Related PRs       | 
| Sponsor company   | Codencode snc
