### PR TITLE
Order combinations by attribute position in the BO order product search

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-manager.ts
@@ -293,10 +293,11 @@ export default class ProductManager {
     this.productRenderer.renderProductMetadata(
       <Record<string, any>> this.selectedProduct,
     );
-    // if product has combinations select the first else leave it null
+    // if product has combinations select the first displayed one else leave it null
     if (this.selectedProduct?.combinations.length !== 0) {
       this.selectCombination(
-        Object.keys(this.selectedProduct?.combinations)[0],
+        ProductRenderer.sortCombinations(this.selectedProduct?.combinations)[0]
+          .attributeCombinationId,
       );
     }
 

--- a/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.ts
@@ -213,6 +213,16 @@ export default class ProductRenderer {
   }
 
   /**
+   * Combinations are keyed by their id, and JS enumerates integer-like keys numerically, so the
+   * order they were serialized in is lost. Sort them back on the position sent by the server.
+   *
+   * @param {Object} combinations
+   */
+  static sortCombinations(combinations: Record<string, any>): Record<string, any>[] {
+    return Object.values(combinations).sort((a, b) => a.position - b.position);
+  }
+
+  /**
    * Renders combinations row with select options
    *
    * @param {Array} combinations
@@ -228,7 +238,7 @@ export default class ProductRenderer {
       return;
     }
 
-    Object.values(combinations).forEach((combination) => {
+    ProductRenderer.sortCombinations(combinations).forEach((combination) => {
       $(createOrderMap.combinationsSelect).append(
         `<option
           value="${combination.attributeCombinationId}">

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.ts
@@ -259,12 +259,16 @@ export default class OrderProductAdd {
   setCombinations(combinations: Record<string, any>): void {
     this.combinationsSelect.empty();
 
-    Object.values(combinations).forEach((val) => {
-      this.combinationsSelect.append(
-        /* eslint-disable-next-line max-len */
-        `<option value="${val.attributeCombinationId}" data-price-tax-excluded="${val.priceTaxExcluded}" data-price-tax-included="${val.priceTaxIncluded}" data-stock="${val.stock}" data-location="${val.location}">${val.attribute}</option>`,
-      );
-    });
+    // Combinations are keyed by their id, which JS enumerates numerically: sort them back on the
+    // position sent by the server.
+    Object.values(combinations)
+      .sort((a, b) => a.position - b.position)
+      .forEach((val) => {
+        this.combinationsSelect.append(
+          /* eslint-disable-next-line max-len */
+          `<option value="${val.attributeCombinationId}" data-price-tax-excluded="${val.priceTaxExcluded}" data-price-tax-included="${val.priceTaxIncluded}" data-stock="${val.stock}" data-location="${val.location}">${val.attribute}</option>`,
+        );
+      });
 
     this.combinationsBlock.toggleClass(
       'd-none',

--- a/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
@@ -239,6 +239,7 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
         $combinations = $product->getAttributeCombinations();
 
         if (false !== $combinations) {
+            $positions = $this->getCombinationPositions($combinations);
             foreach ($combinations as $combination) {
                 $productAttributeId = (int) $combination['id_product_attribute'];
                 $attribute = $combination['attribute_name'];
@@ -259,14 +260,45 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
                     $priceTaxExcluded,
                     $priceTaxIncluded,
                     $combination['location'],
-                    $combination['reference']
+                    $combination['reference'],
+                    $positions[$productAttributeId] ?? 0
                 );
 
                 $productCombinations[$productCombination->getAttributeCombinationId()] = $productCombination;
             }
+
+            uasort($productCombinations, static function (ProductCombination $a, ProductCombination $b): int {
+                return $a->getPosition() <=> $b->getPosition();
+            });
         }
 
         return $productCombinations;
