### PR TITLE
Provide B2B roles and permissions

### DIFF
--- a/classes/lang/B2bRoleLang.php
+++ b/classes/lang/B2bRoleLang.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+class B2bRoleLangCore extends DataLangCore
+{
+    protected $domain = 'Shop.Theme.Customeraccount';
+    protected $keys = ['id_role'];
+    protected $fieldsToUpdate = ['name'];
+}

--- a/classes/lang/B2bRoleLang.php
+++ b/classes/lang/B2bRoleLang.php
@@ -3,7 +3,6 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
-
 class B2bRoleLangCore extends DataLangCore
 {
     protected $domain = 'Shop.Theme.Customeraccount';

--- a/classes/lang/KeysReference/B2bRoleLang.php
+++ b/classes/lang/KeysReference/B2bRoleLang.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+// install-dev/langs/en/data/b2b_role.xml
+trans('Super Admin', 'Shop.Theme.Customeraccount');
+trans('Admin', 'Shop.Theme.Customeraccount');
+trans('Buyer', 'Shop.Theme.Customeraccount');

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -3242,6 +3242,14 @@ CREATE TABLE `PREFIX_b2b_role`
 ) ENGINE = ENGINE_TYPE
   DEFAULT CHARSET = utf8mb4 COLLATION;
 
