### PR TITLE
Drop redundant index on cart_rule_combination

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -256,7 +256,6 @@ CREATE TABLE `PREFIX_cart_rule_combination` (
   PRIMARY KEY (
     `id_cart_rule_1`, `id_cart_rule_2`
   ),
-  KEY `id_cart_rule_1` (`id_cart_rule_1`),
   KEY `id_cart_rule_2` (`id_cart_rule_2`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `cart_rule_combination` declares `KEY id_cart_rule_1 (id_cart_rule_1)` next to `PRIMARY KEY (id_cart_rule_1, id_cart_rule_2)`. The secondary index is the leftmost prefix of the primary key, so the optimizer can never prefer it: any lookup or range scan on `id_cart_rule_1` alone is already served by the clustered primary key, at the same cost and without a second lookup. The index only costs disk space and write amplification on every insert and delete. `KEY id_cart_rule_2` is kept, it is the one that actually serves the reverse lookups on the second column (`checkValidity()`, `getAssociatedRestrictions()`, `CartRule::delete()`).
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a fresh shop and check the schema: `SHOW INDEX FROM ps_cart_rule_combination` must list `PRIMARY` and `id_cart_rule_2` only. Create at least two cart rules, mark them as not combinable with each other in the Compatibility tab, then verify in the front office that adding both vouchers to the same cart is still refused, and that removing the restriction makes them combinable again. `EXPLAIN` on the queries in `CartRule::checkValidity()` and `CartRule::getAssociatedRestrictions()` shows the same access paths before and after.
| UI Tests          | Not run yet, happy to launch a campaign if a maintainer can trigger it.
| Fixed issue or discussion?     | Related to https://github.com/PrestaShop/PrestaShop/discussions/33442
| Related PRs       | -
| Sponsor company   | OpenServis.cz

### Why it is worth it

This table is one of the biggest tables on shops that generate one voucher per customer, because it grows quadratically with the number of cart rules. On a production shop I looked at (PrestaShop 8.1.7, about 14 000 cart rules) it holds 69 555 681 rows and takes 4 289 MB, 2 130 MB of data and 2 159 MB of indexes. The second largest table in that database is 355 MB.

Both secondary indexes cover the same two `int unsigned` columns, so they are the same size: InnoDB appends the missing primary key column to each of them, which makes both leaf structures a pair of ints. Removing the redundant one therefore frees about half of the 2 159 MB of secondary index space, roughly 1 GB on that shop, and removes one index maintenance operation from every insert and delete on the table.

The gain is proportional on any shop, and it costs nothing: the access paths do not change.

### Existing shops

The change updates the canonical schema, so new installations get the clean structure. Existing shops can drop it with a single statement, and it may be worth handling in the autoupgrade schema comparison as well:

```sql
ALTER TABLE `ps_cart_rule_combination` DROP INDEX `id_cart_rule_1`;
```

### Scope

This is deliberately the smallest possible change. It does not touch the quadratic growth of the table itself, which is the subject of discussion #33442 and of the closed issue #10003. I kept the two topics apart so this one can be reviewed on its own.
