### PR TITLE
Fix image thumbnail regeneration execution time 

### DIFF
--- a/src/Adapter/ImageThumbnailsRegenerator.php
+++ b/src/Adapter/ImageThumbnailsRegenerator.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class ImageThumbnailsRegenerator
 {
-    private int $maxExecutionTime = 7200;
+    private int $maxExecutionTime = 86400;
     private int $startTime = 0;
 
     public function __construct(

--- a/src/Adapter/ImageThumbnailsRegenerator.php
+++ b/src/Adapter/ImageThumbnailsRegenerator.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class ImageThumbnailsRegenerator
 {
-    private int $maxExecutionTime = 86400;
+    private int $maxExecutionTime = 7200;
     private int $startTime = 0;
 
     public function __construct(
@@ -38,8 +38,10 @@ class ImageThumbnailsRegenerator
     ) {
         // Save start time to calculate remaining time and to avoid timeout on long running processes
         $this->startTime = time();
-        ini_set('max_execution_time', $this->maxExecutionTime); // ini_set may be disabled, we need the real value
-        $this->maxExecutionTime = (int) ini_get('max_execution_time');
+        if (PHP_SAPI !== 'cli') {
+            ini_set('max_execution_time', $this->maxExecutionTime); // ini_set may be disabled, we need the real value
+            $this->maxExecutionTime = (int) ini_get('max_execution_time');
+        }
     }
 
     /**
@@ -174,7 +176,7 @@ class ImageThumbnailsRegenerator
                         }
 
                         // stop 4 seconds before the timeout, just enough time to process the end of the page on a slow server
-                        if (time() - $this->startTime > $this->maxExecutionTime - 4) {
+                        if (PHP_SAPI !== 'cli' && time() - $this->startTime > $this->maxExecutionTime - 4) {
                             return ['timeout'];
                         }
                     }
@@ -238,7 +240,7 @@ class ImageThumbnailsRegenerator
                         'Admin.Design.Notification'
                     );
                 }
-                if (time() - $this->startTime > $this->maxExecutionTime - 4) { // stop 4 seconds before the tiemout, just enough time to process the end of the page on a slow server
+                if (PHP_SAPI !== 'cli' && time() - $this->startTime > $this->maxExecutionTime - 4) { // stop 4 seconds before the tiemout, just enough time to process the end of the page on a slow server
                     return ['timeout'];
                 }
             }
@@ -273,7 +275,7 @@ class ImageThumbnailsRegenerator
                             );
                         }
 
-                        if (time() - $this->startTime > $this->maxExecutionTime - 4) { // stop 4 seconds before the tiemout, just enough time to process the end of the page on a slow server
+                        if (PHP_SAPI !== 'cli' && time() - $this->startTime > $this->maxExecutionTime - 4) { // stop 4 seconds before the tiemout, just enough time to process the end of the page on a slow server
                             return 'timeout';
                         }
                     }


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------- |
| Branch?           | develop |
| Description?      | The current image thumbnail regeneration timeout is limited to 7,200 seconds (2 hours). This limit is too short for CLI regeneration on large catalogs, especially with the new image formats, which require additional processing time.  |
| Type?             | bug fix |
| Category?         | CO |
| BC breaks?        | no |
| Deprecations?     | no |
| How to test?      | Run image thumbnail regeneration from the CLI on a large catalog, including the new image formats. Verify that the process can continue beyond the previous 7,200-second limit |
| UI Tests          | Not needed; this change only affects the execution timeout of the image thumbnail regeneration process. |
| Fixed issue or discussion? | N/A |
| Related PRs       | N/A |
| Sponsor company   | @Touxten 