+CREATE TABLE `PREFIX_b2b_role_lang`
+(
+    `id_role`   INT UNSIGNED NOT NULL,
+    `id_lang`   INT NOT NULL,
+    `name`      VARCHAR(128) NOT NULL,
+    PRIMARY KEY (`id_role`, `id_lang`)
+) ENGINE = ENGINE_TYPE DEFAULT CHARSET = utf8mb4 COLLATION;
+
 CREATE TABLE `PREFIX_b2b_role_authorization_role`
 (
   `id_role`               INT UNSIGNED NOT NULL,

--- a/install-dev/data/xml/authorization_role.xml
+++ b/install-dev/data/xml/authorization_role.xml
@@ -486,5 +486,12 @@
     <authorization_role id="TAB_DEFAULT_CREATE" slug="ROLE_MOD_TAB_DEFAULT_CREATE"/>
     <authorization_role id="TAB_DEFAULT_UPDATE" slug="ROLE_MOD_TAB_DEFAULT_UPDATE"/>
     <authorization_role id="TAB_DEFAULT_DELETE" slug="ROLE_MOD_TAB_DEFAULT_DELETE"/>
+    <!-- B2B customer permissions -->
+    <authorization_role id="B2B_BUSINESS_ENTITY_EDIT" slug="B2B_BUSINESS_ENTITY_EDIT"/>
+    <authorization_role id="B2B_BUSINESS_ENTITY_CUSTOMER_INVITE" slug="B2B_BUSINESS_ENTITY_CUSTOMER_INVITE"/>
+    <authorization_role id="B2B_BUSINESS_ENTITY_CUSTOMER_EDIT" slug="B2B_BUSINESS_ENTITY_CUSTOMER_EDIT"/>
+    <authorization_role id="B2B_BUSINESS_ENTITY_CUSTOMER_DELETE" slug="B2B_BUSINESS_ENTITY_CUSTOMER_DELETE"/>
+    <authorization_role id="B2B_ORDER_VIEW" slug="B2B_ORDER_VIEW"/>
+    <authorization_role id="B2B_ORDER_CREATE" slug="B2B_ORDER_CREATE"/>
   </entities>
 </entity_authorization_role>

--- a/install-dev/data/xml/b2b_role.xml
+++ b/install-dev/data/xml/b2b_role.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity_b2b_role>
+  <fields primary="id_role">
+    <field name="role"/>
+  </fields>
+  <entities>
+    <b2b_role id="SuperAdmin" role="ROLE_B2B_SUPER_ADMIN"/>
+    <b2b_role id="Admin" role="ROLE_B2B_ADMIN"/>
+    <b2b_role id="Buyer" role="ROLE_B2B_BUYER"/>
+  </entities>
+</entity_b2b_role>

--- a/install-dev/data/xml/b2b_role_authorization_role.xml
+++ b/install-dev/data/xml/b2b_role_authorization_role.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity_b2b_role_authorization_role>
+  <fields primary="id_role, id_authorization_role">
+    <field name="id_role" relation="b2b_role"/>
+    <field name="id_authorization_role" relation="authorization_role"/>
+  </fields>
+  <entities>
+    <b2b_role_authorization_role id="b2b_role_ar_1_1" id_role="SuperAdmin" id_authorization_role="B2B_BUSINESS_ENTITY_EDIT"/>
+    <b2b_role_authorization_role id="b2b_role_ar_1_2" id_role="SuperAdmin" id_authorization_role="B2B_BUSINESS_ENTITY_CUSTOMER_INVITE"/>
+    <b2b_role_authorization_role id="b2b_role_ar_1_3" id_role="SuperAdmin" id_authorization_role="B2B_BUSINESS_ENTITY_CUSTOMER_EDIT"/>
+    <b2b_role_authorization_role id="b2b_role_ar_1_4" id_role="SuperAdmin" id_authorization_role="B2B_BUSINESS_ENTITY_CUSTOMER_DELETE"/>
+    <b2b_role_authorization_role id="b2b_role_ar_1_5" id_role="SuperAdmin" id_authorization_role="B2B_ORDER_VIEW"/>
+    <b2b_role_authorization_role id="b2b_role_ar_1_6" id_role="SuperAdmin" id_authorization_role="B2B_ORDER_CREATE"/>
+
+    <b2b_role_authorization_role id="b2b_role_ar_2_1" id_role="Admin" id_authorization_role="B2B_BUSINESS_ENTITY_EDIT"/>
+    <b2b_role_authorization_role id="b2b_role_ar_2_2" id_role="Admin" id_authorization_role="B2B_BUSINESS_ENTITY_CUSTOMER_INVITE"/>
+    <b2b_role_authorization_role id="b2b_role_ar_2_3" id_role="Admin" id_authorization_role="B2B_BUSINESS_ENTITY_CUSTOMER_EDIT"/>
+    <b2b_role_authorization_role id="b2b_role_ar_2_5" id_role="Admin" id_authorization_role="B2B_ORDER_VIEW"/>
+    <b2b_role_authorization_role id="b2b_role_ar_2_6" id_role="Admin" id_authorization_role="B2B_ORDER_CREATE"/>
+
+    <b2b_role_authorization_role id="b2b_role_ar_3_6" id_role="Buyer" id_authorization_role="B2B_ORDER_CREATE"/>
+  </entities>
+</entity_b2b_role_authorization_role>

--- a/install-dev/langs/en/data/b2b_role.xml
+++ b/install-dev/langs/en/data/b2b_role.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<entity_b2b_role>
+  <b2b_role id="SuperAdmin">
+    <name>Super Admin</name>
+  </b2b_role>
+  <b2b_role id="Admin">
+    <name>Admin</name>
+  </b2b_role>
+  <b2b_role id="Buyer">
+    <name>Buyer</name>
+  </b2b_role>
+</entity_b2b_role>

--- a/src/Core/Domain/B2bRole/Exception/B2bRoleException.php
+++ b/src/Core/Domain/B2bRole/Exception/B2bRoleException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\B2bRole\Exception;
+
+use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+
+class B2bRoleException extends DomainException
+{
+}

--- a/src/Core/Domain/B2bRole/Permission.php
+++ b/src/Core/Domain/B2bRole/Permission.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\B2bRole;
+
+final class Permission
+{
+    public const BUSINESS_ENTITY_EDIT = 'B2B_BUSINESS_ENTITY_EDIT';
+
+    public const BUSINESS_ENTITY_CUSTOMER_INVITE = 'B2B_BUSINESS_ENTITY_CUSTOMER_INVITE';
+    public const BUSINESS_ENTITY_CUSTOMER_EDIT = 'B2B_BUSINESS_ENTITY_CUSTOMER_EDIT';
+    public const BUSINESS_ENTITY_CUSTOMER_DELETE = 'B2B_BUSINESS_ENTITY_CUSTOMER_DELETE';
+
+    public const ORDER_VIEW = 'B2B_ORDER_VIEW';
+    public const ORDER_CREATE = 'B2B_ORDER_CREATE';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Core/Domain/B2bRole/Role.php
+++ b/src/Core/Domain/B2bRole/Role.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\B2bRole;
+
+final class Role
+{
+    public const PREFIX = 'ROLE_B2B_';
+
+    public const SUPER_ADMIN = self::PREFIX . 'SUPER_ADMIN';
+    public const ADMIN = self::PREFIX . 'ADMIN';
+    public const BUYER = self::PREFIX . 'BUYER';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/PrestaShopBundle/Entity/B2B/B2bRole.php
+++ b/src/PrestaShopBundle/Entity/B2B/B2bRole.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use PrestaShop\PrestaShop\Core\Domain\B2bRole\Exception\B2bRoleException;
+use PrestaShopBundle\Entity\Repository\B2bRoleRepository;
 
 /**
  * B2bRole.
@@ -18,7 +19,7 @@ use PrestaShop\PrestaShop\Core\Domain\B2bRole\Exception\B2bRoleException;
  *     indexes={@ORM\Index(name="uniq_b2b_role", columns={"role"})}
  * )
  *
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass=B2bRoleRepository::class)
  */
 class B2bRole
 {

--- a/src/PrestaShopBundle/Entity/B2B/B2bRole.php
+++ b/src/PrestaShopBundle/Entity/B2B/B2bRole.php
@@ -9,6 +9,7 @@ namespace PrestaShopBundle\Entity\B2B;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use PrestaShop\PrestaShop\Core\Domain\B2bRole\Exception\B2bRoleException;
 
 /**
  * B2bRole.
@@ -45,10 +46,18 @@ class B2bRole
      */
     private Collection $b2bRoleAuthorizationRoles;
 
+    /**
+     * @var Collection<int, B2bRoleLang>
+     *
+     * @ORM\OneToMany(targetEntity=B2bRoleLang::class, mappedBy="role", cascade={"persist", "remove"}, orphanRemoval=true, indexBy="id_lang")
+     */
+    private Collection $translations;
+
     public function __construct()
     {
         $this->businessEntityCustomerB2bs = new ArrayCollection();
         $this->b2bRoleAuthorizationRoles = new ArrayCollection();
+        $this->translations = new ArrayCollection();
     }
 
     public function getIdRole(): int
@@ -108,6 +117,37 @@ class B2bRole
     public function removeB2bRoleAuthorizationRole(B2bRoleAuthorizationRole $b2bRoleAuthorizationRole): self
     {
         $this->b2bRoleAuthorizationRoles->removeElement($b2bRoleAuthorizationRole);
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, B2bRoleLang>
+     */
+    public function getTranslations(): array
+    {
+        return $this->translations->toArray();
+    }
+
+    public function translate(int $languageId): ?B2bRoleLang
+    {
+        return $this->translations->get($languageId);
+    }
+
+    public function addTranslation(B2bRoleLang $translation): static
+    {
+        $role = $translation->getRole();
+        if (null !== $role && $this !== $role) {
+            throw new B2bRoleException('The translation belongs to another role.');
+        }
+
+        $languageId = $translation->getLanguage()->getId();
+        if ($this->translations->containsKey($languageId)) {
+            throw new B2bRoleException(\sprintf('The "%s" role is already translated in language "%s".', $this->role, $translation->getLanguage()->getIsoCode()));
+        }
+
+        $translation->setRole($this);
+        $this->translations->set($languageId, $translation);
 
         return $this;
     }

--- a/src/PrestaShopBundle/Entity/B2B/B2bRoleLang.php
+++ b/src/PrestaShopBundle/Entity/B2B/B2bRoleLang.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Entity\B2B;
+
+use Doctrine\ORM\Mapping as ORM;
+use PrestaShopBundle\Entity\Lang;
+
+/**
+ * @ORM\Table()
+ *
+ * @ORM\Entity()
+ */
+class B2bRoleLang
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\ManyToOne(targetEntity=B2bRole::class, inversedBy="translations")
+     *
+     * @ORM\JoinColumn(name="id_role", referencedColumnName="id_role", nullable=false, options={"unsigned"=true})
+     */
+    private B2bRole $role;
+
+    /**
+     * @ORM\Id
+     *
+     * @ORM\ManyToOne(targetEntity=Lang::class)
+     *
+     * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false)
+     */
+    private Lang $language;
+
+    /**
+     * @ORM\Column(type="string", length=128)
+     */
+    private string $name;
+
+    public function __construct(Lang $language, string $name)
+    {
+        $this->language = $language;
+        $this->setName($name);
+    }
+
+    public function getRole(): ?B2bRole
+    {
+        return $this->role ?? null;
+    }
+
+    public function getLanguage(): Lang
+    {
+        return $this->language;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @internal use {@see B2bRole::addTranslation()} instead
+     */
+    public function setRole(B2bRole $role): void
+    {
+        $this->role = $role;
+    }
+}

--- a/src/PrestaShopBundle/Entity/Repository/B2bRoleRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/B2bRoleRepository.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Entity\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use PrestaShopBundle\Entity\B2B\B2bRole;
+
+/**
+ * @extends ServiceEntityRepository<B2bRole>
+ *
+ * @experimental
+ */
+class B2bRoleRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, B2bRole::class);
+    }
+
+    public function createByLanguageIdQueryBuilder(int $languageId): QueryBuilder
+    {
+        return $this
+            ->createQueryBuilder('r')
+            ->addSelect('rt')
+            ->leftJoin('r.translations', 'rt', Join::WITH, 'rt.language = :languageId')
+            ->orderBy('r.id', 'ASC')
+            ->setParameter('languageId', $languageId);
+    }
+}

--- a/src/PrestaShopBundle/Form/DataTransformer/IdToEntityTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/IdToEntityTransformer.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\DataTransformer;
+
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * @template T of object
+ */
+final class IdToEntityTransformer implements DataTransformerInterface
+{
+    /**
+     * @param class-string<T> $class
+     */
+    public function __construct(
+        private readonly EntityManagerInterface $manager,
+        private readonly string $class,
+    ) {
+        $this->assertIsSingleColumnIdentifier();
+    }
+
+    /**
+     * @return T|null
+     */
+    public function transform(mixed $value): ?object
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (null === $entity = $this->manager->find($this->class, $value)) {
+            throw new TransformationFailedException('Entity not found.');
+        }
+
+        return $entity;
+    }
+
+    public function reverseTransform(mixed $value): mixed
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!$value instanceof $this->class) {
+            throw new TransformationFailedException(\sprintf('Expected an instance of "%s".', $this->class));
+        }
+
+        return $this->readId($value);
+    }
+
+    private function readId(object $entity): mixed
+    {
+        $metadata = $this->manager->getClassMetadata($entity::class);
+        $ids = $metadata->getIdentifierValues($entity);
+        $id = current($ids);
+
+        if (!\is_object($id) || !$metadata->hasAssociation(array_key_first($ids))) {
+            return $id;
+        }
+
+        return $this->readId($id);
+    }
+
+    private function assertIsSingleColumnIdentifier(): void
+    {
+        if (!$this->manager->getClassMetadata($this->class)->isIdentifierComposite) {
+            return;
+        }
+
+        throw new LogicException(\sprintf('The "%s" does not support entities with composite identifiers.', self::class));
+    }
+}

