### PR TITLE
Fix crash when an email template format is missing

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2271,12 +2271,12 @@ class AdminTranslationsControllerCore extends AdminController
                     $base_uri = str_replace('//', '/', $base_uri);
                     $url_mail = $base_uri . $mail_name . '.html';
 
-                    $mail_files_html = empty($mail_files['html']) ? false : $mail_files['html'];
+                    $mail_files_html = empty($mail_files['html']) ? [] : $mail_files['html'];
                     $str_return .= '<div class="tab-pane active" id="' . $mail_name . '-html">';
                     $str_return .= $this->displayMailBlockHtml($mail_files_html, $obj_lang->iso_code, $url_mail, $mail_name, $group_name, $name_for_module);
                     $str_return .= '</div>';
 
-                    $mail_files_txt = empty($mail_files['txt']) ? false : $mail_files['txt'];
+                    $mail_files_txt = empty($mail_files['txt']) ? [] : $mail_files['txt'];
                     $str_return .= '<div class="tab-pane" id="' . $mail_name . '-text">';
                     $str_return .= $this->displayMailBlockTxt($mail_files_txt, $obj_lang->iso_code, $mail_name, $group_name, $name_for_module);
                     $str_return .= '</div>';

--- a/tests/Unit/Classes/controller/AdminTranslationsControllerTest.php
+++ b/tests/Unit/Classes/controller/AdminTranslationsControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Controller;
+
+use AdminTranslationsControllerCore;
+use Language;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class AdminTranslationsControllerTest extends TestCase
+{
+    /**
+     * @dataProvider mailFilesProvider
+     */
+    public function testDisplayMailContentSupportsMissingMailFormat(array $mailFiles): void
+    {
+        $language = (new ReflectionClass(Language::class))->newInstanceWithoutConstructor();
+        $language->iso_code = 'en';
+
+        $content = (new TestAdminTranslationsController())->displayMailContentForTest(
+            [
+                'empty_values' => 0,
+                'total_filled' => 1,
+                'directory' => _PS_ROOT_DIR_ . '/mails/',
+                'files' => ['test_mail' => $mailFiles],
+            ],
+            [],
+            $language
+        );
+
+        $this->assertStringContainsString('name="mail[html][test_mail]"', $content);
+        $this->assertStringContainsString('name="mail[txt][test_mail]"', $content);
+    }
+
+    public static function mailFilesProvider(): iterable
+    {
+        yield 'missing HTML template' => [
+            ['txt' => ['en' => 'Text content']],
+        ];
+
+        yield 'missing TXT template' => [
+            ['html' => ['en' => '<html><body>HTML content</body></html>']],
+        ];
+    }
+}
+
+class TestAdminTranslationsController extends AdminTranslationsControllerCore
+{
+    public function __construct()
+    {
+    }
+
+    public function displayMailContentForTest(array $mails, array $subjects, Language $language): string
+    {
+        return parent::displayMailContent($mails, $subjects, $language, 'mail-content', 'Mail content');
+    }
+
+    protected function trans($id, array $parameters = [], $domain = null, $locale = null)
+    {
+        return strtr($id, $parameters);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Prevents the legacy Back Office email translations page from passing `false` to methods that require an array when an email template has no HTML or TXT variant. Missing formats now use an empty array, and a unit test covers both cases.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `php vendor/bin/phpunit --configuration tests/Unit/phpunit.xml tests/Unit/Classes/controller/AdminTranslationsControllerTest.php`. Manually, open International > Translations, select Email translations and Core emails, then verify that templates with only one format render without a `TypeError`.
| UI Tests          | Not run. The missing HTML and missing TXT cases are covered by the new PHPUnit regression test.
| Fixed issue or discussion?     | Fixes #42408
| Related PRs       | None
| Sponsor company   | https://www.openservis.cz/
