### PR TITLE
Keep default route keywords out of the generated query string

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -1031,7 +1031,7 @@ class DispatcherCore
      * @param array $params
      * @param bool $force_routes
      * @param string $anchor Optional anchor to add at the end of this url
-     * @param null $id_shop
+     * @param int|null $id_shop Defaults to the shop in context
      *
      * @return string
      *
@@ -1090,7 +1090,12 @@ class DispatcherCore
 
             foreach ($params as $key => $value) {
                 if (!isset($routeDefinition['keywords'][$key])) {
-                    $add_param[$key] = $value;
+                    // A customised rule may deliberately drop a keyword the default route still
+                    // declares (removing {id} from the schema, for instance). Such a parameter is
+                    // consumed by the route, not an extra one, so it must not reach the query string.
+                    if (!isset($this->default_routes[$routeName]['keywords'][$key])) {
+                        $add_param[$key] = $value;
+                    }
                 } else {
                     if ($params[$key]) {
                         $parameter = $params[$key];
@@ -1117,7 +1122,9 @@ class DispatcherCore
             // Build a classic url index.php?controller=foo&...
             $add_params = [];
             foreach ($params as $key => $value) {
-                if (!isset($routeDefinition['keywords'][$key])) {
+                if (!isset($routeDefinition['keywords'][$key])
+                    && !isset($this->default_routes[$routeName]['keywords'][$key])
+                ) {
                     $add_params[$key] = $value;
                 }
             }

--- a/tests/Unit/Classes/DispatcherTest.php
+++ b/tests/Unit/Classes/DispatcherTest.php
@@ -35,6 +35,119 @@ class DispatcherTest extends TestCase
         $this->assertEquals($expectedErrors, $errors);
     }
 
+    /**
+     * A customised route rule may deliberately omit a keyword that the DEFAULT route still declares -
+     * removing {id} from the category schema in SEO & URLs is a supported option. That parameter is
+     * consumed by the route, so it must not be appended to the query string.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/42440
+     *
+     * @dataProvider createUrlKeywordProvider
+     */
+    public function testCreateUrlDropsKeywordsOfTheDefaultRoute($useRoutes, $rule, $params, $expected)
+    {
+        $dispatcher = DispatcherCore::getInstance();
+        $reflection = new ReflectionClass($dispatcher);
+
+        $defaultRoutes = [
+            'category_rule' => [
+                'controller' => 'category',
+                'rule' => '{id}-{rewrite}',
+                'keywords' => [
+                    'id' => ['regexp' => '[0-9]+', 'param' => 'id_category'],
+                    'rewrite' => ['regexp' => '[_a-zA-Z0-9\pL\pS-]*'],
+                    'meta_title' => ['regexp' => '[_a-zA-Z0-9-\pL]*'],
+                ],
+            ],
+        ];
+
+        $defaultRoutesProperty = $reflection->getProperty('default_routes');
+        $defaultRoutesProperty->setAccessible(true);
+        $defaultRoutesProperty->setValue($dispatcher, $defaultRoutes);
+
+        // Only the keywords the customised rule actually uses stay in the computed route, which is
+        // what loadRoutes() produces for a merchant-defined schema.
+        $keywords = [];
+        foreach ($defaultRoutes['category_rule']['keywords'] as $keyword => $data) {
+            if (strpos($rule, '{' . $keyword . '}') !== false) {
+                $keywords[$keyword] = $data;
+            }
+        }
+
+        $routesProperty = $reflection->getProperty('routes');
+        $routesProperty->setAccessible(true);
+        $routesProperty->setValue($dispatcher, [
+            1 => [
+                1 => [
+                    'category_rule' => $dispatcher->computeRoute($rule, 'category', $keywords),
+                ],
+            ],
+        ]);
+
+        $useRoutesProperty = $reflection->getProperty('use_routes');
+        $useRoutesProperty->setAccessible(true);
+        $useRoutesProperty->setValue($dispatcher, $useRoutes);
+
+        $this->assertSame($expected, $dispatcher->createUrl('category_rule', 1, $params, false, '', 1));
+    }
+
+    public function createUrlKeywordProvider()
+    {
+        return [
+            // Native schema: {id} is in the rule, so it is substituted and never appended.
+            'friendly, default rule' => [
+                true,
+                '{id}-{rewrite}',
+                ['id' => 3, 'rewrite' => 'clothes'],
+                '3-clothes',
+            ],
+            // Customised schema without {id}: it is still a default-route keyword, so it is dropped
+            // rather than appended as ?id=3.
+            'friendly, id removed from the rule' => [
+                true,
+                '{rewrite}',
+                ['id' => 3, 'rewrite' => 'clothes'],
+                'clothes',
+            ],
+            // A parameter that is not a keyword of either rule is genuinely extra and must survive.
+            'friendly, unrelated parameter is kept' => [
+                true,
+                '{rewrite}',
+                ['id' => 3, 'rewrite' => 'clothes', 'search_query' => 'shoes'],
+                'clothes?search_query=shoes',
+            ],
+            // A keyword the DEFAULT route declares but the rule does not use (meta_title is declared
+            // by category_rule yet absent from '{id}-{rewrite}') is also route data rather than an
+            // extra parameter, so it is dropped as well. Link::getCategoryLink() only passes it when
+            // hasKeyword() says the computed route uses it, so core's own links are unaffected; this
+            // pins the behaviour for callers that build the URL directly.
+            'friendly, default-route keyword absent from the rule' => [
+                true,
+                '{id}-{rewrite}',
+                ['id' => 3, 'rewrite' => 'clothes', 'meta_title' => 'my-title'],
+                '3-clothes',
+            ],
+            // #42426: Link::getProductLink() always passes id_product_attribute, null when there is no
+            // combination. Appended as an extra parameter it produced an EMPTY query string that was
+            // still prefixed with '?', and FrontController::canonicalRedirection() then compared
+            // 'slug-p-1?' with the requested 'slug-p-1' and redirected forever. The rule is the same for
+            // every route, so it is pinned here on category_rule.
+            'friendly, default-route keyword passed as null leaves no dangling question mark' => [
+                true,
+                '{id}-{rewrite}',
+                ['id' => 3, 'rewrite' => 'clothes', 'meta_title' => null],
+                '3-clothes',
+            ],
+            // The same rule applies to the non friendly URL branch.
+            'non friendly, id removed from the rule' => [
+                false,
+                '{rewrite}',
+                ['id' => 3, 'rewrite' => 'clothes'],
+                'index.php?controller=category',
+            ],
+        ];
+    }
+
     public function validateRouteProvider()
     {
         return [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A customised route rule may deliberately omit a keyword that the default route still declares. Removing `{id}` from the category schema in Traffic & SEO > SEO & URLs is a supported option, and `id` is then consumed by the route rather than being an extra parameter.<br><br>`createUrl()` lost its check against `$this->default_routes` in **both** branches, so those parameters are now appended instead. A shop with an id-less schema gets `?id=N` on every category, product, manufacturer and CMS URL, including `rel="canonical"`, so every page exists as two crawlable, internally linked URLs. Both return HTTP 200, so nothing looks broken; it surfaces as duplicate URLs and canonical drift.<br><br>This restores the check in the friendly URL branch and in the classic `index.php` branch. Parameters that belong to neither the customised rule nor the default route are untouched and still reach the query string.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Unit tests are included in `tests/Unit/Classes/DispatcherTest.php` (`testCreateUrlDropsKeywordsOfTheDefaultRoute`), covering five cases: the native schema, a customised schema without `{id}`, an unrelated parameter that must still be appended, a default-route keyword absent from the rule (`meta_title`), and the non friendly URL branch. Four of the five data sets fail without the change and pass with it; the native-schema one passes either way, since there `{id}` is substituted into the rule.<br><br>Manually: enable Friendly URLs, set "Route to category" to `{rewrite}` in Traffic & SEO > SEO & URLs, then open a category page and view the source. Before: `/clothes?id=3` and a canonical pointing at it. After: `/clothes`. The same applies with `{rewrite}` set for the product, manufacturer and CMS rules.
| UI Tests          | Not run. This change is covered by unit tests on URL generation and touches no UI flow; happy to launch a campaign if you would like one.
| Fixed issue or discussion?     | Fixes #42440, Fixes #42426
| Related PRs       | #41386 is where the check was dropped (route refactor, merged into 9.1.x). #41809 was an earlier attempt at the same fix and was closed during the revert-or-fix discussion, where the request was for URL generation tests before changing this again; those tests are what this PR adds. #39635 is an adjacent feature that makes id-less URLs a first-class mode via a new setting, and is not affected by this change.
| Sponsor company   |

### What this restores

Both loops carried this check before #41386. From `f2cecd08a30^1:classes/Dispatcher.php`:

```php
// friendly branch (line 1031)
foreach ($params as $key => $value) {
    if (!isset($route['keywords'][$key])) {
        if (!isset($this->default_routes[$route_id]['keywords'][$key])) {
            $add_param[$key] = $value;
        }
    } else {

// classic branch (line 1060)
if (!isset($route['keywords'][$key]) && !isset($this->default_routes[$route_id]['keywords'][$key])) {
    $add_params[$key] = $value;
}
```

This PR reinstates both, unchanged apart from the `$route` / `$route_id` to `$routeDefinition` /
`$routeName` renames the refactor introduced.

Flagging one consequence explicitly, since it is wider than "customised schemas": the check keys on the
default route's keywords, so a keyword the default route declares but the active rule does not use is
also consumed rather than appended - `meta_title` and `categories` on `category_rule`, or the `ean13`
case from #41809. On the native schema,
`createUrl('category_rule', ..., ['id' => 3, 'rewrite' => 'clothes', 'meta_title' => 'my-title'])`
returns `3-clothes?meta_title=my-title` today and `3-clothes` here. That is the pre-#41386 contract, and
it is what `Link::*` is written against: every optional keyword there is added only behind
`hasKeyword()`, so core's own links are byte identical on a default schema. It is pinned by its own data
set rather than left incidental.

If you would rather restore only the customised-schema half, say so and I will narrow the condition to
keywords that carry a `param`.

Measured on a 9.2.0 install with each rule set to `{rewrite}`:

```
before:  getCategoryLink(3)     -> /clothes?id=3
         getProductLink(1)      -> /hummingbird-printed-t-shirt?id=1
         getManufacturerLink(1) -> /studio-design?id=1
         getCMSLink(1)          -> /delivery?id=1

after:   /clothes  /hummingbird-printed-t-shirt  /studio-design  /delivery
```

The `@param null $id_shop` docblock on `createUrl()` is corrected to `int|null` in passing: the method already casts the context shop id when the argument is null and then uses it as an int key, and PHPStan rejects passing an int while the annotation says `null`.

### Also fixes the 302 loop reported in #42426

@Codencode connected the two, and the mechanism holds when measured. `Link::getProductLink()` always passes `id_product_attribute`, null when there is no combination. On a shop whose product route omits `{id_product_attribute}` the value became an extra query parameter, `http_build_query()` dropped the null and returned an empty string, and the `?` was appended anyway - so `canonicalRedirection()` compared `slug-p-1?` against the requested `slug-p-1` and redirected forever.

Measured on this shop with the product route set to `{rewrite}-p-{id}`:

    9.2.x as shipped   http://localhost:8001/hummingbird-printed-t-shirt-p-1?
    with this PR       http://localhost:8001/hummingbird-printed-t-shirt-p-1

`id_product_attribute` is a keyword of the default `product_rule` (`Dispatcher.php:102`), so restoring the guard keeps it out of the extra parameters and the dangling `?` is never produced.

The data provider gains that case: a default-route keyword passed as **null** with a rule that does not use it. It is the only one of the five that produces an empty query string, and it fails on 9.2.x with `3-clothes?` against the expected `3-clothes`.
