### PR TITLE
Cast the submitted supplier ids before building SetSuppliersCommand

### DIFF
--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductSuppliersCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductSuppliersCommandsBuilder.php
@@ -28,7 +28,15 @@ final class ProductSuppliersCommandsBuilder implements ProductCommandsBuilderInt
             return [];
         }
 
-        $associatedSuppliers = $formData['options']['suppliers']['supplier_ids'] ?? [];
+        // The form choice values come from the database as strings, and SetSuppliersCommand builds
+        // SupplierId (an int parameter) under strict_types, so they have to be cast here. The two
+        // other supplier paths below already do it. Blank entries are dropped so that a submission
+        // with nothing selected falls through to RemoveAllAssociatedProductSuppliersCommand rather
+        // than reaching SupplierId with 0.
+        $associatedSuppliers = array_values(array_filter(array_map(
+            'intval',
+            $formData['options']['suppliers']['supplier_ids'] ?? []
+        )));
         if (empty($associatedSuppliers)) {
             return [new RemoveAllAssociatedProductSuppliersCommand($productId->getValue())];
         }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductSuppliersCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductSuppliersCommandsBuilderTest.php
@@ -142,6 +142,39 @@ class ProductSuppliersCommandsBuilderTest extends AbstractProductCommandBuilderT
             [$suppliersCommand],
         ];
 
+        // The supplier choice list is built from raw database rows, so the submitted values are
+        // strings. SetSuppliersCommand builds SupplierId (int) under strict_types, so an uncast
+        // value throws a TypeError and saving any product with a supplier fails.
+        // @see https://github.com/PrestaShop/PrestaShop/issues/41102
+        $suppliersCommand = new SetSuppliersCommand(
+            $this->getProductId()->getValue(),
+            [3, 5]
+        );
+
+        yield [
+            [
+                'options' => [
+                    'suppliers' => [
+                        'supplier_ids' => ['3', '5'],
+                    ],
+                ],
+            ],
+            [$suppliersCommand],
+        ];
+
+        // A submission carrying only blank values means no supplier is selected, so it has to reach
+        // RemoveAllAssociatedProductSuppliersCommand instead of SupplierId with 0.
+        yield [
+            [
+                'options' => [
+                    'suppliers' => [
+                        'supplier_ids' => ['', '0'],
+                    ],
+                ],
+            ],
+            [new RemoveAllAssociatedProductSuppliersCommand($this->getProductId()->getValue())],
+        ];
+
         $suppliersCommand = new SetSuppliersCommand(
             $this->getProductId()->getValue(),
             [5, 3]


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Saving any product that has at least one supplier associated ends in a 500. `SupplierNameByIdChoiceProvider` builds its choice list from `Supplier::getSuppliers()`, whose rows carry `id_supplier` as a string, and `FormChoiceFormatter` stores the value as-is, so `SuppliersType::supplier_ids` normalises to an array of strings.<br><br>`ProductSuppliersCommandsBuilder::buildCommands()` forwarded that array uncast to `SetSuppliersCommand`, which declares `strict_types` and builds `SupplierId` from an `int`, so the loop throws `TypeError`. The same builder **already casts** in the two neighbouring paths, `(int) $defaultSupplierId` and `(int) $productSupplierUpdate['supplier_id']` - only the associated list was missed.<br><br>Blank entries are dropped as well, so a submission with nothing selected reaches `RemoveAllAssociatedProductSuppliersCommand` instead of reaching `SupplierId` with `0` and throwing a different exception. This is not PHP-version specific: `strict_types` rejects a numeric string for an `int` parameter on every supported version.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Two unit tests are added to `ProductSuppliersCommandsBuilderTest`: one submitting `supplier_ids` as `['3', '5']`, which is what the form actually posts, and one submitting `['', '0']`. Both error on the current code with `SupplierId::__construct(): Argument #1 ($supplierId) must be of type int, string given, called in .../SetSuppliersCommand.php on line 74`, and pass with the change. The existing data sets all pass integers, which is why this was not caught.<br><br>Manually: edit any product that has a supplier associated (Combinations / Suppliers section), tick at least one supplier and save. Before: HTTP 500 with the TypeError above. After: the product saves.
| UI Tests          | Not run. The change is covered by unit tests on the command builder; happy to launch a campaign if you would like one.
| Fixed issue or discussion?     | Fixes #41102
| Related PRs       |
| Sponsor company   |

The reproduction and the root-cause walkthrough in the issue are @Artur67pl's; this PR is the fix plus the regression tests.
