### PR TITLE
Fix the Shipment domain defects that do not depend on the Admin API

### DIFF
--- a/src/Adapter/Shipment/CommandHandler/EditShipmentHandler.php
+++ b/src/Adapter/Shipment/CommandHandler/EditShipmentHandler.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Shipment\CommandHandler;
 
+use PrestaShop\PrestaShop\Adapter\Carrier\Repository\CarrierRepository;
 use PrestaShop\PrestaShop\Adapter\Configuration as AdapterConfiguration;
 use PrestaShop\PrestaShop\Adapter\Shipment\ShipmentShippingCostUpdater;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\EditShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\CommandHandler\EditShipmentHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\CannotSaveShipmentException;
@@ -28,6 +30,7 @@ class EditShipmentHandler implements EditShipmentHandlerInterface
 {
     public function __construct(
         private readonly ShipmentRepository $shipmentRepository,
+        private readonly CarrierRepository $carrierRepository,
         private TranslatorInterface $translator,
         private ShipmentShippingCostUpdater $shipmentShippingCostUpdater,
         private AdapterConfiguration $configuration,
@@ -38,12 +41,16 @@ class EditShipmentHandler implements EditShipmentHandlerInterface
      * {@inheritdoc}
      *
      * @throws ShipmentNotFoundException
+     * @throws CarrierNotFoundException
      * @throws CannotSaveShipmentException
      */
     public function handle(EditShipment $command): void
     {
         $shipmentId = $command->getShipmentId()->getValue();
         $carrierId = $command->getCarrierId()->getValue();
+
+        // There is no foreign key on the shipment table, an unknown carrier id would silently be stored
+        $this->carrierRepository->get($command->getCarrierId());
 
         try {
             /** @var Shipment|null $shipment */

--- a/src/Adapter/Shipment/CommandHandler/SwitchShipmentCarrierHandler.php
+++ b/src/Adapter/Shipment/CommandHandler/SwitchShipmentCarrierHandler.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Shipment\CommandHandler;
 
+use PrestaShop\PrestaShop\Adapter\Carrier\Repository\CarrierRepository;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\SwitchShipmentCarrierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\CommandHandler\SwitchShipmentCarrierHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\CannotSaveShipmentException;
@@ -26,6 +28,7 @@ class SwitchShipmentCarrierHandler implements SwitchShipmentCarrierHandlerInterf
 {
     public function __construct(
         private readonly ShipmentRepository $shipmentRepository,
+        private readonly CarrierRepository $carrierRepository,
         private TranslatorInterface $translator,
     ) {
     }
@@ -34,12 +37,16 @@ class SwitchShipmentCarrierHandler implements SwitchShipmentCarrierHandlerInterf
      * {@inheritdoc}
      *
      * @throws ShipmentNotFoundException
+     * @throws CarrierNotFoundException
      * @throws CannotSaveShipmentException
      */
     public function handle(SwitchShipmentCarrierCommand $command): void
     {
         $shipmentId = $command->getShipmentId()->getValue();
         $carrierId = $command->getCarrierId()->getValue();
+
+        // There is no foreign key on the shipment table, an unknown carrier id would silently be stored
+        $this->carrierRepository->get($command->getCarrierId());
 
         try {
             /** @var Shipment|null $shipment */

--- a/src/Adapter/Shipment/QueryHandler/GetShipmentForEditingHandler.php
+++ b/src/Adapter/Shipment/QueryHandler/GetShipmentForEditingHandler.php
@@ -45,7 +45,7 @@ class GetShipmentForEditingHandler implements GetShipmentForEditingHandlerInterf
             foreach ($shipmentProducts as $shipmentProduct) {
                 $shipmentDetails['selectedProducts'][
                     (new OrderDetail($shipmentProduct->getOrderDetailId()))->product_id
-                ] = 0;
+                ] = $shipmentProduct->getQuantity();
             }
         } catch (Throwable $e) {
             throw new ShipmentNotFoundException(
@@ -62,7 +62,7 @@ class GetShipmentForEditingHandler implements GetShipmentForEditingHandlerInterf
         return new ShipmentForEditing(
             $shipmentDetails['carrier'],
             $shipmentDetails['tracking_number'] ?? '',
-            $shipmentDetails['selectedProducts']
+            $shipmentDetails['selectedProducts'] ?? []
         );
     }
 }

--- a/src/Adapter/Shipment/QueryHandler/ListAvailableShipmentsForProductHandler.php
+++ b/src/Adapter/Shipment/QueryHandler/ListAvailableShipmentsForProductHandler.php
@@ -6,9 +6,11 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Shipment\QueryHandler;
 
+use PrestaShop\PrestaShop\Adapter\Order\Repository\OrderDetailRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Shop\Context as ShopContext;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotFindProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\ListAvailableShipmentsForProduct;
@@ -27,15 +29,26 @@ class ListAvailableShipmentsForProductHandler implements ListAvailableShipmentsF
         private readonly TranslatorInterface $translator,
         private readonly ShopContext $shopContext,
         private readonly ProductRepository $productRepository,
+        private readonly OrderDetailRepository $orderDetailRepository,
     ) {
     }
 
     /**
      * @return ShipmentsForProduct[]
+     *
+     * @throws CannotFindProductInOrderException
      */
     public function handle(ListAvailableShipmentsForProduct $query)
     {
         $orderId = $query->getOrderId()->getValue();
+
+        // Without this check every shipment of the order is returned for a product it does not contain
+        if ($this->orderDetailRepository->findByOrderIdAndProductId($query->getOrderId(), $query->getProductId(), null) === null) {
+            throw new CannotFindProductInOrderException(
+                sprintf('Product with id %d was not found in order %d', $query->getProductId()->getValue(), $orderId)
+            );
+        }
+
         $productInstance = $this->productRepository->get(new ProductId($query->getProductId()->getValue()), new ShopId($this->shopContext->getContextShopID()));
         $availableShipmentsForProductSelected = [];
 

--- a/src/Core/Domain/Shipment/Command/CreateShipment.php
+++ b/src/Core/Domain/Shipment/Command/CreateShipment.php
@@ -36,7 +36,7 @@ class CreateShipment
         $this->productId = new ProductId($productId);
         $this->quantity = $quantity;
         if ($combinationId > 0) {
-            $this->productCombinationId = new CombinationId($quantity);
+            $this->productCombinationId = new CombinationId($combinationId);
         }
     }
 

--- a/src/Core/Domain/Shipment/QueryResult/ShipmentForEditing.php
+++ b/src/Core/Domain/Shipment/QueryResult/ShipmentForEditing.php
@@ -32,7 +32,7 @@ class ShipmentForEditing
     }
 
     /**
-     * @return int[]
+     * @return array<int, int> Map of productId to quantity
      */
     public function getProductsIds()
     {

--- a/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
@@ -212,26 +212,44 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then the available shipments of order :orderReference for product :productReference should contain the shipment :shipmentReference
+     * @Then the available shipments of order :orderReference for product :productReference should be:
+     *
+     * @param string $orderReference
+     * @param string $productReference
+     * @param TableNode $table
      */
     public function assertAvailableShipmentsForProduct(
         string $orderReference,
         string $productReference,
-        string $shipmentReference
+        TableNode $table
     ): void {
-        $shipments = $this->getAvailableShipmentsForProduct($orderReference, $productReference);
+        $expected = [];
+        foreach ($table->getColumnsHash() as $row) {
+            $expected[] = [
+                'id' => $this->referenceToId($row['shipment']),
+                'name' => $row['name'],
+            ];
+        }
 
-        Assert::assertContains(
-            $this->referenceToId($shipmentReference),
-            array_map(static fn (ShipmentsForProduct $shipment) => $shipment->getId(), $shipments),
-            sprintf('Shipment "%s" was not listed as available for product "%s"', $shipmentReference, $productReference)
+        $actual = array_map(
+            static fn (ShipmentsForProduct $shipment) => [
+                'id' => $shipment->getId(),
+                'name' => $shipment->getName(),
+            ],
+            $this->getAvailableShipmentsForProduct($orderReference, $productReference)
+        );
+
+        Assert::assertSame(
+            $expected,
+            $actual,
+            sprintf('Wrong available shipments listed for product "%s" of order "%s"', $productReference, $orderReference)
         );
     }
 
     /**
-     * @When I list the available shipments of order :orderReference for product :productReference
+     * @When I try to list the available shipments of order :orderReference for product :productReference
      */
-    public function listAvailableShipmentsForProduct(string $orderReference, string $productReference): void
+    public function tryToListAvailableShipmentsForProduct(string $orderReference, string $productReference): void
     {
         try {
             $this->getAvailableShipmentsForProduct($orderReference, $productReference);

--- a/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
@@ -13,8 +13,11 @@ use Exception;
 use Order;
 use OrderDetail;
 use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotFindProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\CreateShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\DeleteProductFromShipment;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\EditShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\FulfillShipmentCommand;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\MergeProductsToShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\SplitShipment;
@@ -27,9 +30,11 @@ use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentProducts;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentsForOrderDetail;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\ListAvailableShipments;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\ListAvailableShipmentsForProduct;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\ShipmentForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\ShipmentForOrderDetail;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\ShipmentForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\ShipmentsForProduct;
 use PrestaShopBundle\Entity\Repository\ShipmentRepository;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
@@ -181,6 +186,101 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
             $selectedQuantities,
             sprintf('Wrong selected products reported by the edit view of shipment "%s"', $shipmentReference)
         );
+    }
+
+    /**
+     * @When I try to switch the carrier for shipment :shipmentReference to a carrier that does not exist
+     */
+    public function switchShipmentCarrierToUnknownCarrier(string $shipmentReference): void
+    {
+        $shipmentId = SharedStorage::getStorage()->get($shipmentReference);
+
+        try {
+            $this->getCommandBus()->handle(new SwitchShipmentCarrierCommand($shipmentId, 999999));
+        } catch (Exception $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I try to edit the shipment :shipmentReference with a carrier that does not exist
+     */
+    public function editShipmentWithUnknownCarrier(string $shipmentReference): void
+    {
+        $shipmentId = SharedStorage::getStorage()->get($shipmentReference);
+
+        try {
+            $this->getCommandBus()->handle(new EditShipment($shipmentId, 999999));
+        } catch (Exception $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then I should get an error that the carrier was not found
+     */
+    public function assertCarrierNotFoundException(): void
+    {
+        $this->assertLastErrorIs(CarrierNotFoundException::class);
+    }
+
+    /**
+     * @Then the available shipments of order :orderReference for the ordered product :productName should contain the shipment :shipmentReference
+     */
+    public function assertAvailableShipmentsForOrderedProduct(
+        string $orderReference,
+        string $productName,
+        string $shipmentReference
+    ): void {
+        $orderId = $this->referenceToId($orderReference);
+
+        $productId = 0;
+        foreach ((new Order($orderId))->getOrderDetailList() as $orderDetail) {
+            if ($orderDetail['product_name'] === $productName) {
+                $productId = (int) $orderDetail['product_id'];
+                break;
+            }
+        }
+
+        Assert::assertNotSame(
+            0,
+            $productId,
+            sprintf('Product "%s" was not found in order "%s"', $productName, $orderReference)
+        );
+
+        /** @var ShipmentsForProduct[] $shipments */
+        $shipments = $this->getQueryBus()->handle(
+            new ListAvailableShipmentsForProduct($orderId, $productId)
+        );
+
+        Assert::assertContains(
+            SharedStorage::getStorage()->get($shipmentReference),
+            array_map(static fn (ShipmentsForProduct $shipment) => $shipment->getId(), $shipments),
+            sprintf('Shipment "%s" was not listed as available for product "%s"', $shipmentReference, $productName)
+        );
+    }
+
+    /**
+     * @When I list the available shipments of order :orderReference for product :productReference
+     */
+    public function listAvailableShipmentsForProduct(string $orderReference, string $productReference): void
+    {
+        try {
+            $this->getQueryBus()->handle(new ListAvailableShipmentsForProduct(
+                $this->referenceToId($orderReference),
+                $this->referenceToId($productReference)
+            ));
+        } catch (Exception $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then I should get an error that the product was not found in the order
+     */
+    public function assertCannotFindProductInOrderException(): void
+    {
+        $this->assertLastErrorIs(CannotFindProductInOrderException::class);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
@@ -225,9 +225,12 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
     ): void {
         $expected = [];
         foreach ($table->getColumnsHash() as $row) {
+            $shipmentId = $this->referenceToId($row['shipment']);
             $expected[] = [
-                'id' => $this->referenceToId($row['shipment']),
-                'name' => $row['name'],
+                'id' => $shipmentId,
+                // the shipment id is assigned by the database, so the expected name carries a
+                // placeholder rather than a literal that would only hold for one fixture state
+                'name' => str_replace('{shipmentId}', (string) $shipmentId, $row['name']),
             ];
         }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
@@ -153,29 +153,16 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertShipmentForEditing(string $shipmentReference, string $orderReference, TableNode $table): void
     {
-        $orderId = $this->referenceToId($orderReference);
-        $shipmentId = SharedStorage::getStorage()->get($shipmentReference);
-
         /** @var ShipmentForEditing $shipment */
         $shipment = $this->getQueryBus()->handle(
-            new GetShipmentForEditing($orderId, $shipmentId)
+            new GetShipmentForEditing($this->referenceToId($orderReference), $this->referenceToId($shipmentReference))
         );
 
         $selectedQuantities = $shipment->getProductsIds();
 
-        $productNames = [];
-        foreach ((new Order($orderId))->getOrderDetailList() as $orderDetail) {
-            $productNames[(int) $orderDetail['product_id']] = $orderDetail['product_name'];
-        }
-
         $expectedQuantities = [];
         foreach ($table->getColumnsHash() as $row) {
-            $productId = array_search($row['product_name'], $productNames, true);
-            Assert::assertNotFalse(
-                $productId,
-                sprintf('Product "%s" was not found in order "%s"', $row['product_name'], $orderReference)
-            );
-            $expectedQuantities[$productId] = (int) $row['quantity'];
+            $expectedQuantities[$this->referenceToId($row['product'])] = (int) $row['quantity'];
         }
 
         ksort($expectedQuantities);
@@ -193,10 +180,10 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
      */
     public function switchShipmentCarrierToUnknownCarrier(string $shipmentReference): void
     {
-        $shipmentId = SharedStorage::getStorage()->get($shipmentReference);
-
         try {
-            $this->getCommandBus()->handle(new SwitchShipmentCarrierCommand($shipmentId, 999999));
+            $this->getCommandBus()->handle(
+                new SwitchShipmentCarrierCommand($this->referenceToId($shipmentReference), 999999)
+            );
         } catch (Exception $e) {
             $this->setLastException($e);
         }
@@ -207,10 +194,10 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
      */
     public function editShipmentWithUnknownCarrier(string $shipmentReference): void
     {
-        $shipmentId = SharedStorage::getStorage()->get($shipmentReference);
-
         try {
-            $this->getCommandBus()->handle(new EditShipment($shipmentId, 999999));
+            $this->getCommandBus()->handle(
+                new EditShipment($this->referenceToId($shipmentReference), 999999)
+            );
         } catch (Exception $e) {
             $this->setLastException($e);
         }
@@ -225,38 +212,19 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then the available shipments of order :orderReference for the ordered product :productName should contain the shipment :shipmentReference
+     * @Then the available shipments of order :orderReference for product :productReference should contain the shipment :shipmentReference
      */
-    public function assertAvailableShipmentsForOrderedProduct(
+    public function assertAvailableShipmentsForProduct(
         string $orderReference,
-        string $productName,
+        string $productReference,
         string $shipmentReference
     ): void {
-        $orderId = $this->referenceToId($orderReference);
-
-        $productId = 0;
-        foreach ((new Order($orderId))->getOrderDetailList() as $orderDetail) {
-            if ($orderDetail['product_name'] === $productName) {
-                $productId = (int) $orderDetail['product_id'];
-                break;
-            }
-        }
-
-        Assert::assertNotSame(
-            0,
-            $productId,
-            sprintf('Product "%s" was not found in order "%s"', $productName, $orderReference)
-        );
-
-        /** @var ShipmentsForProduct[] $shipments */
-        $shipments = $this->getQueryBus()->handle(
-            new ListAvailableShipmentsForProduct($orderId, $productId)
-        );
+        $shipments = $this->getAvailableShipmentsForProduct($orderReference, $productReference);
 
         Assert::assertContains(
-            SharedStorage::getStorage()->get($shipmentReference),
+            $this->referenceToId($shipmentReference),
             array_map(static fn (ShipmentsForProduct $shipment) => $shipment->getId(), $shipments),
-            sprintf('Shipment "%s" was not listed as available for product "%s"', $shipmentReference, $productName)
+            sprintf('Shipment "%s" was not listed as available for product "%s"', $shipmentReference, $productReference)
         );
     }
 
@@ -266,13 +234,21 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
     public function listAvailableShipmentsForProduct(string $orderReference, string $productReference): void
     {
         try {
-            $this->getQueryBus()->handle(new ListAvailableShipmentsForProduct(
-                $this->referenceToId($orderReference),
-                $this->referenceToId($productReference)
-            ));
+            $this->getAvailableShipmentsForProduct($orderReference, $productReference);
         } catch (Exception $e) {
             $this->setLastException($e);
         }
+    }
+
+    /**
+     * @return ShipmentsForProduct[]
+     */
+    private function getAvailableShipmentsForProduct(string $orderReference, string $productReference): array
+    {
+        return $this->getQueryBus()->handle(new ListAvailableShipmentsForProduct(
+            $this->referenceToId($orderReference),
+            $this->referenceToId($productReference)
+        ));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
@@ -22,10 +22,12 @@ use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\SwitchShipmentCarrierComm
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\InvalidShipmentTrackingNumberException;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetOrderShipments;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentProducts;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentsForOrderDetail;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\ListAvailableShipments;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\ShipmentForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\ShipmentForOrderDetail;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\ShipmentForViewing;
 use PrestaShopBundle\Entity\Repository\ShipmentRepository;
@@ -135,6 +137,50 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
             Assert::assertEquals($shipmentProducts[$i]->getQuantity(), (int) $data[$i]['quantity']);
             Assert::assertEquals($shipmentProducts[$i]->getProductName(), $data[$i]['product_name']);
         }
+    }
+
+    /**
+     * @Then the shipment :shipmentReference of order :orderReference should be editable with the following products:
+     *
+     * @param string $shipmentReference
+     * @param string $orderReference
+     * @param TableNode $table
+     */
+    public function assertShipmentForEditing(string $shipmentReference, string $orderReference, TableNode $table): void
+    {
+        $orderId = $this->referenceToId($orderReference);
+        $shipmentId = SharedStorage::getStorage()->get($shipmentReference);
+
+        /** @var ShipmentForEditing $shipment */
+        $shipment = $this->getQueryBus()->handle(
+            new GetShipmentForEditing($orderId, $shipmentId)
+        );
+
+        $selectedQuantities = $shipment->getProductsIds();
+
+        $productNames = [];
+        foreach ((new Order($orderId))->getOrderDetailList() as $orderDetail) {
+            $productNames[(int) $orderDetail['product_id']] = $orderDetail['product_name'];
+        }
+
+        $expectedQuantities = [];
+        foreach ($table->getColumnsHash() as $row) {
+            $productId = array_search($row['product_name'], $productNames, true);
+            Assert::assertNotFalse(
+                $productId,
+                sprintf('Product "%s" was not found in order "%s"', $row['product_name'], $orderReference)
+            );
+            $expectedQuantities[$productId] = (int) $row['quantity'];
+        }
+
+        ksort($expectedQuantities);
+        ksort($selectedQuantities);
+
+        Assert::assertSame(
+            $expectedQuantities,
+            $selectedQuantities,
+            sprintf('Wrong selected products reported by the edit view of shipment "%s"', $shipmentReference)
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
@@ -25,6 +25,8 @@ Feature: Retrieving shipment for orders
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
     And I reference order "bo_order1" delivery address as "US"
+    And there is a product "mug_best" with name "Mug The best is yet to come"
+    And there is a product "mug_today" with name "Mug Today is a good day"
 
   Scenario: Retrieve shipmets for existing order
     Given the order "bo_order1" should have the following shipments:
@@ -40,9 +42,9 @@ Feature: Retrieving shipment for orders
       | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
       | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
     Then the shipment "shipment1" of order "bo_order1" should be editable with the following products:
-      | product_name                | quantity |
-      | Mug The best is yet to come |        1 |
-      | Mug Today is a good day     |        2 |
+      | product   | quantity |
+      | mug_best  |        1 |
+      | mug_today |        2 |
 
   Scenario: Switch shipment carrier
     Given the order "bo_order1" should have the following shipments:
@@ -89,7 +91,7 @@ Feature: Retrieving shipment for orders
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
       | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
-    Then the available shipments of order "bo_order1" for the ordered product "Mug The best is yet to come" should contain the shipment "shipment1"
+    Then the available shipments of order "bo_order1" for product "mug_best" should contain the shipment "shipment1"
 
   Scenario: List the available shipments of a product that is not in the order
     Given the order "bo_order1" should have the following shipments:

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
@@ -92,8 +92,8 @@ Feature: Retrieving shipment for orders
       | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
       | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
     Then the available shipments of order "bo_order1" for product "mug_best" should be:
-      | shipment  | name       |
-      | shipment1 | Shipment 1 |
+      | shipment  | name                  |
+      | shipment1 | Shipment {shipmentId} |
 
   Scenario: List the available shipments of a product that is not in the order
     Given the order "bo_order1" should have the following shipments:

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
@@ -35,6 +35,15 @@ Feature: Retrieving shipment for orders
       | Mug The best is yet to come |        1 |
       | Mug Today is a good day     |        2 |
 
+  Scenario: Retrieve shipment for editing
+    Given the order "bo_order1" should have the following shipments:
+      | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
+      | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
+    Then the shipment "shipment1" of order "bo_order1" should be editable with the following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come |        1 |
+      | Mug Today is a good day     |        2 |
+
   Scenario: Switch shipment carrier
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
@@ -91,7 +91,9 @@ Feature: Retrieving shipment for orders
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
       | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
-    Then the available shipments of order "bo_order1" for product "mug_best" should contain the shipment "shipment1"
+    Then the available shipments of order "bo_order1" for product "mug_best" should be:
+      | shipment  | name       |
+      | shipment1 | Shipment 1 |
 
   Scenario: List the available shipments of a product that is not in the order
     Given the order "bo_order1" should have the following shipments:
@@ -100,7 +102,7 @@ Feature: Retrieving shipment for orders
     And I add product "product_not_ordered" with following information:
       | name[en-US] | Product not ordered |
       | type        | standard            |
-    When I list the available shipments of order "bo_order1" for product "product_not_ordered"
+    When I try to list the available shipments of order "bo_order1" for product "product_not_ordered"
     Then I should get an error that the product was not found in the order
 
   Scenario: Edit a shipment with a carrier that does not exist

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
@@ -85,6 +85,36 @@ Feature: Retrieving shipment for orders
       | shipment1    | default_carrier |                 | US      |                    7.0 |                   7.42 |
       | new_shipment | default_carrier |                 | US      |                    7.0 |                   7.42 |
 
+  Scenario: List the available shipments of a product of the order
+    Given the order "bo_order1" should have the following shipments:
+      | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
+      | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
+    Then the available shipments of order "bo_order1" for the ordered product "Mug The best is yet to come" should contain the shipment "shipment1"
+
+  Scenario: List the available shipments of a product that is not in the order
+    Given the order "bo_order1" should have the following shipments:
+      | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
+      | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
+    And I add product "product_not_ordered" with following information:
+      | name[en-US] | Product not ordered |
+      | type        | standard            |
+    When I list the available shipments of order "bo_order1" for product "product_not_ordered"
+    Then I should get an error that the product was not found in the order
+
+  Scenario: Edit a shipment with a carrier that does not exist
+    Given the order "bo_order1" should have the following shipments:
+      | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
+      | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
+    When I try to edit the shipment "shipment1" with a carrier that does not exist
+    Then I should get an error that the carrier was not found
+
+  Scenario: Switch shipment carrier to a carrier that does not exist
+    Given the order "bo_order1" should have the following shipments:
+      | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
+      | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
+    When I try to switch the carrier for shipment "shipment1" to a carrier that does not exist
+    Then I should get an error that the carrier was not found
+
   Scenario: Retrieve shipment for viewing
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |

--- a/tests/Unit/Core/Domain/Shipment/Command/CreateShipmentTest.php
+++ b/tests/Unit/Core/Domain/Shipment/Command/CreateShipmentTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Shipment\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\CreateShipment;
+
+class CreateShipmentTest extends TestCase
+{
+    public function testCombinationIdIsBuiltFromTheCombinationArgument(): void
+    {
+        $command = new CreateShipment(1, 2, 3, 7, 42);
+
+        $this->assertNotNull($command->getProductCombinationId());
+        $this->assertSame(42, $command->getProductCombinationId()->getValue());
+        $this->assertSame(7, $command->getQuantity());
+    }
+
+    /**
+     * @dataProvider provideEmptyCombinationIds
+     */
+    public function testNoCombinationIsBuiltWhenNoneIsProvided(?int $combinationId): void
+    {
+        $command = new CreateShipment(1, 2, 3, 7, $combinationId);
+
+        $this->assertNull($command->getProductCombinationId());
+    }
+
+    /**
+     * @return iterable<string, array{0: int|null}>
+     */
+    public static function provideEmptyCombinationIds(): iterable
+    {
+        yield 'null' => [null];
+        yield 'zero' => [0];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Fixes the Shipment domain defects that do not depend on the Admin API: the edit view reporting every quantity as 0, the combination built from the wrong argument, and three missing validations (carrier existence on edit and switch, product belonging to the order).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the `improved_shipment` feature flag, open an order with several units of a product, edit one of its shipments and check the carrier list. Behat: `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shipment --tags shipment`
| UI Tests          | :green_circle: https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/33375882160
| Fixed issue or discussion?     | #42410
| Related PRs       | #42092
| Sponsor company   | @PrestaShopCorp

Fixes #42410

Both fixes were authored by @nicosomb inside #42092, which adds the Shipment Admin API endpoints. That PR is on hold while the maturity of the write side of the domain is discussed in #42397, so these two are extracted here: they stand on their own and one of them affects the back office, not only the API.

### Why the first one matters outside the API

`EditShipmentFormDataProvider::getData()` returns `$shipment->toArray()`, which carries `selectedProducts` into `EditShipmentType`:

```php
'choices' => $this->availableCarriersForShipmentChoiceProvider->getChoices([
    'selectedProducts' => $data['selectedProducts'],
    ...
])
```

and the choice provider turns it into the basket used to resolve available carriers:

```php
foreach ($options['selectedProducts'] as $productId => $quantity) {
    $productQuantities[] = new ProductQuantity(new ProductId($productId), (int) $quantity);
}
$carriers = $this->commandBus->handle(new GetAvailableCarriers($productQuantities, ...));
```

With every quantity at 0 the carrier list is computed from an empty basket, so it can offer carriers that cannot handle what the shipment really holds. How visible that is depends on the shop's carrier ranges; with a single unbounded range nothing changes.

### Tests

- `Scenario: Retrieve shipment for editing` asserts the full product to quantity map returned by the query, so a regression to `0` fails the suite.
- `CreateShipmentTest` pins the combination argument. Checked it fails against the old code: `Failed asserting that 7 is identical to 42`.






