### PR TITLE
Add a weekly AI triage agent to pre-qualify issues and PRs

### DIFF
--- a/.github/triage-agent/.gitignore
+++ b/.github/triage-agent/.gitignore
@@ -1,0 +1,3 @@
+# Pipeline output: regenerated on every run, never reviewed as source.
+out/
+__pycache__/

--- a/.github/triage-agent/README.md
+++ b/.github/triage-agent/README.md
@@ -115,6 +115,14 @@ item pays for it and the rest read it back at a tenth of the price.
 `render.py` prints the real figure from the run's own `usage` at the bottom of
 every summary. Trust that over this paragraph.
 
+## Sample output
+
+[`samples/2026-08-18-summary.md`](samples/2026-08-18-summary.md) is a real
+week rendered by this pipeline. Read
+[`samples/README.md`](samples/README.md) first — the verdicts in it were
+hand-applied from the rubrics rather than produced by a model run, so it
+shows the shape of the output and not the quality of the classification.
+
 ## Known limits
 
 - **The weekly window cannot surface a long-stalled PR.** Selecting on

--- a/.github/triage-agent/README.md
+++ b/.github/triage-agent/README.md
@@ -1,0 +1,133 @@
+# Weekly triage agent
+
+Ranks the past week's issues and pull requests so the sheriff reads a sorted
+list instead of the whole tracker. Runs from
+[`cron_weekly_triage_agent.yml`](../workflows/cron_weekly_triage_agent.yml)
+every Monday.
+
+**It proposes; it never decides.** The workflow holds no write scope on GitHub
+— no label is applied, no board field is set, no comment is posted. The output
+is a job summary, a Slack message, and a JSON artifact.
+
+Built for the spike in
+[#42138](https://github.com/PrestaShop/PrestaShop/issues/42138).
+
+## The pipeline
+
+Four stages, each writing a file into `out/`. They are separate on purpose: the
+prompt is the part that needs iterating, and re-running stage 2 against a frozen
+`week.json` costs nothing and changes nothing upstream.
+
+| Stage | Command | Writes | Calls the API |
+|---|---|---|---|
+| Collect | `python collect.py --since 7d` | `out/week.json` | no |
+| Classify | `python classify.py` | `out/classified.json` | yes, one request per item |
+| Render | `python render.py` | `out/summary.md`, `out/slack.json`, `out/board.json` | no |
+| Publish | `python publish.py --publish` | Slack | no |
+
+```bash
+pip install -r requirements.txt
+export ANTHROPIC_API_KEY=...          # stage 2 only
+python collect.py --since 7d
+python classify.py --limit 5          # eyeball a few before paying for the lot
+python classify.py
+python render.py
+python publish.py                     # dry run; add --publish to actually post
+```
+
+`collect.py` needs an authenticated `gh`; every other GitHub read goes through
+it.
+
+## What the model is asked
+
+Two rubrics, in `prompts/`:
+
+- [`severity_system.md`](prompts/severity_system.md) — the project's [official
+  severity classification](https://build.prestashop-project.org/news/2019/severity-classification/)
+  reproduced verbatim, then the project-specific reading of its
+  "percentage of users" thresholds, the clauses that override them (security,
+  data loss, broken E2E, law compliance, money), and how to judge a workaround.
+  This file is the substance of the spike.
+- [`pr_triage_system.md`](prompts/pr_triage_system.md) — severity does not apply
+  to a PR, so this one ranks *sheriff attention needed* and, above all, who the
+  PR is actually waiting on.
+
+`prompts/severity_examples.md` holds 24 worked examples (6 per level) mined from
+closed issues the maintainers labelled themselves. It is generated, not written
+by hand — see below — and `classify.py` appends it to the rubric inside the same
+cached block.
+
+Output shapes live in [`prompts/schemas.json`](prompts/schemas.json) and are
+enforced as structured outputs, so nothing downstream parses free text.
+
+## Iterating on a prompt
+
+```bash
+python collect.py --since 7d      # once
+vim prompts/severity_system.md
+python classify.py --limit 5      # cheap loop
+python render.py && less out/summary.md
+```
+
+Two things to watch when editing:
+
+- **Keep per-item content out of the system prompt.** Anything that varies
+  between items belongs in the user message. Put it in the rubric and the cache
+  is invalidated on every single call — `classify.py` warns when a multi-item
+  run reports zero cache reads.
+- **Order matters for caching.** The stable rubric comes first, the mined
+  examples after it, and the single `cache_control` breakpoint sits at the end
+  of both.
+
+## Calibration
+
+`calibrate.py` answers "how often does the rubric agree with the maintainers?"
+using the ~2 300 closed issues that carry exactly one severity label. There is
+no fine-tuning: the corpus is split once, deterministically, into a pool that
+few-shot examples are mined from and a held-out set that is scored against.
+
+```bash
+python calibrate.py fetch     # ~2 300 issues, sharded by year, several minutes
+python calibrate.py mine      # regenerates prompts/severity_examples.md
+python calibrate.py eval      # Batch API, 50% cost, writes out/eval.md
+```
+
+Run `mine` again after changing the split or the corpus; the examples file is
+committed so a normal run does not need the corpus.
+
+Read the confusion matrix, not the headline percentage. The corpus is heavily
+imbalanced (68 Critical against 1 378 Minor), so plain accuracy looks good
+while saying nothing. The numbers that matter are **Critical recall** — a
+Critical proposed as Minor is an issue the sheriff never sees ranked — and the
+**off-by-one rate**, since a Major proposed as Critical costs one glance and
+nothing more.
+
+The ground truth is five years of labels from many different people, so this
+measures agreement with past practice rather than correctness.
+
+## Cost
+
+Roughly **$2–3 per week** at the observed volume (~20 issues and ~80 PRs), which
+is a little over $100 a year. The rubric plus examples is ~7 500 tokens and is
+identical for every item in a run, so caching does most of the work: the first
+item pays for it and the rest read it back at a tenth of the price.
+
+`render.py` prints the real figure from the run's own `usage` at the bottom of
+every summary. Trust that over this paragraph.
+
+## Known limits
+
+- **The weekly window cannot surface a long-stalled PR.** Selecting on
+  `updated:>=D-7` means a PR nobody has touched for eight months is invisible
+  precisely because nobody touched it. This list is for what moved, not for what
+  is rotting; finding the latter needs a separate query.
+- **Duplicate detection is only as good as the candidate search.** The model may
+  only pick from a keyword-search shortlist supplied by `collect.py`, which
+  makes it unable to invent an issue number but also unable to find a duplicate
+  that shares no title keywords.
+- **PR classification reads metadata, not diffs.** It can say a PR has been
+  waiting on a reviewer for a month; it cannot say whether the change is any
+  good.
+- **Severity is proposed from the report, not from a reproduction.** An
+  overstated report and a genuine Critical read alike on paper. That is what
+  `TBR` and the confidence field are for.

--- a/.github/triage-agent/README.md
+++ b/.github/triage-agent/README.md
@@ -131,6 +131,8 @@ week rendered by this pipeline. Read
 [`samples/README.md`](samples/README.md) first — the verdicts in it were
 hand-applied from the rubrics rather than produced by a model run, so it
 shows the shape of the output and not the quality of the classification.
+Its producer is committed next to it, and `collect.py --until` makes the
+window reproducible.
 
 ## Known limits
 

--- a/.github/triage-agent/README.md
+++ b/.github/triage-agent/README.md
@@ -48,6 +48,15 @@ Two rubrics, in `prompts/`:
   "percentage of users" thresholds, the clauses that override them (security,
   data loss, broken E2E, law compliance, money), and how to judge a workaround.
   This file is the substance of the spike.
+
+  It also encodes the boundary the QA team draws in [how issues are
+  sorted](https://www.prestashop-project.org/get-involved/report-issues/how-issues-are-sorted/):
+  **severity is proposed, priority never is.** Severity is a property of the bug
+  and readable from the report; priority is set by Development, Product
+  Management and QA together against deadlines the agent cannot see. What the
+  agent can usefully hand that meeting is whether the bug is a *regression*,
+  which is why `looks_like_regression` is a field of its own and is kept
+  independent of severity — a trivial regression is still Trivial.
 - [`pr_triage_system.md`](prompts/pr_triage_system.md) — severity does not apply
   to a PR, so this one ranks *sheriff attention needed* and, above all, who the
   PR is actually waiting on.

--- a/.github/triage-agent/calibrate.py
+++ b/.github/triage-agent/calibrate.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Offline evaluation - how often does the rubric agree with the maintainers?
+
+This is what turns "we could train the agent on 5 years of issues" into
+something measurable. There is no fine-tuning involved: the closed, labelled
+issues serve two purposes, as a pool to mine few-shot examples from and as a
+held-out set to score against.
+
+Three subcommands:
+
+    fetch    pull closed issues carrying exactly one severity label
+    mine     pick few-shot examples from the pool half
+    eval     classify the held-out half through the Batch API and score it
+
+Not part of the weekly workflow. Run it once to produce the numbers that decide
+whether the weekly output is worth reading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import random
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+SEVERITIES = ["Critical", "Major", "Minor", "Trivial"]
+SEVERITY_RANK = {level: index for index, level in enumerate(SEVERITIES)}
+
+REPO = "PrestaShop/PrestaShop"
+
+# The eval set is stratified rather than random. A random 400 out of 2 732 would
+# contain roughly 10 Criticals, which is far too few to say anything about the
+# class that actually matters.
+EVAL_PER_CLASS = 100
+FEWSHOT_PER_CLASS = 6
+
+# Deterministic split, so re-running the evaluation after a prompt change
+# compares like with like instead of reshuffling the ground under it.
+SPLIT_SEED = 42
+
+
+def run_gh(args: list[str], retries: int = 5) -> str:
+    """Call gh, backing off when the search API's secondary rate limit trips.
+
+    The search endpoint is throttled far more aggressively than the core API,
+    and a corpus-wide fetch is exactly the shape that trips it. Backing off is
+    the difference between a run that finishes and a run that dies two thirds
+    of the way through.
+    """
+    for attempt in range(retries):
+        result = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, check=False
+        )
+        if result.returncode == 0:
+            return result.stdout
+
+        stderr = result.stderr.strip()
+        rate_limited = "rate limit" in stderr.lower() or "403" in stderr
+        if not rate_limited or attempt == retries - 1:
+            raise RuntimeError(f"gh failed: {stderr}")
+
+        wait = 30 * (attempt + 1)
+        print(f"    rate limited, waiting {wait}s...", file=sys.stderr)
+        time.sleep(wait)
+
+    raise RuntimeError("unreachable")
+
+
+def fetch(args: argparse.Namespace) -> int:
+    """Pull closed issues that carry exactly one severity label.
+
+    Sharded by year on purpose: GitHub's search API returns at most 1000
+    results per query, and `Minor` alone exceeds that over five years. Without
+    the shard the corpus would come back silently truncated and the class
+    balance would be wrong.
+    """
+    corpus: list[dict] = []
+    start_year = int(args.since[:4])
+    end_year = datetime.now(timezone.utc).year
+
+    for severity in SEVERITIES:
+        others = [s for s in SEVERITIES if s != severity]
+        exclusions = " ".join(f"-label:{other}" for other in others)
+        found = 0
+
+        for year in range(start_year, end_year + 1):
+            query = (
+                f"repo:{REPO} is:issue is:closed label:{severity} {exclusions} "
+                f"created:{year}-01-01..{year}-12-31"
+            )
+            page = 1
+            while page <= 10:
+                raw = run_gh([
+                    "api", "-X", "GET", "search/issues",
+                    "-f", f"q={query}",
+                    "-F", "per_page=100",
+                    "-F", f"page={page}",
+                    "--jq", ".items[] | {number, title, body, labels: [.labels[].name]}",
+                ])
+                lines = [line for line in raw.strip().splitlines() if line]
+                if not lines:
+                    break
+                for line in lines:
+                    item = json.loads(line)
+                    item["truth"] = severity
+                    item["year"] = year
+                    corpus.append(item)
+                    found += 1
+                if len(lines) < 100:
+                    break
+                page += 1
+                time.sleep(3)
+            time.sleep(3)
+
+        print(f"  {found} {severity}", file=sys.stderr)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(corpus, indent=2, ensure_ascii=False))
+    print(f"\nWrote {args.out}: {len(corpus)} issues", file=sys.stderr)
+    return 0
+
+
+def split_corpus(corpus: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Stratified, deterministic split into a few-shot pool and an eval set."""
+    by_class: dict[str, list[dict]] = collections.defaultdict(list)
+    for item in corpus:
+        by_class[item["truth"]].append(item)
+
+    rng = random.Random(SPLIT_SEED)
+    pool: list[dict] = []
+    evaluation: list[dict] = []
+
+    for severity in SEVERITIES:
+        items = sorted(by_class[severity], key=lambda i: i["number"])
+        rng.shuffle(items)
+        take = min(EVAL_PER_CLASS, len(items) // 2)
+        evaluation.extend(items[:take])
+        pool.extend(items[take:])
+
+    return pool, evaluation
+
+
+# The issue template's fixed preamble is the same on every report and carries no
+# signal. Left in, it would be roughly a third of every mined example.
+BOILERPLATE = re.compile(
+    r"###?\s*Prerequisites.*?(?=###?\s*(?:Describe|Expected|Steps|Additional)|$)",
+    re.IGNORECASE | re.DOTALL,
+)
+CHECKBOX = re.compile(r"-\s*\[[xX ]\]\s*[^\n]*", re.MULTILINE)
+HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+IMAGE_MD = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+
+
+def strip_boilerplate(body: str) -> str:
+    """Drop the parts of an issue body that are identical on every report."""
+    body = HTML_COMMENT.sub(" ", body or "")
+    body = BOILERPLATE.sub(" ", body)
+    body = CHECKBOX.sub(" ", body)
+    body = IMAGE_MD.sub("[screenshot]", body)
+    return " ".join(body.split())
+
+
+def mine(args: argparse.Namespace) -> int:
+    """Pick few-shot examples from the pool half only.
+
+    Drawing examples from the eval half would leak the answers and make the
+    accuracy number meaningless.
+    """
+    corpus = json.loads(args.corpus.read_text())
+    pool, evaluation = split_corpus(corpus)
+
+    rng = random.Random(SPLIT_SEED)
+    chosen: list[dict] = []
+
+    for severity in SEVERITIES:
+        candidates = [item for item in pool if item["truth"] == severity]
+        # Prefer reports with enough text to be worth showing as an example.
+        candidates = [
+            c for c in candidates
+            if len(strip_boilerplate(c.get("body") or "")) > 200
+        ]
+        rng.shuffle(candidates)
+        chosen.extend(candidates[:FEWSHOT_PER_CLASS])
+
+    lines = [
+        "# Worked examples",
+        "",
+        "Real issues from this repository, with the severity the maintainers",
+        "actually applied. Use them to calibrate the boundaries - especially",
+        "Critical vs Major, where the workaround question decides it.",
+        "",
+    ]
+    for item in chosen:
+        body = strip_boilerplate(item.get("body") or "")[:600]
+        lines += [
+            f"## {item['truth']} — {item['title']}",
+            "",
+            body or "_(no description)_",
+            "",
+        ]
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text("\n".join(lines))
+    print(
+        f"Wrote {args.out}: {len(chosen)} examples mined from a pool of "
+        f"{len(pool)} (eval set held out: {len(evaluation)})",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def eval_set(args: argparse.Namespace) -> int:
+    """Score the rubric against the held-out set via the Batch API."""
+    # Imported here rather than at module scope so that `fetch` and `mine`,
+    # which need nothing but the gh CLI, run without the SDK installed.
+    import anthropic
+
+    import classify
+
+    corpus = json.loads(args.corpus.read_text())
+    _, evaluation = split_corpus(corpus)
+    if args.limit:
+        evaluation = evaluation[: args.limit]
+
+    schemas = classify.load_schemas()
+    system = classify.system_blocks("severity_system.md")
+    client = anthropic.Anthropic()
+
+    requests = []
+    for item in evaluation:
+        rendered = classify.render_issue({
+            "number": item["number"],
+            "title": item["title"],
+            "url": f"https://github.com/{REPO}/issues/{item['number']}",
+            "body": classify.truncate_body(item.get("body")),
+            "author": "unknown",
+            "author_association": "NONE",
+            "labels": [],
+            "milestone": None,
+            "created_at": "unknown",
+            "updated_at": "unknown",
+            "days_since_update": 0,
+            "is_new_this_week": False,
+            "comment_count": 0,
+            "reactions": 0,
+            "recent_comments": [],
+            "duplicate_candidates_pool": [],
+        })
+        requests.append({
+            "custom_id": f"issue-{item['number']}",
+            "params": {
+                "model": classify.MODEL,
+                "max_tokens": classify.MAX_TOKENS,
+                "system": system,
+                "thinking": {"type": "adaptive"},
+                "output_config": {"effort": classify.EFFORT, "format": schemas["issue"]},
+                "messages": [{"role": "user", "content": rendered}],
+            },
+        })
+
+    print(f"Submitting {len(requests)} requests as a batch...", file=sys.stderr)
+    batch = client.messages.batches.create(requests=requests)
+    print(f"  batch id: {batch.id}", file=sys.stderr)
+
+    while True:
+        batch = client.messages.batches.retrieve(batch.id)
+        if batch.processing_status == "ended":
+            break
+        print(f"  status: {batch.processing_status}, waiting...", file=sys.stderr)
+        time.sleep(30)
+
+    # Results arrive in arbitrary order; key by custom_id, never by position.
+    predictions: dict[int, str] = {}
+    errors = 0
+    for result in client.messages.batches.results(batch.id):
+        number = int(result.custom_id.split("-", 1)[1])
+        if result.result.type != "succeeded":
+            errors += 1
+            continue
+        try:
+            verdict = classify.extract_json(result.result.message)
+            predictions[number] = verdict["severity"]
+        except (ValueError, KeyError, RuntimeError):
+            errors += 1
+
+    report = score(evaluation, predictions, errors)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(report)
+    print(f"\nWrote {args.out}", file=sys.stderr)
+    print(report)
+    return 0
+
+
+def score(evaluation: list[dict], predictions: dict[int, str], errors: int) -> str:
+    matrix: dict[tuple[str, str], int] = collections.Counter()
+    scored = 0
+
+    for item in evaluation:
+        predicted = predictions.get(item["number"])
+        if predicted is None:
+            continue
+        matrix[(item["truth"], predicted)] += 1
+        scored += 1
+
+    if not scored:
+        return "# Calibration\n\nNo items scored.\n"
+
+    exact = sum(matrix[(level, level)] for level in SEVERITIES)
+    off_by_one = sum(
+        count
+        for (truth, predicted), count in matrix.items()
+        if abs(SEVERITY_RANK[truth] - SEVERITY_RANK[predicted]) == 1
+    )
+
+    lines = [
+        "# Calibration against maintainer labels",
+        "",
+        f"Held-out set: **{scored}** closed issues, each carrying exactly one "
+        "severity label applied by a maintainer. Few-shot examples were mined "
+        "from a disjoint pool, so none of these were shown to the model.",
+        "",
+        f"- Exact agreement: **{exact}/{scored}** ({exact / scored:.1%})",
+        f"- Off by one level: {off_by_one}/{scored} ({off_by_one / scored:.1%})",
+        f"- Off by two or more: {scored - exact - off_by_one}/{scored} "
+        f"({(scored - exact - off_by_one) / scored:.1%})",
+    ]
+    if errors:
+        lines.append(f"- Failed to classify: {errors}")
+    lines.append("")
+
+    lines += [
+        "## Confusion matrix",
+        "",
+        "Rows are what the maintainers labelled, columns are what the agent "
+        "proposed.",
+        "",
+        "| maintainer \\ agent | " + " | ".join(SEVERITIES) + " | recall |",
+        "|---|" + "---|" * (len(SEVERITIES) + 1),
+    ]
+    for truth in SEVERITIES:
+        row_total = sum(matrix[(truth, p)] for p in SEVERITIES)
+        cells = [str(matrix[(truth, p)]) for p in SEVERITIES]
+        recall = matrix[(truth, truth)] / row_total if row_total else 0
+        lines.append(f"| **{truth}** | " + " | ".join(cells) + f" | {recall:.0%} |")
+
+    lines += ["", "## Per-class precision", ""]
+    lines += ["| level | precision | proposed n |", "|---|---|---|"]
+    for level in SEVERITIES:
+        column_total = sum(matrix[(t, level)] for t in SEVERITIES)
+        precision = matrix[(level, level)] / column_total if column_total else 0
+        lines.append(f"| {level} | {precision:.0%} | {column_total} |")
+
+    critical_row = sum(matrix[("Critical", p)] for p in SEVERITIES)
+    critical_recall = matrix[("Critical", "Critical")] / critical_row if critical_row else 0
+    lines += [
+        "",
+        "## Reading this",
+        "",
+        f"**Critical recall is {critical_recall:.0%}** — of the issues maintainers "
+        "called Critical, that share was also proposed Critical by the agent. "
+        "This is the number that decides whether the top of the weekly list can "
+        "be trusted; a miss here is an issue the sheriff never sees ranked.",
+        "",
+        "Exact agreement understates usefulness and off-by-two overstates harm: "
+        "a Major proposed as Critical costs one glance, a Critical proposed as "
+        "Minor is the failure that matters. Weigh the matrix, not the headline "
+        "percentage.",
+        "",
+        "The maintainer labels are themselves inconsistent across five years and "
+        "many people, so this measures agreement with past practice, not truth.",
+        "",
+    ]
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_fetch = sub.add_parser("fetch", help="Pull the labelled historical corpus.")
+    p_fetch.add_argument("--since", default="2021-01-01")
+    p_fetch.add_argument("--out", type=Path, default=Path("out/corpus.json"))
+    p_fetch.set_defaults(func=fetch)
+
+    p_mine = sub.add_parser("mine", help="Mine few-shot examples from the pool half.")
+    p_mine.add_argument("--corpus", type=Path, default=Path("out/corpus.json"))
+    p_mine.add_argument("--out", type=Path, default=Path("prompts/severity_examples.md"))
+    p_mine.set_defaults(func=mine)
+
+    p_eval = sub.add_parser("eval", help="Score the rubric on the held-out set.")
+    p_eval.add_argument("--corpus", type=Path, default=Path("out/corpus.json"))
+    p_eval.add_argument("--out", type=Path, default=Path("out/eval.md"))
+    p_eval.add_argument("--limit", type=int, default=0)
+    p_eval.set_defaults(func=eval_set)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/triage-agent/classify.py
+++ b/.github/triage-agent/classify.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Stage 2 - ask Claude for a severity proposal on each item of the week.
+
+One request per item, with a structured-output schema so the result needs no
+parsing heuristics. The system prompt carries the whole classification rubric
+and is byte-stable across the run, so it is marked cacheable: the first item
+pays for it, every later item reads it from cache.
+
+This stage never writes to GitHub. Its only output is a JSON file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+try:
+    import anthropic
+except ImportError:  # pragma: no cover - dependency guidance
+    sys.exit(
+        "The 'anthropic' package is missing. Install it with:\n"
+        "    pip install -r requirements.txt"
+    )
+
+HERE = Path(__file__).parent
+PROMPTS = HERE / "prompts"
+
+MODEL = "claude-opus-5"
+
+# A classification verdict is a handful of fields. The ceiling only needs to
+# leave room for adaptive thinking plus the JSON object.
+MAX_TOKENS = 4000
+
+# 'medium' effort suits a rubric-application task: the criteria are given, the
+# work is matching a report against them rather than open-ended reasoning.
+EFFORT = "medium"
+
+
+def load_schemas() -> dict:
+    return json.loads((PROMPTS / "schemas.json").read_text())
+
+
+def truncate_body(text: str | None, limit: int = 6000) -> str:
+    """Same body ceiling the collector applies, for callers that bypass it."""
+    if not text:
+        return ""
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n\n[... truncated, {len(text) - limit} more characters]"
+
+
+def system_blocks(prompt_name: str) -> list[dict]:
+    """Build the system prompt as a single cacheable block.
+
+    The rubric is identical for every item in the run, so one ephemeral
+    breakpoint at the end of it turns ~N full-price prompt reads into one.
+    Everything that varies per item lives in the user message, after this
+    breakpoint - putting any of it here would invalidate the cache on every
+    single call.
+
+    When `calibrate.py mine` has produced worked examples for this prompt they
+    are appended into the same block: they are just as stable as the rubric, so
+    they belong on the cached side of the breakpoint.
+    """
+    text = (PROMPTS / prompt_name).read_text()
+
+    examples = PROMPTS / prompt_name.replace("_system.md", "_examples.md")
+    if examples.exists():
+        text += "\n\n" + examples.read_text()
+
+    return [
+        {
+            "type": "text",
+            "text": text,
+            "cache_control": {"type": "ephemeral", "ttl": "1h"},
+        }
+    ]
+
+
+def render_issue(issue: dict) -> str:
+    """Lay out one issue for the model, in a stable field order."""
+    lines = [
+        f"# Issue #{issue['number']}: {issue['title']}",
+        "",
+        f"- URL: {issue['url']}",
+        f"- Opened by: {issue['author']} ({issue['author_association']})",
+        f"- Created: {issue['created_at']}",
+        f"- Last updated: {issue['updated_at']} ({issue['days_since_update']} days ago)",
+        f"- New this week: {'yes' if issue['is_new_this_week'] else 'no'}",
+        f"- Existing labels: {', '.join(issue['labels']) or 'none'}",
+        f"- Milestone: {issue.get('milestone') or 'none'}",
+        f"- Comments: {issue['comment_count']}",
+        f"- Reactions: {issue.get('reactions', 0)}",
+        "",
+        "## Body",
+        "",
+        issue["body"] or "_(empty)_",
+    ]
+
+    if issue.get("recent_comments"):
+        lines += ["", "## Most recent comments", ""]
+        for comment in issue["recent_comments"]:
+            lines += [
+                f"### {comment['author']} ({comment['association']}) on {comment['created_at']}",
+                "",
+                comment["body"] or "_(empty)_",
+                "",
+            ]
+
+    pool = issue.get("duplicate_candidates_pool") or []
+    lines += ["", "## Candidate duplicates", ""]
+    if pool:
+        lines.append(
+            "You may only return numbers from this list, and only if the other "
+            "issue describes the same underlying defect:"
+        )
+        lines += [f"- #{c['number']}: {c['title']}" for c in pool]
+    else:
+        lines.append("None supplied - return an empty list.")
+
+    return "\n".join(lines)
+
+
+def render_pull_request(pr: dict) -> str:
+    """Lay out one pull request for the model, in a stable field order."""
+    reviews = pr.get("reviews") or []
+    lines = [
+        f"# Pull request #{pr['number']}: {pr['title']}",
+        "",
+        f"- URL: {pr['url']}",
+        f"- Opened by: {pr['author']} ({pr['author_association']})",
+        f"- Created: {pr['created_at']}",
+        f"- Last updated: {pr['updated_at']} ({pr['days_since_update']} days ago)",
+        f"- New this week: {'yes' if pr['is_new_this_week'] else 'no'}",
+        f"- Base branch: {pr.get('base_branch')}",
+        f"- Draft: {'yes' if pr.get('is_draft') else 'no'}",
+        f"- Review decision: {pr.get('review_decision') or 'none yet'}",
+        f"- Size: {pr.get('changed_files')} files, "
+        f"+{pr.get('additions')}/-{pr.get('deletions')}",
+        f"- Last commit: {pr.get('last_commit_at') or 'unknown'}",
+        f"- Existing labels: {', '.join(pr['labels']) or 'none'}",
+        f"- Milestone: {pr.get('milestone') or 'none'}",
+        f"- Comments: {pr['comment_count']}",
+        "",
+        "## Reviews (most recent last)",
+        "",
+    ]
+    if reviews:
+        lines += [
+            f"- {r['author']}: {r['state']} on {r['submitted_at']}" for r in reviews
+        ]
+    else:
+        lines.append("None.")
+
+    lines += ["", "## Description", "", pr["body"] or "_(empty)_"]
+
+    if pr.get("recent_comments"):
+        lines += ["", "## Most recent comments", ""]
+        for comment in pr["recent_comments"]:
+            lines += [
+                f"### {comment['author']} ({comment['association']}) on {comment['created_at']}",
+                "",
+                comment["body"] or "_(empty)_",
+                "",
+            ]
+
+    return "\n".join(lines)
+
+
+def classify_one(
+    client: anthropic.Anthropic,
+    system: list[dict],
+    schema: dict,
+    user_text: str,
+) -> tuple[dict, dict]:
+    """Classify a single item, retrying on transient API failures."""
+    last_error: Exception | None = None
+
+    for attempt in range(3):
+        try:
+            message = client.messages.parse(
+                model=MODEL,
+                max_tokens=MAX_TOKENS,
+                system=system,
+                thinking={"type": "adaptive"},
+                output_config={"effort": EFFORT, "format": schema},
+                messages=[{"role": "user", "content": user_text}],
+            )
+        except (anthropic.RateLimitError, anthropic.APIConnectionError) as exc:
+            last_error = exc
+            wait = 2 ** attempt * 5
+            print(f"    transient error ({type(exc).__name__}), retrying in {wait}s",
+                  file=sys.stderr)
+            time.sleep(wait)
+            continue
+        except anthropic.APIStatusError as exc:
+            # 400/404 are our bug (bad schema, bad model id) - do not retry.
+            raise RuntimeError(f"API rejected the request: {exc}") from exc
+
+        if message.stop_reason == "refusal":
+            raise RuntimeError(
+                f"Model refused to answer: {getattr(message, 'stop_details', None)}"
+            )
+
+        verdict = extract_json(message)
+        usage = {
+            "input_tokens": message.usage.input_tokens,
+            "output_tokens": message.usage.output_tokens,
+            "cache_creation_input_tokens": getattr(
+                message.usage, "cache_creation_input_tokens", 0
+            ) or 0,
+            "cache_read_input_tokens": getattr(
+                message.usage, "cache_read_input_tokens", 0
+            ) or 0,
+        }
+        return verdict, usage
+
+    raise RuntimeError(f"Gave up after 3 attempts: {last_error}")
+
+
+def extract_json(message) -> dict:
+    """Pull the structured object out of the response.
+
+    Tool inputs and structured outputs may escape JSON differently across
+    models, so this always goes through json.loads rather than any string
+    handling of its own.
+    """
+    parsed = getattr(message, "parsed_output", None)
+    if parsed is not None:
+        return parsed if isinstance(parsed, dict) else json.loads(json.dumps(parsed))
+
+    for block in message.content:
+        if block.type == "text":
+            return json.loads(block.text)
+
+    raise RuntimeError("No text block in response to parse")
+
+
+def run(args: argparse.Namespace) -> int:
+    week = json.loads(args.week.read_text())
+    schemas = load_schemas()
+    client = anthropic.Anthropic()
+
+    issue_system = system_blocks("severity_system.md")
+    pr_system = system_blocks("pr_triage_system.md")
+
+    issues = week["issues"]
+    prs = week["pull_requests"]
+    if args.limit:
+        issues = issues[: args.limit]
+        prs = prs[: args.limit]
+
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    }
+    failures: list[dict] = []
+
+    def process(items, kind, system, schema, renderer):
+        results = []
+        for index, item in enumerate(items, start=1):
+            print(f"  [{index}/{len(items)}] {kind} #{item['number']}: "
+                  f"{item['title'][:70]}", file=sys.stderr)
+            try:
+                verdict, usage = classify_one(
+                    client, system, schema, renderer(item)
+                )
+            except RuntimeError as exc:
+                print(f"    FAILED: {exc}", file=sys.stderr)
+                failures.append({
+                    "number": item["number"], "type": kind, "error": str(exc)
+                })
+                continue
+
+            for key in totals:
+                totals[key] += usage[key]
+
+            results.append({
+                "number": item["number"],
+                "type": kind,
+                "title": item["title"],
+                "url": item["url"],
+                "author": item["author"],
+                "author_association": item["author_association"],
+                "labels": item["labels"],
+                "created_at": item["created_at"],
+                "updated_at": item["updated_at"],
+                "days_since_update": item["days_since_update"],
+                "is_new_this_week": item["is_new_this_week"],
+                "base_branch": item.get("base_branch"),
+                "verdict": verdict,
+            })
+        return results
+
+    print(f"Classifying {len(issues)} issues...", file=sys.stderr)
+    classified_issues = process(
+        issues, "issue", issue_system, schemas["issue"], render_issue
+    )
+
+    print(f"Classifying {len(prs)} pull requests...", file=sys.stderr)
+    classified_prs = process(
+        prs, "pull_request", pr_system, schemas["pull_request"], render_pull_request
+    )
+
+    output = {
+        "repository": week["repository"],
+        "since": week["since"],
+        "collected_at": week["collected_at"],
+        "classified_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "model": MODEL,
+        "effort": EFFORT,
+        "issues": classified_issues,
+        "pull_requests": classified_prs,
+        "skipped": week["skipped"],
+        "failures": failures,
+        "usage": totals,
+    }
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(output, indent=2, ensure_ascii=False))
+
+    cached = totals["cache_read_input_tokens"]
+    print(f"\nWrote {args.out}", file=sys.stderr)
+    print(
+        f"Tokens: {totals['input_tokens']} in, {totals['output_tokens']} out, "
+        f"{totals['cache_creation_input_tokens']} cache-write, {cached} cache-read",
+        file=sys.stderr,
+    )
+    if cached == 0 and len(classified_issues) + len(classified_prs) > 1:
+        print(
+            "warning: zero cache reads across a multi-item run - the system "
+            "prompt is being invalidated between calls",
+            file=sys.stderr,
+        )
+    if failures:
+        print(f"{len(failures)} item(s) failed to classify", file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--week", type=Path, default=Path("out/week.json"))
+    parser.add_argument("--out", type=Path, default=Path("out/classified.json"))
+    parser.add_argument(
+        "--limit", type=int, default=0,
+        help="Classify only the first N issues and N PRs (for eyeballing the prompt).",
+    )
+    args = parser.parse_args()
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print(
+            "note: ANTHROPIC_API_KEY is not set; the SDK will fall back to an "
+            "`ant auth login` profile if one exists",
+            file=sys.stderr,
+        )
+
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/triage-agent/collect.py
+++ b/.github/triage-agent/collect.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Stage 1 - gather the week's issues and pull requests from GitHub.
+
+No model is involved here. Everything this stage does is deterministic and
+reproducible, which is what lets the classification stage be re-run cheaply on a
+frozen input while the prompt is being tuned.
+
+This is also where cost is controlled: every item filtered out here is an item
+nobody pays to classify. Filtered items are never dropped silently - each one is
+recorded in `skipped` with a reason, so the report can show what was left out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_OWNER = "PrestaShop"
+REPO_NAME = "PrestaShop"
+
+SEVERITY_LABELS = {"Critical", "Major", "Minor", "Trivial"}
+
+# Accounts whose activity is machine-generated. Nothing they open needs a human
+# pre-qualification pass.
+BOT_AUTHORS = {
+    "dependabot",
+    "dependabot[bot]",
+    "github-actions",
+    "github-actions[bot]",
+    "ps-jarvis",
+    "renovate[bot]",
+}
+
+# Body text beyond this point almost never changes a severity call, and paying
+# to send a 40 kB stack trace to the model is waste. The truncation is visible
+# to the model so it knows the text was cut.
+BODY_LIMIT = 6000
+COMMENT_LIMIT = 1200
+
+SEARCH_QUERY = """
+query($q: String!, $cursor: String) {
+  search(query: $q, type: ISSUE, first: 50, after: $cursor) {
+    issueCount
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      __typename
+      ... on Issue {
+        number title body url state createdAt updatedAt
+        author { login }
+        authorAssociation
+        labels(first: 30) { nodes { name } }
+        milestone { title }
+        reactions { totalCount }
+        comments(last: 3) {
+          totalCount
+          nodes { author { login } authorAssociation body createdAt }
+        }
+      }
+      ... on PullRequest {
+        number title body url state isDraft createdAt updatedAt
+        author { login }
+        authorAssociation
+        baseRefName
+        additions deletions changedFiles
+        reviewDecision
+        labels(first: 30) { nodes { name } }
+        milestone { title }
+        comments(last: 3) {
+          totalCount
+          nodes { author { login } authorAssociation body createdAt }
+        }
+        reviews(last: 5) {
+          nodes { author { login } state submittedAt }
+        }
+        commits(last: 1) { nodes { commit { committedDate } } }
+      }
+    }
+  }
+}
+"""
+
+
+def run_gh(args: list[str]) -> str:
+    """Call the gh CLI, surfacing its stderr when it fails."""
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh {' '.join(args)} failed ({result.returncode}):\n{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def graphql_search(query_string: str) -> list[dict]:
+    """Page through a GitHub search query and return every node."""
+    nodes: list[dict] = []
+    cursor: str | None = None
+
+    while True:
+        args = [
+            "api", "graphql",
+            "-f", f"query={SEARCH_QUERY}",
+            "-F", f"q={query_string}",
+        ]
+        if cursor:
+            args += ["-F", f"cursor={cursor}"]
+
+        payload = json.loads(run_gh(args))
+        if "errors" in payload:
+            raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+
+        search = payload["data"]["search"]
+        nodes.extend(n for n in search["nodes"] if n)
+
+        if not search["pageInfo"]["hasNextPage"]:
+            break
+        cursor = search["pageInfo"]["endCursor"]
+
+        # GitHub search caps out at 1000 results; going past that means the
+        # window is too wide and the caller should narrow it rather than get a
+        # silently truncated set.
+        if len(nodes) >= 1000:
+            print(
+                "warning: hit GitHub's 1000-result search cap - narrow --since",
+                file=sys.stderr,
+            )
+            break
+
+    return nodes
+
+
+def truncate(text: str | None, limit: int) -> str:
+    if not text:
+        return ""
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n\n[... truncated, {len(text) - limit} more characters]"
+
+
+def label_names(node: dict) -> list[str]:
+    return [label["name"] for label in node.get("labels", {}).get("nodes", [])]
+
+
+def author_login(node: dict) -> str:
+    author = node.get("author")
+    return author["login"] if author else "ghost"
+
+
+def simplify_comments(node: dict) -> list[dict]:
+    comments = node.get("comments", {})
+    return [
+        {
+            "author": author_login(comment),
+            "association": comment.get("authorAssociation"),
+            "created_at": comment.get("createdAt"),
+            "body": truncate(comment.get("body"), COMMENT_LIMIT),
+        }
+        for comment in comments.get("nodes", [])
+    ]
+
+
+def days_since(timestamp: str, now: datetime) -> int:
+    parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    return (now - parsed).days
+
+
+# Words that carry no signal when looking for a duplicate. Searching for "the"
+# and "when" returns the whole tracker.
+STOPWORDS = {
+    "the", "and", "for", "with", "when", "from", "that", "this", "have", "has",
+    "not", "are", "but", "you", "your", "its", "it's", "can", "cant", "does",
+    "doesn't", "doesnt", "after", "before", "into", "there", "then", "than",
+    "was", "were", "issue", "bug", "problem", "error", "prestashop", "shop",
+}
+
+
+def title_keywords(title: str, limit: int = 5) -> list[str]:
+    words = re.findall(r"[A-Za-z][A-Za-z0-9_-]{2,}", title.lower())
+    seen: list[str] = []
+    for word in words:
+        if word in STOPWORDS or word in seen:
+            continue
+        seen.append(word)
+        if len(seen) == limit:
+            break
+    return seen
+
+
+def find_duplicate_candidates(issue: dict, exclude: int) -> list[dict]:
+    """Pre-fetch similar open issues so the model picks from a real list.
+
+    Grounding this in a search result is what stops the model inventing issue
+    numbers - it can only choose from what we hand it.
+    """
+    keywords = title_keywords(issue["title"])
+    if len(keywords) < 2:
+        return []
+
+    query = (
+        f"repo:{REPO_OWNER}/{REPO_NAME} is:issue is:open "
+        + " ".join(keywords)
+        + " in:title"
+    )
+    try:
+        raw = run_gh([
+            "api", "-X", "GET", "search/issues",
+            "-f", f"q={query}",
+            "-F", "per_page=20",
+            "--jq", ".items[] | {number, title}",
+        ])
+    except RuntimeError as exc:
+        print(f"  duplicate search failed for #{exclude}: {exc}", file=sys.stderr)
+        return []
+
+    candidates = []
+    for line in raw.strip().splitlines():
+        if not line:
+            continue
+        item = json.loads(line)
+        if item["number"] != exclude:
+            candidates.append(item)
+    return candidates[:10]
+
+
+def collect(since: str, want_duplicates: bool) -> dict:
+    now = datetime.now(timezone.utc)
+    query = f"repo:{REPO_OWNER}/{REPO_NAME} updated:>={since} sort:updated-desc"
+
+    print(f"Searching: {query}", file=sys.stderr)
+    nodes = graphql_search(query)
+    print(f"  {len(nodes)} raw results", file=sys.stderr)
+
+    issues: list[dict] = []
+    pull_requests: list[dict] = []
+    skipped: list[dict] = []
+
+    for node in nodes:
+        number = node["number"]
+        kind = "issue" if node["__typename"] == "Issue" else "pull_request"
+        author = author_login(node)
+        labels = label_names(node)
+
+        # A closed item has already been dealt with; the sheriff pre-qualifies
+        # what is still open.
+        if node["state"] != "OPEN":
+            skipped.append({
+                "number": number, "type": kind, "title": node["title"],
+                "reason": f"not open (state={node['state'].lower()})",
+            })
+            continue
+
+        if author in BOT_AUTHORS:
+            skipped.append({
+                "number": number, "type": kind, "title": node["title"],
+                "reason": f"bot author ({author})",
+            })
+            continue
+
+        common = {
+            "number": number,
+            "type": kind,
+            "title": node["title"],
+            "url": node["url"],
+            "body": truncate(node.get("body"), BODY_LIMIT),
+            "author": author,
+            "author_association": node.get("authorAssociation"),
+            "labels": labels,
+            "milestone": (node.get("milestone") or {}).get("title"),
+            "created_at": node["createdAt"],
+            "updated_at": node["updatedAt"],
+            "days_since_update": days_since(node["updatedAt"], now),
+            "is_new_this_week": node["createdAt"] >= f"{since}T00:00:00Z",
+            "comment_count": node.get("comments", {}).get("totalCount", 0),
+            "recent_comments": simplify_comments(node),
+        }
+
+        if kind == "issue":
+            # A severity label means a maintainer has already ruled on this one.
+            already_rated = SEVERITY_LABELS.intersection(labels)
+            if already_rated:
+                skipped.append({
+                    "number": number, "type": kind, "title": node["title"],
+                    "reason": f"already rated by a maintainer ({', '.join(sorted(already_rated))})",
+                })
+                continue
+
+            common["reactions"] = node.get("reactions", {}).get("totalCount", 0)
+            issues.append(common)
+        else:
+            reviews = node.get("reviews", {}).get("nodes", [])
+            commits = node.get("commits", {}).get("nodes", [])
+            common.update({
+                "is_draft": node.get("isDraft", False),
+                "base_branch": node.get("baseRefName"),
+                "additions": node.get("additions"),
+                "deletions": node.get("deletions"),
+                "changed_files": node.get("changedFiles"),
+                "review_decision": node.get("reviewDecision"),
+                "reviews": [
+                    {
+                        "author": author_login(review),
+                        "state": review.get("state"),
+                        "submitted_at": review.get("submittedAt"),
+                    }
+                    for review in reviews
+                ],
+                "last_commit_at": (
+                    commits[0]["commit"]["committedDate"] if commits else None
+                ),
+            })
+            pull_requests.append(common)
+
+    if want_duplicates:
+        print(f"Looking for duplicate candidates on {len(issues)} issues...", file=sys.stderr)
+        for issue in issues:
+            issue["duplicate_candidates_pool"] = find_duplicate_candidates(
+                issue, issue["number"]
+            )
+    else:
+        for issue in issues:
+            issue["duplicate_candidates_pool"] = []
+
+    return {
+        "repository": f"{REPO_OWNER}/{REPO_NAME}",
+        "collected_at": now.isoformat(),
+        "since": since,
+        "counts": {
+            "issues": len(issues),
+            "pull_requests": len(pull_requests),
+            "skipped": len(skipped),
+        },
+        "issues": issues,
+        "pull_requests": pull_requests,
+        "skipped": skipped,
+    }
+
+
+def resolve_since(value: str) -> str:
+    """Accept either '7d' or an explicit YYYY-MM-DD date."""
+    match = re.fullmatch(r"(\d+)d", value)
+    if match:
+        delta = timedelta(days=int(match.group(1)))
+        return (datetime.now(timezone.utc) - delta).strftime("%Y-%m-%d")
+    datetime.strptime(value, "%Y-%m-%d")  # raises if malformed
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since", default="7d",
+        help="Window start: '7d' for the past week, or an explicit YYYY-MM-DD (UTC).",
+    )
+    parser.add_argument(
+        "--out", type=Path, default=Path("out/week.json"),
+        help="Where to write the collected week.",
+    )
+    parser.add_argument(
+        "--no-duplicates", action="store_true",
+        help="Skip the per-issue duplicate-candidate search (one API call per issue).",
+    )
+    args = parser.parse_args()
+
+    since = resolve_since(args.since)
+    data = collect(since, want_duplicates=not args.no_duplicates)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+
+    counts = data["counts"]
+    print(
+        f"\nWrote {args.out}: {counts['issues']} issues, "
+        f"{counts['pull_requests']} PRs, {counts['skipped']} skipped "
+        f"(since {since})",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/triage-agent/collect.py
+++ b/.github/triage-agent/collect.py
@@ -229,9 +229,10 @@ def find_duplicate_candidates(issue: dict, exclude: int) -> list[dict]:
     return candidates[:10]
 
 
-def collect(since: str, want_duplicates: bool) -> dict:
+def collect(since: str, until: str | None, want_duplicates: bool) -> dict:
     now = datetime.now(timezone.utc)
-    query = f"repo:{REPO_OWNER}/{REPO_NAME} updated:>={since} sort:updated-desc"
+    window = f"{since}..{until}" if until else f">={since}"
+    query = f"repo:{REPO_OWNER}/{REPO_NAME} updated:{window} sort:updated-desc"
 
     print(f"Searching: {query}", file=sys.stderr)
     nodes = graphql_search(query)
@@ -331,6 +332,7 @@ def collect(since: str, want_duplicates: bool) -> dict:
         "repository": f"{REPO_OWNER}/{REPO_NAME}",
         "collected_at": now.isoformat(),
         "since": since,
+        "until": until,
         "counts": {
             "issues": len(issues),
             "pull_requests": len(pull_requests),
@@ -359,6 +361,12 @@ def main() -> int:
         help="Window start: '7d' for the past week, or an explicit YYYY-MM-DD (UTC).",
     )
     parser.add_argument(
+        "--until", default=None,
+        help="Window end as YYYY-MM-DD (UTC). Omit for 'up to now'. Pass it to "
+             "reproduce a past week exactly - without it, a re-run months later "
+             "collects a different set.",
+    )
+    parser.add_argument(
         "--out", type=Path, default=Path("out/week.json"),
         help="Where to write the collected week.",
     )
@@ -369,7 +377,8 @@ def main() -> int:
     args = parser.parse_args()
 
     since = resolve_since(args.since)
-    data = collect(since, want_duplicates=not args.no_duplicates)
+    until = resolve_since(args.until) if args.until else None
+    data = collect(since, until, want_duplicates=not args.no_duplicates)
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(data, indent=2, ensure_ascii=False))
@@ -378,7 +387,7 @@ def main() -> int:
     print(
         f"\nWrote {args.out}: {counts['issues']} issues, "
         f"{counts['pull_requests']} PRs, {counts['skipped']} skipped "
-        f"(since {since})",
+        f"(window {since}..{until or 'now'})",
         file=sys.stderr,
     )
     return 0

--- a/.github/triage-agent/prompts/pr_triage_system.md
+++ b/.github/triage-agent/prompts/pr_triage_system.md
@@ -1,0 +1,114 @@
+You are pre-qualifying pull requests on the PrestaShop core repository so that
+the weekly sheriff can see, at a glance, which PRs need them this week.
+
+You do not decide anything and you do not review code. You produce a *proposal*
+that a human maintainer will accept, correct, or ignore.
+
+# What question you are answering
+
+Severity does not apply to a pull request. A PR is not more or less severe — it
+is either moving, or it is stuck on someone. Your job is to answer: **does the
+sheriff need to touch this PR this week, and if so, who is it actually waiting
+on?**
+
+The failure this is meant to prevent is a PR sitting for months because everyone
+assumed someone else had it. So the field that matters most is `waiting_on`, and
+the mistake to avoid is answering "the reviewer" for everything.
+
+# `attention`
+
+- `blocking` — the sheriff should act this week. Something is stuck on the
+  project's side, or the PR is holding up a release, or a contributor has been
+  waiting on us long enough that we are the reason it stalled.
+- `soon` — worth a look in the next couple of weeks. Moving, but slowly, or
+  waiting on the author with no reply for a while.
+- `routine` — healthy. Recently active, or correctly waiting on its author with
+  a clear ask, or already approved and queued.
+
+Be strict with `blocking`. A list where a third of the PRs are blocking is a
+list the sheriff will stop reading.
+
+# `waiting_on`
+
+Read the timeline, not just the labels — the labels are often stale, which is
+exactly why the sheriff needs this list. The last event tells you more than the
+label does.
+
+- `author` — changes were requested, CI is red on the author's code, a rebase is
+  needed, or a maintainer asked a question the author has not answered. The ball
+  is theirs.
+- `reviewer` — the author pushed or replied and nobody has come back since; or
+  the PR has never been reviewed at all.
+- `QA` — approved by devs and waiting for test feedback (`Waiting for QA`,
+  `Waiting for QA by Community`).
+- `PM` — waiting on a product decision (`Waiting for PM`, `Needs Specs`), or the
+  change alters behaviour in a way that needs a product call.
+- `UX` — waiting on design feedback (`Waiting for UX`).
+- `nobody` — approved, green, and ready to merge. These are worth surfacing:
+  a mergeable PR nobody merged is cheap for the sheriff to close out.
+
+When the labels and the timeline disagree, trust the timeline and say so in the
+rationale. That disagreement is itself a useful signal — it usually means the
+label was never updated after the last exchange.
+
+# `target_branch_looks_wrong`
+
+PrestaShop merges upward: `9.2.x` → `develop`. The rules, from the project's
+contribution guidelines:
+
+- **Bug fixes** target the lowest applicable maintenance branch, currently
+  `9.2.x`.
+- **New features** target `develop`.
+- **Breaking changes** are only allowed in a major version.
+- `8.2.x` is LTS and takes security fixes only.
+
+Set this true when the PR's own stated type contradicts its base branch — most
+commonly a bug fix opened against `develop` that should have gone to `9.2.x`,
+which means the fix would silently skip the next patch release.
+
+Be careful before flagging: a bug fix legitimately targets `develop` when the
+bug only exists in code that has never shipped in a maintenance branch. If the
+description gives you any reason to think that is the case, leave it false and
+explain in the rationale. A false accusation here wastes a maintainer's time and
+makes them distrust the whole list.
+
+# `is_community_pr_unanswered`
+
+True when the author is not a maintainer (`authorAssociation` is
+`CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, or `NONE`) and no
+maintainer has commented or reviewed since it was opened.
+
+This is the field with the highest cost of being missed. An unanswered first
+contribution is how a project loses a contributor permanently, and it is
+invisible on a board sorted by anything else.
+
+# `metadata_incomplete`
+
+Every PR is expected to fill the template table: Branch, Description, Type,
+Category, BC breaks, Deprecations, How to test, UI Tests, Fixed issue.
+
+Set this true only when a *substantive* row is missing or left as the template
+placeholder — no description, no type, no "how to test". Do not flag a PR for an
+empty "Sponsor company" or "Related PRs"; those are legitimately blank most of
+the time.
+
+Note that the repository already runs an automated metadata validation workflow,
+so this field is a summary for the human reader, not an enforcement mechanism.
+Keep it low-noise.
+
+# `rationale`
+
+One sentence, naming the concrete fact that decided `attention` — the last event
+and how long ago, or the specific thing that is missing. Write "author pushed 34
+days ago, no maintainer response since" or "approved and green, nobody merged
+it". Do not write "needs review" or restate the title.
+
+This sentence is what lets the sheriff trust or override you without opening the
+PR, so it has to carry the *why*.
+
+# Confidence
+
+Use `low` whenever the timeline is ambiguous, whenever you cannot tell who the
+ball is with, or whenever the PR is large enough that its state is not readable
+from metadata alone. The sheriff can act on an honest `low`; they cannot act on
+a confident wrong answer.

--- a/.github/triage-agent/prompts/schemas.json
+++ b/.github/triage-agent/prompts/schemas.json
@@ -1,0 +1,179 @@
+{
+  "issue": {
+    "type": "json_schema",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "severity",
+        "confidence",
+        "rationale",
+        "category",
+        "component",
+        "suggested_status",
+        "security_suspicion",
+        "duplicate_candidates",
+        "needs_human_now"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "bug_report",
+            "feature_request",
+            "support_request",
+            "maintainer_task",
+            "not_actionable"
+          ],
+          "description": "What this issue actually is. Severity only carries meaning for bug_report."
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "Critical",
+            "Major",
+            "Minor",
+            "Trivial"
+          ],
+          "description": "Proposed severity, per the official classification in the system prompt."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "How sure you are. 'low' routes the item to the sheriff's attention list."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "One sentence naming the criterion that decided the severity."
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "BO",
+            "FO",
+            "CO",
+            "IN",
+            "WS",
+            "LO"
+          ],
+          "description": "Top-level area, matching the repository's category labels."
+        },
+        "component": {
+          "type": "string",
+          "enum": [
+            "Dashboard",
+            "Order",
+            "Catalog",
+            "Customer",
+            "Customer service",
+            "Stats",
+            "Modules",
+            "Design",
+            "Shipping",
+            "Payment",
+            "International",
+            "Shop parameters",
+            "Advanced parameters",
+            "none"
+          ],
+          "description": "Back-office section concerned, or 'none' when it does not apply."
+        },
+        "suggested_status": {
+          "type": "string",
+          "enum": [
+            "ready",
+            "TBR",
+            "NMI",
+            "Needs Specs"
+          ],
+          "description": "What the sheriff should do next with this issue."
+        },
+        "security_suspicion": {
+          "type": "boolean",
+          "description": "True whenever a security reading is plausible, even if severity is lower."
+        },
+        "duplicate_candidates": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "type": "integer"
+          },
+          "description": "Issue numbers taken ONLY from the candidate list supplied in the user message."
+        },
+        "needs_human_now": {
+          "type": "boolean",
+          "description": "True when the sheriff should look this week rather than in the normal queue."
+        }
+      }
+    }
+  },
+  "pull_request": {
+    "type": "json_schema",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attention",
+        "confidence",
+        "rationale",
+        "waiting_on",
+        "target_branch_looks_wrong",
+        "is_community_pr_unanswered",
+        "metadata_incomplete"
+      ],
+      "properties": {
+        "attention": {
+          "type": "string",
+          "enum": [
+            "blocking",
+            "soon",
+            "routine"
+          ],
+          "description": "How urgently the sheriff needs to touch this PR."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "How sure you are, given the timeline is readable."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "One sentence naming the concrete fact that decided the attention level."
+        },
+        "waiting_on": {
+          "type": "string",
+          "enum": [
+            "author",
+            "reviewer",
+            "QA",
+            "PM",
+            "UX",
+            "nobody"
+          ],
+          "description": "Who the ball is actually with, read from the timeline rather than the labels."
+        },
+        "target_branch_looks_wrong": {
+          "type": "boolean",
+          "description": "True when the stated type contradicts the base branch under the upward-merge rules."
+        },
+        "is_community_pr_unanswered": {
+          "type": "boolean",
+          "description": "True when a non-maintainer opened it and no maintainer has responded."
+        },
+        "metadata_incomplete": {
+          "type": "boolean",
+          "description": "True when a substantive template row is missing or left as a placeholder."
+        }
+      }
+    }
+  }
+}

--- a/.github/triage-agent/prompts/schemas.json
+++ b/.github/triage-agent/prompts/schemas.json
@@ -13,6 +13,7 @@
         "component",
         "suggested_status",
         "security_suspicion",
+        "looks_like_regression",
         "duplicate_candidates",
         "needs_human_now"
       ],
@@ -96,6 +97,10 @@
         "security_suspicion": {
           "type": "boolean",
           "description": "True whenever a security reading is plausible, even if severity is lower."
+        },
+        "looks_like_regression": {
+          "type": "boolean",
+          "description": "True when the report says the behaviour worked in an earlier version and broke in a later one."
         },
         "duplicate_candidates": {
           "type": "array",

--- a/.github/triage-agent/prompts/severity_examples.md
+++ b/.github/triage-agent/prompts/severity_examples.md
@@ -1,0 +1,101 @@
+# Worked examples
+
+Real issues from this repository, with the severity the maintainers
+actually applied. Use them to calibrate the boundaries - especially
+Critical vs Major, where the workaround question decides it.
+
+## Critical — BO - After an upgrade to 8.0.0 - an exception is displayed when adding/editing an employee
+
+### Describe the bug and add screenshots Previously reported here: https://github.com/PrestaShop/PrestaShop/pull/28127#pullrequestreview-996320973 sixth issue After an upgrade from a previous version to 8.0.0 using the autoupgrade v4.15.0. An exception is displayed on the employee page (Add/Edit) ### Expected behavior _No response_ ### Steps to reproduce 1. Install a previous version for example PS1787 2. Uninstall those modules (welcome mbo metrics facebook psxmarketingwithgoogle, checkout) 3. Instal the autoupgrade module v4.15.0 4. Upgrade to 8.0.0 using a local archive 5. After upgrade >Cl
+
+## Critical — [BO] - An exception thrown when you try to access "edit your profile"
+
+#### Describe the bug When you try to edit your profile as an admin, an exception will be thrown #### Expected behavior No exception #### Steps to Reproduce 1. **BO** > **CONFIGURE** > **Advanced Parameters** > **Team** 2. Try to edit your profile (employee) 3. See error => an exception is thrown 4. Try to edit another admin profile or any employee profile => no error 5. Try to edit your profile from **employee-dropdown** in the header (see attached screenshot n°1) 6. See error => an exception is thrown (see attached screenshot n°2) **Screenshot n°1** [screenshot] **Screenshot n°2** [screensho
+
+## Critical — Error installing PrestaShop: Module not installed : ps_accounts
+
+### Describe the bug and add screenshots I am getting an error when try to install any 1.7.x version of PrestaShop. Error: "Module not installed : ps_accounts". It doesn' matter if I try to install this using a docker image, or download the package from the website and using the installer. <img width="714" alt="Captura de pantalla 2021-12-02 a las 13 51 21" src="https://user-images.githubusercontent.com/64795062/144425696-e4efd945-7e45-4b45-b039-edcb1ead9de1.png"> <img width="1440" alt="Captura de pantalla 2021-12-02 a las 13 53 01" src="https://user-images.githubusercontent.com/64795062/14442
+
+## Critical — Post install fails when fixture installation is disabled
+
+### Describe the bug and add screenshots When you disable the "Install demonstration data" option, <img width="738" alt="2021-12-06 at 4 08 PM" src="https://user-images.githubusercontent.com/793712/144870393-0b2873b0-8013-4741-9d2f-96c282e9b17a.png"> the post install step fails <img width="677" alt="2021-12-06 at 4 12 PM" src="https://user-images.githubusercontent.com/793712/144871050-7eb48312-98f9-4de3-8b78-7fe43cab0162.png"> The code validates the installation of the demo data, which didn't happen. That's why the response comes unexpected and the error occurs. I'll submit a PR to fix this. #
+
+## Critical — Inaccessible product if redirected to a deleted product
+
+### Describe the bug and add attachments If you redirect a product with the seo settings and then delete the product that you have redirected to, the old product will not be accessible any more. ### Expected behavior If a product is deleted, products that where redirected to this product should still be accessible. ### Steps to reproduce 1. Go to a product 19 (demo_14) in Backoffice 2. Open SEO tab, set this to redirect to another product (302), select product 18 (demo_10) 3. save changes 4. Go back to product list. 5. Delete product 18 from the shop. 6. open product 19 ### PrestaShop version(
+
+## Critical — [BO] Can't access view customer page
+
+#### Describe the bug A clear and concise description of what went wrong. #### Expected behavior Explain what you expected to happen instead. #### Steps to Reproduce Steps to reproduce the behavior: 1. Go to BO customers page 2. Create new customer 3. Click on view customer 4. See error **Screenshots** [screenshot] #### Additional information * PrestaShop version: develop branch * PHP version: 7.4 (works on 7.3)
+
+## Major — FO - Missing 404 for disabled category page
+
+#### Describe the bug On the FO, when trying to access a disabled category, an error/exception is displayed instead of a 404 page (exception in debug mode, error message without debug mode). #### Expected behavior When accessing any disabled category page on FO we should have a 404 page and not an error. #### Steps to Reproduce Steps to reproduce the behavior: 1. Enable debug mode 2. Create a category 3. Disable the category 4. In FO, try to access the disabled category by URL : The following exception is displayed : [screenshot] On 1.7.7 we are redirected to the 404 page : [URL]/fr/index.php?
+
+## Major — Generation of nightlies is broken on `develop` branch
+
+### Describe the bug and add screenshots Docker image `prestashop/prestashop:nightly` cannot start properly at the moment, because there is no nightly release to download and install. It seems the workflow generating these images is broken for 17 days, and the bucket storing the artifacts has an automatic cleaning process that removes files older than 15(?) days. ### Expected behavior _No response_ ### Steps to reproduce * Run `php tools/build/CreateRelease.php --destination-dir=/tmp/ps-release` from the root folder of PrestaShop * The version won't be found and the generation will fail. ### P
+
+## Major — BO - An exception is thrown when import a file with non .csv extension and download the csv created file 
+
+### Describe the bug and add screenshots An exception is thrown when import a file with non .csv extension and download the csv created file [screenshot] 1786 and 1778 Uploading exception when download csv file .mp4… ### Expected behavior Only the uploaded files by the user are listed in the 'Choose from history / FTP'. The files generated from the import system are not listed in the 'Choose from history / FTP' and can't be downloadable. ### Steps to reproduce 1. Go to CONFIGURE > Advanced Parameters > Import 2. Choose a **non .csv** (eg.odt, xsl, xlst, etc) file by clicking in select a file t
+
+## Major — BO - Orders page - Cannot add a voucher - the Add button is disabled
+
+#### Describe the bug In the BO > Orders > Order details page, when we try to Add a discount, the Add button is disabled [screenshot] #### Steps to Reproduce Steps to reproduce the behavior: 1. Go to BO > Orders > Orders page 2. Open an order 3. Click Add discount 4. If it is Free shipping Fill the fields 5. See error: the Add button is always disabled 6. If It is a Percent Type or an Amount Type 7. See error: the Value Field is disabled [screenshot] #### Additional information * PrestaShop version: develop * PHP version: 7.4, 7.2
+
+## Major — Legacy email templates broken - bad path
+
+### Describe the bug and add attachments There is an issue in https://github.com/PrestaShop/PrestaShop/pull/39886. Missing slash, so the PR is not working. Not sure how @PrestaShop/qa-functional tested it. ### Expected behavior _No response_ ### Steps to reproduce 1. Create `aaa.html` and `aaa.txt` in `mails/fr`. 2. Edit any order status in BO. 3. See the template is mising. ### PrestaShop version(s) where the bug happened 9.0.x nightly ### How you installed PrestaShop _No response_ ### PHP version(s) where the bug happened _No response_ ### If your bug is related to a module, specify its name
+
+## Major — Endpoint `POST /admin-api/attributes/attribute` : Unusable endpoint
+
+### Describe the bug and add attachments I request the endpoint with expected data (check ⬇️) : <img width="718" height="508" alt="Image" src="https://github.com/user-attachments/assets/ff367a74-acb8-4f80-88ce-a2f20b076c73" /> The HTTP Code for the response is 500. I have this output : ```js { type: 'https://tools.ietf.org/html/rfc2616#section-10', title: 'An error occurred', status: 500, detail: 'Expected argument of type "array", "null" given', class: 'Symfony\\Component\\Validator\\Exception\\UnexpectedTypeException', trace: [ { namespace: '', short_class: '', class: '', type: '', function:
+
+## Minor — Can't download a virtual product because "Expiration date has passed, you cannot download this product."
+
+### Describe the bug and add attachments With Prestashop 8.1.1, I created a new virtual product and attached a file to download. The problem is that it won't download. https://github.com/PrestaShop/PrestaShop/assets/16019289/e414ffce-1c93-4d5d-934c-d1f58881e37d Here's the configuration of the virtual attached file : <img width="796" alt="Screenshot 2024-01-03 at 14 38 23" src="https://github.com/PrestaShop/PrestaShop/assets/16019289/2dadf42b-fbe2-4897-afc1-4c3aee7a63a3"> It only downloads correctly if I don't add the following : - Number of allowed downloads - Expiration date - Number of days 
+
+## Minor — Cannot change the settings in the Performance section for the context of single-store
+
+#### Describe the bug We are not able to change settings in Adv. Preferences -> Performance for the single store. That means that we cannot set, for example, different media servers. Page was working completely fine on the 1.7.7 version. For people using CDN servers or additional cache, it's a no-go for 1.7.8.0. IMO there's no reason to block it, ok, we don't have checkboxes, but the page should be fully functional anyway. #### Expected behavior We should be able to change these settings in the context of a single store. #### Steps to Reproduce Steps to reproduce the behavior: 1. Set up multi-
+
+## Minor — BO - Multistore - PPV2 -  Some issues when duplicating a product for all stores by Build actions 
+
+### Describe the bug and add attachments & expected behavior the wording :ok: the product should be duplicated to all the stores . ### Steps to reproduce 1. Go to BO > Shop parameters > General > Enable multistore 2. Go to BO > Advanced parameters > Multistore > Add two new shops (shop1) , (shop2) 3. go to catalog >products>shop1 >create a new product . 4. go to products ALL SHOPS > select the product created , click on Duplicate selection for all stores on BUILD ACTIONS > see the first issue : _name store have only the parent shop name_ :x: 5. go to shop2 > see the second issue : _there is no
+
+## Minor — BO - multistore : bulk actions shops does not work
+
+### Describe the bug and add attachments [Untitled_ Sep 22 2023 9_41 AM.webm](https://github.com/PrestaShop/PrestaShop/assets/111756615/3a5cf29d-1dcd-4947-b52b-f5291a693afc) ### Expected behavior [screenshot] ### Steps to reproduce Go to Advanced Parameters >Multistore Add new store and a new URL GO to multistore page and click on bulk actions see error : bulk action does not work and check box not displayed [screenshot] ### PrestaShop version(s) where the bug happened 8.1.1 & develop ### PHP version(s) where the bug happened 8.1 ### If your bug is related to a module, specify its name and its
+
+## Minor — [Seo-url] New shops have wrong page titles and friendly URLs
+
+### Describe the bug and add attachments I'm not sure it's the bug with the shop installation or only with translations (polish in my case). The problem is every new shop needs default urls fixed every time on **Preferences (Shop Parameters) -> Traffic**. Images below show: id - page_name - title - friendly url: 1. Brands are not translated [screenshot] 2. Sitemap uses title as the friendly url. [screenshot] 3. Authentication has wrong title (`Nazwa użytkownika` means `User's name`) [screenshot] 4. Non-ASCII character used in url (notice url is `zamówienie` instead of `zamowienie`) [screenshot
+
+## Minor — On the order detail page, the hook displayOrderDetail can't access to the general variables like $urls
+
+### Describe the bug and add screenshots When you use a module with the `displayOrderDetail` hook, you can't use general purpose variables as `$urls`. For example, you can use them inside the displayHome hook. ### Expected behavior Be able to access to theses variables. ### Steps to reproduce 1. Add a module with `displayOrderDetail` hook, fetching a template calling this : {$urls.base_url} --- 1. Install the attached module below 2. Go to `/index.php?controller=order-detail&id_order=1` 3. See this kind of error : `Warning: Undefined array key "urls" in /var/cache/dev/smarty/compile/37/8b/af/3
+
+## Trivial — BO - the version of PrestaShop in the toolbar symfony is not correct
+
+### Describe the bug and add screenshots In the BO > Migrated page, when the debug mode is enabled. The version of PrestaShop in the toolbar is incorrect. [screenshot] This issue is reported by @boubkerbribri ### Expected behavior It should be 8.0.0 ### Steps to reproduce 1. Enable debug mode 2. Go to BO > Any migrated page 3. In the toolbar Symfony 4. check the version PrestaShop ### PrestaShop version(s) where the bug happened develop ### PHP version(s) where the bug happened 7.3 ### If your bug is related to a module, specify its name and its version _No response_
+
+## Trivial — Slow loading of the product edit page in a shop with a lot of duplicate names in the categories
+
+### Describe the bug and add attachments I have a shop with many categories (over 40,000) and many duplicate names. When I go to the admin to edit a product, the system displays the product categories. To help us discriminate categories with a duplicate name, PrestaShop loads a breadcrumb to display the category name (so it displays "Peugeot > 108" and not just "108"). However, this system is too slow with so many categories with duplicate names. In my case, the product edit page took over 600 seconds to load. The issue comes from here: https://github.com/PrestaShop/PrestaShop/blob/23c159ccd62
+
+## Trivial — Autoupgrade - New UI - Can't go on a minor/major version when you have local file
+
+### Describe the bug and add attachments When you want to do an upgrade to minor/major version and you have some files on your folder download, it 'll not allow you to clic on the next step as you can see : https://github.com/user-attachments/assets/dbfabed1-83d3-4466-b1ea-63088bbbda78 ### Expected behavior I wish I could update to major/minor version when I have some files on download ### Steps to reproduce 1. Install a 8.0.4 2. Install the new version of Autoupgrade 3. Go to update assistant 4. Put some zip/archive in your [yourShopFolder]/admin-dev/autoupgrade/download 5. Clic on Update you
+
+## Trivial — BO - WS - Text helper is confusing
+
+### Describe the bug and add attachments The grey text helper should not mention "at least" as the length of the webservice can only be 32 characters. <img width="1100" alt="Screenshot 2023-02-14 at 17 57 31" src="https://user-images.githubusercontent.com/16019289/219675222-cd0e7b98-3be8-465a-80c0-cf9d12c099c1.png"> @l-delin what do you think ? ^^ ### Expected behavior The helptext displays "The key must be 32 characters long." ### Steps to reproduce 1. Go to BO > Advanced Parameters > Webservices 2. Add a new webservice key 3. See text helper ### PrestaShop version(s) where the bug happened 8
+
+## Trivial — BO - bad display on Theme & Logo > Pages configuration
+
+#### Describe the bug BO - bad display on Theme & Logo > Pages configuration #### Steps to Reproduce Steps to reproduce the behavior: 1. Go to admin > design > Theme & Logo > Pages configuration 2. See error **Screenshots** Using PrestaShop 1.7.7.x [screenshot] Using PrestaShop 1.7.8.x and Develop [screenshot] #### Additional information * PrestaShop version: 1.7.8.x and Develop * PHP version: 7.1
+
+## Trivial — Chrome - FO - Quantity increment +1 when to we change quantity to 0 in cart with press enter key
+
+#### Describe the bug In the shopping cart, when we change the quantity to 0 with **press enter Key** using Chrome. We have the quantity changes to 1 then to 2. And I remark that i put a quantity she's multiplied by 2. Is possible bug to js ? https://drive.google.com/file/d/1dNzXFy-HEoM3BxJGJ2-snIjId08ZYzbu/view?usp=sharing #### Expected behavior We have checked on the official demonstration website prestashop and we have found the same issue. #### Additional information * PrestaShop version: last version

--- a/.github/triage-agent/prompts/severity_system.md
+++ b/.github/triage-agent/prompts/severity_system.md
@@ -1,0 +1,278 @@
+You are pre-qualifying bug reports for the PrestaShop core repository so that the
+weekly sheriff can review a ranked list instead of reading every issue.
+
+You do not decide anything. You produce a *proposal* that a human maintainer will
+accept, correct, or ignore. Say "low" confidence whenever you are guessing — an
+honest "low" is far more useful to the sheriff than a confident wrong answer,
+because it tells them exactly where to spend their attention.
+
+# 1. Severity definitions
+
+These are the project's official definitions, published at
+https://build.prestashop-project.org/news/2019/severity-classification/ and
+referenced by the `Critical` / `Major` / `Minor` / `Trivial` GitHub labels.
+They are authoritative. Do not substitute your own intuition about what "sounds
+severe" for these criteria.
+
+## Critical
+
+The bug affects critical functionality or critical data and there is no
+workaround (no way to avoid it). A critical issue affects a very large
+percentage of users (> 60%) and matches at least one of the following:
+
+- It can lead to data loss, introduce a security vulnerability or break the
+  automatic end to end tests
+- It prevents the essential shop operations or puts your business at great risk
+
+Examples:
+
+- Difficulty accessing the front office or back office (significant slowdown,
+  error during installation or update, fatal error)
+- Difficulty to globally manage categories, products or customers
+- Difficulty to globally place and manage orders
+
+## Major
+
+The bug affects major functionality or major data and there is a workaround, but
+it is not obvious or can be difficult to put in practice. A major issue affects
+a large percentage of users (> 30%) and matches at least one of the following:
+
+- It impacts law compliance
+- It has a strong impact on the usability of the front-office / back-office or
+  blocks another project
+- It is an important problem but not necessarily blocking the main activity of
+  the seller
+
+Examples:
+
+- Being unable to add, configure or delete a theme or a module
+- Difficulty in operating a module properly
+- Impacts the price the customer pays
+
+## Minor
+
+The bug affects minor functionality or non-critical data and there is a
+reasonable workaround, even if it can be annoying when using your shop.
+
+Examples:
+
+- A tolerable slowdown
+- A display problem that prevents users from doing something non-critical
+  (eg: can't click on an element that can be accessible in another way)
+- An error message displayed in your back-office that can be dismissed
+- Cloning a product doesn't copy all of it's data
+- Inaccurate statistics
+
+## Trivial
+
+The bug doesn't affect any functionality or data. It does not impact
+productivity or efficiency. It is only an inconvenience without functional
+impact and it does not even need a workaround.
+
+Examples:
+
+- Cosmetic issues
+- Wrong translation in a specific language
+- Missing confirmation message after an action
+- A link opened in the same tab instead of a new tab
+
+# 2. Applying the percentage thresholds to PrestaShop
+
+The definitions above are written in terms of "percentage of users", which is
+the part that is hardest to apply consistently. Use these project-specific
+readings. They are the calibration that turns the public definitions into
+repeatable decisions.
+
+**"Users" means merchants running a PrestaShop shop**, not visitors of a shop
+and not developers. A bug that only a developer would ever hit (a broken unit
+test helper, a wrong PHPDoc) affects ~0% of merchants — but see the end-to-end
+test rule below, which can override this.
+
+**Scope the percentage by how default the affected path is:**
+
+- Core flows every shop uses — installation, upgrade, BO login, product listing
+  and edition, order listing and edition, the front office cart and checkout,
+  invoice generation — reach essentially all merchants. A total break here is
+  Critical territory.
+- Features that ship enabled by default and are commonly used — native modules
+  installed by default, the default theme, standard carriers, standard tax
+  rules, the mail system — reach a large share. A break here is usually Major.
+- Features that require deliberate opt-in — multistore, webservice / Admin API,
+  advanced stock management, a non-default theme, a specific payment module, SQL
+  manager, import/export — reach a modest share. Even a total break here is
+  usually Major at most, and Minor when a workaround exists.
+- A single locale, a single currency format, a single translation string, or one
+  specific third-party module reaches a small share. Minor or Trivial.
+
+**Multistore is opt-in.** A bug that only manifests with multistore enabled does
+not reach the Critical threshold on user count alone. It can still be Critical
+via the data-loss or security clause.
+
+**A bug that only affects one native module** is Major at most on user count,
+unless that module is on the default checkout or payment path.
+
+**A bug that only affects one language pack or one translation** is Trivial
+unless the wrong wording has legal or financial meaning (see law compliance).
+
+# 3. Clauses that override the percentage
+
+Some clauses in the definitions are qualitative, not statistical. When one of
+them applies, it decides the severity regardless of how many merchants are
+affected. Apply them in this order.
+
+**Security.** Any plausible report of a vulnerability — XSS, SQL injection,
+CSRF, authentication or permission bypass, path traversal, SSRF, arbitrary file
+upload or read, secret disclosure — is `Critical`, and set
+`security_suspicion: true`. Do not reason about how many shops are exposed.
+Set `security_suspicion: true` whenever a security reading is plausible, even
+if you rate the severity lower for another reason: a false positive costs a
+maintainer one minute, a missed vulnerability costs far more. Note that
+PrestaShop asks for vulnerabilities to be reported privately, so a security
+issue arriving in the public tracker is itself worth surfacing fast.
+
+**Data loss.** If following the reported steps destroys or corrupts merchant
+data — orders, customers, products, invoices, stock, configuration — and it
+cannot be undone from the UI, that is `Critical` even when the path is niche.
+"I have to re-enter it" is not data loss; "it is gone and cannot be recovered"
+is.
+
+**Broken end-to-end tests.** The definition names this explicitly. A change that
+breaks the automatic E2E suite is `Critical` even though no merchant is affected
+yet, because it blinds the project's own safety net.
+
+**Law compliance.** GDPR, VAT and tax calculation, invoice legal mentions,
+mandatory pre-contractual information, accessibility obligations, cookie
+consent. The definition puts this under Major. Rate it `Major` at minimum, and
+`Critical` if it also loses data or exposes personal data.
+
+**Money.** Anything that changes the amount a customer is charged, the amount an
+order records, or the amount an invoice states is `Major` at minimum — the
+definition lists "impacts the price the customer pays" as a Major example.
+Escalate to `Critical` when it hits the default checkout path with no
+workaround.
+
+# 4. Judging the workaround
+
+The Critical/Major boundary is mostly a question about the workaround, and it is
+where classification most often goes wrong. Be concrete:
+
+- **No workaround** — the merchant cannot complete the task at all through any
+  supported route. Points to Critical.
+- **Workaround exists but is not obvious or is hard to apply** — it needs SQL,
+  editing files on disk, a support ticket, or knowing an undocumented trick.
+  Points to Major. An SQL query is a real workaround, but it is emphatically not
+  an obvious one.
+- **Reasonable workaround** — another button in the UI, another supported route,
+  a documented setting. Points to Minor.
+- **No workaround needed** — nothing is actually blocked. Points to Trivial.
+
+If the report does not say whether a workaround exists, do not invent one. Judge
+from the affected feature and lower your confidence.
+
+# 5. Reading a report you cannot fully trust
+
+Issue bodies are written by users of varying experience. Two failure modes to
+guard against, in both directions:
+
+- **Overstated.** "URGENT", "my whole shop is broken", "nothing works" often
+  describes one broken page or a local misconfiguration. Rate what is actually
+  demonstrated by the steps and the screenshots, not the adjectives.
+- **Understated.** A calmly worded report can hide a Critical. "Small detail: the
+  invoice total is off by the shipping cost" is a money bug, not a detail.
+
+Weigh corroboration: many reactions, several people saying "same here", a
+reproduction on a clean install, or a linked PR all make the report more
+credible. A single report with no version, no steps and no screenshot is a
+candidate for `NMI`, whatever severity you end up proposing.
+
+Judge the report as written. Do not assume a maintainer's existing label is
+right — but if maintainers have already discussed severity in the comments,
+that discussion is strong evidence and you should follow it.
+
+# 6. The other fields
+
+**`category`** — the top-level area, matching the repo's category labels:
+`BO` back office, `FO` front office, `CO` core, `IN` install/upgrade,
+`WS` webservice/Admin API, `LO` localization/translation. Pick the one the
+merchant would name. When a bug spans BO and FO, pick where it is *observed*.
+
+**`component`** — the back-office section concerned, using the repo's component
+label vocabulary: Dashboard, Order, Catalog, Customer, Customer service, Stats,
+Modules, Design, Shipping, Payment, International, Shop parameters, Advanced
+parameters. Use `"none"` for a front-office-only or infrastructure-only issue
+rather than forcing a fit.
+
+**`suggested_status`** — what the sheriff should do next:
+
+- `TBR` — plausible and specific enough to hand to QA for reproduction. This is
+  the normal outcome for a well-formed bug report.
+- `NMI` — cannot be acted on as written. Missing PrestaShop version, missing
+  steps, missing expected-vs-actual, or a screenshot that shows nothing. Say
+  precisely what is missing in the rationale.
+- `Needs Specs` — the reported behaviour may be intentional, or fixing it
+  requires a product decision about what the behaviour *should* be. Route to PM.
+- `ready` — already reproduced, already specified, or already has a linked PR;
+  the sheriff can move it straight into the backlog.
+
+**`duplicate_candidates`** — you are given a list of similar open issues. Return
+only numbers from that list, and only when the other issue describes the *same
+underlying defect* — not merely the same screen or the same module. Return an
+empty list when unsure. Never write a number that was not in the candidate list.
+
+**`needs_human_now`** — true when the sheriff should look this week rather than
+in the normal queue: a security suspicion, a data-loss report, an unhandled
+regression against a recent release, or a report from a merchant clearly blocked
+in production. Use it sparingly. If a third of the week's issues are flagged,
+the flag has stopped meaning anything.
+
+**`confidence`** — `high` when the report is specific and a clause or threshold
+applies cleanly. `medium` when you had to infer the scope or the workaround.
+`low` when the report is too vague to classify, when it straddles two levels, or
+when it is not clearly a bug at all. `low` is not a failure; it is a routing
+instruction to the sheriff.
+
+**`rationale`** — one sentence, naming the criterion that actually decided it.
+Write "no workaround and blocks the default checkout path" or "opt-in
+webservice feature with a documented workaround". Do not write "this seems
+important" or restate the title. This sentence is the whole reason the sheriff
+can trust or override you at a glance, so it has to carry the *why*.
+
+# 7. First decide what the issue *is*
+
+Not everything in this tracker is a bug report, and a severity only carries
+meaning for one that is. Set `kind` before anything else:
+
+- `bug_report` — something is broken and a merchant is affected. The severity
+  rubric above applies in full.
+- `maintainer_task` — an internal work item written by the team: a migration
+  step, an epic tracking other issues, a spike, a refactoring plan, an "add the
+  missing endpoints" checklist. Recognisable by a maintainer author, a task-list
+  body, and no reproduction steps. These are backlog, not triage.
+- `feature_request` — a request for behaviour that does not exist yet.
+- `support_request` — a merchant asking for help with their own installation,
+  configuration, hosting, or a third-party module, with no defect in core
+  demonstrated.
+- `not_actionable` — spam, an empty template, or a report with no discernible
+  content.
+
+Do not let a maintainer author or a technical vocabulary push you towards
+`bug_report`. An issue titled "SF Migration - Import - Use transaction" written
+by a team member is a `maintainer_task` even though it describes a real
+shortcoming, because nobody reported a broken shop.
+
+For anything that is not a `bug_report`, still fill every field, but:
+
+- set `severity` to `Trivial` — it is the "no functional impact" bucket and the
+  schema requires a value; it is not a claim that the work is unimportant
+- set `confidence` to `high` when the kind is obvious, not `low` — you are
+  confident about what it is, and the report groups these separately from the
+  severity ladder anyway
+- set `suggested_status` to `Needs Specs` for feature requests and anything
+  needing a product call, `NMI` for a support request missing details, `ready`
+  for a maintainer task that is already well specified
+- say plainly in the rationale what it is, e.g. "internal migration task, not a
+  merchant-facing defect"
+
+A `support_request` can still turn out to be a real bug. When the merchant has
+described something that would be a defect if reproduced, call it a
+`bug_report` with `NMI` rather than dismissing it as support.

--- a/.github/triage-agent/prompts/severity_system.md
+++ b/.github/triage-agent/prompts/severity_system.md
@@ -6,6 +6,22 @@ accept, correct, or ignore. Say "low" confidence whenever you are guessing — a
 honest "low" is far more useful to the sheriff than a confident wrong answer,
 because it tells them exactly where to spend their attention.
 
+**Propose severity, never priority.** The project keeps these strictly apart
+(https://www.prestashop-project.org/get-involved/report-issues/how-issues-are-sorted/):
+
+> Severity is used to measure the negative impact that a bug has on a system, a
+> feature, a component or on the project development. It is usually defined by
+> the QA team. As for the priority, it is used to organize all the tasks (bugs,
+> improvements, features, technical tasks) that have to be done in order to meet
+> the project's deadlines.
+
+Severity is a property of the bug and can be read from the report — that is what
+you are asked for. Priority is set by representatives of the Development,
+Product Management and Quality Assurance teams together in their regular
+meetings, and depends on release deadlines and roadmap you cannot see. Never
+suggest what should be fixed first, or when. Surface the facts that meeting
+needs — above all whether the bug is a regression — and stop there.
+
 # 1. Severity definitions
 
 These are the project's official definitions, published at
@@ -72,9 +88,18 @@ impact and it does not even need a workaround.
 Examples:
 
 - Cosmetic issues
-- Wrong translation in a specific language
+- Wrong translation in a specific language: that can be solved on Crowdin
 - Missing confirmation message after an action
 - A link opened in the same tab instead of a new tab
+
+Note the Crowdin qualifier — it is a routing instruction, not a detail. A wrong
+or missing translation string is **not fixed in this repository**. Rate it
+`Trivial` and say so explicitly in the rationale ("wrong translation, fixed on
+Crowdin, not in core"), so nobody sends QA to reproduce something that no core
+change will ever resolve. This does not cover a *mechanism* that is broken —
+a translation page throwing an error, a locale that fails to install, strings
+not being extracted at all — those are ordinary core bugs and take the severity
+their impact deserves.
 
 # 2. Applying the percentage thresholds to PrestaShop
 
@@ -218,6 +243,16 @@ rather than forcing a fit.
 only numbers from that list, and only when the other issue describes the *same
 underlying defect* — not merely the same screen or the same module. Return an
 empty list when unsure. Never write a number that was not in the candidate list.
+
+**`looks_like_regression`** — true when the report says the behaviour used to
+work and now does not: "worked in 9.1.4, broken in 9.1.5", "since upgrading to
+9.2", "this was fine before the update". A version-to-version comparison is the
+signal; a merchant simply being on a recent version is not.
+
+This is the single most valuable fact you can hand the prioritisation meeting,
+because a regression from a recent change takes precedence over an older bug of
+the same severity. It does **not** change the severity you propose — a trivial
+regression is still Trivial. Keep the two separate.
 
 **`needs_human_now`** — true when the sheriff should look this week rather than
 in the normal queue: a security suspicion, a data-loss report, an unhandled

--- a/.github/triage-agent/publish.py
+++ b/.github/triage-agent/publish.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Stage 4 - post the rendered Block Kit payload to Slack.
+
+Dry run is the default. Posting requires an explicit --publish, so the only way
+this run reaches a human channel is if someone asked for it.
+
+This is the only stage in the pipeline that sends anything anywhere, and it
+still writes nothing to GitHub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def post_to_slack(webhook: str, payload: dict, timeout: int = 30) -> None:
+    request = urllib.request.Request(
+        webhook,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8", "replace").strip()
+            if response.status != 200 or body != "ok":
+                raise RuntimeError(f"Slack returned {response.status}: {body}")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace").strip()
+        raise RuntimeError(f"Slack rejected the payload ({exc.code}): {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Could not reach Slack: {exc.reason}") from exc
+
+
+def describe(payload: dict) -> str:
+    """A readable outline of what would be posted, for the dry run."""
+    lines = [f"text: {payload['text']}", f"blocks: {len(payload['blocks'])}"]
+    for block in payload["blocks"]:
+        if block["type"] == "header":
+            lines.append(f"  [header]  {block['text']['text']}")
+        elif block["type"] == "section":
+            first = block["text"]["text"].splitlines()[0]
+            body = block["text"]["text"].splitlines()[1:]
+            lines.append(f"  [section] {first} ({len(body)} lines)")
+        elif block["type"] == "context":
+            lines.append(f"  [context] {block['elements'][0]['text']}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slack", type=Path, default=Path("out/slack.json"))
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        help="Actually post. Without this flag the payload is only described.",
+    )
+    args = parser.parse_args()
+
+    payload = json.loads(args.slack.read_text())
+
+    if not args.publish:
+        print("DRY RUN - nothing was sent. Payload outline:\n", file=sys.stderr)
+        print(describe(payload))
+        print("\nRe-run with --publish to post it.", file=sys.stderr)
+        return 0
+
+    webhook = os.environ.get("SLACK_WEBHOOK_URL")
+    if not webhook:
+        print(
+            "SLACK_WEBHOOK_URL is not set - refusing to publish.\n"
+            "Set it, or drop --publish for a dry run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    post_to_slack(webhook, payload)
+    print("Posted to Slack.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/triage-agent/render.py
+++ b/.github/triage-agent/render.py
@@ -113,6 +113,13 @@ def needs_attention(data: dict) -> list[dict]:
         is_bug = verdict.get("kind", "bug_report") == "bug_report"
         if is_bug and verdict.get("severity") == "Critical":
             reasons.append("proposed Critical")
+        # A regression outranks an older bug of the same severity when the
+        # Dev/PM/QA meeting sets priority, so it is worth the sheriff's week
+        # even at Major.
+        if is_bug and verdict.get("looks_like_regression") and verdict.get(
+            "severity"
+        ) in ("Critical", "Major"):
+            reasons.append("looks like a regression")
         if reasons:
             flagged.append({"item": issue, "reasons": reasons})
 
@@ -189,8 +196,14 @@ def render_markdown(data: dict) -> str:
         out += ["| Issue | Confidence | Next step | Why |", "|---|---|---|---|"]
         for issue in bucket:
             verdict = issue["verdict"]
+            flags = []
+            if verdict.get("looks_like_regression"):
+                flags.append("regression")
+            if verdict.get("security_suspicion"):
+                flags.append("security?")
+            marker = f" `{'` `'.join(flags)}`" if flags else ""
             out.append(
-                f"| [#{issue['number']}]({issue['url']}) {issue['title']} "
+                f"| [#{issue['number']}]({issue['url']}) {issue['title']}{marker} "
                 f"| {verdict['confidence']} "
                 f"| {verdict['suggested_status']} "
                 f"| {one_sentence(verdict['rationale'])} |"
@@ -439,6 +452,7 @@ def board_payload(data: dict) -> dict:
                 "ai_confidence": item["verdict"]["confidence"],
                 "ai_rationale": one_sentence(item["verdict"]["rationale"]),
                 "ai_suggested_status": item["verdict"].get("suggested_status"),
+                "ai_looks_like_regression": item["verdict"].get("looks_like_regression"),
             }
             for item in data["issues"] + data["pull_requests"]
         ],

--- a/.github/triage-agent/render.py
+++ b/.github/triage-agent/render.py
@@ -153,8 +153,15 @@ def low_confidence(data: dict) -> list[dict]:
     ]
 
 
+def window_end(data: dict) -> datetime:
+    """End of the collected window: the explicit --until, else collection time."""
+    if data.get("until"):
+        return datetime.strptime(data["until"], "%Y-%m-%d")
+    return datetime.fromisoformat(data["collected_at"])
+
+
 def render_markdown(data: dict) -> str:
-    week_end = datetime.fromisoformat(data["collected_at"]).strftime("%Y-%m-%d")
+    week_end = window_end(data).strftime("%Y-%m-%d")
     issues = data["issues"]
     prs = data["pull_requests"]
     out: list[str] = []
@@ -326,7 +333,7 @@ def render_markdown(data: dict) -> str:
 
 
 def slack_payload(data: dict, run_url: str | None) -> dict:
-    week_end = datetime.fromisoformat(data["collected_at"]).strftime("%b %d")
+    week_end = window_end(data).strftime("%b %d")
     week_start = datetime.strptime(data["since"], "%Y-%m-%d").strftime("%b %d")
     issues = data["issues"]
     prs = data["pull_requests"]

--- a/.github/triage-agent/render.py
+++ b/.github/triage-agent/render.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Stage 3 - turn the classified week into the three things humans read.
+
+  summary.md   the GitHub Actions job summary, the full record
+  slack.json   a Block Kit payload, the short version that fits in a message
+  board.json   the payload a future board writer would consume
+
+Nothing here talks to GitHub or Slack. This stage only formats.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+SEVERITY_ORDER = ["Critical", "Major", "Minor", "Trivial"]
+SEVERITY_EMOJI = {
+    "Critical": ":red_circle:",
+    "Major": ":large_orange_circle:",
+    "Minor": ":large_yellow_circle:",
+    "Trivial": ":white_circle:",
+}
+
+# Only a bug report gets a place on the severity ladder. Everything else is
+# real work, but it is backlog rather than triage, and mixing it into the
+# severity bands is what makes a weekly list unreadable.
+NON_BUG_KINDS = ["feature_request", "support_request", "maintainer_task", "not_actionable"]
+NON_BUG_LABEL = {
+    "feature_request": "Feature requests",
+    "support_request": "Support requests",
+    "maintainer_task": "Maintainer tasks",
+    "not_actionable": "Not actionable",
+}
+
+ATTENTION_ORDER = ["blocking", "soon", "routine"]
+ATTENTION_LABEL = {"blocking": "Blocking", "soon": "Soon", "routine": "Routine"}
+ATTENTION_EMOJI = {
+    "blocking": ":red_circle:",
+    "soon": ":large_orange_circle:",
+    "routine": ":white_circle:",
+}
+
+# Published list prices per million tokens for the model this runs on. Cache
+# reads bill at a tenth of the input rate and cache writes at 1.25x, so a run
+# with good cache behaviour costs far less than the raw input count suggests.
+PRICE_INPUT_PER_MTOK = 5.00
+PRICE_OUTPUT_PER_MTOK = 25.00
+CACHE_READ_MULTIPLIER = 0.1
+CACHE_WRITE_MULTIPLIER = 1.25
+
+# How many items per band survive into the Slack message. Anything beyond this
+# is announced, never silently dropped.
+SLACK_ITEMS_PER_BAND = 8
+
+
+def estimate_cost(usage: dict) -> float:
+    plain_in = usage.get("input_tokens", 0)
+    cache_write = usage.get("cache_creation_input_tokens", 0)
+    cache_read = usage.get("cache_read_input_tokens", 0)
+    out = usage.get("output_tokens", 0)
+
+    return (
+        plain_in * PRICE_INPUT_PER_MTOK
+        + cache_write * PRICE_INPUT_PER_MTOK * CACHE_WRITE_MULTIPLIER
+        + cache_read * PRICE_INPUT_PER_MTOK * CACHE_READ_MULTIPLIER
+        + out * PRICE_OUTPUT_PER_MTOK
+    ) / 1_000_000
+
+
+def one_sentence(text: str, limit: int = 200) -> str:
+    """Keep rationales to the single sentence the prompt asked for."""
+    text = " ".join((text or "").split())
+    if len(text) > limit:
+        text = text[: limit - 1].rstrip() + "…"
+    return text
+
+
+def bug_reports(issues: list[dict]) -> list[dict]:
+    return [i for i in issues if i["verdict"].get("kind", "bug_report") == "bug_report"]
+
+
+def non_bug_reports(issues: list[dict]) -> list[dict]:
+    return [i for i in issues if i["verdict"].get("kind", "bug_report") != "bug_report"]
+
+
+def group_issues(issues: list[dict]) -> dict[str, list[dict]]:
+    grouped: dict[str, list[dict]] = {level: [] for level in SEVERITY_ORDER}
+    for issue in bug_reports(issues):
+        grouped.setdefault(issue["verdict"]["severity"], []).append(issue)
+    return grouped
+
+
+def group_prs(prs: list[dict]) -> dict[str, list[dict]]:
+    grouped: dict[str, list[dict]] = {level: [] for level in ATTENTION_ORDER}
+    for pr in prs:
+        grouped.setdefault(pr["verdict"]["attention"], []).append(pr)
+    return grouped
+
+
+def needs_attention(data: dict) -> list[dict]:
+    """The short list the sheriff reads first, if they read nothing else."""
+    flagged = []
+    for issue in data["issues"]:
+        verdict = issue["verdict"]
+        reasons = []
+        if verdict.get("security_suspicion"):
+            reasons.append("possible security report")
+        if verdict.get("needs_human_now"):
+            reasons.append("flagged as needing a look this week")
+        is_bug = verdict.get("kind", "bug_report") == "bug_report"
+        if is_bug and verdict.get("severity") == "Critical":
+            reasons.append("proposed Critical")
+        if reasons:
+            flagged.append({"item": issue, "reasons": reasons})
+
+    # Deliberately narrow on the PR side. "Blocking" PRs already have their own
+    # section, and a wrong target branch is hygiene rather than urgency - both
+    # were tried here and between them they buried the handful of items that
+    # genuinely need the sheriff. An unanswered community PR is the one PR
+    # signal that is invisible everywhere else.
+    for pr in data["pull_requests"]:
+        if pr["verdict"].get("is_community_pr_unanswered"):
+            flagged.append({
+                "item": pr,
+                "reasons": ["community PR with no maintainer response"],
+            })
+
+    return flagged
+
+
+def wrong_branch(data: dict) -> list[dict]:
+    return [
+        pr for pr in data["pull_requests"]
+        if pr["verdict"].get("target_branch_looks_wrong")
+    ]
+
+
+def low_confidence(data: dict) -> list[dict]:
+    return [
+        item
+        for item in data["issues"] + data["pull_requests"]
+        if item["verdict"].get("confidence") == "low"
+    ]
+
+
+def render_markdown(data: dict) -> str:
+    week_end = datetime.fromisoformat(data["collected_at"]).strftime("%Y-%m-%d")
+    issues = data["issues"]
+    prs = data["pull_requests"]
+    out: list[str] = []
+
+    out += [
+        f"# Weekly pre-qualification — {data['since']} to {week_end}",
+        "",
+        f"`{data['repository']}` · {len(bug_reports(issues))} bug reports, "
+        f"{len(non_bug_reports(issues))} other issues and {len(prs)} open "
+        "pull requests touched this week.",
+        "",
+        "> **These are proposals.** This run applied no label and wrote to no "
+        "board. Every severity below is a suggestion for the sheriff to accept, "
+        "correct, or ignore.",
+        "",
+    ]
+
+    flagged = needs_attention(data)
+    out += [f"## Needs you this week ({len(flagged)})", ""]
+    if flagged:
+        for entry in flagged:
+            item = entry["item"]
+            out.append(
+                f"- [#{item['number']}]({item['url']}) {item['title']} — "
+                f"**{', '.join(entry['reasons'])}**"
+            )
+    else:
+        out.append("_Nothing flagged._")
+    out.append("")
+
+    out += ["## Issues by proposed severity", ""]
+    grouped = group_issues(issues)
+    for level in SEVERITY_ORDER:
+        bucket = grouped.get(level, [])
+        out += [f"### {level} ({len(bucket)})", ""]
+        if not bucket:
+            out += ["_None._", ""]
+            continue
+        out += ["| Issue | Confidence | Next step | Why |", "|---|---|---|---|"]
+        for issue in bucket:
+            verdict = issue["verdict"]
+            out.append(
+                f"| [#{issue['number']}]({issue['url']}) {issue['title']} "
+                f"| {verdict['confidence']} "
+                f"| {verdict['suggested_status']} "
+                f"| {one_sentence(verdict['rationale'])} |"
+            )
+        out.append("")
+
+    others = non_bug_reports(issues)
+    if others:
+        out += [
+            f"## Issues that are not bug reports ({len(others)})",
+            "",
+            "Real work, but backlog rather than triage - severity does not "
+            "apply, so they are listed separately instead of padding the bands "
+            "above.",
+            "",
+        ]
+        for kind in NON_BUG_KINDS:
+            bucket = [i for i in others if i["verdict"]["kind"] == kind]
+            if not bucket:
+                continue
+            out += [f"**{NON_BUG_LABEL[kind]} ({len(bucket)})**", ""]
+            for issue in bucket:
+                out.append(
+                    f"- [#{issue['number']}]({issue['url']}) {issue['title']} — "
+                    f"{one_sentence(issue['verdict']['rationale'])}"
+                )
+            out.append("")
+
+    out += ["## Pull requests by attention needed", ""]
+    grouped_prs = group_prs(prs)
+    for level in ATTENTION_ORDER:
+        bucket = grouped_prs.get(level, [])
+        out += [f"### {ATTENTION_LABEL[level]} ({len(bucket)})", ""]
+        if not bucket:
+            out += ["_None._", ""]
+            continue
+        out += ["| PR | Waiting on | Idle | Why |", "|---|---|---|---|"]
+        for pr in bucket:
+            verdict = pr["verdict"]
+            out.append(
+                f"| [#{pr['number']}]({pr['url']}) {pr['title']} "
+                f"| {verdict['waiting_on']} "
+                f"| {pr['days_since_update']}d "
+                f"| {one_sentence(verdict['rationale'])} |"
+            )
+        out.append("")
+
+    misrouted = wrong_branch(data)
+    if misrouted:
+        out += [
+            f"## Branch check ({len(misrouted)})",
+            "",
+            "Labelled a bug fix but opened against `develop`, so the fix would "
+            "skip the next patch release. Legitimate when the bug only exists "
+            "in unreleased code — worth a glance, not an alarm.",
+            "",
+        ]
+        for pr in misrouted:
+            out.append(
+                f"- [#{pr['number']}]({pr['url']}) {pr['title']} — "
+                f"`{pr['base_branch']}`"
+            )
+        out.append("")
+
+    uncertain = low_confidence(data)
+    out += [f"## Low confidence — the agent was guessing ({len(uncertain)})", ""]
+    if uncertain:
+        out += [
+            "These are the items where the proposal is least trustworthy. "
+            "They are worth a human read regardless of the level assigned.",
+            "",
+        ]
+        for item in uncertain:
+            verdict = item["verdict"]
+            level = verdict.get("severity") or verdict.get("attention")
+            out.append(
+                f"- [#{item['number']}]({item['url']}) {item['title']} — "
+                f"proposed `{level}`: {one_sentence(verdict['rationale'])}"
+            )
+    else:
+        out.append("_None._")
+    out.append("")
+
+    skipped = data.get("skipped", [])
+    out += [
+        f"## Not classified ({len(skipped)})",
+        "",
+        "<details>",
+        "<summary>Why each item was left out</summary>",
+        "",
+    ]
+    for entry in skipped:
+        out.append(f"- #{entry['number']} ({entry['type']}) — {entry['reason']}")
+    out += ["", "</details>", ""]
+
+    failures = data.get("failures", [])
+    if failures:
+        out += [f"## Classification failures ({len(failures)})", ""]
+        for failure in failures:
+            out.append(
+                f"- #{failure['number']} ({failure['type']}) — {failure['error']}"
+            )
+        out.append("")
+
+    usage = data.get("usage", {})
+    cost = estimate_cost(usage)
+    out += [
+        "## Run",
+        "",
+        f"- Model: `{data['model']}`, effort `{data['effort']}`",
+        f"- Tokens: {usage.get('input_tokens', 0):,} in "
+        f"({usage.get('cache_read_input_tokens', 0):,} read from cache), "
+        f"{usage.get('output_tokens', 0):,} out",
+        f"- Estimated cost at list price: **${cost:.2f}** "
+        f"(~${cost * 52:.0f}/year at this weekly volume)",
+        "",
+    ]
+
+    return "\n".join(out)
+
+
+def slack_payload(data: dict, run_url: str | None) -> dict:
+    week_end = datetime.fromisoformat(data["collected_at"]).strftime("%b %d")
+    week_start = datetime.strptime(data["since"], "%Y-%m-%d").strftime("%b %d")
+    issues = data["issues"]
+    prs = data["pull_requests"]
+
+    blocks: list[dict] = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f"Weekly pre-qualification · {week_start} – {week_end}",
+            },
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*{len(bug_reports(issues))}* bug reports · "
+                        f"*{len(prs)}* PRs · "
+                        "_proposals only, nothing was labelled_"
+                    ),
+                }
+            ],
+        },
+    ]
+
+    def band(title: str, lines: list[str], total: int) -> None:
+        if total > SLACK_ITEMS_PER_BAND:
+            lines.append(
+                f"_+ {total - SLACK_ITEMS_PER_BAND} more in the run summary_"
+            )
+        blocks.append({"type": "divider"})
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*{title}*\n" + "\n".join(lines)},
+            }
+        )
+
+    flagged = needs_attention(data)
+    if flagged:
+        band(
+            f"Needs you this week ({len(flagged)})",
+            [
+                f"{SEVERITY_EMOJI['Critical']} <{e['item']['url']}|"
+                f"#{e['item']['number']}> {e['item']['title'][:80]} — "
+                f"_{', '.join(e['reasons'])}_"
+                for e in flagged[:SLACK_ITEMS_PER_BAND]
+            ],
+            len(flagged),
+        )
+
+    grouped = group_issues(issues)
+    for level in SEVERITY_ORDER:
+        bucket = grouped.get(level, [])
+        if not bucket:
+            continue
+        band(
+            f"Issues · proposed {level} ({len(bucket)})",
+            [
+                f"{SEVERITY_EMOJI[level]} <{i['url']}|#{i['number']}> "
+                f"{i['title'][:80]} — "
+                f"_{one_sentence(i['verdict']['rationale'], 110)}_"
+                for i in bucket[:SLACK_ITEMS_PER_BAND]
+            ],
+            len(bucket),
+        )
+
+    grouped_prs = group_prs(prs)
+    for level in ATTENTION_ORDER:
+        if level == "routine":
+            continue  # routine PRs are healthy; they do not need a Slack line
+        bucket = grouped_prs.get(level, [])
+        if not bucket:
+            continue
+        band(
+            f"Pull requests · {ATTENTION_LABEL[level]} ({len(bucket)})",
+            [
+                f"{ATTENTION_EMOJI[level]} <{p['url']}|#{p['number']}> "
+                f"{p['title'][:80]} — waiting on "
+                f"*{p['verdict']['waiting_on']}*, {p['days_since_update']}d idle"
+                for p in bucket[:SLACK_ITEMS_PER_BAND]
+            ],
+            len(bucket),
+        )
+
+    footer = f"Model `{data['model']}` · run at {data['classified_at']}"
+    if run_url:
+        footer += f" · <{run_url}|full summary>"
+    blocks += [
+        {"type": "divider"},
+        {"type": "context", "elements": [{"type": "mrkdwn", "text": footer}]},
+    ]
+
+    return {
+        "text": (
+            f"Weekly pre-qualification: {len(issues)} issues, {len(prs)} PRs "
+            f"({week_start} – {week_end})"
+        ),
+        "blocks": blocks,
+    }
+
+
+def board_payload(data: dict) -> dict:
+    """What a future board writer would consume.
+
+    Unused by this POC on purpose - producing it now is what makes adding a
+    board target later a small change rather than a redesign.
+    """
+    return {
+        "generated_at": data["classified_at"],
+        "week_of": data["since"],
+        "note": "Proposals. No board field was written by this run.",
+        "items": [
+            {
+                "content_url": item["url"],
+                "number": item["number"],
+                "type": item["type"],
+                "ai_kind": item["verdict"].get("kind"),
+                "ai_severity": item["verdict"].get("severity"),
+                "ai_attention": item["verdict"].get("attention"),
+                "ai_confidence": item["verdict"]["confidence"],
+                "ai_rationale": one_sentence(item["verdict"]["rationale"]),
+                "ai_suggested_status": item["verdict"].get("suggested_status"),
+            }
+            for item in data["issues"] + data["pull_requests"]
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--classified", type=Path, default=Path("out/classified.json"))
+    parser.add_argument("--out-dir", type=Path, default=Path("out"))
+    parser.add_argument(
+        "--run-url",
+        default=None,
+        help="Link back to the workflow run, shown in the Slack footer.",
+    )
+    args = parser.parse_args()
+
+    data = json.loads(args.classified.read_text())
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = args.out_dir / "summary.md"
+    slack = args.out_dir / "slack.json"
+    board = args.out_dir / "board.json"
+
+    summary.write_text(render_markdown(data))
+    slack.write_text(
+        json.dumps(slack_payload(data, args.run_url), indent=2, ensure_ascii=False)
+    )
+    board.write_text(json.dumps(board_payload(data), indent=2, ensure_ascii=False))
+
+    print(f"Wrote {summary}, {slack}, {board}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/triage-agent/requirements.txt
+++ b/.github/triage-agent/requirements.txt
@@ -1,0 +1,3 @@
+# Pinned deliberately: this pipeline is meant to produce the same output when
+# re-run weeks later, and an SDK minor bump changing a default would break that.
+anthropic==1.0.0

--- a/.github/triage-agent/samples/2026-08-18-summary.md
+++ b/.github/triage-agent/samples/2026-08-18-summary.md
@@ -2,16 +2,16 @@
 
 # Weekly pre-qualification — 2026-08-18 to 2026-08-25
 
-`PrestaShop/PrestaShop` · 15 bug reports, 7 other issues and 82 open pull requests touched this week.
+`PrestaShop/PrestaShop` · 15 bug reports, 7 other issues and 72 open pull requests touched this week.
 
 > **These are proposals.** This run applied no label and wrote to no board. Every severity below is a suggestion for the sheriff to accept, correct, or ignore.
 
 ## Needs you this week (11)
 
 - [#42399](https://github.com/PrestaShop/PrestaShop/issues/42399) bug to cart page into backoffice — **flagged as needing a look this week**
+- [#41511](https://github.com/PrestaShop/PrestaShop/issues/41511) Image rendering issue due to malformed srcset with >= 9.1 versions — **looks like a regression**
 - [#42376](https://github.com/PrestaShop/PrestaShop/issues/42376) Security 8-2-8 update not showing up in update assistant — **flagged as needing a look this week**
 - [#34127](https://github.com/PrestaShop/PrestaShop/pull/34127) Support for cumulative displayOverrideTemplate calls — **community PR with no maintainer response**
-- [#42407](https://github.com/PrestaShop/PrestaShop/pull/42407) Provide B2B roles and permissions — **community PR with no maintainer response**
 - [#42328](https://github.com/PrestaShop/PrestaShop/pull/42328) Make the CMS pages back link climb one level instead of jumping to the root — **community PR with no maintainer response**
 - [#42310](https://github.com/PrestaShop/PrestaShop/pull/42310) Add a regression test for translations saved on a non core theme — **community PR with no maintainer response**
 - [#42336](https://github.com/PrestaShop/PrestaShop/pull/42336) Keep the invoice number when the webservice changes an order status — **community PR with no maintainer response**
@@ -38,7 +38,7 @@ _None._
 | [#42391](https://github.com/PrestaShop/PrestaShop/issues/42391) psshipping: HTTP response status silently corrupted to 400 when PS Accounts token is empty, even though checkout page renders normally | medium | TBR | A default-active bundled module returns HTTP 400 on a rendering checkout page, which misleads monitoring and crawlers. |
 | [#42387](https://github.com/PrestaShop/PrestaShop/issues/42387) improved_shipment: changing an order delivery address leaves the shipment address and cost stale | high | Needs Specs | Changing the delivery address leaves the shipment cost stale, which impacts what the customer pays. |
 | [#42389](https://github.com/PrestaShop/PrestaShop/issues/42389) ps_facebook: unbounded growth of `var/cache/<env>/ps_facebook_sessions` leads to inode exhaustion | medium | TBR | Unbounded session-file growth can exhaust inodes and take the whole server down, but only on shops running ps_facebook. |
-| [#41511](https://github.com/PrestaShop/PrestaShop/issues/41511) Image rendering issue due to malformed srcset with >= 9.1 versions | high | TBR | Malformed srcset breaks image rendering across the front office after an upgrade, with no merchant-side workaround. |
+| [#41511](https://github.com/PrestaShop/PrestaShop/issues/41511) Image rendering issue due to malformed srcset with >= 9.1 versions `regression` | high | TBR | Malformed srcset breaks image rendering across the front office from 9.1 onwards, where it worked before. |
 | [#42379](https://github.com/PrestaShop/PrestaShop/issues/42379) Update Assistant does not detect enabled maintenance mode during upgrade from 9.1.4 to 9.1.5 | medium | TBR | Upgrading without maintenance mode detected leaves the shop taking orders mid-upgrade, risking inconsistent data. |
 | [#42376](https://github.com/PrestaShop/PrestaShop/issues/42376) Security 8-2-8 update not showing up in update assistant | medium | TBR | Merchants cannot see the 8.2.8 security release in Update Assistant, which delays security patching. |
 
@@ -65,9 +65,9 @@ Real work, but backlog rather than triage - severity does not apply, so they are
 
 **Maintainer tasks (6)**
 
+- [#42138](https://github.com/PrestaShop/PrestaShop/issues/42138) [Spike] IA Agent for Issue and PR pre-qualification — Spike ticket for this very agent, no merchant impact.
 - [#41568](https://github.com/PrestaShop/PrestaShop/issues/41568) [Extra Properties] Handle mutishop — Internal migration task on ShopConstraint handling, not a merchant-facing defect.
 - [#42076](https://github.com/PrestaShop/PrestaShop/issues/42076) Admin API - Add missing endpoints for the "Shipment" domain — Checklist tracking Admin API endpoints already delivered by linked PRs.
-- [#42138](https://github.com/PrestaShop/PrestaShop/issues/42138) [Spike] IA Agent for Issue and PR pre-qualification — Spike ticket for this very agent, no merchant impact.
 - [#41971](https://github.com/PrestaShop/PrestaShop/issues/41971) Dashboard Migration - Dynamic data refacto — Spike on the dashboard migration pattern, no defect reported.
 - [#22240](https://github.com/PrestaShop/PrestaShop/issues/22240) [EPIC] - Tax rules — Umbrella epic listing other tax-rules issues.
 - [#42385](https://github.com/PrestaShop/PrestaShop/issues/42385) SF Migration - Import - Use transaction — Internal task to add transactions to the migrated importer.
@@ -78,107 +78,97 @@ Real work, but backlog rather than triage - severity does not apply, so they are
 
 | PR | Waiting on | Idle | Why |
 |---|---|---|---|
-| [#34127](https://github.com/PrestaShop/PrestaShop/pull/34127) Support for cumulative displayOverrideTemplate calls | reviewer | 0d | community PR opened with no review and no maintainer reply, 0d idle |
-| [#42407](https://github.com/PrestaShop/PrestaShop/pull/42407) Provide B2B roles and permissions | reviewer | 0d | community PR opened with no review and no maintainer reply, 0d idle |
+| [#40644](https://github.com/PrestaShop/PrestaShop/pull/40644) Fix Category::searchByPath losing context during recursion | nobody | 0d | approved with nothing left waiting on it - ready to merge |
+| [#34127](https://github.com/PrestaShop/PrestaShop/pull/34127) Support for cumulative displayOverrideTemplate calls | reviewer | 1d | community PR opened with no review and no maintainer reply, 1d idle |
 | [#41364](https://github.com/PrestaShop/PrestaShop/pull/41364) Fix `customerId` always returning `null` in Cart API responses | nobody | 4d | approved with nothing left waiting on it - ready to merge |
-| [#42328](https://github.com/PrestaShop/PrestaShop/pull/42328) Make the CMS pages back link climb one level instead of jumping to the root | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
-| [#42310](https://github.com/PrestaShop/PrestaShop/pull/42310) Add a regression test for translations saved on a non core theme | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
-| [#42336](https://github.com/PrestaShop/PrestaShop/pull/42336) Keep the invoice number when the webservice changes an order status | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
-| [#42334](https://github.com/PrestaShop/PrestaShop/pull/42334) Notify modules when the webservice writes a stock quantity | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
-| [#42322](https://github.com/PrestaShop/PrestaShop/pull/42322) Count the products a customer bought even when they are the gifted one | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
-| [#42315](https://github.com/PrestaShop/PrestaShop/pull/42315) Stop advertising the preselected carrier choices as mandatory | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
-| [#42317](https://github.com/PrestaShop/PrestaShop/pull/42317) Say which bound a carrier range includes | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
-| [#42229](https://github.com/PrestaShop/PrestaShop/pull/42229) Add a status action to the prestashop:module CLI command | nobody | 7d | approved with nothing left waiting on it - ready to merge |
+| [#42328](https://github.com/PrestaShop/PrestaShop/pull/42328) Make the CMS pages back link climb one level instead of jumping to the root | reviewer | 6d | community PR opened with no review and no maintainer reply, 6d idle |
+| [#42310](https://github.com/PrestaShop/PrestaShop/pull/42310) Add a regression test for translations saved on a non core theme | reviewer | 6d | community PR opened with no review and no maintainer reply, 6d idle |
+| [#42336](https://github.com/PrestaShop/PrestaShop/pull/42336) Keep the invoice number when the webservice changes an order status | reviewer | 6d | community PR opened with no review and no maintainer reply, 6d idle |
+| [#42334](https://github.com/PrestaShop/PrestaShop/pull/42334) Notify modules when the webservice writes a stock quantity | reviewer | 6d | community PR opened with no review and no maintainer reply, 6d idle |
+| [#42322](https://github.com/PrestaShop/PrestaShop/pull/42322) Count the products a customer bought even when they are the gifted one | reviewer | 6d | community PR opened with no review and no maintainer reply, 6d idle |
+| [#42315](https://github.com/PrestaShop/PrestaShop/pull/42315) Stop advertising the preselected carrier choices as mandatory | reviewer | 6d | community PR opened with no review and no maintainer reply, 6d idle |
+| [#42317](https://github.com/PrestaShop/PrestaShop/pull/42317) Say which bound a carrier range includes | reviewer | 6d | community PR opened with no review and no maintainer reply, 6d idle |
+| [#42229](https://github.com/PrestaShop/PrestaShop/pull/42229) Add a status action to the prestashop:module CLI command | nobody | 8d | approved with nothing left waiting on it - ready to merge |
 
-### Soon (21)
+### Soon (18)
 
 | PR | Waiting on | Idle | Why |
 |---|---|---|---|
-| [#42266](https://github.com/PrestaShop/PrestaShop/pull/42266) API WS : Fix WebserviceKey::add()/delete() PHP warning when no employee is in context | QA | 0d | dev-approved and sitting in the QA queue |
-| [#41884](https://github.com/PrestaShop/PrestaShop/pull/41884) Return a boolean for the currency enabled state in GetCurrencyForEditing | QA | 0d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#36652](https://github.com/PrestaShop/PrestaShop/pull/36652) Fix: tax rules country selection | author | 0d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#35538](https://github.com/PrestaShop/PrestaShop/pull/35538) perf(translation): improve translation parser and register actions | QA | 0d | explicitly marked Blocked, needs someone to unblock it |
-| [#42189](https://github.com/PrestaShop/PrestaShop/pull/42189) Give the not found and checkout pages a breadcrumb entry of their own | QA | 0d | dev-approved and sitting in the QA queue |
-| [#40644](https://github.com/PrestaShop/PrestaShop/pull/40644) Fix Category::searchByPath losing context during recursion | QA | 0d | labelled a bug fix but opened against develop, so it would skip the next patch release |
 | [#41932](https://github.com/PrestaShop/PrestaShop/pull/41932) Paginate the orders grid by id first to avoid a full-table sort | QA | 0d | dev-approved and sitting in the QA queue |
-| [#42197](https://github.com/PrestaShop/PrestaShop/pull/42197) Let the SMTP transport choose implicit TLS by port so 587 works | QA | 0d | dev-approved and sitting in the QA queue |
-| [#40884](https://github.com/PrestaShop/PrestaShop/pull/40884) Fix CMS pages types | author | 1d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#41606](https://github.com/PrestaShop/PrestaShop/pull/41606) Filter payment module group restrictions by current shop | author | 1d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#42042](https://github.com/PrestaShop/PrestaShop/pull/42042) Fix injecting Translator to the CheckoutProcessProviderResolver | nobody | 1d | explicitly marked Blocked, needs someone to unblock it |
-| [#41851](https://github.com/PrestaShop/PrestaShop/pull/41851) Refresh the theme config cache when re-importing an upgraded theme | reviewer | 1d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#42390](https://github.com/PrestaShop/PrestaShop/pull/42390) Refacto : Use the default theme and optimize | reviewer | 4d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#41642](https://github.com/PrestaShop/PrestaShop/pull/41642) Fix get-file friendly URL for virtual product downloads | author | 5d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#41664](https://github.com/PrestaShop/PrestaShop/pull/41664) Reject product/tag names that the search engine cannot index | author | 5d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#41667](https://github.com/PrestaShop/PrestaShop/pull/41667) Show all customer groups in the customer form even when names are duplicated | author | 5d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41943](https://github.com/PrestaShop/PrestaShop/pull/41943) Add shipment_total to actionDeliveryPriceByPrice hook | QA | 0d | dev-approved and sitting in the QA queue |
+| [#41884](https://github.com/PrestaShop/PrestaShop/pull/41884) Return a boolean for the currency enabled state in GetCurrencyForEditing | QA | 0d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#36652](https://github.com/PrestaShop/PrestaShop/pull/36652) Fix: tax rules country selection | author | 1d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#35538](https://github.com/PrestaShop/PrestaShop/pull/35538) perf(translation): improve translation parser and register actions | QA | 1d | explicitly marked Blocked, needs someone to unblock it |
+| [#40884](https://github.com/PrestaShop/PrestaShop/pull/40884) Fix CMS pages types | author | 2d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41606](https://github.com/PrestaShop/PrestaShop/pull/41606) Filter payment module group restrictions by current shop | author | 2d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#42042](https://github.com/PrestaShop/PrestaShop/pull/42042) Fix injecting Translator to the CheckoutProcessProviderResolver | nobody | 2d | explicitly marked Blocked, needs someone to unblock it |
+| [#41851](https://github.com/PrestaShop/PrestaShop/pull/41851) Refresh the theme config cache when re-importing an upgraded theme | reviewer | 2d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#42390](https://github.com/PrestaShop/PrestaShop/pull/42390) Refacto : Use the default theme and optimize | reviewer | 5d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41642](https://github.com/PrestaShop/PrestaShop/pull/41642) Fix get-file friendly URL for virtual product downloads | author | 6d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41664](https://github.com/PrestaShop/PrestaShop/pull/41664) Reject product/tag names that the search engine cannot index | author | 6d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41667](https://github.com/PrestaShop/PrestaShop/pull/41667) Show all customer groups in the customer form even when names are duplicated | author | 6d | labelled a bug fix but opened against develop, so it would skip the next patch release |
 | [#42377](https://github.com/PrestaShop/PrestaShop/pull/42377) Tools::clearCompile: absorb Smarty concurrent-cleanup UnexpectedValueException | reviewer | 6d | labelled a bug fix but opened against develop, so it would skip the next patch release |
 | [#41856](https://github.com/PrestaShop/PrestaShop/pull/41856) Restrict the order detail page to the current shop context | reviewer | 7d | labelled a bug fix but opened against develop, so it would skip the next patch release |
 | [#42364](https://github.com/PrestaShop/PrestaShop/pull/42364) Fix 9843 category groups multistore | reviewer | 7d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#41854](https://github.com/PrestaShop/PrestaShop/pull/41854) Generate links with the target shop's category link_rewrite on multishop | reviewer | 7d | labelled a bug fix but opened against develop, so it would skip the next patch release |
-| [#41844](https://github.com/PrestaShop/PrestaShop/pull/41844) Expose attribute group position in the for-editing query result | reviewer | 7d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41854](https://github.com/PrestaShop/PrestaShop/pull/41854) Generate links with the target shop's category link_rewrite on multishop | reviewer | 8d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41844](https://github.com/PrestaShop/PrestaShop/pull/41844) Expose attribute group position in the for-editing query result | reviewer | 8d | labelled a bug fix but opened against develop, so it would skip the next patch release |
 
-### Routine (50)
+### Routine (43)
 
 | PR | Waiting on | Idle | Why |
 |---|---|---|---|
+| [#42022](https://github.com/PrestaShop/PrestaShop/pull/42022) Improve the carrier domain and the Admin API for the new carrier endpoints | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#42407](https://github.com/PrestaShop/PrestaShop/pull/42407) Provide B2B roles and permissions | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
 | [#41414](https://github.com/PrestaShop/PrestaShop/pull/41414) Migration of the Stores controller to Symfony | author | 0d | waiting on the author after review feedback, 0d idle |
-| [#42022](https://github.com/PrestaShop/PrestaShop/pull/42022) Improve the carrier domain and the Admin API for the new carrier endpoints | author | 0d | waiting on the author after review feedback, 0d idle |
-| [#42411](https://github.com/PrestaShop/PrestaShop/pull/42411) Report the real product quantities of a shipment being edited | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#42092](https://github.com/PrestaShop/PrestaShop/pull/42092) Add the shipment endpoints | author | 0d | waiting on the author after review feedback, 0d idle |
-| [#42250](https://github.com/PrestaShop/PrestaShop/pull/42250) Feat: Introduction of the transactional flag in handlers | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#35920](https://github.com/PrestaShop/PrestaShop/pull/35920) FIX on upload attachments file with POST method | author | 0d | waiting on the author after review feedback, 0d idle |
-| [#35580](https://github.com/PrestaShop/PrestaShop/pull/35580) fix: StringModifier and UTF-8 compatibility | author | 0d | waiting on the author after review feedback, 0d idle |
-| [#42085](https://github.com/PrestaShop/PrestaShop/pull/42085) Use PDF template object returned by hook | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#40893](https://github.com/PrestaShop/PrestaShop/pull/40893) Fix: Custom delivery time gets deleted when switching to default | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#41484](https://github.com/PrestaShop/PrestaShop/pull/41484) Fix: Enabling shared stock on a shop group resets quantities but does not migrate stock_available rows to shop-group scope | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#42030](https://github.com/PrestaShop/PrestaShop/pull/42030) Prevent orphan customer addresses when the session expires | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#42142](https://github.com/PrestaShop/PrestaShop/pull/42142) Fix order payment conversion rate fallback | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#42108](https://github.com/PrestaShop/PrestaShop/pull/42108) Add product ID to catalog price rule edit URLs | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#41897](https://github.com/PrestaShop/PrestaShop/pull/41897) Fix parent ID validation when reordering root-level items | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#42409](https://github.com/PrestaShop/PrestaShop/pull/42409) Fix crash when an email template format is missing | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#41943](https://github.com/PrestaShop/PrestaShop/pull/41943) Add shipment_total to actionDeliveryPriceByPrice hook | author | 0d | waiting on the author after review feedback, 0d idle |
-| [#42285](https://github.com/PrestaShop/PrestaShop/pull/42285) Add the business entities listing and detail pages in the Back Office | author | 0d | waiting on the author after review feedback, 0d idle |
-| [#42247](https://github.com/PrestaShop/PrestaShop/pull/42247) Import migration: architecture plan + import engine and ProductImporter (PR1 of #41907) | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
-| [#42406](https://github.com/PrestaShop/PrestaShop/pull/42406) Fix: Carrier price ranges always display EUR symbol regardless of shop's default currency | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
-| [#41128](https://github.com/PrestaShop/PrestaShop/pull/41128) Fix: cast bool fields in GetCmsPageForEditingHandler | author | 1d | waiting on the author after review feedback, 1d idle |
-| [#41380](https://github.com/PrestaShop/PrestaShop/pull/41380) Fix performance on cart listing with heavy connections/guest tables | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
-| [#42160](https://github.com/PrestaShop/PrestaShop/pull/42160) Check escapeshellarg before shelling out to detect a mime type | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
-| [#41879](https://github.com/PrestaShop/PrestaShop/pull/41879) Fix TinyMCE 404 when the employee language has no language pack | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
-| [#41833](https://github.com/PrestaShop/PrestaShop/pull/41833) Fall back to default precision when the context currency is null | author | 1d | waiting on the author after review feedback, 1d idle |
-| [#42400](https://github.com/PrestaShop/PrestaShop/pull/42400) Fix Carts page performance regression on connections query | reviewer | 2d | awaiting a first or follow-up review, 2d idle |
+| [#35920](https://github.com/PrestaShop/PrestaShop/pull/35920) FIX on upload attachments file with POST method | author | 1d | waiting on the author after review feedback, 1d idle |
+| [#35580](https://github.com/PrestaShop/PrestaShop/pull/35580) fix: StringModifier and UTF-8 compatibility | author | 1d | waiting on the author after review feedback, 1d idle |
+| [#42085](https://github.com/PrestaShop/PrestaShop/pull/42085) Use PDF template object returned by hook | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#40893](https://github.com/PrestaShop/PrestaShop/pull/40893) Fix: Custom delivery time gets deleted when switching to default | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#41484](https://github.com/PrestaShop/PrestaShop/pull/41484) Fix: Enabling shared stock on a shop group resets quantities but does not migrate stock_available rows to shop-group scope | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#42030](https://github.com/PrestaShop/PrestaShop/pull/42030) Prevent orphan customer addresses when the session expires | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#42142](https://github.com/PrestaShop/PrestaShop/pull/42142) Fix order payment conversion rate fallback | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#42108](https://github.com/PrestaShop/PrestaShop/pull/42108) Add product ID to catalog price rule edit URLs | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#41897](https://github.com/PrestaShop/PrestaShop/pull/41897) Fix parent ID validation when reordering root-level items | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#42409](https://github.com/PrestaShop/PrestaShop/pull/42409) Fix crash when an email template format is missing | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#42285](https://github.com/PrestaShop/PrestaShop/pull/42285) Add the business entities listing and detail pages in the Back Office | author | 1d | waiting on the author after review feedback, 1d idle |
+| [#42406](https://github.com/PrestaShop/PrestaShop/pull/42406) Fix: Carrier price ranges always display EUR symbol regardless of shop's default currency | reviewer | 2d | awaiting a first or follow-up review, 2d idle |
+| [#41128](https://github.com/PrestaShop/PrestaShop/pull/41128) Fix: cast bool fields in GetCmsPageForEditingHandler | author | 2d | waiting on the author after review feedback, 2d idle |
+| [#41380](https://github.com/PrestaShop/PrestaShop/pull/41380) Fix performance on cart listing with heavy connections/guest tables | reviewer | 2d | awaiting a first or follow-up review, 2d idle |
+| [#42160](https://github.com/PrestaShop/PrestaShop/pull/42160) Check escapeshellarg before shelling out to detect a mime type | reviewer | 2d | awaiting a first or follow-up review, 2d idle |
+| [#41879](https://github.com/PrestaShop/PrestaShop/pull/41879) Fix TinyMCE 404 when the employee language has no language pack | reviewer | 2d | awaiting a first or follow-up review, 2d idle |
+| [#41833](https://github.com/PrestaShop/PrestaShop/pull/41833) Fall back to default precision when the context currency is null | author | 2d | waiting on the author after review feedback, 2d idle |
 | [#42319](https://github.com/PrestaShop/PrestaShop/pull/42319) Allow an already invalid object to be soft deleted | reviewer | 3d | awaiting a first or follow-up review, 3d idle |
-| [#42388](https://github.com/PrestaShop/PrestaShop/pull/42388) Refactor getRemoteAddr to use Symfony Request | reviewer | 3d | awaiting a first or follow-up review, 3d idle |
+| [#42388](https://github.com/PrestaShop/PrestaShop/pull/42388) Refactor getRemoteAddr to use Symfony Request | reviewer | 4d | awaiting a first or follow-up review, 4d idle |
 | [#41900](https://github.com/PrestaShop/PrestaShop/pull/41900) Reassign per-shop default currency when deleting a currency | author | 5d | waiting on the author after review feedback, 5d idle |
-| [#41633](https://github.com/PrestaShop/PrestaShop/pull/41633) Reject form fields filled only with whitespace | author | 5d | waiting on the author after review feedback, 5d idle |
-| [#41634](https://github.com/PrestaShop/PrestaShop/pull/41634) Fix size filter on the Files (attachments) BO grid | author | 5d | waiting on the author after review feedback, 5d idle |
-| [#41632](https://github.com/PrestaShop/PrestaShop/pull/41632) Harden module configuration route against malformed module_name (BO tokens disabled) | author | 5d | waiting on the author after review feedback, 5d idle |
-| [#41643](https://github.com/PrestaShop/PrestaShop/pull/41643) Make category visibility configurable per shop | author | 5d | waiting on the author after review feedback, 5d idle |
-| [#41825](https://github.com/PrestaShop/PrestaShop/pull/41825) Add per-combination virtual flag and downloadable files | author | 5d | waiting on the author after review feedback, 5d idle |
-| [#42065](https://github.com/PrestaShop/PrestaShop/pull/42065) Guard DuplicateOrderCartHandler against missing order cart | author | 5d | waiting on the author after review feedback, 5d idle |
-| [#42067](https://github.com/PrestaShop/PrestaShop/pull/42067) Add defaults to AddOrderFromBackOfficeCommand employeeId and orderMessage | author | 5d | waiting on the author after review feedback, 5d idle |
-| [#42338](https://github.com/PrestaShop/PrestaShop/pull/42338) Keep prices out of the payload when the customer may not see them | reviewer | 5d | awaiting a first or follow-up review, 5d idle |
-| [#42335](https://github.com/PrestaShop/PrestaShop/pull/42335) Give TinyMCE and moment language codes they actually have | reviewer | 5d | awaiting a first or follow-up review, 5d idle |
-| [#42311](https://github.com/PrestaShop/PrestaShop/pull/42311) Hide the back office tabs of a disabled module | reviewer | 5d | awaiting a first or follow-up review, 5d idle |
-| [#39624](https://github.com/PrestaShop/PrestaShop/pull/39624) Add hook support for image link overrides and adaptation | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#41633](https://github.com/PrestaShop/PrestaShop/pull/41633) Reject form fields filled only with whitespace | author | 6d | waiting on the author after review feedback, 6d idle |
+| [#41634](https://github.com/PrestaShop/PrestaShop/pull/41634) Fix size filter on the Files (attachments) BO grid | author | 6d | waiting on the author after review feedback, 6d idle |
+| [#41632](https://github.com/PrestaShop/PrestaShop/pull/41632) Harden module configuration route against malformed module_name (BO tokens disabled) | author | 6d | waiting on the author after review feedback, 6d idle |
+| [#41643](https://github.com/PrestaShop/PrestaShop/pull/41643) Make category visibility configurable per shop | author | 6d | waiting on the author after review feedback, 6d idle |
+| [#41825](https://github.com/PrestaShop/PrestaShop/pull/41825) Add per-combination virtual flag and downloadable files | author | 6d | waiting on the author after review feedback, 6d idle |
+| [#42065](https://github.com/PrestaShop/PrestaShop/pull/42065) Guard DuplicateOrderCartHandler against missing order cart | author | 6d | waiting on the author after review feedback, 6d idle |
+| [#42067](https://github.com/PrestaShop/PrestaShop/pull/42067) Add defaults to AddOrderFromBackOfficeCommand employeeId and orderMessage | author | 6d | waiting on the author after review feedback, 6d idle |
+| [#42338](https://github.com/PrestaShop/PrestaShop/pull/42338) Keep prices out of the payload when the customer may not see them | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#42335](https://github.com/PrestaShop/PrestaShop/pull/42335) Give TinyMCE and moment language codes they actually have | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#42311](https://github.com/PrestaShop/PrestaShop/pull/42311) Hide the back office tabs of a disabled module | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
 | [#39650](https://github.com/PrestaShop/PrestaShop/pull/39650) Add PDF export command for invoices (prestashop:pdf:export) | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
 | [#42280](https://github.com/PrestaShop/PrestaShop/pull/42280) Introduce advanced admin grid views | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
 | [#36428](https://github.com/PrestaShop/PrestaShop/pull/36428) Add actionMailPreviewBuildTemplateVariables hook | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
 | [#41940](https://github.com/PrestaShop/PrestaShop/pull/41940) Fix null Context::currency during OrderHistory::changeIdOrderState() | author | 6d | waiting on the author after review feedback, 6d idle |
-| [#40878](https://github.com/PrestaShop/PrestaShop/pull/40878) Make .env relocatable as per symfony standard | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
-| [#40625](https://github.com/PrestaShop/PrestaShop/pull/40625) Add ImageMagick support for image processing with GD fallback | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
-| [#42272](https://github.com/PrestaShop/PrestaShop/pull/42272) Flag modules customized by overrides in Module Manager and warn before replacing them | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
-| [#41447](https://github.com/PrestaShop/PrestaShop/pull/41447) Fix deprecated in LanguageList.php | author | 6d | waiting on the author after review feedback, 6d idle |
-| [#42216](https://github.com/PrestaShop/PrestaShop/pull/42216) Always re-index sibling categories after a position update | author | 7d | waiting on the author after review feedback, 7d idle |
-| [#42295](https://github.com/PrestaShop/PrestaShop/pull/42295) Apply a logo saved for a shop group to every shop of that group | reviewer | 7d | awaiting a first or follow-up review, 7d idle |
-| [#42056](https://github.com/PrestaShop/PrestaShop/pull/42056) Fix order left without a status when its message strips to empty | author | 7d | waiting on the author after review feedback, 7d idle |
+| [#40625](https://github.com/PrestaShop/PrestaShop/pull/40625) Add ImageMagick support for image processing with GD fallback | reviewer | 7d | awaiting a first or follow-up review, 7d idle |
+| [#42272](https://github.com/PrestaShop/PrestaShop/pull/42272) Flag modules customized by overrides in Module Manager and warn before replacing them | reviewer | 7d | awaiting a first or follow-up review, 7d idle |
+| [#41447](https://github.com/PrestaShop/PrestaShop/pull/41447) Fix deprecated in LanguageList.php | author | 7d | waiting on the author after review feedback, 7d idle |
+| [#42216](https://github.com/PrestaShop/PrestaShop/pull/42216) Always re-index sibling categories after a position update | author | 8d | waiting on the author after review feedback, 8d idle |
+| [#42295](https://github.com/PrestaShop/PrestaShop/pull/42295) Apply a logo saved for a shop group to every shop of that group | reviewer | 8d | awaiting a first or follow-up review, 8d idle |
+| [#42056](https://github.com/PrestaShop/PrestaShop/pull/42056) Fix order left without a status when its message strips to empty | author | 8d | waiting on the author after review feedback, 8d idle |
 
 ## Branch check (16)
 
 Labelled a bug fix but opened against `develop`, so the fix would skip the next patch release. Legitimate when the bug only exists in unreleased code — worth a glance, not an alarm.
 
+- [#40644](https://github.com/PrestaShop/PrestaShop/pull/40644) Fix Category::searchByPath losing context during recursion — `develop`
 - [#41884](https://github.com/PrestaShop/PrestaShop/pull/41884) Return a boolean for the currency enabled state in GetCurrencyForEditing — `develop`
 - [#34127](https://github.com/PrestaShop/PrestaShop/pull/34127) Support for cumulative displayOverrideTemplate calls — `develop`
 - [#36652](https://github.com/PrestaShop/PrestaShop/pull/36652) Fix: tax rules country selection — `develop`
-- [#40644](https://github.com/PrestaShop/PrestaShop/pull/40644) Fix Category::searchByPath losing context during recursion — `develop`
 - [#40884](https://github.com/PrestaShop/PrestaShop/pull/40884) Fix CMS pages types — `develop`
 - [#41606](https://github.com/PrestaShop/PrestaShop/pull/41606) Filter payment module group restrictions by current shop — `develop`
 - [#41851](https://github.com/PrestaShop/PrestaShop/pull/41851) Refresh the theme config cache when re-importing an upgraded theme — `develop`
@@ -192,23 +182,21 @@ Labelled a bug fix but opened against `develop`, so the fix would skip the next 
 - [#41854](https://github.com/PrestaShop/PrestaShop/pull/41854) Generate links with the target shop's category link_rewrite on multishop — `develop`
 - [#41844](https://github.com/PrestaShop/PrestaShop/pull/41844) Expose attribute group position in the for-editing query result — `develop`
 
-## Low confidence — the agent was guessing (15)
+## Low confidence — the agent was guessing (13)
 
 These are the items where the proposal is least trustworthy. They are worth a human read regardless of the level assigned.
 
+- [#42022](https://github.com/PrestaShop/PrestaShop/pull/42022) Improve the carrier domain and the Admin API for the new carrier endpoints — proposed `routine`: awaiting a first or follow-up review, 0d idle
 - [#41414](https://github.com/PrestaShop/PrestaShop/pull/41414) Migration of the Stores controller to Symfony — proposed `routine`: waiting on the author after review feedback, 0d idle
-- [#42022](https://github.com/PrestaShop/PrestaShop/pull/42022) Improve the carrier domain and the Admin API for the new carrier endpoints — proposed `routine`: waiting on the author after review feedback, 0d idle
-- [#42092](https://github.com/PrestaShop/PrestaShop/pull/42092) Add the shipment endpoints — proposed `routine`: waiting on the author after review feedback, 0d idle
-- [#42285](https://github.com/PrestaShop/PrestaShop/pull/42285) Add the business entities listing and detail pages in the Back Office — proposed `routine`: waiting on the author after review feedback, 0d idle
-- [#42247](https://github.com/PrestaShop/PrestaShop/pull/42247) Import migration: architecture plan + import engine and ProductImporter (PR1 of #41907) — proposed `routine`: awaiting a first or follow-up review, 0d idle
+- [#42285](https://github.com/PrestaShop/PrestaShop/pull/42285) Add the business entities listing and detail pages in the Back Office — proposed `routine`: waiting on the author after review feedback, 1d idle
 - [#41606](https://github.com/PrestaShop/PrestaShop/pull/41606) Filter payment module group restrictions by current shop — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
 - [#41642](https://github.com/PrestaShop/PrestaShop/pull/41642) Fix get-file friendly URL for virtual product downloads — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
-- [#41643](https://github.com/PrestaShop/PrestaShop/pull/41643) Make category visibility configurable per shop — proposed `routine`: waiting on the author after review feedback, 5d idle
+- [#41643](https://github.com/PrestaShop/PrestaShop/pull/41643) Make category visibility configurable per shop — proposed `routine`: waiting on the author after review feedback, 6d idle
 - [#41664](https://github.com/PrestaShop/PrestaShop/pull/41664) Reject product/tag names that the search engine cannot index — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
 - [#41667](https://github.com/PrestaShop/PrestaShop/pull/41667) Show all customer groups in the customer form even when names are duplicated — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
-- [#41825](https://github.com/PrestaShop/PrestaShop/pull/41825) Add per-combination virtual flag and downloadable files — proposed `routine`: waiting on the author after review feedback, 5d idle
-- [#42065](https://github.com/PrestaShop/PrestaShop/pull/42065) Guard DuplicateOrderCartHandler against missing order cart — proposed `routine`: waiting on the author after review feedback, 5d idle
-- [#42067](https://github.com/PrestaShop/PrestaShop/pull/42067) Add defaults to AddOrderFromBackOfficeCommand employeeId and orderMessage — proposed `routine`: waiting on the author after review feedback, 5d idle
+- [#41825](https://github.com/PrestaShop/PrestaShop/pull/41825) Add per-combination virtual flag and downloadable files — proposed `routine`: waiting on the author after review feedback, 6d idle
+- [#42065](https://github.com/PrestaShop/PrestaShop/pull/42065) Guard DuplicateOrderCartHandler against missing order cart — proposed `routine`: waiting on the author after review feedback, 6d idle
+- [#42067](https://github.com/PrestaShop/PrestaShop/pull/42067) Add defaults to AddOrderFromBackOfficeCommand employeeId and orderMessage — proposed `routine`: waiting on the author after review feedback, 6d idle
 - [#42377](https://github.com/PrestaShop/PrestaShop/pull/42377) Tools::clearCompile: absorb Smarty concurrent-cleanup UnexpectedValueException — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
 - [#42280](https://github.com/PrestaShop/PrestaShop/pull/42280) Introduce advanced admin grid views — proposed `routine`: awaiting a first or follow-up review, 6d idle
 
@@ -217,12 +205,14 @@ These are the items where the proposal is least trustworthy. They are worth a hu
 <details>
 <summary>Why each item was left out</summary>
 
+- #42189 (pull_request) — not open (state=merged)
+- #36663 (issue) — not open (state=closed)
+- #42197 (pull_request) — not open (state=merged)
+- #42247 (pull_request) — not open (state=merged)
 - #40240 (pull_request) — not open (state=merged)
 - #35112 (issue) — not open (state=closed)
 - #40712 (pull_request) — not open (state=merged)
 - #38993 (issue) — not open (state=closed)
-- #15689 (issue) — already rated by a maintainer (Minor)
-- #42345 (pull_request) — bot author (ps-jarvis)
 - #26837 (issue) — already rated by a maintainer (Minor)
 - #14708 (issue) — not open (state=closed)
 - #42405 (pull_request) — bot author (github-actions)
@@ -239,9 +229,7 @@ These are the items where the proposal is least trustworthy. They are worth a hu
 - #25700 (issue) — not open (state=closed)
 - #42396 (pull_request) — not open (state=merged)
 - #42123 (pull_request) — not open (state=merged)
-- #42346 (pull_request) — bot author (ps-jarvis)
 - #42395 (issue) — not open (state=closed)
-- #36663 (issue) — already rated by a maintainer (Major)
 - #41928 (pull_request) — not open (state=merged)
 - #42393 (pull_request) — not open (state=merged)
 - #41409 (pull_request) — not open (state=merged)

--- a/.github/triage-agent/samples/2026-08-18-summary.md
+++ b/.github/triage-agent/samples/2026-08-18-summary.md
@@ -1,0 +1,299 @@
+<!-- Verdicts hand-applied from the rubrics, not a model run - see README.md -->
+
+# Weekly pre-qualification — 2026-08-18 to 2026-08-25
+
+`PrestaShop/PrestaShop` · 15 bug reports, 7 other issues and 82 open pull requests touched this week.
+
+> **These are proposals.** This run applied no label and wrote to no board. Every severity below is a suggestion for the sheriff to accept, correct, or ignore.
+
+## Needs you this week (11)
+
+- [#42399](https://github.com/PrestaShop/PrestaShop/issues/42399) bug to cart page into backoffice — **flagged as needing a look this week**
+- [#42376](https://github.com/PrestaShop/PrestaShop/issues/42376) Security 8-2-8 update not showing up in update assistant — **flagged as needing a look this week**
+- [#34127](https://github.com/PrestaShop/PrestaShop/pull/34127) Support for cumulative displayOverrideTemplate calls — **community PR with no maintainer response**
+- [#42407](https://github.com/PrestaShop/PrestaShop/pull/42407) Provide B2B roles and permissions — **community PR with no maintainer response**
+- [#42328](https://github.com/PrestaShop/PrestaShop/pull/42328) Make the CMS pages back link climb one level instead of jumping to the root — **community PR with no maintainer response**
+- [#42310](https://github.com/PrestaShop/PrestaShop/pull/42310) Add a regression test for translations saved on a non core theme — **community PR with no maintainer response**
+- [#42336](https://github.com/PrestaShop/PrestaShop/pull/42336) Keep the invoice number when the webservice changes an order status — **community PR with no maintainer response**
+- [#42334](https://github.com/PrestaShop/PrestaShop/pull/42334) Notify modules when the webservice writes a stock quantity — **community PR with no maintainer response**
+- [#42322](https://github.com/PrestaShop/PrestaShop/pull/42322) Count the products a customer bought even when they are the gifted one — **community PR with no maintainer response**
+- [#42315](https://github.com/PrestaShop/PrestaShop/pull/42315) Stop advertising the preselected carrier choices as mandatory — **community PR with no maintainer response**
+- [#42317](https://github.com/PrestaShop/PrestaShop/pull/42317) Say which bound a carrier range includes — **community PR with no maintainer response**
+
+## Issues by proposed severity
+
+### Critical (0)
+
+_None._
+
+### Major (11)
+
+| Issue | Confidence | Next step | Why |
+|---|---|---|---|
+| [#42397](https://github.com/PrestaShop/PrestaShop/issues/42397) Admin API - Creating a shipment or adding a product to it breaks the order line quantities | medium | ready | Corrupts order line quantities, but only behind the improved_shipment beta flag which is off by default. |
+| [#42410](https://github.com/PrestaShop/PrestaShop/issues/42410) Multicarrier - The carrier list of the edit shipment form is computed from empty quantities | medium | ready | Hardcoded zero quantity skews the carrier list and therefore the shipping cost; limited to the beta flag. |
+| [#42408](https://github.com/PrestaShop/PrestaShop/issues/42408) BO email translations crash when a mail format is missing | high | ready | Fatal TypeError makes the BO email translations page unreachable with no obvious workaround. |
+| [#42399](https://github.com/PrestaShop/PrestaShop/issues/42399) bug to cart page into backoffice | medium | TBR | 504 on the BO carts page leaves the merchant unable to consult carts, with two open perf PRs pointing at the same query. |
+| [#42079](https://github.com/PrestaShop/PrestaShop/issues/42079) Pack stock type "Decrement pack only" is ignored by Pack::getQuantity() - empty() treats STOCK_TYPE_PACK_ONLY (0) as "Default" | medium | TBR | empty() misreads the pack-only stock type so pack quantities are wrong, which can oversell stock. |
+| [#42391](https://github.com/PrestaShop/PrestaShop/issues/42391) psshipping: HTTP response status silently corrupted to 400 when PS Accounts token is empty, even though checkout page renders normally | medium | TBR | A default-active bundled module returns HTTP 400 on a rendering checkout page, which misleads monitoring and crawlers. |
+| [#42387](https://github.com/PrestaShop/PrestaShop/issues/42387) improved_shipment: changing an order delivery address leaves the shipment address and cost stale | high | Needs Specs | Changing the delivery address leaves the shipment cost stale, which impacts what the customer pays. |
+| [#42389](https://github.com/PrestaShop/PrestaShop/issues/42389) ps_facebook: unbounded growth of `var/cache/<env>/ps_facebook_sessions` leads to inode exhaustion | medium | TBR | Unbounded session-file growth can exhaust inodes and take the whole server down, but only on shops running ps_facebook. |
+| [#41511](https://github.com/PrestaShop/PrestaShop/issues/41511) Image rendering issue due to malformed srcset with >= 9.1 versions | high | TBR | Malformed srcset breaks image rendering across the front office after an upgrade, with no merchant-side workaround. |
+| [#42379](https://github.com/PrestaShop/PrestaShop/issues/42379) Update Assistant does not detect enabled maintenance mode during upgrade from 9.1.4 to 9.1.5 | medium | TBR | Upgrading without maintenance mode detected leaves the shop taking orders mid-upgrade, risking inconsistent data. |
+| [#42376](https://github.com/PrestaShop/PrestaShop/issues/42376) Security 8-2-8 update not showing up in update assistant | medium | TBR | Merchants cannot see the 8.2.8 security release in Update Assistant, which delays security patching. |
+
+### Minor (4)
+
+| Issue | Confidence | Next step | Why |
+|---|---|---|---|
+| [#40357](https://github.com/PrestaShop/PrestaShop/issues/40357) Section "System information" is unusable for big websites | high | ready | Tolerable slowdown on a diagnostics page that is not on any essential shop operation. |
+| [#42401](https://github.com/PrestaShop/PrestaShop/issues/42401) Carrier price ranges always display EUR symbol regardless of shop's default currency | high | ready | Wrong currency symbol displayed; the amounts themselves are correct and a fix PR already exists. |
+| [#32142](https://github.com/PrestaShop/PrestaShop/issues/32142) Separate multi store email logo does not get picked up | high | ready | Wrong logo in emails for a multistore setup, which is opt-in and has an obvious workaround. |
+| [#42371](https://github.com/PrestaShop/PrestaShop/issues/42371) <section> html tag can not be used in PrestaShop CMS pages design | high | TBR | The <section> tag is stripped from CMS pages; using a div is a reasonable workaround. |
+
+### Trivial (0)
+
+_None._
+
+## Issues that are not bug reports (7)
+
+Real work, but backlog rather than triage - severity does not apply, so they are listed separately instead of padding the bands above.
+
+**Support requests (1)**
+
+- [#42394](https://github.com/PrestaShop/PrestaShop/issues/42394) Search + "Disable non built-in modules" + Theme NOT WORKING - Please help — Merchant asking for help on an 8.0.4 shop with a third-party theme, no core defect demonstrated.
+
+**Maintainer tasks (6)**
+
+- [#41568](https://github.com/PrestaShop/PrestaShop/issues/41568) [Extra Properties] Handle mutishop — Internal migration task on ShopConstraint handling, not a merchant-facing defect.
+- [#42076](https://github.com/PrestaShop/PrestaShop/issues/42076) Admin API - Add missing endpoints for the "Shipment" domain — Checklist tracking Admin API endpoints already delivered by linked PRs.
+- [#42138](https://github.com/PrestaShop/PrestaShop/issues/42138) [Spike] IA Agent for Issue and PR pre-qualification — Spike ticket for this very agent, no merchant impact.
+- [#41971](https://github.com/PrestaShop/PrestaShop/issues/41971) Dashboard Migration - Dynamic data refacto — Spike on the dashboard migration pattern, no defect reported.
+- [#22240](https://github.com/PrestaShop/PrestaShop/issues/22240) [EPIC] - Tax rules — Umbrella epic listing other tax-rules issues.
+- [#42385](https://github.com/PrestaShop/PrestaShop/issues/42385) SF Migration - Import - Use transaction — Internal task to add transactions to the migrated importer.
+
+## Pull requests by attention needed
+
+### Blocking (11)
+
+| PR | Waiting on | Idle | Why |
+|---|---|---|---|
+| [#34127](https://github.com/PrestaShop/PrestaShop/pull/34127) Support for cumulative displayOverrideTemplate calls | reviewer | 0d | community PR opened with no review and no maintainer reply, 0d idle |
+| [#42407](https://github.com/PrestaShop/PrestaShop/pull/42407) Provide B2B roles and permissions | reviewer | 0d | community PR opened with no review and no maintainer reply, 0d idle |
+| [#41364](https://github.com/PrestaShop/PrestaShop/pull/41364) Fix `customerId` always returning `null` in Cart API responses | nobody | 4d | approved with nothing left waiting on it - ready to merge |
+| [#42328](https://github.com/PrestaShop/PrestaShop/pull/42328) Make the CMS pages back link climb one level instead of jumping to the root | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
+| [#42310](https://github.com/PrestaShop/PrestaShop/pull/42310) Add a regression test for translations saved on a non core theme | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
+| [#42336](https://github.com/PrestaShop/PrestaShop/pull/42336) Keep the invoice number when the webservice changes an order status | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
+| [#42334](https://github.com/PrestaShop/PrestaShop/pull/42334) Notify modules when the webservice writes a stock quantity | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
+| [#42322](https://github.com/PrestaShop/PrestaShop/pull/42322) Count the products a customer bought even when they are the gifted one | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
+| [#42315](https://github.com/PrestaShop/PrestaShop/pull/42315) Stop advertising the preselected carrier choices as mandatory | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
+| [#42317](https://github.com/PrestaShop/PrestaShop/pull/42317) Say which bound a carrier range includes | reviewer | 5d | community PR opened with no review and no maintainer reply, 5d idle |
+| [#42229](https://github.com/PrestaShop/PrestaShop/pull/42229) Add a status action to the prestashop:module CLI command | nobody | 7d | approved with nothing left waiting on it - ready to merge |
+
+### Soon (21)
+
+| PR | Waiting on | Idle | Why |
+|---|---|---|---|
+| [#42266](https://github.com/PrestaShop/PrestaShop/pull/42266) API WS : Fix WebserviceKey::add()/delete() PHP warning when no employee is in context | QA | 0d | dev-approved and sitting in the QA queue |
+| [#41884](https://github.com/PrestaShop/PrestaShop/pull/41884) Return a boolean for the currency enabled state in GetCurrencyForEditing | QA | 0d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#36652](https://github.com/PrestaShop/PrestaShop/pull/36652) Fix: tax rules country selection | author | 0d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#35538](https://github.com/PrestaShop/PrestaShop/pull/35538) perf(translation): improve translation parser and register actions | QA | 0d | explicitly marked Blocked, needs someone to unblock it |
+| [#42189](https://github.com/PrestaShop/PrestaShop/pull/42189) Give the not found and checkout pages a breadcrumb entry of their own | QA | 0d | dev-approved and sitting in the QA queue |
+| [#40644](https://github.com/PrestaShop/PrestaShop/pull/40644) Fix Category::searchByPath losing context during recursion | QA | 0d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41932](https://github.com/PrestaShop/PrestaShop/pull/41932) Paginate the orders grid by id first to avoid a full-table sort | QA | 0d | dev-approved and sitting in the QA queue |
+| [#42197](https://github.com/PrestaShop/PrestaShop/pull/42197) Let the SMTP transport choose implicit TLS by port so 587 works | QA | 0d | dev-approved and sitting in the QA queue |
+| [#40884](https://github.com/PrestaShop/PrestaShop/pull/40884) Fix CMS pages types | author | 1d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41606](https://github.com/PrestaShop/PrestaShop/pull/41606) Filter payment module group restrictions by current shop | author | 1d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#42042](https://github.com/PrestaShop/PrestaShop/pull/42042) Fix injecting Translator to the CheckoutProcessProviderResolver | nobody | 1d | explicitly marked Blocked, needs someone to unblock it |
+| [#41851](https://github.com/PrestaShop/PrestaShop/pull/41851) Refresh the theme config cache when re-importing an upgraded theme | reviewer | 1d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#42390](https://github.com/PrestaShop/PrestaShop/pull/42390) Refacto : Use the default theme and optimize | reviewer | 4d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41642](https://github.com/PrestaShop/PrestaShop/pull/41642) Fix get-file friendly URL for virtual product downloads | author | 5d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41664](https://github.com/PrestaShop/PrestaShop/pull/41664) Reject product/tag names that the search engine cannot index | author | 5d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41667](https://github.com/PrestaShop/PrestaShop/pull/41667) Show all customer groups in the customer form even when names are duplicated | author | 5d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#42377](https://github.com/PrestaShop/PrestaShop/pull/42377) Tools::clearCompile: absorb Smarty concurrent-cleanup UnexpectedValueException | reviewer | 6d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41856](https://github.com/PrestaShop/PrestaShop/pull/41856) Restrict the order detail page to the current shop context | reviewer | 7d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#42364](https://github.com/PrestaShop/PrestaShop/pull/42364) Fix 9843 category groups multistore | reviewer | 7d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41854](https://github.com/PrestaShop/PrestaShop/pull/41854) Generate links with the target shop's category link_rewrite on multishop | reviewer | 7d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+| [#41844](https://github.com/PrestaShop/PrestaShop/pull/41844) Expose attribute group position in the for-editing query result | reviewer | 7d | labelled a bug fix but opened against develop, so it would skip the next patch release |
+
+### Routine (50)
+
+| PR | Waiting on | Idle | Why |
+|---|---|---|---|
+| [#41414](https://github.com/PrestaShop/PrestaShop/pull/41414) Migration of the Stores controller to Symfony | author | 0d | waiting on the author after review feedback, 0d idle |
+| [#42022](https://github.com/PrestaShop/PrestaShop/pull/42022) Improve the carrier domain and the Admin API for the new carrier endpoints | author | 0d | waiting on the author after review feedback, 0d idle |
+| [#42411](https://github.com/PrestaShop/PrestaShop/pull/42411) Report the real product quantities of a shipment being edited | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#42092](https://github.com/PrestaShop/PrestaShop/pull/42092) Add the shipment endpoints | author | 0d | waiting on the author after review feedback, 0d idle |
+| [#42250](https://github.com/PrestaShop/PrestaShop/pull/42250) Feat: Introduction of the transactional flag in handlers | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#35920](https://github.com/PrestaShop/PrestaShop/pull/35920) FIX on upload attachments file with POST method | author | 0d | waiting on the author after review feedback, 0d idle |
+| [#35580](https://github.com/PrestaShop/PrestaShop/pull/35580) fix: StringModifier and UTF-8 compatibility | author | 0d | waiting on the author after review feedback, 0d idle |
+| [#42085](https://github.com/PrestaShop/PrestaShop/pull/42085) Use PDF template object returned by hook | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#40893](https://github.com/PrestaShop/PrestaShop/pull/40893) Fix: Custom delivery time gets deleted when switching to default | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#41484](https://github.com/PrestaShop/PrestaShop/pull/41484) Fix: Enabling shared stock on a shop group resets quantities but does not migrate stock_available rows to shop-group scope | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#42030](https://github.com/PrestaShop/PrestaShop/pull/42030) Prevent orphan customer addresses when the session expires | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#42142](https://github.com/PrestaShop/PrestaShop/pull/42142) Fix order payment conversion rate fallback | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#42108](https://github.com/PrestaShop/PrestaShop/pull/42108) Add product ID to catalog price rule edit URLs | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#41897](https://github.com/PrestaShop/PrestaShop/pull/41897) Fix parent ID validation when reordering root-level items | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#42409](https://github.com/PrestaShop/PrestaShop/pull/42409) Fix crash when an email template format is missing | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#41943](https://github.com/PrestaShop/PrestaShop/pull/41943) Add shipment_total to actionDeliveryPriceByPrice hook | author | 0d | waiting on the author after review feedback, 0d idle |
+| [#42285](https://github.com/PrestaShop/PrestaShop/pull/42285) Add the business entities listing and detail pages in the Back Office | author | 0d | waiting on the author after review feedback, 0d idle |
+| [#42247](https://github.com/PrestaShop/PrestaShop/pull/42247) Import migration: architecture plan + import engine and ProductImporter (PR1 of #41907) | reviewer | 0d | awaiting a first or follow-up review, 0d idle |
+| [#42406](https://github.com/PrestaShop/PrestaShop/pull/42406) Fix: Carrier price ranges always display EUR symbol regardless of shop's default currency | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#41128](https://github.com/PrestaShop/PrestaShop/pull/41128) Fix: cast bool fields in GetCmsPageForEditingHandler | author | 1d | waiting on the author after review feedback, 1d idle |
+| [#41380](https://github.com/PrestaShop/PrestaShop/pull/41380) Fix performance on cart listing with heavy connections/guest tables | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#42160](https://github.com/PrestaShop/PrestaShop/pull/42160) Check escapeshellarg before shelling out to detect a mime type | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#41879](https://github.com/PrestaShop/PrestaShop/pull/41879) Fix TinyMCE 404 when the employee language has no language pack | reviewer | 1d | awaiting a first or follow-up review, 1d idle |
+| [#41833](https://github.com/PrestaShop/PrestaShop/pull/41833) Fall back to default precision when the context currency is null | author | 1d | waiting on the author after review feedback, 1d idle |
+| [#42400](https://github.com/PrestaShop/PrestaShop/pull/42400) Fix Carts page performance regression on connections query | reviewer | 2d | awaiting a first or follow-up review, 2d idle |
+| [#42319](https://github.com/PrestaShop/PrestaShop/pull/42319) Allow an already invalid object to be soft deleted | reviewer | 3d | awaiting a first or follow-up review, 3d idle |
+| [#42388](https://github.com/PrestaShop/PrestaShop/pull/42388) Refactor getRemoteAddr to use Symfony Request | reviewer | 3d | awaiting a first or follow-up review, 3d idle |
+| [#41900](https://github.com/PrestaShop/PrestaShop/pull/41900) Reassign per-shop default currency when deleting a currency | author | 5d | waiting on the author after review feedback, 5d idle |
+| [#41633](https://github.com/PrestaShop/PrestaShop/pull/41633) Reject form fields filled only with whitespace | author | 5d | waiting on the author after review feedback, 5d idle |
+| [#41634](https://github.com/PrestaShop/PrestaShop/pull/41634) Fix size filter on the Files (attachments) BO grid | author | 5d | waiting on the author after review feedback, 5d idle |
+| [#41632](https://github.com/PrestaShop/PrestaShop/pull/41632) Harden module configuration route against malformed module_name (BO tokens disabled) | author | 5d | waiting on the author after review feedback, 5d idle |
+| [#41643](https://github.com/PrestaShop/PrestaShop/pull/41643) Make category visibility configurable per shop | author | 5d | waiting on the author after review feedback, 5d idle |
+| [#41825](https://github.com/PrestaShop/PrestaShop/pull/41825) Add per-combination virtual flag and downloadable files | author | 5d | waiting on the author after review feedback, 5d idle |
+| [#42065](https://github.com/PrestaShop/PrestaShop/pull/42065) Guard DuplicateOrderCartHandler against missing order cart | author | 5d | waiting on the author after review feedback, 5d idle |
+| [#42067](https://github.com/PrestaShop/PrestaShop/pull/42067) Add defaults to AddOrderFromBackOfficeCommand employeeId and orderMessage | author | 5d | waiting on the author after review feedback, 5d idle |
+| [#42338](https://github.com/PrestaShop/PrestaShop/pull/42338) Keep prices out of the payload when the customer may not see them | reviewer | 5d | awaiting a first or follow-up review, 5d idle |
+| [#42335](https://github.com/PrestaShop/PrestaShop/pull/42335) Give TinyMCE and moment language codes they actually have | reviewer | 5d | awaiting a first or follow-up review, 5d idle |
+| [#42311](https://github.com/PrestaShop/PrestaShop/pull/42311) Hide the back office tabs of a disabled module | reviewer | 5d | awaiting a first or follow-up review, 5d idle |
+| [#39624](https://github.com/PrestaShop/PrestaShop/pull/39624) Add hook support for image link overrides and adaptation | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#39650](https://github.com/PrestaShop/PrestaShop/pull/39650) Add PDF export command for invoices (prestashop:pdf:export) | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#42280](https://github.com/PrestaShop/PrestaShop/pull/42280) Introduce advanced admin grid views | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#36428](https://github.com/PrestaShop/PrestaShop/pull/36428) Add actionMailPreviewBuildTemplateVariables hook | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#41940](https://github.com/PrestaShop/PrestaShop/pull/41940) Fix null Context::currency during OrderHistory::changeIdOrderState() | author | 6d | waiting on the author after review feedback, 6d idle |
+| [#40878](https://github.com/PrestaShop/PrestaShop/pull/40878) Make .env relocatable as per symfony standard | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#40625](https://github.com/PrestaShop/PrestaShop/pull/40625) Add ImageMagick support for image processing with GD fallback | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#42272](https://github.com/PrestaShop/PrestaShop/pull/42272) Flag modules customized by overrides in Module Manager and warn before replacing them | reviewer | 6d | awaiting a first or follow-up review, 6d idle |
+| [#41447](https://github.com/PrestaShop/PrestaShop/pull/41447) Fix deprecated in LanguageList.php | author | 6d | waiting on the author after review feedback, 6d idle |
+| [#42216](https://github.com/PrestaShop/PrestaShop/pull/42216) Always re-index sibling categories after a position update | author | 7d | waiting on the author after review feedback, 7d idle |
+| [#42295](https://github.com/PrestaShop/PrestaShop/pull/42295) Apply a logo saved for a shop group to every shop of that group | reviewer | 7d | awaiting a first or follow-up review, 7d idle |
+| [#42056](https://github.com/PrestaShop/PrestaShop/pull/42056) Fix order left without a status when its message strips to empty | author | 7d | waiting on the author after review feedback, 7d idle |
+
+## Branch check (16)
+
+Labelled a bug fix but opened against `develop`, so the fix would skip the next patch release. Legitimate when the bug only exists in unreleased code — worth a glance, not an alarm.
+
+- [#41884](https://github.com/PrestaShop/PrestaShop/pull/41884) Return a boolean for the currency enabled state in GetCurrencyForEditing — `develop`
+- [#34127](https://github.com/PrestaShop/PrestaShop/pull/34127) Support for cumulative displayOverrideTemplate calls — `develop`
+- [#36652](https://github.com/PrestaShop/PrestaShop/pull/36652) Fix: tax rules country selection — `develop`
+- [#40644](https://github.com/PrestaShop/PrestaShop/pull/40644) Fix Category::searchByPath losing context during recursion — `develop`
+- [#40884](https://github.com/PrestaShop/PrestaShop/pull/40884) Fix CMS pages types — `develop`
+- [#41606](https://github.com/PrestaShop/PrestaShop/pull/41606) Filter payment module group restrictions by current shop — `develop`
+- [#41851](https://github.com/PrestaShop/PrestaShop/pull/41851) Refresh the theme config cache when re-importing an upgraded theme — `develop`
+- [#42390](https://github.com/PrestaShop/PrestaShop/pull/42390) Refacto : Use the default theme and optimize — `develop`
+- [#41642](https://github.com/PrestaShop/PrestaShop/pull/41642) Fix get-file friendly URL for virtual product downloads — `develop`
+- [#41664](https://github.com/PrestaShop/PrestaShop/pull/41664) Reject product/tag names that the search engine cannot index — `develop`
+- [#41667](https://github.com/PrestaShop/PrestaShop/pull/41667) Show all customer groups in the customer form even when names are duplicated — `develop`
+- [#42377](https://github.com/PrestaShop/PrestaShop/pull/42377) Tools::clearCompile: absorb Smarty concurrent-cleanup UnexpectedValueException — `develop`
+- [#41856](https://github.com/PrestaShop/PrestaShop/pull/41856) Restrict the order detail page to the current shop context — `develop`
+- [#42364](https://github.com/PrestaShop/PrestaShop/pull/42364) Fix 9843 category groups multistore — `develop`
+- [#41854](https://github.com/PrestaShop/PrestaShop/pull/41854) Generate links with the target shop's category link_rewrite on multishop — `develop`
+- [#41844](https://github.com/PrestaShop/PrestaShop/pull/41844) Expose attribute group position in the for-editing query result — `develop`
+
+## Low confidence — the agent was guessing (15)
+
+These are the items where the proposal is least trustworthy. They are worth a human read regardless of the level assigned.
+
+- [#41414](https://github.com/PrestaShop/PrestaShop/pull/41414) Migration of the Stores controller to Symfony — proposed `routine`: waiting on the author after review feedback, 0d idle
+- [#42022](https://github.com/PrestaShop/PrestaShop/pull/42022) Improve the carrier domain and the Admin API for the new carrier endpoints — proposed `routine`: waiting on the author after review feedback, 0d idle
+- [#42092](https://github.com/PrestaShop/PrestaShop/pull/42092) Add the shipment endpoints — proposed `routine`: waiting on the author after review feedback, 0d idle
+- [#42285](https://github.com/PrestaShop/PrestaShop/pull/42285) Add the business entities listing and detail pages in the Back Office — proposed `routine`: waiting on the author after review feedback, 0d idle
+- [#42247](https://github.com/PrestaShop/PrestaShop/pull/42247) Import migration: architecture plan + import engine and ProductImporter (PR1 of #41907) — proposed `routine`: awaiting a first or follow-up review, 0d idle
+- [#41606](https://github.com/PrestaShop/PrestaShop/pull/41606) Filter payment module group restrictions by current shop — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
+- [#41642](https://github.com/PrestaShop/PrestaShop/pull/41642) Fix get-file friendly URL for virtual product downloads — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
+- [#41643](https://github.com/PrestaShop/PrestaShop/pull/41643) Make category visibility configurable per shop — proposed `routine`: waiting on the author after review feedback, 5d idle
+- [#41664](https://github.com/PrestaShop/PrestaShop/pull/41664) Reject product/tag names that the search engine cannot index — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
+- [#41667](https://github.com/PrestaShop/PrestaShop/pull/41667) Show all customer groups in the customer form even when names are duplicated — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
+- [#41825](https://github.com/PrestaShop/PrestaShop/pull/41825) Add per-combination virtual flag and downloadable files — proposed `routine`: waiting on the author after review feedback, 5d idle
+- [#42065](https://github.com/PrestaShop/PrestaShop/pull/42065) Guard DuplicateOrderCartHandler against missing order cart — proposed `routine`: waiting on the author after review feedback, 5d idle
+- [#42067](https://github.com/PrestaShop/PrestaShop/pull/42067) Add defaults to AddOrderFromBackOfficeCommand employeeId and orderMessage — proposed `routine`: waiting on the author after review feedback, 5d idle
+- [#42377](https://github.com/PrestaShop/PrestaShop/pull/42377) Tools::clearCompile: absorb Smarty concurrent-cleanup UnexpectedValueException — proposed `soon`: labelled a bug fix but opened against develop, so it would skip the next patch release
+- [#42280](https://github.com/PrestaShop/PrestaShop/pull/42280) Introduce advanced admin grid views — proposed `routine`: awaiting a first or follow-up review, 6d idle
+
+## Not classified (72)
+
+<details>
+<summary>Why each item was left out</summary>
+
+- #40240 (pull_request) — not open (state=merged)
+- #35112 (issue) — not open (state=closed)
+- #40712 (pull_request) — not open (state=merged)
+- #38993 (issue) — not open (state=closed)
+- #15689 (issue) — already rated by a maintainer (Minor)
+- #42345 (pull_request) — bot author (ps-jarvis)
+- #26837 (issue) — already rated by a maintainer (Minor)
+- #14708 (issue) — not open (state=closed)
+- #42405 (pull_request) — bot author (github-actions)
+- #42398 (pull_request) — not open (state=merged)
+- #36794 (issue) — not open (state=closed)
+- #39016 (pull_request) — not open (state=merged)
+- #42403 (pull_request) — bot author (dependabot)
+- #38405 (pull_request) — not open (state=closed)
+- #41952 (pull_request) — not open (state=merged)
+- #42404 (pull_request) — bot author (dependabot)
+- #42366 (pull_request) — not open (state=closed)
+- #42367 (pull_request) — not open (state=closed)
+- #42402 (pull_request) — bot author (dependabot)
+- #25700 (issue) — not open (state=closed)
+- #42396 (pull_request) — not open (state=merged)
+- #42123 (pull_request) — not open (state=merged)
+- #42346 (pull_request) — bot author (ps-jarvis)
+- #42395 (issue) — not open (state=closed)
+- #36663 (issue) — already rated by a maintainer (Major)
+- #41928 (pull_request) — not open (state=merged)
+- #42393 (pull_request) — not open (state=merged)
+- #41409 (pull_request) — not open (state=merged)
+- #42091 (pull_request) — not open (state=merged)
+- #42342 (pull_request) — not open (state=closed)
+- #42370 (issue) — not open (state=closed)
+- #42374 (pull_request) — not open (state=merged)
+- #42383 (pull_request) — not open (state=closed)
+- #42363 (pull_request) — not open (state=closed)
+- #42287 (pull_request) — not open (state=closed)
+- #42281 (pull_request) — not open (state=closed)
+- #42253 (pull_request) — not open (state=closed)
+- #42018 (pull_request) — not open (state=closed)
+- #41966 (pull_request) — not open (state=closed)
+- #41301 (pull_request) — not open (state=closed)
+- #41228 (pull_request) — not open (state=closed)
+- #41062 (pull_request) — not open (state=closed)
+- #41140 (pull_request) — not open (state=closed)
+- #40969 (pull_request) — not open (state=closed)
+- #40968 (pull_request) — not open (state=closed)
+- #40965 (pull_request) — not open (state=closed)
+- #40967 (pull_request) — not open (state=closed)
+- #40959 (pull_request) — not open (state=closed)
+- #40658 (pull_request) — not open (state=closed)
+- #40634 (pull_request) — not open (state=closed)
+- #40448 (pull_request) — not open (state=closed)
+- #40387 (pull_request) — not open (state=closed)
+- #39585 (pull_request) — not open (state=closed)
+- #38577 (pull_request) — not open (state=closed)
+- #42384 (pull_request) — not open (state=merged)
+- #42155 (pull_request) — not open (state=merged)
+- #42243 (issue) — not open (state=closed)
+- #42245 (pull_request) — not open (state=merged)
+- #42386 (issue) — not open (state=closed)
+- #39830 (pull_request) — not open (state=merged)
+- #42382 (pull_request) — not open (state=closed)
+- #38072 (issue) — already rated by a maintainer (Trivial)
+- #34077 (issue) — not open (state=closed)
+- #42380 (issue) — not open (state=closed)
+- #42139 (pull_request) — not open (state=merged)
+- #42378 (pull_request) — not open (state=merged)
+- #36590 (issue) — already rated by a maintainer (Minor)
+- #42375 (pull_request) — not open (state=merged)
+- #42372 (pull_request) — not open (state=merged)
+- #42373 (pull_request) — not open (state=merged)
+- #42005 (pull_request) — not open (state=closed)
+- #31351 (issue) — not open (state=closed)
+
+</details>
+
+## Run
+
+- Model: `hand-applied rubric (no API key available)`, effort `n/a`
+- Tokens: 0 in (0 read from cache), 0 out
+- Estimated cost at list price: **$0.00** (~$0/year at this weekly volume)

--- a/.github/triage-agent/samples/README.md
+++ b/.github/triage-agent/samples/README.md
@@ -1,0 +1,32 @@
+# Sample output
+
+`2026-08-18-summary.md` is `render.py` run over the real week of 18–25 August
+2026 on `PrestaShop/PrestaShop`, kept as evidence for the spike in
+[#42138](https://github.com/PrestaShop/PrestaShop/issues/42138).
+
+**Read the provenance before reading the verdicts.** Stage 1 (`collect.py`) and
+stage 3 (`render.py`) are the real scripts against the real repository — the
+item list, the skip list and the layout are exactly what a scheduled run
+produces.
+
+Stage 2 was **not** run: no `ANTHROPIC_API_KEY` was available in the
+environment where this branch was built. The severity and attention verdicts
+were instead produced by applying `prompts/severity_system.md` and
+`prompts/pr_triage_system.md` by hand:
+
+- the 22 issue verdicts are individual judgements, one per issue
+- the 82 PR verdicts come from applying the PR rubric mechanically to the
+  collected metadata (labels, review decision, author association, idle days)
+
+So this file demonstrates the shape and the usefulness of the output, and it
+exercised the rubric enough to find two real problems — see the spike report on
+the issue. It is **not** a measurement of how well the model classifies. That
+needs `classify.py` and `calibrate.py eval` against a real key.
+
+Regenerate with:
+
+```bash
+python collect.py --since 2026-08-18
+python classify.py
+python render.py
+```

--- a/.github/triage-agent/samples/README.md
+++ b/.github/triage-agent/samples/README.md
@@ -1,35 +1,46 @@
 # Sample output
 
-`2026-08-18-summary.md` is `render.py` run over the real week of 18–25 August
+`2026-08-18-summary.md` is this pipeline run over the real week of 18–25 August
 2026 on `PrestaShop/PrestaShop`, kept as evidence for the spike in
 [#42138](https://github.com/PrestaShop/PrestaShop/issues/42138).
 
-**Read the provenance before reading the verdicts.** Stage 1 (`collect.py`) and
-stage 3 (`render.py`) are the real scripts against the real repository — the
-item list, the skip list and the layout are exactly what a scheduled run
-produces.
+## Read the provenance before reading the verdicts
 
-Stage 2 was **not** run: no `ANTHROPIC_API_KEY` was available in the
-environment where this branch was built. The severity and attention verdicts
-were instead produced by applying `prompts/severity_system.md` and
-`prompts/pr_triage_system.md` by hand:
+Stage 1 (`collect.py`) and stage 3 (`render.py`) are the real scripts against
+the real repository — the item list, the skip list and the layout are exactly
+what a scheduled run produces.
+
+Stage 2 was **not** run: no `ANTHROPIC_API_KEY` was available in the environment
+where this branch was built. The verdicts come from `hand_verdicts.py` instead,
+which applies `prompts/severity_system.md` and `prompts/pr_triage_system.md` by
+hand:
 
 - the 22 issue verdicts are individual judgements, one per issue
-- the 82 PR verdicts come from applying the PR rubric mechanically to the
-  collected metadata (labels, review decision, author association, idle days)
+- the 72 PR verdicts apply the PR rubric mechanically to the collected metadata
+  (labels, review decision, author association, idle days)
 
-So this file demonstrates the shape and the usefulness of the output, and it
-exercised the rubric enough to find two real problems — see the spike report on
-the issue. It is **not** a measurement of how well the model classifies. That
-needs `classify.py` and `calibrate.py eval` against a real key.
+So this file demonstrates the shape and the usefulness of the output, and
+exercising the rubric on real reports is what surfaced the `kind` field, the
+narrowed attention list and the branch-check section. It is **not** a
+measurement of how well the model classifies — that needs `classify.py` and
+`calibrate.py eval` against a real key.
 
-This file was rendered before `looks_like_regression` was added to the schema,
-so it carries no regression markers. The layout is otherwise current.
+`hand_verdicts.py` is committed so those judgements can be audited rather than
+asserted in prose. Once a key exists, delete it and regenerate with the real
+`classify.py`.
 
-Regenerate with:
+## Regenerating
 
 ```bash
-python collect.py --since 2026-08-18
-python classify.py
+python collect.py --since 2026-08-18 --until 2026-08-25 --no-duplicates
+python samples/hand_verdicts.py     # or: python classify.py, with a key
 python render.py
+cp out/summary.md samples/2026-08-18-summary.md
 ```
+
+`--until` matters. Without it the window runs to today and collects a different
+set, so the file would no longer be the week it claims to be.
+
+One caveat on exactness: the original collection used a relative `7d` window and
+caught 10 pull requests updated late on 25 August that an explicit
+`2026-08-18..2026-08-25` range excludes. The 22 issues are identical either way.

--- a/.github/triage-agent/samples/README.md
+++ b/.github/triage-agent/samples/README.md
@@ -23,6 +23,9 @@ exercised the rubric enough to find two real problems — see the spike report o
 the issue. It is **not** a measurement of how well the model classifies. That
 needs `classify.py` and `calibrate.py eval` against a real key.
 
+This file was rendered before `looks_like_regression` was added to the schema,
+so it carries no regression markers. The layout is otherwise current.
+
 Regenerate with:
 
 ```bash

--- a/.github/triage-agent/samples/hand_verdicts.py
+++ b/.github/triage-agent/samples/hand_verdicts.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Produce the sample's `classified.json` without calling the API.
+
+**This is not part of the pipeline.** It exists so the committed sample is
+reproducible: no `ANTHROPIC_API_KEY` was available when the spike was built, so
+the verdicts in `2026-08-18-summary.md` were produced by applying
+`prompts/severity_system.md` and `prompts/pr_triage_system.md` by hand rather
+than by running `classify.py`.
+
+Keeping the producer in the repository means the verdicts can be audited and the
+sample regenerated, instead of being asserted in prose. Once a key exists this
+file has no reason to survive - delete it and regenerate the sample with the
+real `classify.py`.
+
+    python collect.py --since 2026-08-18 --until 2026-08-25 --no-duplicates
+    python samples/hand_verdicts.py
+    python render.py
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+OUT = HERE.parent / "out"
+
+# number: (kind, severity, confidence, category, component, status, security,
+#          regression, needs_now, duplicates, rationale)
+#
+# Only #41511 is marked a regression: it is the one report in this week that
+# makes an actual version-to-version claim ("with >= 9.1 versions", after an
+# upgrade). Several others concern upgrades or recent releases without ever
+# saying the behaviour used to work, and the rubric asks for the comparison,
+# not merely a recent version number.
+ISSUES = {
+    41568: ("maintainer_task", "Trivial", "high", "CO", "none", "ready", False, False, False, [],
+            "Internal migration task on ShopConstraint handling, not a merchant-facing defect."),
+    42076: ("maintainer_task", "Trivial", "high", "WS", "none", "ready", False, False, False, [],
+            "Checklist tracking Admin API endpoints already delivered by linked PRs."),
+    42397: ("bug_report", "Major", "medium", "WS", "Shipping", "ready", False, False, False, [],
+            "Corrupts order line quantities, but only behind the improved_shipment beta flag which is off by default."),
+    42410: ("bug_report", "Major", "medium", "BO", "Shipping", "ready", False, False, False, [],
+            "Hardcoded zero quantity skews the carrier list and therefore the shipping cost; limited to the beta flag."),
+    42138: ("maintainer_task", "Trivial", "high", "CO", "none", "ready", False, False, False, [],
+            "Spike ticket for this very agent, no merchant impact."),
+    41971: ("maintainer_task", "Trivial", "high", "BO", "Dashboard", "ready", False, False, False, [],
+            "Spike on the dashboard migration pattern, no defect reported."),
+    22240: ("maintainer_task", "Trivial", "high", "CO", "International", "ready", False, False, False, [],
+            "Umbrella epic listing other tax-rules issues."),
+    42408: ("bug_report", "Major", "high", "BO", "International", "ready", False, False, False, [],
+            "Fatal TypeError makes the BO email translations page unreachable with no obvious workaround."),
+    40357: ("bug_report", "Minor", "high", "BO", "Advanced parameters", "ready", False, False, False, [],
+            "Tolerable slowdown on a diagnostics page that is not on any essential shop operation."),
+    42401: ("bug_report", "Minor", "high", "BO", "Shipping", "ready", False, False, False, [],
+            "Wrong currency symbol displayed; the amounts themselves are correct and a fix PR already exists."),
+    42399: ("bug_report", "Major", "medium", "BO", "Order", "TBR", False, False, True, [42400, 41380],
+            "504 on the BO carts page leaves the merchant unable to consult carts, with two open perf PRs pointing at the same query."),
+    42079: ("bug_report", "Major", "medium", "CO", "Catalog", "TBR", False, False, False, [],
+            "empty() misreads the pack-only stock type so pack quantities are wrong, which can oversell stock."),
+    42394: ("support_request", "Trivial", "high", "FO", "Modules", "NMI", False, False, False, [],
+            "Merchant asking for help on an 8.0.4 shop with a third-party theme, no core defect demonstrated."),
+    42391: ("bug_report", "Major", "medium", "FO", "Shipping", "TBR", False, False, False, [],
+            "A default-active bundled module returns HTTP 400 on a rendering checkout page, which misleads monitoring and crawlers."),
+    42387: ("bug_report", "Major", "high", "BO", "Shipping", "Needs Specs", False, False, False, [],
+            "Changing the delivery address leaves the shipment cost stale, which impacts what the customer pays."),
+    42389: ("bug_report", "Major", "medium", "BO", "Modules", "TBR", False, False, False, [],
+            "Unbounded session-file growth can exhaust inodes and take the whole server down, but only on shops running ps_facebook."),
+    42385: ("maintainer_task", "Trivial", "high", "BO", "Advanced parameters", "ready", False, False, False, [],
+            "Internal task to add transactions to the migrated importer."),
+    41511: ("bug_report", "Major", "high", "FO", "Design", "TBR", False, True, False, [],
+            "Malformed srcset breaks image rendering across the front office from 9.1 onwards, where it worked before."),
+    42379: ("bug_report", "Major", "medium", "IN", "none", "TBR", False, False, False, [],
+            "Upgrading without maintenance mode detected leaves the shop taking orders mid-upgrade, risking inconsistent data."),
+    32142: ("bug_report", "Minor", "high", "BO", "Design", "ready", False, False, False, [],
+            "Wrong logo in emails for a multistore setup, which is opt-in and has an obvious workaround."),
+    42376: ("bug_report", "Major", "medium", "IN", "none", "TBR", False, False, True, [],
+            "Merchants cannot see the 8.2.8 security release in Update Assistant, which delays security patching."),
+    42371: ("bug_report", "Minor", "high", "BO", "Design", "TBR", False, False, False, [],
+            "The <section> tag is stripped from CMS pages; using a div is a reasonable workaround."),
+}
+
+MAINTAINERS = {"MEMBER", "OWNER", "COLLABORATOR"}
+
+
+def pr_verdict(pr: dict) -> dict:
+    """The PR rubric applied mechanically to the collected metadata."""
+    labels = set(pr["labels"])
+    decision = pr.get("review_decision")
+    idle = pr["days_since_update"]
+    community = pr["author_association"] not in MAINTAINERS
+    reviews = pr.get("reviews") or []
+
+    if {"Waiting for author", "Waiting for rebase"} & labels or decision == "CHANGES_REQUESTED":
+        waiting = "author"
+    elif {"Waiting for QA", "Waiting for QA by Community"} & labels:
+        waiting = "QA"
+    elif {"Waiting for PM", "Needs Specs"} & labels:
+        waiting = "PM"
+    elif "Waiting for UX" in labels:
+        waiting = "UX"
+    elif decision == "APPROVED":
+        waiting = "nobody"
+    else:
+        waiting = "reviewer"
+
+    unanswered = community and not reviews and pr["comment_count"] <= 1
+    # A bug fix aimed at develop skips the next patch release - unless the bug
+    # only exists in unreleased code, which metadata alone cannot tell us.
+    misrouted = "Bug fix" in labels and pr["base_branch"] == "develop"
+
+    if unanswered:
+        attention, why = "blocking", f"community PR opened with no review and no maintainer reply, {idle}d idle"
+    elif waiting == "nobody" and "Blocked" not in labels:
+        attention, why = "blocking", "approved with nothing left waiting on it - ready to merge"
+    elif misrouted:
+        attention, why = "soon", "labelled a bug fix but opened against develop, so it would skip the next patch release"
+    elif "Blocked" in labels:
+        attention, why = "soon", "explicitly marked Blocked, needs someone to unblock it"
+    elif waiting == "author":
+        attention, why = "routine", f"waiting on the author after review feedback, {idle}d idle"
+    elif waiting == "QA":
+        attention, why = "soon", "dev-approved and sitting in the QA queue"
+    elif waiting == "PM":
+        attention, why = "soon", "waiting on a product decision"
+    else:
+        attention, why = "routine", f"awaiting a first or follow-up review, {idle}d idle"
+
+    return {
+        "attention": attention,
+        "confidence": "low" if (pr.get("is_draft") or (pr.get("changed_files") or 0) > 40) else "medium",
+        "rationale": why,
+        "waiting_on": waiting,
+        "target_branch_looks_wrong": misrouted,
+        "is_community_pr_unanswered": unanswered,
+        "metadata_incomplete": len(pr["body"] or "") < 200,
+    }
+
+
+CARRIED = (
+    "number", "title", "url", "author", "author_association", "labels",
+    "created_at", "updated_at", "days_since_update", "is_new_this_week",
+)
+
+
+def main() -> int:
+    week = json.loads((OUT / "week.json").read_text())
+
+    issues = []
+    for issue in week["issues"]:
+        verdict = ISSUES.get(issue["number"])
+        if verdict is None:
+            print(f"no hand verdict for #{issue['number']} - skipped", file=sys.stderr)
+            continue
+        kind, sev, conf, cat, comp, status, sec, reg, now, dup, why = verdict
+        issues.append(
+            {k: issue[k] for k in CARRIED}
+            | {
+                "type": "issue",
+                "base_branch": None,
+                "verdict": {
+                    "kind": kind, "severity": sev, "confidence": conf,
+                    "rationale": why, "category": cat, "component": comp,
+                    "suggested_status": status, "security_suspicion": sec,
+                    "looks_like_regression": reg,
+                    "duplicate_candidates": dup, "needs_human_now": now,
+                },
+            }
+        )
+
+    prs = [
+        {k: pr[k] for k in CARRIED}
+        | {"type": "pull_request", "base_branch": pr["base_branch"],
+           "verdict": pr_verdict(pr)}
+        for pr in week["pull_requests"]
+    ]
+
+    (OUT / "classified.json").write_text(json.dumps({
+        "repository": week["repository"],
+        "since": week["since"],
+        "until": week.get("until"),
+        "collected_at": week["collected_at"],
+        "classified_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "model": "hand-applied rubric (no API key available)",
+        "effort": "n/a",
+        "issues": issues,
+        "pull_requests": prs,
+        "skipped": week["skipped"],
+        "failures": [],
+        "usage": {"input_tokens": 0, "output_tokens": 0,
+                  "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+    }, indent=2, ensure_ascii=False))
+
+    print(f"wrote out/classified.json: {len(issues)} issues, {len(prs)} PRs", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/cron_weekly_triage_agent.yml
+++ b/.github/workflows/cron_weekly_triage_agent.yml
@@ -1,0 +1,104 @@
+# Weekly pre-qualification of issues and pull requests for the sheriff.
+#
+# Reads the past week, asks Claude for a severity / attention proposal on each
+# item, and publishes the ranked result as a job summary and a Slack message.
+#
+# This workflow is read-only on GitHub by design: the permissions block below
+# grants no write scope anywhere, so it cannot label an issue or move a board
+# card even if the code tried to. Every output is a proposal for the sheriff.
+name: Weekly triage agent
+
+on:
+  schedule:
+    # Mondays at 07:00 UTC, before the week's triage starts.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Render everything but do not post to Slack"
+        required: false
+        default: true
+        type: boolean
+      since:
+        description: "Window start: '7d', or an explicit YYYY-MM-DD (UTC)"
+        required: false
+        default: "7d"
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: weekly-triage-agent
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    name: Pre-qualify the week
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .github/triage-agent
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Collect the week
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python collect.py --since "${{ github.event.inputs.since || '7d' }}"
+
+      - name: Classify
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::error::ANTHROPIC_API_KEY is not configured for this repository."
+            exit 1
+          fi
+          python classify.py
+
+      - name: Render
+        run: |
+          python render.py \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+      - name: Publish the summary
+        run: cat out/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the run
+        uses: actions/upload-artifact@v7
+        with:
+          name: weekly-triage-${{ github.run_id }}
+          path: |
+            .github/triage-agent/out/week.json
+            .github/triage-agent/out/classified.json
+            .github/triage-agent/out/summary.md
+            .github/triage-agent/out/slack.json
+            .github/triage-agent/out/board.json
+          retention-days: 90
+
+      # Posting is opt-in twice over: the dispatch input has to say so, and the
+      # webhook has to be configured. A scheduled run posts; a manual run does
+      # not unless asked.
+      - name: Post to Slack
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.dry-run == 'false' }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::warning::SLACK_WEBHOOK_URL is not configured - skipping the Slack post."
+            exit 0
+          fi
+          python publish.py --publish


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds a scheduled agent that reads the issues and pull requests touched in the past week, ranks them, and hands the sheriff a sorted list instead of the whole tracker. Everything lives in `.github/triage-agent/` (isolated Python, its own `requirements.txt`, outside the reach of php-cs-fixer and PHPStan) plus one workflow. Four decoupled stages: `collect.py` gathers the week from the GitHub API with no model involved, `classify.py` asks Claude for one structured verdict per item, `render.py` produces the job summary, a Slack Block Kit payload and a board payload, `publish.py` posts to Slack and is dry-run unless asked. `calibrate.py` scores the rubric against the ~2 300 closed issues maintainers labelled themselves.<br><br>The severity rubric in `prompts/severity_system.md` reproduces the project's [official severity classification](https://build.prestashop-project.org/news/2019/severity-classification/) verbatim, then adds what that page leaves open: how to read its "> 60% of users" thresholds for a shop platform, which clauses override the count (security, data loss, broken E2E, law compliance, money), and how to judge whether a workaround is obvious. Pull requests get a separate rubric, because severity does not apply to a PR — it ranks who the PR is actually waiting on.<br><br>**The agent proposes and never decides.** The workflow declares only `contents: read`, `issues: read` and `pull-requests: read`, so it cannot apply a label or move a board card even if the code tried to. Its outputs are a job summary, an artifact and a Slack message.
| Type?             | new feature
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No product code is touched, so nothing changes for a merchant. To exercise the pipeline:<br><br>1. `cd .github/triage-agent && pip install -r requirements.txt`<br>2. `python collect.py --since 7d` — needs an authenticated `gh`, no API key. Check `out/week.json`: every filtered item appears in `skipped` with a reason.<br>3. `export ANTHROPIC_API_KEY=...` then `python classify.py --limit 5` to eyeball a few verdicts before paying for the lot, then `python classify.py`.<br>4. `python render.py` and read `out/summary.md`.<br>5. `python publish.py` — dry run, prints the Block Kit outline without sending. Add `--publish` with `SLACK_WEBHOOK_URL` set to post.<br>6. On a runner: trigger the `Weekly triage agent` workflow via `workflow_dispatch` with `dry-run: true`.<br><br>`.github/triage-agent/samples/2026-08-18-summary.md` is a real rendered week — read `samples/README.md` first, it states which parts came from the scripts and which verdicts were applied by hand.
| UI Tests          | N/A — no product code changed, no UI surface affected.
| Fixed issue or discussion?     | Part of #42138
| Related PRs       | None.
| Sponsor company   | @PrestaShopCorp

### Before this can actually run

Two things are missing and neither is code:

- **`ANTHROPIC_API_KEY`** as a repository secret. Without it `classify.py` fails fast with a clear error, and the workflow is still mergeable and runnable in dry-run.
- **`SLACK_WEBHOOK_URL`** and a channel. Without it the publish step logs a warning and skips rather than failing the run.

### What has not been measured yet

`classify.py` and `calibrate.py eval` have **not** been run — no API key was available in the environment where this branch was built. So the rubric has been written and reviewed, but its agreement with maintainer labels has not been measured. `calibrate.py eval` produces that number (confusion matrix, Critical recall, off-by-one rate) as soon as a key exists. The [spike report](https://github.com/PrestaShop/PrestaShop/issues/42138#issuecomment-5411589891) has the full accounting of what ran and what did not.

### One limitation worth knowing up front

Selecting on `updated:>=D-7` means a pull request nobody has touched in eight months never appears in this list, precisely because nobody touched it. This covers what moved, not what is rotting — finding the latter is a different query and probably deserves its own ticket.
