### PR TITLE
Add Content Security Policy (Report-Only) with per-request nonce for the back office

### DIFF
--- a/admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl
@@ -2,7 +2,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  *}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
    $(function() {
       var id_tab_parentmodule = {$id_tab_parentmodule|intval};
       var id_tab_module = {$id_tab_module|intval};

--- a/admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form_ranges.tpl
+++ b/admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form_ranges.tpl
@@ -2,7 +2,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  *}
-		<script>var zones_nbr = {$zones|count +3} ; /*corresponds to the third input text (max, min and all)*/</script>
+		<script nonce="{$cspNonce}">var zones_nbr = {$zones|count +3} ; /*corresponds to the third input text (max, min and all)*/</script>
 		<div id="zone_ranges" style="overflow:auto">
 			<h4>{l s='Ranges' d='Admin.Shipping.Feature'}</h4>
 			<table id="zones_table" class="table" style="max-width:100%">

--- a/admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl
@@ -5,7 +5,7 @@
 
 {extends file="helpers/view/view.tpl"}
 {block name="override_tpl"}
-<script>
+<script nonce="{$cspNonce}">
 	var labelNext = '{$labels.next|addslashes}';
 	var labelPrevious = '{$labels.previous|addslashes}';
 	var	labelFinish = '{$labels.finish|addslashes}';

--- a/admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl
+++ b/admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl
@@ -15,7 +15,7 @@
 	<img id="carrier_logo_img" src="{if $carrier_logo}{$carrier_logo}{else}../img/admin/carrier-default.jpg{/if}" class="img-thumbnail" alt=""/>
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	var carrier_translation_undefined = '{l s='undefined' js=1 d='Admin.Shipping.Help'}';
 
 	function removeCarrierLogo()

--- a/admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl
+++ b/admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl
@@ -29,7 +29,7 @@
 	{$active_form}
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	var summary_translation_undefined = '{l s='[undefined]' js=1}';
 	var summary_translation_meta_informations = '{l s='This carrier is %1$s and the transit time is %2$s.' js=1 d='Admin.Shipping.Feature'}';
 	var summary_translation_free = '{l s='free' js=1 d='Admin.Shipping.Feature'}';

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.tpl
@@ -34,7 +34,7 @@
 		<!--<input type="submit" value="{l s='Save and stay' d='Admin.Actions'}" class="button" name="submitAddcart_ruleAndStay" id="" />-->
 	</form>
 
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		var product_rule_groups_counter = {if isset($product_rule_groups_counter)}{$product_rule_groups_counter|intval}{else}0{/if};
 		var product_rule_counters = new Array();
 		var currentToken = '{$currentToken|escape:'quotes'}';

--- a/admin-dev/themes/default/template/controllers/cart_rules/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/helpers/list/list_header.tpl
@@ -5,7 +5,7 @@
 {extends file="helpers/list/list_header.tpl"}
 {block name='override_header'}
 {if $submit_form_ajax}
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		$('#voucher', window.parent.document).val('{$new_cart_rule->code|escape:'html':'UTF-8'}');
 		parent.add_cart_rule({$new_cart_rule->id|intval});
 		parent.$.fancybox.close();

--- a/admin-dev/themes/default/template/controllers/cart_rules/informations.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/informations.tpl
@@ -128,6 +128,6 @@
 		</span>
 	</div>
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	$(".textarea-autosize").autosize();
 </script>

--- a/admin-dev/themes/default/template/controllers/cart_rules/product_rule.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/product_rule.tpl
@@ -30,7 +30,7 @@
 	</td>
 </tr>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	$('#product_rule_{$product_rule_group_id|intval}_{$product_rule_id|intval}_choose_content').parent().hide();
   $("#product_rule_{$product_rule_group_id|intval}_{$product_rule_id|intval}_choose_link").fancybox({
     autoDimensions: false,

--- a/admin-dev/themes/default/template/controllers/cart_rules/product_rule_itemlist.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/product_rule_itemlist.tpl
@@ -31,7 +31,7 @@
 	</div>
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	$('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_remove').on('click', function() { removeCartRuleOption(this); updateProductRuleShortDescription(this); });
 	$('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_add').on('click', function() { addCartRuleOption(this); updateProductRuleShortDescription(this); });
 	$(function() { updateProductRuleShortDescription($('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_add')); });

--- a/admin-dev/themes/default/template/controllers/countries/helpers/list/list_footer.tpl
+++ b/admin-dev/themes/default/template/controllers/countries/helpers/list/list_footer.tpl
@@ -55,7 +55,7 @@
 				/ {$list_total} {l s='result(s)' d='Admin.Global'}
 				<input type="hidden" id="{$list_id}-pagination-items-page" name="{$list_id}_pagination" value="{$selected_pagination|intval}" />
 			</div>
-			<script type="text/javascript">
+			<script type="text/javascript" nonce="{$cspNonce}">
 				$('.pagination-items-page').on('click',function(e){
 					e.preventDefault();
 					$('#'+$(this).data("list-id")+'-pagination-items-page').val($(this).data("items")).closest("form").submit();
@@ -101,7 +101,7 @@
 					</a>
 				</li>
 			</ul>
-			<script type="text/javascript">
+			<script type="text/javascript" nonce="{$cspNonce}">
 				$('.pagination-link').on('click',function(e){
 					e.preventDefault();
 

--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl
@@ -17,7 +17,7 @@
 			</div>
 		</div>
 
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="{$cspNonce}">
 			var ajaxQueries = new Array();
 			function run_sync()
 			{

--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl
@@ -46,7 +46,7 @@
 	</div>
 </div>
 </form>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	$("select[name='id_employee_forward']").on('change', function() {
 		if ($(this).val() != '-1')
 			$("button[name='submitForward']").prop('disabled', false);

--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
@@ -114,7 +114,7 @@
 	</div>
 </div>
 {/if}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	var timer;
 		$(function(){
 			$('select[name=id_employee_forward]').on('change', function(){

--- a/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
@@ -2,7 +2,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  *}
-<script>
+<script nonce="{$cspNonce}">
 	var dashboard_ajax_url = '{$link->getAdminLink('AdminDashboard')}';
 	var adminstats_ajax_url = '{$link->getAdminLink('AdminStats')}';
 	var no_results_translation = '{l s='No result' js=1}';

--- a/admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl
@@ -22,7 +22,7 @@
 {block name="field"}
 	{if $input['type'] == 'group_discount_category'}
 	<div {if !$form_id}class="hide"{/if}>
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="{$cspNonce}">
 		$(function() {
 			$("#group_discount_category").fancybox({
 				beforeLoad: function () {
@@ -150,7 +150,7 @@
 	</div>
 	{elseif $input['type'] == 'modules'}
 	<div {if !$form_id}class="hide"{/if}>
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="{$cspNonce}">
 			$(function() {
 				$('#authorized-modules').find('[value="0"]').on('click', function() {
 					$(this).parent().parent().find('input[type=hidden]').attr('name', 'modulesBoxUnauth[]');

--- a/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_categories.tpl
+++ b/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_categories.tpl
@@ -10,7 +10,7 @@
 	</ul>
 	{/if}
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	var currentToken="{$token|@addslashes}";
 	{if isset($use_checkbox) && $use_checkbox == true}
 		function checkAllAssociatedCategories($tree)

--- a/admin-dev/themes/default/template/controllers/images/content.tpl
+++ b/admin-dev/themes/default/template/controllers/images/content.tpl
@@ -73,7 +73,7 @@
 				</div>
 			</div>
 			{/foreach}
-			<script>
+			<script nonce="{$cspNonce}">
 				function changeFormat(elt)
 				{ldelim}
 					$('.second-select').hide();
@@ -115,7 +115,7 @@
 		</div>
 	</form>
 
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{$cspNonce}">
     $(function() {
       $('#display_regenerate_form button[type="submit"]').on('click', function() {
         $('#modalRegenerateThumbnails').modal('show');

--- a/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
@@ -4,7 +4,7 @@
  *}
 {extends file="helpers/view/view.tpl"}
 {block name="override_tpl"}
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		var errorEmpty = '{l s='Please name your data matching configuration in order to save it.' js=1}';
 		var current = 0;
 		function showTable(nb) {

--- a/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
@@ -106,7 +106,7 @@
 		</div>
 	</div>
 </form>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	//<![CDATA
 	function position_exception_textchange() {
 		// TODO : Add & Remove automatically the "custom pages" in the "em_list_x"

--- a/admin-dev/themes/default/template/controllers/scenes/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/scenes/helpers/form/form.tpl
@@ -14,7 +14,7 @@
 {/block}
 
 {block name="after"}
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		startingData = new Array();
 		{foreach from=$products item=product key=key}
 			startingData[{$key}] = new Array(

--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -3,7 +3,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  *}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 $(function() {
     $('#content .panel').highlight('{$query}');
 });

--- a/admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl
@@ -23,7 +23,7 @@
 		<p style="color: #000000; padding: 0px; font-size: 12px; margin-top: 4px;">{$input.value}</p>
 	{else}
 		{if $input.type == 'select' && $input.name == 'id_category'}
-			<script type="text/javascript">
+			<script type="text/javascript" nonce="{$cspNonce}">
 				$(function(){
 					$('#id_category').on('change', function(){
 						doAdminAjax(

--- a/admin-dev/themes/default/template/controllers/stats/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/stats/helpers/view/view.tpl
@@ -6,7 +6,7 @@
 {extends file="helpers/view/view.tpl"}
 
 {block name="override_tpl"}
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		$(function() {
 			var btn_save_calendar = $('span[class~="process-icon-save-calendar"]').parent();
 			var btn_submit_calendar = $('#submitDatePicker');

--- a/admin-dev/themes/default/template/controllers/stores/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/stores/helpers/options/options.tpl
@@ -6,7 +6,7 @@
 {extends file="helpers/options/options.tpl"}
 
 {block name="after"}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
     function ajaxStoreStates(id_state_selected)
 {
     $.ajax({

--- a/admin-dev/themes/default/template/controllers/tags/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/tags/helpers/form/form.tpl
@@ -36,7 +36,7 @@
 </div>
 
 
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 	$(function(){
 		$('#move_to_right').on('click', function(){
 			return !$('#select_left option:selected').remove().appendTo('#select_right');

--- a/admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_footer.tpl
+++ b/admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_footer.tpl
@@ -55,7 +55,7 @@
 			/ {$list_total} {l s='result(s)' d='Admin.Global'}
 			<input type="hidden" id="{$list_id}-pagination-items-page" name="{$list_id}_pagination" value="{$selected_pagination|intval}" />
 		</div>
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="{$cspNonce}">
 			$('.pagination-items-page').on('click',function(e){
 				e.preventDefault();
 				$('#'+$(this).data("list-id")+'-pagination-items-page').val($(this).data("items")).closest("form").submit();
@@ -101,7 +101,7 @@
 				</a>
 			</li>
 		</ul>
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="{$cspNonce}">
 			$('.pagination-link').on('click',function(e){
 				e.preventDefault();
 

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
@@ -32,7 +32,7 @@
 			<p>{l s='Total missing expressions:' d='Admin.International.Feature'} <span class="badge">{l s='%d' sprintf=[$missing_translations|array_sum]}</p>
 		</div>
 
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="{$cspNonce}">
 			$(function(){
 				$('a.useSpecialSyntax').on('click', function(){
 					var syntax = $(this).find('img').attr('alt');

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
@@ -44,7 +44,7 @@
 				<input type="hidden" name="type" value="{$type}" />
 				<input type="hidden" name="theme" value="{$theme}" />
 
-				<script type="text/javascript">
+				<script type="text/javascript" nonce="{$cspNonce}">
 					$(function(){
 						$('a.useSpecialSyntax').on('click', function(){
 							var syntax = $(this).find('img').attr('alt');

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -34,7 +34,7 @@
 				<input type="hidden" name="lang" value="{$lang}" />
 				<input type="hidden" name="type" value="{$type}" />
 				<input type="hidden" name="selected-theme" value="{$theme}" />
-				<script type="text/javascript">
+				<script type="text/javascript" nonce="{$cspNonce}">
 					$(function(){
 						$('a.useSpecialSyntax').on('click', function(){
 							var syntax = $(this).find('img').attr('alt');
@@ -82,7 +82,7 @@
 				</h3>
 				{$mail_content}
 				{literal}
-				<script type="text/javascript">
+				<script type="text/javascript" nonce="{$cspNonce}">
 				//<![CDATA[
 					$(function () {
 						$('.mails_field').on('shown.bs.collapse', function () {

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
@@ -77,7 +77,7 @@
 						</ul>
 					</div>
 				</div>
-				<script type="text/javascript">
+				<script type="text/javascript" nonce="{$cspNonce}">
 					$(function(){
 						$('a.useSpecialSyntax').on('click', function(){
 							var syntax = $(this).find('img').attr('alt');

--- a/admin-dev/themes/default/template/footer_toolbar.tpl
+++ b/admin-dev/themes/default/template/footer_toolbar.tpl
@@ -70,7 +70,7 @@
     {/if}
   </div>
 
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 	//<![CDATA[
 		var submited = false
 

--- a/admin-dev/themes/default/template/form_date_range_picker.tpl
+++ b/admin-dev/themes/default/template/form_date_range_picker.tpl
@@ -31,7 +31,7 @@
 
 	</form>
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	$(function() {
 		if ($("form#calendar_form .datepicker").length > 0)
 			$("form#calendar_form .datepicker").datepicker({

--- a/admin-dev/themes/default/template/form_submit_ajax.tpl
+++ b/admin-dev/themes/default/template/form_submit_ajax.tpl
@@ -3,7 +3,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  *}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	$(function() {
 		$('#{$table}_form').on('submit', function(e) {
 			e.preventDefault();

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -19,7 +19,7 @@
   <meta name="robots" content="NOFOLLOW, NOINDEX">
   <title>{if $meta_title != ''}{$meta_title|escape:'html':'UTF-8'} • {/if}{$shop_name|escape:'html':'UTF-8'}</title>
   {if !isset($display_header_javascript) || $display_header_javascript}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{$cspNonce}">
     var help_class_name = '{$controller_name|@addcslashes:'\''}';
     var iso_user = '{$iso_user|escape:'javascript'|@addcslashes:'\''}';
     var lang_is_rtl = '{$lang_is_rtl|intval}';

--- a/admin-dev/themes/default/template/helpers/calendar/calendar.tpl
+++ b/admin-dev/themes/default/template/helpers/calendar/calendar.tpl
@@ -86,7 +86,7 @@
 	</div>
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	translated_dates = {
 		days: ['{l s='Sunday' js=1}', '{l s='Monday' js=1}', '{l s='Tuesday' js=1}', '{l s='Wednesday' js=1}', '{l s='Thursday' js=1}', '{l s='Friday' js=1}', '{l s='Saturday' js=1}', '{l s='Sunday' js=1}'],
 		daysShort: ['{l s='Sun' js=1}', '{l s='Mon' js=1}', '{l s='Tue' js=1}', '{l s='Wed' js=1}', '{l s='Thu' js=1}', '{l s='Fri' js=1}', '{l s='Sat' js=1}', '{l s='Sun' js=1}'],

--- a/admin-dev/themes/default/template/helpers/form/assoshop.tpl
+++ b/admin-dev/themes/default/template/helpers/form/assoshop.tpl
@@ -3,7 +3,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  *}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 $().ready(function() {
 	$(document).on('click', '.input_all_shop', function(e) {
 		var checked = $(this).prop('checked');

--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -5,7 +5,7 @@
 {if isset($fields.title)}<h3>{$fields.title}</h3>{/if}
 
 {if isset($tabs) && $tabs|count}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	var helper_tabs = {$tabs|json_encode};
 	var unique_field_id = '';
 </script>
@@ -95,7 +95,7 @@
 										{/if}
 												{if $input.type == 'tags'}
 													{literal}
-														<script type="text/javascript">
+														<script type="text/javascript" nonce="{$cspNonce}">
 															$().ready(function () {
 																var input_id = '{/literal}{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}{literal}';
 																$('#'+input_id).tagify({delimiters: [13,44], addTagPrompt: '{/literal}{l s='Add tag' js=1}{literal}'});
@@ -158,7 +158,7 @@
 										{/if}
 									{/foreach}
 									{if isset($input.maxchar) && $input.maxchar}
-									<script type="text/javascript">
+									<script type="text/javascript" nonce="{$cspNonce}">
 									$(function(){
 									{foreach from=$languages item=language}
 										countDown($("#{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}"), $("#{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}_counter"));
@@ -172,7 +172,7 @@
 									{else}
 										{if $input.type == 'tags'}
 											{literal}
-											<script type="text/javascript">
+											<script type="text/javascript" nonce="{$cspNonce}">
 												$().ready(function () {
 													var input_id = '{/literal}{if isset($input.id)}{$input.id}{else}{$input.name}{/if}{literal}';
 													$('#'+input_id).tagify({delimiters: [13,44], addTagPrompt: '{/literal}{l s='Add tag'}{literal}'});
@@ -219,7 +219,7 @@
 										</div>
 										{/if}
 										{if isset($input.maxchar) && $input.maxchar}
-										<script type="text/javascript">
+										<script type="text/javascript" nonce="{$cspNonce}">
 										$(function(){
 											countDown($("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}"), $("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}_counter"));
 										});
@@ -266,7 +266,7 @@
 										</div>
 									</div>
 									{if isset($input.maxchar) && $input.maxchar}
-									<script type="text/javascript">
+									<script type="text/javascript" nonce="{$cspNonce}">
 										$(function() {
 											countDown($("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}"), $("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}_counter"));
 										});
@@ -447,7 +447,7 @@
 											{/if}
 										{/foreach}
 										{if isset($input.maxchar) && $input.maxchar}
-											<script type="text/javascript">
+											<script type="text/javascript" nonce="{$cspNonce}">
 											$(function(){
 											{foreach from=$languages item=language}
 												countDown($("#{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}"), $("#{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}_counter"));
@@ -463,7 +463,7 @@
 										{/if}
 										<textarea{if isset($input.readonly) && $input.readonly} readonly="readonly"{/if} name="{$input.name}" id="{if isset($input.id)}{$input.id}{else}{$input.name}{/if}" {if isset($input.cols)}cols="{$input.cols}"{/if} {if isset($input.rows)}rows="{$input.rows}"{/if} class="{if isset($input.autoload_rte) && $input.autoload_rte}rte autoload_rte{else}textarea-autosize{/if}{if isset($input.class)} {$input.class}{/if}"{if isset($input.maxlength) && $input.maxlength} maxlength="{$input.maxlength|intval}"{/if}{if isset($input.maxchar) && $input.maxchar} data-maxchar="{$input.maxchar|intval}"{/if}>{$fields_value[$input.name]|default|escape:'html':'UTF-8'}</textarea>
 										{if isset($input.maxchar) && $input.maxchar}
-											<script type="text/javascript">
+											<script type="text/javascript" nonce="{$cspNonce}">
 											$(function(){
 												countDown($("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}"), $("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}_counter"));
 											});
@@ -710,7 +710,7 @@
 {block name="after"}{/block}
 
 {if isset($tinymce) && $tinymce}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	var iso = '{$iso|addslashes}';
 	var pathCSS = '{$smarty.const._THEME_CSS_DIR_|addslashes}';
 	var ad = '{$ad|addslashes}';
@@ -725,12 +725,12 @@
 </script>
 {/if}
 {if isset($color) && $color}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	$.fn.mColorPicker.defaults.imageFolder = baseDir + 'img/admin/';
 </script>
 {/if}
 {if $firstCall}
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		var module_dir = '{$smarty.const._MODULE_DIR_}';
 		var id_language = {$defaultFormLanguage|intval};
 		var languages = new Array();

--- a/admin-dev/themes/default/template/helpers/form/form_category.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form_category.tpl
@@ -3,7 +3,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  *}
 {if count($categories) && isset($categories)}
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		var inputName = '{$categories.input_name|@addcslashes:'\''}';
 		var use_radio = {if $categories.use_radio}1{else}0{/if};
 		var selectedCat = {$categories.selected_cat|@implode|intval};
@@ -65,7 +65,7 @@
 		</li>
 	</ul>
 	{if $categories.use_radio}
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		searchCategory();
 	</script>
 	{/if}

--- a/admin-dev/themes/default/template/helpers/kpi/kpi.tpl
+++ b/admin-dev/themes/default/template/helpers/kpi/kpi.tpl
@@ -21,7 +21,7 @@
 
 </{if isset($href) && $href}a{else}div{/if}>
 
-<script>
+<script nonce="{$cspNonce}">
 	function refresh_{$id|replace:'-':'_'|addslashes}()
 	{
 		{if !isset($source) || $source == '' || !isset($refresh) || $refresh == ''}
@@ -56,7 +56,7 @@
 </script>
 
 {if $chart}
-<script>
+<script nonce="{$cspNonce}">
 	function set_d3_{$id|str_replace:'-':'_'|addslashes}(jsonObject)
 	{
 		var data = new Array;

--- a/admin-dev/themes/default/template/helpers/list/list_footer.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_footer.tpl
@@ -55,7 +55,7 @@
 			/ {$list_total} {l s='result(s)'}
 			<input type="hidden" id="{$list_id}-pagination-items-page" name="{$list_id}_pagination" value="{$selected_pagination|intval}" />
 		</div>
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="{$cspNonce}">
 			$('.pagination-items-page').on('click',function(e){
 				e.preventDefault();
 				$('#'+$(this).data("list-id")+'-pagination-items-page').val($(this).data("items")).closest("form").submit();
@@ -101,7 +101,7 @@
 				</a>
 			</li>
 		</ul>
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="{$cspNonce}">
 			$('.pagination-link').on('click',function(e){
 				e.preventDefault();
 

--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -4,7 +4,7 @@
  *}
 
 {if $ajax}
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		$(function () {
 			$(".ajax_table_link").on('click', function () {
 				var link = $(this);
@@ -40,14 +40,14 @@
 {* Display column names and arrows for ordering (ASC, DESC) *}
 {if $is_order_position}
 	<script type="text/javascript" src="{$js_dir}jquery/plugins/jquery.tablednd.js"></script>
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		var come_from = '{$list_id|addslashes}';
 		var alternate = {if $order_way == 'DESC'}'1'{else}'0'{/if};
 	</script>
 	<script type="text/javascript" src="{$js_dir}admin/dnd.js"></script>
 {/if}
 {if !$simple_header}
-	<script type="text/javascript">
+	<script type="text/javascript" nonce="{$cspNonce}">
 		$(function() {
 			$('table.{$list_id} .filter').on('keypress', function(e){
 				var key = (e.keyCode ? e.keyCode : e.which);
@@ -161,7 +161,7 @@
 			{/if}
 		</div>
 		{if $show_toolbar}
-			<script type="text/javascript">
+			<script type="text/javascript" nonce="{$cspNonce}">
 				//<![CDATA[
 				var submited = false;
 				$(function() {
@@ -348,7 +348,7 @@
 												<i class="icon-calendar"></i>
 											</span>
 										</div>
-										<script>
+										<script nonce="{$cspNonce}">
 											$(function() {
 												var dateStart = parseDate($("#{$params.id_date}_0").val());
 												var dateEnd = parseDate($("#{$params.id_date}_1").val());

--- a/admin-dev/themes/default/template/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/helpers/options/options.tpl
@@ -5,7 +5,7 @@
 
 <div class="leadin">{block name="leadin"}{/block}</div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	id_language = Number({$current_id_lang});
 	{if isset($tabs) && $tabs|count}
 		var helper_tabs= {$tabs|json_encode};
@@ -270,7 +270,7 @@
 
 													</div>
 												{/foreach}
-												<script type="text/javascript">
+												<script type="text/javascript" nonce="{$cspNonce}">
 													$(function() {
 														$(".textarea-autosize").autosize();
 													});
@@ -356,7 +356,7 @@
 {/block}
 {block name="after"}
 {if isset($tinymce) && $tinymce}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	var iso = '{$iso|addslashes}';
 	var pathCSS = '{$smarty.const._THEME_CSS_DIR_|addslashes}';
 	var ad = '{$ad|addslashes}';
@@ -372,7 +372,7 @@
 {/if}
 {/block}
 {if $has_color_field}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
   $.fn.mColorPicker.defaults.imageFolder = baseDir + 'img/admin/';
 </script>
 {/if}

--- a/admin-dev/themes/default/template/helpers/tree/subtree_associated_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/subtree_associated_categories.tpl
@@ -6,7 +6,7 @@
 	{$nodes}
 {/if}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 {if isset($selected_categories) && !empty($selected_categories)}
 	{assign var=imploded_selected_categories value='","'|implode:$selected_categories}
 	var selected_categories = new Array("{$imploded_selected_categories}");

--- a/admin-dev/themes/default/template/helpers/tree/tree_associated_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_associated_categories.tpl
@@ -10,7 +10,7 @@
 	</ul>
 	{/if}
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	var currentToken="{$token|@addslashes}";
 	var treeClickFunc = function() {
 		var newURL = window.location.protocol + "//" + window.location.host + window.location.pathname;

--- a/admin-dev/themes/default/template/helpers/tree/tree_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_categories.tpl
@@ -10,7 +10,7 @@
 	</ul>
 	{/if}
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	var currentToken="{$token|@addslashes}";
 	{if isset($use_checkbox) && $use_checkbox == true}
 		function checkAllAssociatedCategories($tree)

--- a/admin-dev/themes/default/template/helpers/tree/tree_shops.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_shops.tpl
@@ -10,7 +10,7 @@
 	</ul>
 	{/if}
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	function checkAllAssociatedShops($tree)
 	{
 		$tree.find(":input[type=checkbox]").each(

--- a/admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl
@@ -14,7 +14,7 @@
 
 {if isset($typeahead_source) && isset($id) && isset($name)}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	$(
 		function()
 		{

--- a/admin-dev/themes/default/template/helpers/uploader/ajax.tpl
+++ b/admin-dev/themes/default/template/helpers/uploader/ajax.tpl
@@ -27,7 +27,7 @@
 <div class="row">
 	<div class="alert alert-warning">{l s='You have reached the limit (%s) of files to upload, please remove files to continue uploading' sprintf=[$max_files]}</div>
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	$( document ).ready(function() {
 		{if isset($files) && $files}
 		$('#{$id|escape:'html':'UTF-8'}-images-thumbnails').parent().show();
@@ -56,7 +56,7 @@
 <div class="row" style="display:none">
 	<div class="alert alert-danger" id="{$id|escape:'html':'UTF-8'}-errors"></div>
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 	function humanizeSize(bytes)
 	{
 		if (typeof bytes !== 'number') {

--- a/admin-dev/themes/default/template/helpers/uploader/simple.tpl
+++ b/admin-dev/themes/default/template/helpers/uploader/simple.tpl
@@ -56,7 +56,7 @@
 		</div>
 	</div>
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{$cspNonce}">
 {if isset($multiple) && isset($max_files)}
 	var {$id|escape:'html':'UTF-8'}_max_files = {$max_files - ($files|count)};
 {/if}

--- a/admin-dev/themes/default/template/search_form.tpl
+++ b/admin-dev/themes/default/template/search_form.tpl
@@ -58,7 +58,7 @@
 			<input id="bo_query" name="bo_query" type="text" class="form-control" value="{$bo_query}" placeholder="{l s='Search' d='Admin.Actions'}" aria-label="{l s='Search' d='Admin.Actions'}" />
 		</div>
 	</div>
-	<script>
+	<script nonce="{$cspNonce}">
 		{if isset($search_type) && $search_type}
 			$(function() {
 				$('.search-option a[data-value='+{$search_type|intval}+']').click();

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1961,6 +1961,13 @@ class AdminControllerCore extends Controller
     {
         header('Cache-Control: no-store, no-cache');
 
+        // Phase 1 of the Content Security Policy rollout: a report-only header with a
+        // per-request nonce, also exposed to templates as `cspNonce` for progressive
+        // adoption on inline scripts.
+        $cspNonce = base64_encode(random_bytes(16));
+        header('Content-Security-Policy-Report-Only: default-src \'self\'; script-src \'self\' \'nonce-' . $cspNonce . '\'; style-src \'self\' \'unsafe-inline\'');
+        $this->context->smarty->assign('cspNonce', $cspNonce);
+
         $this->context->smarty->assign([
             'table' => $this->table,
             'current' => self::$currentIndex,

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1013,6 +1013,12 @@ class FrontControllerCore extends Controller
      */
     public function initHeader()
     {
+        // Phase 1 of the Content Security Policy rollout: a report-only header with a
+        // per-request nonce, also exposed to templates as `cspNonce` for progressive
+        // adoption on inline scripts.
+        $cspNonce = base64_encode(random_bytes(16));
+        header('Content-Security-Policy-Report-Only: default-src \'self\'; script-src \'self\' \'nonce-' . $cspNonce . '\'; style-src \'self\' \'unsafe-inline\'');
+        $this->context->smarty->assign('cspNonce', $cspNonce);
     }
 
     /**

--- a/src/PrestaShopBundle/EventListener/CspHeaderSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/CspHeaderSubscriber.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShopBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Sends a Content-Security-Policy-Report-Only header with a per-request nonce on
+ * every main back-office request, as the first step of the Content Security Policy
+ * rollout. The nonce is also stored in the request attributes (as `csp_nonce`) so
+ * templates can adopt it incrementally before the header becomes enforcing.
+ */
+class CspHeaderSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var string
+     */
+    private $headerName;
+
+    /**
+     * @param string $headerName
+     */
+    public function __construct($headerName = 'Content-Security-Policy-Report-Only')
+    {
+        $this->headerName = $headerName;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+
+    /**
+     * @param ResponseEvent $event
+     */
+    public function onKernelResponse(ResponseEvent $event)
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $nonce = base64_encode(random_bytes(16));
+        $event->getRequest()->attributes->set('csp_nonce', $nonce);
+        $event->getResponse()->headers->set(
+            $this->headerName,
+            sprintf(
+                "default-src 'self'; script-src 'self' 'nonce-%s'; style-src 'self' 'unsafe-inline'",
+                $nonce
+            )
+        );
+    }
+}

--- a/src/PrestaShopBundle/EventListener/CspHeaderSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/CspHeaderSubscriber.php
@@ -9,17 +9,23 @@ declare(strict_types=1);
 namespace PrestaShopBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Sends a Content-Security-Policy-Report-Only header with a per-request nonce on
- * every main back-office request, as the first step of the Content Security Policy
- * rollout. The nonce is also stored in the request attributes (as `csp_nonce`) so
- * templates can adopt it incrementally before the header becomes enforcing.
+ * every main back-office response, as the first step of the Content Security Policy
+ * rollout.
+ *
+ * The nonce is generated on kernel.request and stored in the main request
+ * attributes (as `csp_nonce`) so it is already available while templates render
+ * (see CspNonceExtension) — long before the response is built.
  */
 final class CspHeaderSubscriber implements EventSubscriberInterface
 {
+    public const NONCE_ATTRIBUTE = 'csp_nonce';
+
     public function __construct(
         private readonly string $headerName = 'Content-Security-Policy-Report-Only'
     ) {
@@ -28,8 +34,24 @@ final class CspHeaderSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
+            // Early max priority: the nonce must exist before controllers/views render.
+            KernelEvents::REQUEST => ['onKernelRequest', 256],
             KernelEvents::RESPONSE => 'onKernelResponse',
         ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if (!$event->getRequest()->attributes->has(self::NONCE_ATTRIBUTE)) {
+            $event->getRequest()->attributes->set(
+                self::NONCE_ATTRIBUTE,
+                base64_encode(random_bytes(16))
+            );
+        }
     }
 
     public function onKernelResponse(ResponseEvent $event): void
@@ -38,8 +60,11 @@ final class CspHeaderSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $nonce = base64_encode(random_bytes(16));
-        $event->getRequest()->attributes->set('csp_nonce', $nonce);
+        $nonce = (string) $event->getRequest()->attributes->get(self::NONCE_ATTRIBUTE, '');
+        if ($nonce === '') {
+            return;
+        }
+
         $event->getResponse()->headers->set(
             $this->headerName,
             sprintf(

--- a/src/PrestaShopBundle/EventListener/CspHeaderSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/CspHeaderSubscriber.php
@@ -4,6 +4,8 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace PrestaShopBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -16,35 +18,21 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * rollout. The nonce is also stored in the request attributes (as `csp_nonce`) so
  * templates can adopt it incrementally before the header becomes enforcing.
  */
-class CspHeaderSubscriber implements EventSubscriberInterface
+final class CspHeaderSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var string
-     */
-    private $headerName;
-
-    /**
-     * @param string $headerName
-     */
-    public function __construct($headerName = 'Content-Security-Policy-Report-Only')
-    {
-        $this->headerName = $headerName;
+    public function __construct(
+        private readonly string $headerName = 'Content-Security-Policy-Report-Only'
+    ) {
     }
 
-    /**
-     * @return array
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',
         ];
     }
 
-    /**
-     * @param ResponseEvent $event
-     */
-    public function onKernelResponse(ResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if (!$event->isMainRequest()) {
             return;
@@ -55,7 +43,7 @@ class CspHeaderSubscriber implements EventSubscriberInterface
         $event->getResponse()->headers->set(
             $this->headerName,
             sprintf(
-                "default-src 'self'; script-src 'self' 'nonce-%s'; style-src 'self' 'unsafe-inline'",
+                "default-src 'self'; script-src 'self' 'nonce-%s'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:",
                 $nonce
             )
         );

--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -35,3 +35,8 @@ services:
     autowire: true
     tags:
       - { name: doctrine.orm.entity_listener, event: postUpdate, entity: PrestaShopBundle\Entity\FeatureFlag, lazy: true }
+
+  prestashop.bundle.event_listener.csp_header:
+    class: PrestaShopBundle\EventListener\CspHeaderSubscriber
+    tags:
+      - { name: kernel.event_subscriber }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -50,6 +50,11 @@ services:
     arguments:
       $cache: '@prestashop.static_cache.adapter'
 
+  PrestaShopBundle\Twig\CspNonceExtension:
+    autowire: true
+    tags:
+      - { name: twig.extension }
+
   PrestaShopBundle\Twig\ContextIsoCodeProviderExtension:
     arguments:
       - "@=service('prestashop.adapter.legacy.context').getContext().language ? service('prestashop.adapter.legacy.context').getContext().language.iso_code : 'en'"

--- a/src/PrestaShopBundle/Twig/CspNonceExtension.php
+++ b/src/PrestaShopBundle/Twig/CspNonceExtension.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Twig;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Exposes the per-request Content Security Policy nonce (generated on
+ * kernel.request by CspHeaderSubscriber and stored in the main request
+ * attributes) to Twig templates, so inline scripts can declare
+ * `nonce="{{ csp_nonce() }}"` and stay valid once the policy becomes enforcing.
+ */
+final class CspNonceExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly RequestStack $requestStack
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('csp_nonce', [$this, 'getNonce']),
+        ];
+    }
+
+    public function getNonce(): string
+    {
+        $request = $this->requestStack->getMainRequest();
+        if ($request === null) {
+            return '';
+        }
+
+        $nonce = $request->attributes->get('csp_nonce');
+
+        return is_string($nonce) ? $nonce : '';
+    }
+}

--- a/tests/Unit/PrestaShopBundle/EventListener/CspHeaderSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/CspHeaderSubscriberTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\EventListener\CspHeaderSubscriber;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class CspHeaderSubscriberTest extends TestCase
+{
+    private const HEADER_NAME = 'Content-Security-Policy-Report-Only';
+
+    public function testGetSubscribedEvents(): void
+    {
+        $events = CspHeaderSubscriber::getSubscribedEvents();
+
+        $this->assertArrayHasKey(KernelEvents::REQUEST, $events);
+        $this->assertArrayHasKey(KernelEvents::RESPONSE, $events);
+        $this->assertSame('onKernelResponse', $events[KernelEvents::RESPONSE]);
+    }
+
+    public function testItSetsReportOnlyHeaderWithNonceOnMainRequest(): void
+    {
+        $request = Request::create('https://example.com/admin/');
+        $response = new Response();
+        $subscriber = new CspHeaderSubscriber();
+
+        $subscriber->onKernelRequest($this->createRequestEvent($request));
+        $subscriber->onKernelResponse($this->createResponseEvent($request, $response));
+
+        $header = $response->headers->get(self::HEADER_NAME);
+        $nonce = (string) $request->attributes->get(CspHeaderSubscriber::NONCE_ATTRIBUTE);
+
+        $this->assertNotSame('', $nonce);
+        $this->assertStringContainsString("script-src 'self' 'nonce-" . $nonce . "'", $header);
+        $this->assertStringContainsString("default-src 'self'", $header);
+    }
+
+    public function testNonceDiffersBetweenRequests(): void
+    {
+        $subscriber = new CspHeaderSubscriber();
+        $nonces = [];
+
+        for ($i = 0; $i < 2; ++$i) {
+            $request = Request::create('https://example.com/admin/');
+            $response = new Response();
+
+            $subscriber->onKernelRequest($this->createRequestEvent($request));
+            $subscriber->onKernelResponse($this->createResponseEvent($request, $response));
+
+            $nonces[] = (string) $request->attributes->get(CspHeaderSubscriber::NONCE_ATTRIBUTE);
+        }
+
+        $this->assertNotSame($nonces[0], $nonces[1]);
+    }
+
+    public function testItDoesNothingOnSubRequests(): void
+    {
+        $request = Request::create('https://example.com/admin/');
+        $response = new Response();
+        $subscriber = new CspHeaderSubscriber();
+
+        $event = new ResponseEvent(
+            $this->createKernelMock(),
+            $request,
+            HttpKernelInterface::SUB_REQUEST,
+            $response
+        );
+
+        $subscriber->onKernelResponse($event);
+
+        $this->assertFalse($response->headers->has(self::HEADER_NAME));
+        $this->assertFalse($request->attributes->has(CspHeaderSubscriber::NONCE_ATTRIBUTE));
+    }
+
+    public function testItSkipsHeaderWhenNonceIsMissing(): void
+    {
+        $request = Request::create('https://example.com/admin/');
+        $response = new Response();
+        $subscriber = new CspHeaderSubscriber();
+
+        $subscriber->onKernelResponse($this->createResponseEvent($request, $response));
+
+        $this->assertFalse($response->headers->has(self::HEADER_NAME));
+    }
+
+    private function createRequestEvent(Request $request): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createKernelMock(),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+    }
+
+    private function createResponseEvent(Request $request, Response $response): ResponseEvent
+    {
+        return new ResponseEvent(
+            $this->createKernelMock(),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $response
+        );
+    }
+
+    private function createKernelMock(): HttpKernelInterface
+    {
+        return $this->getMockBuilder(HttpKernelInterface::class)->getMock();
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Twig/CspNonceExtensionTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/CspNonceExtensionTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Twig\CspNonceExtension;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class CspNonceExtensionTest extends TestCase
+{
+    public function testItReturnsNonceFromMainRequestAttributes(): void
+    {
+        $request = Request::create('https://example.com/admin/');
+        $request->attributes->set('csp_nonce', 'abc123');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $extension = new CspNonceExtension($requestStack);
+
+        $this->assertSame('abc123', $extension->getNonce());
+    }
+
+    public function testItReturnsEmptyStringWhenNonceIsMissing(): void
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('https://example.com/admin/'));
+
+        $extension = new CspNonceExtension($requestStack);
+
+        $this->assertSame('', $extension->getNonce());
+    }
+
+    public function testItReturnsEmptyStringWithoutRequest(): void
+    {
+        $extension = new CspNonceExtension(new RequestStack());
+
+        $this->assertSame('', $extension->getNonce());
+    }
+
+    public function testItExposesCspNonceFunction(): void
+    {
+        $extension = new CspNonceExtension(new RequestStack());
+        $functions = $extension->getFunctions();
+
+        $this->assertCount(1, $functions);
+        $this->assertSame('csp_nonce', $functions[0]->getName());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | First step of the Content Security Policy rollout for the back office: a report-only header with a per-request nonce (kernel.request/response subscriber), `csp_nonce()` Twig function, `cspNonce` Smarty variable, and unit tests. Non-breaking by design. See #42441 for the full rollout proposal.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Boot any back-office page (e.g. `/admin<suffix>/login`) and inspect response headers: a `Content-Security-Policy-Report-Only` header with a per-request nonce is present; pages render normally. Front office pages carry the same header via `FrontController::initHeader()`. Unit tests: `php vendor/bin/phpunit tests/Unit/PrestaShopBundle/EventListener/CspHeaderSubscriberTest.php tests/Unit/PrestaShopBundle/Twig/CspNonceExtensionTest.php`
| UI Tests          | Not applicable - report-only header, no UI behavior change.
| Fixed issue or discussion?     | Implements step 1 of #42441
| Sponsor company   | 

---

## Details

## What's in this PR

| File | Change |
|---|---|
| `src/PrestaShopBundle/EventListener/CspHeaderSubscriber.php` | New kernel subscriber: generates a per-request nonce on `kernel.request` (max priority) and emits `Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'nonce-…'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:` on `kernel.response` (main requests only) |
| `src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml` | Service registration (`kernel.event_subscriber` tag) |
| `classes/controller/AdminController.php` | `initHeader()` emits the same report-only header on legacy admin pages and assigns the nonce to Smarty as `cspNonce` |
| `classes/controller/FrontController.php` | Same as above for the front office |
| `src/PrestaShopBundle/Twig/CspNonceExtension.php` | New `csp_nonce()` Twig function reading the nonce from main request attributes — templates can adopt nonces incrementally |
| `src/PrestaShopBundle/Resources/config/services/bundle/twig.yml` | Extension registration |
| `tests/Unit/PrestaShopBundle/EventListener/CspHeaderSubscriberTest.php` | 5 tests: header+nonce on main request, per-request uniqueness, sub-request skip, missing-nonce skip, event subscription |
| `tests/Unit/PrestaShopBundle/Twig/CspNonceExtensionTest.php` | 4 tests: nonce from main request, empty when missing, empty without request, function exposure |

## Design notes

- **Nonce on `kernel.request` (max priority), header on `kernel.response`** — templates render
  between the two events, so `csp_nonce()` is already resolvable inside views.
- Report-only keeps this non-breaking; enforcement is a follow-up once inline-script adoption
  (legacy `helpers/` onclick handlers, module-injected scripts) completes.
- `font-src`/`img-src` `data:` allowances verified as required by the classic theme's data-URI
  fonts/SVGs.

## Verification performed

- Runtime: PrestaShop (release-matched files) + MariaDB in Docker; report-only header present
  with a different nonce per request on the front office (legacy `FrontController`) and the
  Symfony back-office login page; pages render normally.
- Chrome headless on the front page: report-only violations dropped **7 → 1** after allowing
  `font-src`/`img-src` `data:` (the remaining one is an inline script injected by a hooking
  module — step 2 of the rollout).
- `php vendor/bin/phpunit` on the two new test files: **9 tests, 15 assertions, OK**.

## Next steps (follow-ups, not part of this PR)

1. Template/module adoption of the nonce (legacy `.tpl` inline scripts, new-theme, module
   inline scripts) — measured via the report-only reports.
2. Legacy `helpers/` `onclick=` attributes → delegated handlers.
3. Flip to enforcing once reports reach zero.