--- a/src/PrestaShopBundle/Form/Type/B2b/B2bRoleChoiceType.php
+++ b/src/PrestaShopBundle/Form/Type/B2b/B2bRoleChoiceType.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Type\B2b;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Domain\B2bRole\Role;
+use PrestaShopBundle\Entity\B2B\B2bRole;
+use PrestaShopBundle\Entity\Repository\B2bRoleRepository;
+use PrestaShopBundle\Form\DataTransformer\IdToEntityTransformer;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class B2bRoleChoiceType extends AbstractType
+{
+    public function __construct(
+        private readonly LanguageContext $languageContext,
+    ) {
+    }
+
+    public function getParent(): string
+    {
+        return EntityType::class;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setDefaults([
+                'class' => B2bRole::class,
+                'input' => 'entity',
+                'query_builder' => fn (B2bRoleRepository $repository) => $repository->createByLanguageIdQueryBuilder($this->languageContext->getId()),
+                'choice_label' => fn (B2bRole $role) => $role->translate($this->languageContext->getId())?->getName()
+                    ?? self::humanizeRole($role->getRole()),
+            ])
+            ->setAllowedValues('input', ['entity', 'id'])
+            ->setNormalizer('input', static function (Options $options, string $value) {
+                if ('id' !== $value || !$options['multiple']) {
+                    return $value;
+                }
+
+                throw new InvalidOptionsException('The "id" input is not supported for "multiple" choice.');
+            });
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        if ('id' !== $options['input']) {
+            return;
+        }
+
+        $builder->addModelTransformer(new IdToEntityTransformer($options['em'], B2bRole::class));
+    }
+
+    private static function humanizeRole(string $role): string
+    {
+        if (str_starts_with($role, Role::PREFIX)) {
+            $role = \substr($role, \strlen(Role::PREFIX));
+        }
+
+        return ucfirst(strtolower(str_replace('_', ' ', $role)));
+    }
+}

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -540,7 +540,7 @@ class XmlLoader
                 }
 
                 foreach ($real_data_lang as $id_lang => $insert_data_lang) {
-                    $insert_data_lang['id_' . $entity] = $entity_id;
+                    $insert_data_lang[$primary] = $entity_id;
                     $insert_data_lang['id_lang'] = $id_lang;
                     $this->delayed_inserts[$entity . '_lang'][] = array_map('pSQL', $insert_data_lang);
                 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -42,6 +42,8 @@ services:
       $productTypeListener: '@PrestaShopBundle\Form\Admin\Sell\Product\EventListener\ProductTypeListener'
       $isAllShopContext: '@=service("prestashop.adapter.shop.context").isAllShopContext()'
 
+  PrestaShopBundle\Form\Type\:
+    resource: "%kernel.project_dir%/src/PrestaShopBundle/Form/Type/*"
   PrestaShopBundle\Form\Admin\Sell\Discount\:
     resource: "%kernel.project_dir%/src/PrestaShopBundle/Form/Admin/Sell/Discount/*"
   PrestaShopBundle\Form\Admin\Sell\Product\:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -187,3 +187,7 @@ services:
     factory: [ '@doctrine.orm.default_entity_manager', getRepository ]
     arguments:
       - PrestaShopBundle\Entity\B2B\BusinessEntity
+
+  PrestaShopBundle\Entity\Repository\B2bRoleRepository:
+    autowire: true
+    autoconfigure: true

--- a/tests/Integration/PrestaShopBundle/Form/Type/B2b/B2bRoleChoiceTypeTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Type/B2b/B2bRoleChoiceTypeTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Type\B2b;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShopBundle\Entity\B2B\B2bRole;
+use PrestaShopBundle\Entity\Repository\B2bRoleRepository;
+use PrestaShopBundle\Form\Type\B2b\B2bRoleChoiceType;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use Symfony\Bridge\Doctrine\Middleware\Debug\Middleware;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Tests\Resources\DatabaseDump;
+
+class B2bRoleChoiceTypeTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private B2bRoleRepository $repository;
+    private DebugDataHolder $debugDataHolder;
+
+    /**
+     * @var B2bRole[]
+     */
+    private array $addedRoles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+
+        /* @see AlertsTrackingExtension::buildView() reads the flash bag for any root form. */
+        $request = new Request();
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        self::getContainer()->get('request_stack')->push($request);
+
+        $this->debugDataHolder = new DebugDataHolder();
+        /** @var Configuration $dbalConfiguration */
+        $dbalConfiguration = self::getContainer()->get('doctrine.dbal.default_connection.configuration');
+        $dbalConfiguration->setMiddlewares([
+            ...$dbalConfiguration->getMiddlewares(),
+            new Middleware($this->debugDataHolder, null),
+        ]);
+
+        $this->entityManager = self::getContainer()->get('doctrine')->getManagerForClass(B2bRole::class);
+        $this->repository = $this->entityManager->getRepository(B2bRole::class);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->addedRoles as $addedRole) {
+            $this->entityManager->remove($addedRole);
+        }
+
+        if ([] !== $this->addedRoles) {
+            $this->entityManager->flush();
+            $this->addedRoles = [];
+        }
+
+        parent::tearDown();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['b2b_role', 'b2b_role_lang']);
+    }
+
+    public static function getNewRoleIds(): iterable
+    {
+        yield 'single' => ['ROLE_B2B_CUSTOM_ROLE'];
+        yield 'multiple' => ['ROLE_B2B_CUSTOM_ROLE_1', 'ROLE_B2B_CUSTOM_ROLE_2'];
+    }
+
+    public function testDefaultRolesAreAvailableAsChoices(): void
+    {
+        $roles = $this->repository->findAll();
+
+        $this->assertNotEmpty($roles);
+        $this->checkChoicesExist($roles);
+    }
+
+    #[DataProvider('getNewRoleIds')]
+    public function testNewRolesAreAvailableAsChoices(string ...$roleIds): void
+    {
+        $newRoles = $this->addRoles(...$roleIds);
+
+        $this->checkChoicesExist($newRoles);
+    }
+
+    public function testChoicesAreLoadedInASingleQuery(): void
+    {
+        $form = $this->createForm();
+
+        $this->debugDataHolder->reset();
+        $form->createView();
+        $debugData = $this->debugDataHolder->getData()['default'] ?? [];
+
+        $this->assertCount(1, $debugData);
+    }
+
+    /**
+     * @param B2bRole[] $roles
+     */
+    private function checkChoicesExist(array $roles): void
+    {
+        $form = $this->createForm();
+        $view = $form->createView();
+
+        foreach ($roles as $role) {
+            $this->assertTrue($this->hasChoice($view, $role), \sprintf('Role "%s" is not available as a choice', $role->getRole()));
+        }
+    }
+
+    private function hasChoice(FormView $view, B2bRole $role): bool
+    {
+        $choices = $view->vars['choices'];
+
+        return null !== array_find($choices, static fn (ChoiceView $choice) => $role === $choice->data);
+    }
+
+    private function createForm(): FormInterface
+    {
+        return self::getContainer()->get('form.factory')->create(B2bRoleChoiceType::class);
+    }
+
+    /**
+     * @return B2bRole[]
+     */
+    private function addRoles(string ...$roles): array
+    {
+        $entities = [];
+        foreach ($roles as $role) {
+            $entities[] = $entity = (new B2bRole())->setRole($role);
+            $this->entityManager->persist($entity);
+        }
+
+        $this->entityManager->flush();
+        $this->addedRoles = array_merge($this->addedRoles, $entities);
+
+        return $entities;
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/DataTransformer/IdToEntityTransformerTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/DataTransformer/IdToEntityTransformerTest.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\DataTransformer;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Form\DataTransformer\IdToEntityTransformer;
+use stdClass;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class IdToEntityTransformerTest extends TestCase
+{
+    private MockObject&EntityManagerInterface $entityManager;
+
+    /**
+     * @var array<string, ClassMetadata>
+     */
+    private array $classMetadata = [];
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager->method('getClassMetadata')->willReturnCallback($this->getClassMetadata(...));
+    }
+
+    public static function getTransformValues(): iterable
+    {
+        yield 'integer id' => [1, new SingleIdEntity(1)];
+        yield 'string id' => ['id', new SingleIdEntity('id')];
+        yield 'subclass' => [2, new ChildSingleIdEntity(2)];
+    }
+
+    public static function getInvalidReverseTransformValues(): iterable
+    {
+        yield 'integer' => [1];
+        yield 'string' => ['id'];
+        yield 'class mismatch' => [new stdClass()];
+    }
+
+    public function testConstructorThrowsOnCompositeIdentifier(): void
+    {
+        $this->expectException(LogicException::class);
+
+        $this->createTransformer(CompositeIdEntity::class);
+    }
+
+    #[DataProvider('getTransformValues')]
+    public function testTransform(mixed $id, object $entity): void
+    {
+        $this->entityManager->expects($this->once())->method('find')->with(SingleIdEntity::class, $id)->willReturn($entity);
+
+        $this->assertSame($entity, $this->createTransformer()->transform($id));
+    }
+
+    public function testTransformNull(): void
+    {
+        $this->entityManager->expects($this->never())->method('find');
+
+        $this->assertNull($this->createTransformer()->transform(null));
+    }
+
+    public function testTransformThrowsOnEntityNotFound(): void
+    {
+        $this->entityManager->method('find')->willReturn(null);
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Entity not found.');
+
+        $this->createTransformer()->transform(1);
+    }
+
+    #[DataProvider('getTransformValues')]
+    public function testReverseTransform(mixed $id, object $entity): void
+    {
+        $this->assertSame($id, $this->createTransformer()->reverseTransform($entity));
+    }
+
+    public function testReverseTransformNull(): void
+    {
+        $this->assertNull($this->createTransformer()->reverseTransform(null));
+    }
+
+    public function testReverseTransformObjectIdWithoutAssociation(): void
+    {
+        $id = new DateTimeImmutable('2000-01-01 00:00:00');
+
+        $this->assertSame($id, $this->createTransformer()->reverseTransform(new SingleIdEntity($id)));
+    }
+
+    public function testReverseTransformReturnsDerivedId(): void
+    {
+        $simple = new SingleIdEntity(123);
+        $entity = new DerivedIdEntity($simple);
+        $transformer = $this->createTransformer(DerivedIdEntity::class);
+
+        $this->assertSame(123, $transformer->reverseTransform($entity));
+    }
+
+    #[DataProvider('getInvalidReverseTransformValues')]
+    public function testReverseTransformThrowsOnUnexpectedType(mixed $value): void
+    {
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessageMatches('/^Expected an instance of/');
+
+        $this->createTransformer()->reverseTransform($value);
+    }
+
+    private function createTransformer(string $class = SingleIdEntity::class): IdToEntityTransformer
+    {
+        return new IdToEntityTransformer($this->entityManager, $class);
+    }
+
+    private function getClassMetadata(string $class): ClassMetadata
+    {
+        return $this->classMetadata[$class] ??= $this->createClassMetadata($class);
+    }
+
+    private function createClassMetadata(string $class): ClassMetadata
+    {
+        $metadata = new ClassMetadata($class);
+
+        switch ($class) {
+            case SingleIdEntity::class:
+            case ChildSingleIdEntity::class:
+                $metadata->mapField(['fieldName' => 'id', 'id' => true]);
+                break;
+            case DerivedIdEntity::class:
+                $metadata->mapOneToOne(['fieldName' => 'entity', 'targetEntity' => SingleIdEntity::class, 'id' => true]);
+                break;
+            case CompositeIdEntity::class:
+                $metadata->mapField(['fieldName' => 'a', 'id' => true]);
+                $metadata->mapField(['fieldName' => 'b', 'id' => true]);
+                break;
+            default:
+                $this->fail(\sprintf('Unexpected class "%s".', $class));
+        }
+
+        $metadata->wakeupReflection(new RuntimeReflectionService());
+
+        return $metadata;
+    }
+}
+
+class SingleIdEntity
+{
+    public function __construct(
+        public readonly mixed $id,
+    ) {
+    }
+}
+
+class ChildSingleIdEntity extends SingleIdEntity
+{
+}
+
+class DerivedIdEntity
+{
+    public function __construct(
+        public readonly SingleIdEntity $entity,
+    ) {
+    }
+}
+
+class CompositeIdEntity
+{
+    public function __construct(
+        public readonly int $a,
+        public readonly int $b,
+    ) {
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/Type/B2b/B2bRoleChoiceTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Type/B2b/B2bRoleChoiceTypeTest.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Type\B2b;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Domain\B2bRole\Role;
+use PrestaShopBundle\Entity\B2B\B2bRole;
+use PrestaShopBundle\Entity\B2B\B2bRoleLang;
+use PrestaShopBundle\Entity\Lang;
+use PrestaShopBundle\Entity\Repository\B2bRoleRepository;
+use PrestaShopBundle\Form\Type\B2b\B2bRoleChoiceType;
+use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
+use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class B2bRoleChoiceTypeTest extends TypeTestCase
+{
+    private ClassMetadata $classMetadata;
+    private MockObject&LanguageContext $languageContext;
+    private MockObject&EntityManagerInterface $entityManager;
+
+    /**
+     * @var B2bRole[]
+     */
+    private array $roles;
+    private ?int $qbLanguageId = null;
+
+    protected function getExtensions(): array
+    {
+        $this->classMetadata ??= $this->createClassMetadata();
+        $this->languageContext = $this->createMock(LanguageContext::class);
+
+        $repository = $this->createMock(B2bRoleRepository::class);
+        $repository->method('createByLanguageIdQueryBuilder')->willReturnCallback(function (int $languageId) {
+            $this->qbLanguageId = $languageId;
+
+            return $this->createMock(QueryBuilder::class);
+        });
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager->method('getClassMetadata')->willReturn($this->classMetadata);
+        $this->entityManager->method('getRepository')->willReturn($repository);
+        $this->entityManager->method('contains')->willReturn(true);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($this->entityManager);
+
+        return [
+            new DoctrineOrmExtension($registry),
+            new PreloadedExtension([new B2bRoleChoiceType($this->languageContext)], []),
+        ];
+    }
+
+    public static function getLanguageIds(): iterable
+    {
+        yield from [[1], [4]];
+    }
+
+    public static function getChoiceLabels(): iterable
+    {
+        yield 'language 1' => [1, [
+            'Administrator',
+            'Buyer',
+            'Custom role',
+        ]];
+        yield 'language 2' => [2, [
+            'Localized admin',
+            'Localized buyer',
+            'Custom role',
+        ]];
+    }
+
+    public static function getFixtureIndexes(): iterable
+    {
+        yield from [[0], [2]];
+    }
+
+    #[DataProvider('getLanguageIds')]
+    public function testItQueriesForDataInContextLanguage(int $languageId): void
+    {
+        $this->languageContext->method('getId')->willReturn($languageId);
+
+        $this->createForm();
+
+        $this->assertSame($languageId, $this->qbLanguageId);
+    }
+
+    #[DataProvider('getChoiceLabels')]
+    public function testChoiceLabelGeneration(int $languageId, array $labels): void
+    {
+        $this->languageContext->method('getId')->willReturn($languageId);
+
+        $roles = $this->getRoles();
+        $view = $this->createForm()->createView();
+
+        $this->assertEquals([
+            1 => new ChoiceView($roles[0], '1', $labels[0]),
+            2 => new ChoiceView($roles[1], '2', $labels[1]),
+            4 => new ChoiceView($roles[2], '4', $labels[2]),
+        ], $view->vars['choices']);
+    }
+
+    #[DataProvider('getFixtureIndexes')]
+    public function testInitialDataTransformation(int $index): void
+    {
+        $role = $this->getRoles()[$index];
+        $id = $role->getIdRole();
+
+        $this->entityManager->method('find')->with(B2bRole::class, $id)->willReturn($role);
+
+        $form = $this->createForm(['input' => 'id'], $id);
+
+        $this->assertSame($role, $form->getNormData());
+        $this->assertSame((string) $id, $form->getViewData());
+    }
+
+    #[DataProvider('getFixtureIndexes')]
+    public function testValidDataSubmission(int $index): void
+    {
+        $this->submitValidData($index);
+    }
+
+    #[DataProvider('getFixtureIndexes')]
+    public function testValidDataSubmissionWithIdInput(int $index): void
+    {
+        $this->submitValidData($index, ['input' => 'id']);
+    }
+
+    private function submitValidData(int $index, array $options = []): void
+    {
+        $role = $this->getRoles()[$index];
+        $id = $role->getIdRole();
+        $expectedData = 'id' === ($options['input'] ?? null) ? $id : $role;
+
+        $form = $this->createForm($options);
+        $form->submit((string) $id);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame($expectedData, $form->getData());
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function createForm(array $options = [], mixed $data = null): FormInterface
+    {
+        return $this->factory->create(B2bRoleChoiceType::class, $data, [
+            'choices' => $this->getRoles(), // trying to mock the default QB result would be way too much trouble
+            ...$options,
+        ]);
+    }
+
+    /**
+     * @return B2bRole[]
+     */
+    private function getRoles(): array
+    {
+        return $this->roles ??= [
+            $this->createRole(1, Role::ADMIN, [
+                1 => 'Administrator',
+                2 => 'Localized admin',
+            ]),
+            $this->createRole(2, Role::BUYER, [
+                2 => 'Localized buyer',
+            ]),
+            $this->createRole(4, 'CUSTOM_ROLE'),
+        ];
+    }
+
+    /**
+     * @param array<int, string> $names
+     */
+    private function createRole(int $id, string $role, array $names = []): B2bRole
+    {
+        $entity = (new B2bRole())->setRole($role);
+        $this->classMetadata->setIdentifierValues($entity, ['id' => $id]);
+
+        foreach ($names as $languageId => $name) {
+            $entity->addTranslation(new B2bRoleLang($this->createLanguage($languageId), $name));
+        }
+
+        return $entity;
+    }
+
+    private function createLanguage(int $id): Lang
+    {
+        $language = $this->createMock(Lang::class);
+        $language->method('getId')->willReturn($id);
+
+        return $language;
+    }
+
+    private function createClassMetadata(): ClassMetadata
+    {
+        $metadata = new ClassMetadata(B2bRole::class);
+        $metadata->mapField(['fieldName' => 'id', 'id' => true, 'type' => 'integer']);
+        $metadata->wakeupReflection(new RuntimeReflectionService());
+
+        return $metadata;
+    }
+}


### PR DESCRIPTION
| Questions                  | Answers                                                                                                                                                                                                                                                                                                                                                  |                                                                                                                                                                                     
|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Branch?                    | develop                                                                                                                                                                                                                                                                                                                                                  |
| Description?               | Populates the B2B role tables with default data and introduces a B2B role choice form type.                                                                                                                                                                                                                                                              |
| Type?                      | new feature                                                                                                                                                                                                                                                                                                                                              |
| Category?                  | IN                                                                                                                                                                                                                                                                                                                                                   |
| BC breaks?                 | no                                                                                                                                                                                                                                                                                                                                                       |
| Deprecations?              | no                                                                                                                                                                                                                                                                                                                                                       |
| How to test?               | After installation the `authorization_role` table should contain additional rows corresponding to B2B customer permissions. The `b2b_role`, `b2b_role_authorization_role` and the new `b2b_role_lang` tables should be populated with data for the 3 default roles.<br/><br/>The PR includes automated tests for the new form type and data transformer. |
| UI Tests                   | https://github.com/WaynetPS/ga.tests.ui.pr/actions/runs/32701903357<br/>https://github.com/WaynetPS/ga.tests.ui.pr/actions/runs/32702300219                                                                                                                                                                                                                                                                                                                                                        |
| Fixed issue or discussion? | Fixes #42275                                                                                                                                                                                                                                                                                                                                             |
| Related PRs                | We will provide a PR to the autoupgrade module after the proposed data shape is accepted.                                                                                                                                                                                                                                                                |
| Sponsor company            | Waynet                                                                                                                                                                                                                                                                                                                                                   |

The `B2bRoleLang` entity was added to hold localized human-readable role names. I've chosen this approach over matching
the base entity's `role` property to catalogue translations because I think it will allow for easier future extension.

---

AC2 of the User Story lists 5 specific actions requiring authorization. However, after looking at the backlog,
I believe that this list may be incomplete. The PR adds 4 permissions directly corresponding to AC2:

* `ROLE_B2B_ORDER_CREATE` - order placement on behalf of the Business Entity
* `ROLE_B2B_BUSINESS_ENTITY_CUSTOMER_INVITE` - invitation of new BE members
* `ROLE_B2B_BUSINESS_ENTITY_CUSTOMER_EDIT` - modification of BE members' roles and status (I felt that splitting these into 2 separate permissions would be excessive)
* `ROLE_B2B_BUSINESS_ENTITY_CUSTOMER_DELETE` - removal of BE members

The other 2 permissions are related to backlog items:

* `ROLE_B2B_BUSINESS_ENTITY_EDIT` - modification of BE information (#41377 - clearly missing)
* `ROLE_B2B_ORDER_VIEW` - listing/viewing of BE orders (#41374 - may not be needed if Buyers can view orders placed by other members)

---

AC5 cannot be fully satisfied at this point. The selectors it mentions are delivered by later stories, so they do not
exist in the UI yet.

This PR provides a reusable form type that can be used in both the BO B2B customer creation form and the list filters
(as well as in the FO forms, once those are handled by Symfony). `B2bRoleChoiceType` extends Symfony's `EntityType`.
With default options, the form retrieves all roles along with their translations and uses the localized name
as the choice label. The `input` option allows specifying the entity ID as the model data.

The transformation between the entity and its ID is handled by `IdToEntityTransformer` - a generic, reusable
data transformer. ID input is currently incompatible with the `multiple` option since multi-choice is not needed
for any of the subsequent tasks and supporting it would require a separate transformer.

Such an optional data transformation could be generally useful in other `EntityType`-based forms, so it might be worth
exposing it via a form type extension. However, this could be a breaking change - the new option may collide with one
already defined by a third-party `EntityType` descendant or type extension. The safer alternative could be a new base
type extending `EntityType`.
