### PR TITLE
Fix undefined array key warning in StatisticsController::postProcess()

### DIFF
--- a/controllers/front/StatisticsController.php
+++ b/controllers/front/StatisticsController.php
@@ -19,9 +19,11 @@ class StatisticsControllerCore extends FrontController
             die;
         }
 
-        if ($_POST['type'] == 'navinfo') {
+        $type = Tools::getValue('type');
+
+        if ($type == 'navinfo') {
             $this->processNavigationStats();
-        } elseif ($_POST['type'] == 'pagetime') {
+        } elseif ($type == 'pagetime') {
             $this->processPageTime();
         } else {
             exit;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | StatisticsController::postProcess() reads \$_POST[type] without checking if the key exists, emitting two PHP warnings on PHP 8.x when the parameter is absent. Uses Tools::getValue() instead, matching the pattern already used for other parameters in the same method.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Send a request to the statistics controller with a token but without a POST type parameter: `curl -i "https://example.test/index.php?controller=statistics&token=test"`. Before the fix, two "Undefined array key" warnings appear in the PHP error log. After the fix, no warnings are emitted.
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes #42433
| Related PRs       | N/A
| Sponsor company   | N/A