+    }
+
+    /**
+     * Combinations are listed in the order configured in Catalog > Attributes & Features, like the front
+     * office does, instead of the combination creation order.
+     *
+     * Rows returned by Product::getAttributeCombinations() are ordered by attribute group position then
+     * attribute position, so the attribute positions collected for a combination are already comparable
+     * group by group.
+     *
+     * @param array<int, array<string, mixed>> $combinations
+     *
+     * @return array<int, int> Position indexed by combination id
+     */
+    private function getCombinationPositions(array $combinations): array
+    {
+        $attributePositions = [];
+        foreach ($combinations as $combination) {
+            $attributePositions[(int) $combination['id_product_attribute']][] = (int) $combination['attribute_position'];
+        }
+
+        uasort($attributePositions, static function (array $a, array $b): int {
+            return $a <=> $b;
+        });
+
+        return array_flip(array_keys($attributePositions));
     }
 
     /**

--- a/src/Core/Domain/Product/QueryResult/ProductCombination.php
+++ b/src/Core/Domain/Product/QueryResult/ProductCombination.php
@@ -54,6 +54,11 @@ class ProductCombination
     private $formattedPrice;
 
     /**
+     * @var int
+     */
+    private $position;
+
+    /**
      * @param int $attributeCombinationId
      * @param string $attribute
      * @param int $stock
@@ -62,6 +67,7 @@ class ProductCombination
      * @param float $priceTaxIncluded
      * @param string $location
      * @param string $reference
+     * @param int $position
      */
     public function __construct(
         int $attributeCombinationId,
@@ -71,7 +77,8 @@ class ProductCombination
         float $priceTaxExcluded,
         float $priceTaxIncluded,
         string $location,
-        string $reference
+        string $reference,
+        int $position = 0
     ) {
         $this->attributeCombinationId = $attributeCombinationId;
         $this->attribute = $attribute;
@@ -81,6 +88,7 @@ class ProductCombination
         $this->priceTaxIncluded = $priceTaxIncluded;
         $this->location = $location;
         $this->reference = $reference;
+        $this->position = $position;
     }
 
     /**
@@ -145,6 +153,17 @@ class ProductCombination
     public function getReference(): string
     {
         return $this->reference;
+    }
+
+    /**
+     * Position of the combination in the list, based on the attribute position
+     * configured in Catalog > Attributes & Features.
+     *
+     * @return int
+     */
+    public function getPosition(): int
+    {
+        return $this->position;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Combinations shown when adding a product to an order in the back office (Orders > Add new order, and the "Add a product" block of an existing order) were listed in combination creation order instead of the attribute position configured in Catalog > Attributes & Features. The front office product page already orders them by position, so the two sides disagreed. This completes #41225 for that surface.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run yet — will add the campaign link.
| Fixed issue or discussion?     | Fixes #42416
| Related PRs       | —
| Sponsor company   | Evolutive

### Why

#41225 (following #41224) made `Product::getAttributeCombinations()` aware of attribute positions, but kept `pa.id_product_attribute` as the *primary* sort key:

```sql
ORDER BY pa.`id_product_attribute`, ag.`position`, a.`position`
```

That correctly orders the attributes *within* one combination — which is what the `Size - Colour` label concatenation needs — but the list of combinations itself is still in creation order. `SearchProductsHandler::getProductCombinations()` returns it unchanged, so the BO order product search disagrees with the front office.

There is a second cause that a SQL-only fix cannot address: the handler's result is serialized as a JSON object keyed by `id_product_attribute`, and browsers enumerate integer-like object keys in ascending numeric order. `Object.values(combinations)` therefore discards whatever order the server sent.

### What

- `ProductCombination` (query result) carries a new `position`, defaulted so the constructor stays backward compatible.
- `SearchProductsHandler` ranks combinations on the `attribute_position` column that #41225 already added to `getAttributeCombinations()`, so no extra query is needed. Positions are collected per combination in the order the rows arrive — which is attribute group position, then attribute position — and compared as tuples, so multi-group combinations sort exactly like the front office. The resulting dense rank is what `position` exposes.
- `product-renderer.ts` gains a `sortCombinations()` helper used to build the `<select>`, and `product-manager.ts` uses it so the pre-selected combination is the first *displayed* one rather than the lowest id.
- `order-product-add.ts` applies the same sort for the "Add a product" block of an existing order.

No public constructor signature is broken and no query is added.

### How to test

1. Go to **Catalog > Attributes & Features > Size** and reorder the values so the position order differs from the creation order (dragging a recently created value to the top is the quickest way).
2. Make sure a product carries combinations on that attribute.
3. Open the **front office** product page and note the order of the size selector.
4. Go to **Orders > Add new order**, pick a customer, search for that product, and open the combinations dropdown — the order now matches the front office, and the first entry is pre-selected.
5. Open an existing order, use **Add a product**, and check the same dropdown.
6. Check a product with two attribute groups (e.g. Size + Colour): combinations are grouped by the first group's position, then by the second group's position within it, and the `Size - Colour` labels are unchanged.

### Verified on

A 9.x Docker instance, with two seeded products whose combination creation order deliberately differs from the configured attribute positions.

Single attribute group — sizes created XL, S, L, M and positioned S, M, L, XL:

| | Combination order |
| --- | --- |
| Before | XL, S, L, M (`id_product_attribute` 1, 2, 3, 4) |
| After | S, M, L, XL (`id_product_attribute` 2, 4, 3, 1) |

Two attribute groups — combinations created M/Rouge, S/Bleu, M/Bleu, S/Rouge, with Size before Colour and S before M, Bleu before Rouge:

| | Combination order |
| --- | --- |
| Before | M - Rouge, S - Bleu, M - Bleu, S - Rouge |
| After | S - Bleu, S - Rouge, M - Bleu, M - Rouge |

The serialized response confirms both halves of the fix are needed. The JSON *text* carries the keys in the right order and each combination now exposes its position:

```json
"combinations":{"2":{"attributeCombinationId":2,"attribute":"S",…,"position":0},"4":{…,"position":1},"3":{…,"position":2},"1":{…,"position":3}}
```

but those keys are integer-like, so after `JSON.parse` a browser enumerates them as 1, 2, 3, 4 — which is why `Object.values()` has to be sorted on `position` client-side.
