### PR TITLE
Fix PHP 8.5 null array offset deprecations

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -244,11 +244,13 @@ class CartCore extends ObjectModel
 
     public function resetProductRelatedStaticCache()
     {
-        if (isset(self::$_nbProducts[$this->id])) {
-            unset(self::$_nbProducts[$this->id]);
+        $cacheKey = (int) $this->id;
+
+        if (isset(self::$_nbProducts[$cacheKey])) {
+            unset(self::$_nbProducts[$cacheKey]);
         }
-        if (isset(self::$_totalWeight[$this->id])) {
-            unset(self::$_totalWeight[$this->id]);
+        if (isset(self::$_totalWeight[$cacheKey])) {
+            unset(self::$_totalWeight[$cacheKey]);
         }
         $this->_products = null;
         $this->_products_with_separated_gifts = null;
@@ -2650,7 +2652,8 @@ class CartCore extends ObjectModel
                 // With PS_ATCP_SHIPWRAP, wrapping fee is by default tax included
                 // so nothing to do here.
             } else {
-                if (!isset($address[$this->id])) {
+                $cacheKey = (int) $this->id;
+                if (!isset($address[$cacheKey])) {
                     // If no address ID was provided, we use the cart tax address ID
                     if ($id_address === null) {
                         $id_address = (int) $this->{Configuration::get('PS_TAX_ADDRESS_TYPE')};
@@ -2663,13 +2666,13 @@ class CartCore extends ObjectModel
                      * again, but without any address specified.
                      */
                     try {
-                        $address[$this->id] = Address::initialize($id_address);
+                        $address[$cacheKey] = Address::initialize($id_address);
                     } catch (Exception $e) {
-                        $address[$this->id] = Address::initialize();
+                        $address[$cacheKey] = Address::initialize();
                     }
                 }
 
-                $tax_manager = TaxManagerFactory::getManager($address[$this->id], (int) Configuration::get('PS_GIFT_WRAPPING_TAX_RULES_GROUP'));
+                $tax_manager = TaxManagerFactory::getManager($address[$cacheKey], (int) Configuration::get('PS_GIFT_WRAPPING_TAX_RULES_GROUP'));
                 $tax_calculator = $tax_manager->getTaxCalculator();
                 $wrapping_fees = $tax_calculator->addTaxes($wrapping_fees);
             }
@@ -4083,11 +4086,12 @@ class CartCore extends ObjectModel
         }
 
         // Otherwise, we return the total weight of the cart
-        if (!isset(self::$_totalWeight[$this->id])) {
-            $this->updateProductWeight($this->id);
+        $cacheKey = (int) $this->id;
+        if (!isset(self::$_totalWeight[$cacheKey])) {
+            $this->updateProductWeight($cacheKey);
         }
 
-        return self::$_totalWeight[(int) $this->id];
+        return self::$_totalWeight[$cacheKey];
     }
 
     /**
@@ -4347,17 +4351,18 @@ class CartCore extends ObjectModel
             return false;
         }
 
-        if (!isset(self::$_isVirtualCart[$this->id])) {
+        $cacheKey = (int) $this->id;
+        if (!isset(self::$_isVirtualCart[$cacheKey])) {
             if (!$this->hasProducts()) {
                 $isVirtual = false;
             } else {
                 $isVirtual = !$this->hasRealProducts();
             }
 
-            self::$_isVirtualCart[$this->id] = $isVirtual;
+            self::$_isVirtualCart[$cacheKey] = $isVirtual;
         }
 
-        return self::$_isVirtualCart[$this->id];
+        return self::$_isVirtualCart[$cacheKey];
     }
 
     /**

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -369,6 +369,8 @@ class CartRuleCore extends ObjectModel
      */
     public static function haveCartRuleToday($idCustomer)
     {
+        $idCustomer = (int) $idCustomer;
+
         static $haveCartRuleToday = [];
 
         if (!isset($haveCartRuleToday[$idCustomer])) {
@@ -1494,22 +1496,23 @@ class CartRuleCore extends ObjectModel
 
         $all_cart_rules_ids = $context->cart->getOrderedCartRulesIds();
 
-        if (!array_key_exists($context->cart->id, static::$cartAmountCache)) {
+        $cartId = (int) $context->cart->id;
+        if (!array_key_exists($cartId, static::$cartAmountCache)) {
             if (!Configuration::get('PS_TAX')) {
-                static::$cartAmountCache[$context->cart->id]['te'] = $context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
-                static::$cartAmountCache[$context->cart->id]['ti'] = static::$cartAmountCache[$context->cart->id]['te'];
+                static::$cartAmountCache[$cartId]['te'] = $context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
+                static::$cartAmountCache[$cartId]['ti'] = static::$cartAmountCache[$cartId]['te'];
             } else {
-                static::$cartAmountCache[$context->cart->id]['ti'] = $context->cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
-                static::$cartAmountCache[$context->cart->id]['te'] = $context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
+                static::$cartAmountCache[$cartId]['ti'] = $context->cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
+                static::$cartAmountCache[$cartId]['te'] = $context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
             }
         }
 
-        $cart_amount_te = static::$cartAmountCache[$context->cart->id]['te'];
-        $cart_amount_ti = static::$cartAmountCache[$context->cart->id]['ti'];
+        $cart_amount_te = static::$cartAmountCache[$cartId]['te'];
+        $cart_amount_ti = static::$cartAmountCache[$cartId]['ti'];
 
         $reduction_value = 0;
 
-        $cache_id = 'getContextualValue_' . (int) $this->id . '_' . (int) $use_tax . '_' . (int) $context->cart->id . '_' . (int) $filter;
+        $cache_id = 'getContextualValue_' . (int) $this->id . '_' . (int) $use_tax . '_' . $cartId . '_' . (int) $filter;
         foreach ($package_products as $product) {
             $cache_id .= '_' . (int) $product['id_product'] . '_' . (int) $product['id_product_attribute'] . (isset($product['in_stock']) ? '_' . (int) $product['in_stock'] : '');
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Fix PHP 8.5 deprecation warnings caused by nullable cart or customer IDs being used as array offsets.<br>Normalize the remaining affected cache keys in `Cart.php` and `CartRule.php`.<br>Warnings already indirectly fixed by #42143 (`getDeliveryOptionList()` and `getNbOfPackages()`) are intentionally not duplicated in this PR.<br>Fixes #42435.
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install PrestaShop `9.2.x` with PHP `8.5.10`.<br>2. Enable PHP deprecation warnings.<br>3. Reach a front-office flow where cart calculations are executed with a non-persisted cart or without an associated customer ID.<br>4. Before this PR, verify that several `Using null as an array offset is deprecated` warnings are triggered in `Cart.php` and `CartRule.php`.<br>5. Apply this PR and repeat the same flow.<br>6. Check that the PHP 8.5 deprecation warnings no longer occur for the cache accesses fixed by this PR.<br>7. Warnings related to `Cart::getDeliveryOptionList()` and `Cart::getNbOfPackages()` are intentionally not part of this PR, as they are already addressed by #42143.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/33236445282
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42435
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/42143
| Sponsor company   | Codencode snc

---

## What does this PR do?

This PR fixes PHP 8.5 deprecation warnings caused by nullable cart or customer IDs being used directly as array offsets.

The issue is reproducible on PrestaShop `9.2.x` with PHP `8.5.10`.

It updates the remaining affected cache accesses in `Cart.php` and `CartRule.php` by normalizing nullable IDs before using them as array keys.

## Changes

### `Cart.php`

Normalize the cart ID before using it as a cache key in:

* `resetProductRelatedStaticCache()`
* `getGiftWrappingPrice()`
* `getTotalWeight()`
* `isVirtualCart()`

### `CartRule.php`

Normalize nullable IDs before using them as cache keys in:

* `haveCartRuleToday()`
* `getContextualValue()`

In `haveCartRuleToday()`, this keeps the cache behavior consistent with the existing SQL query, which already casts `$idCustomer` to an integer.

## Related PR

Part of the warnings reported in #42435 are already indirectly fixed by #42143.

In particular, #42143 updates the cache keys used by:

* `Cart::getDeliveryOptionList()`
* `Cart::getNbOfPackages()`

Those changes are intentionally not duplicated in this PR.

This PR only addresses the remaining PHP 8.5 null array offset warnings.


