### PR TITLE
Fix theme.yml hook module exceptions being dropped

### DIFF
--- a/src/Core/Module/HookConfigurator.php
+++ b/src/Core/Module/HookConfigurator.php
@@ -29,11 +29,17 @@ class HookConfigurator
      *     ],
      *     "someOtherHookName" => [
      *         null,
-     *         "blockmenu" => [
-     *             "except_pages" => ["category", "product"]
+     *         [
+     *             "blockmenu" => [
+     *                 "except_pages" => ["category", "product"]
+     *             ]
      *         ]
      *     ]
      * ].
+     *
+     * The second hook shows a module carrying settings. It is a list entry rather than an array
+     * key because that is what parsing a theme.yml produces, and a mapping cannot be written
+     * alongside the `~` placeholder in the same YAML sequence.
      */
     public function getThemeHooksConfiguration(array $hooks)
     {
@@ -43,7 +49,11 @@ class HookConfigurator
 
         foreach ($currentHooks as $hookName => $moduleList) {
             foreach ($moduleList as $key => $value) {
-                if (in_array($value, $uniqueModuleList)) {
+                // A module hooked with exceptions comes back under its own name, holding them.
+                // Comparing the raw value left those entries hooked where they already were as
+                // well as where the theme asks for them.
+                [$moduleName] = $this->readModuleEntry($key, $value);
+                if (in_array($moduleName, $uniqueModuleList, true)) {
                     unset($currentHooks[$hookName][$key]);
                 }
             }
@@ -58,21 +68,23 @@ class HookConfigurator
             foreach ($modules as $key => $module) {
                 if ($module === null && $firstNullValueFound) {
                     $firstNullValueFound = false;
-                    foreach ($existing as $m) {
+                    foreach ($existing as $existingKey => $m) {
+                        [$existingName, $existingSettings] = $this->readModuleEntry($existingKey, $m);
                         // If module has been removed we ignore it but inform via a warning
-                        if ($this->moduleManager && !$this->moduleManager->isOnDisk($m)) {
-                            $this->logger?->warning(sprintf('Module %s was removed from disk, impossible to hook it', $m));
+                        if ($this->moduleManager && !$this->moduleManager->isOnDisk($existingName)) {
+                            $this->logger?->warning(sprintf('Module %s was removed from disk, impossible to hook it', $existingName));
                             continue;
                         }
-                        $currentHooks[$hookName][] = $m;
+                        $currentHooks[$hookName][] = $existingSettings === [] ? $existingName : [$existingName => $existingSettings];
                     }
                 } elseif (is_array($module)) {
+                    [$moduleName, $moduleSettings] = $this->readModuleEntry($key, $module);
                     // If module has been removed we ignore it but inform via a warning
-                    if ($this->moduleManager && !$this->moduleManager->isOnDisk($key)) {
-                        $this->logger?->warning(sprintf('Module %s was removed from disk, impossible to hook it', $key));
+                    if ($this->moduleManager && !$this->moduleManager->isOnDisk($moduleName)) {
+                        $this->logger?->warning(sprintf('Module %s was removed from disk, impossible to hook it', $moduleName));
                         continue;
                     }
-                    $currentHooks[$hookName][$key] = $module;
+                    $currentHooks[$hookName][] = [$moduleName => $moduleSettings];
                 } elseif ($module !== null) {
                     // If module has been removed we ignore it but inform via a warning
                     if ($this->moduleManager && !$this->moduleManager->isOnDisk($module)) {
@@ -131,9 +143,49 @@ class HookConfigurator
     {
         $list = [];
         foreach ($hooks as $modules) {
-            $list = array_merge($list, $modules);
+            foreach ($modules as $key => $module) {
+                if ($module === null) {
+                    // The placeholder keeping existing modules, not a module of its own.
+                    continue;
+                }
+                // Only the name identifies the module. Keeping the whole entry left the
+                // comparison above unable to match it.
+                [$moduleName] = $this->readModuleEntry($key, $module);
+                $list[] = $moduleName;
+            }
         }
 
         return $list;
+    }
+
+    /**
+     * A module in a hook list is either a plain name, or - when it carries settings - a
+     * single-entry map of that name to them. YAML can express the second form only as a list
+     * item (`- blocklanguages: {except_pages: [...]}`), which is also the only form that can sit
+     * next to the `~` placeholder every shipped theme uses, so the name is inside the entry and
+     * never in its position. Configurations written as an array key are still accepted.
+     *
+     * The name is what `HookRepository::persistHooksConfiguration()` reads back out of the entry,
+     * so both forms are normalised here rather than in each caller.
+     *
+     * The same two shapes come back out of `HookRepository::getDisplayHooksWithModules()`, where a
+     * module without exceptions is a list value and one with exceptions is a key holding them.
+     *
+     * @param int|string $key the entry's position, or the module name in the array-key form
+     * @param mixed $module a module name, or an entry carrying its settings
+     *
+     * @return array{0: string, 1: array} the module name and its settings
+     */
+    private function readModuleEntry($key, $module): array
+    {
+        if (!is_array($module)) {
+            return [(string) $module, []];
+        }
+
+        if (is_int($key)) {
+            return [(string) key($module), (array) current($module)];
+        }
+
+        return [(string) $key, $module];
     }
 }

--- a/tests/Unit/Core/Module/HookConfiguratorTest.php
+++ b/tests/Unit/Core/Module/HookConfiguratorTest.php
@@ -11,17 +11,33 @@ namespace Tests\Unit\Core\Module;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Module\HookConfigurator;
 use PrestaShop\PrestaShop\Core\Module\HookRepository;
+use PrestaShop\PrestaShop\Core\Module\ModuleManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Yaml\Yaml;
 
 class HookConfiguratorTest extends TestCase
 {
     private $hookConfigurator;
     private $hookRepository;
+    private $moduleManager;
 
     protected function setUp(): void
     {
         $this->hookRepository = $this->createMock(HookRepository::class);
+        $this->moduleManager = $this->createMock(ModuleManager::class);
+        // Both service definitions inject the module manager, so the on-disk guard runs in
+        // production. Injecting it here too is what exercises the module name lookup, and the
+        // stub answers for a fixed set of names: anything else, a list position included, is
+        // not a module on disk, which is exactly what the real manager reports.
+        $this->moduleManager
+            ->method('isOnDisk')
+            ->willReturnCallback(static fn ($name): bool => in_array($name, [
+                'block_already_here',
+                'blockcurrencies',
+                'blocklanguages',
+            ], true));
 
-        $this->hookConfigurator = new HookConfigurator($this->hookRepository);
+        $this->hookConfigurator = new HookConfigurator($this->hookRepository, null, $this->moduleManager);
         parent::setUp();
     }
 
@@ -57,6 +73,10 @@ class HookConfiguratorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * The module name as an array key is the older form, reachable only from a hand-built
+     * array. It stays supported, and normalises to the same list entry as the YAML form.
+     */
     public function testSingleModuleAppendedToHookWithExceptions()
     {
         $this->setCurrentDisplayHooksConfiguration([
@@ -68,10 +88,12 @@ class HookConfiguratorTest extends TestCase
         $expected = [
             'displayTop' => [
                 'block_already_here',
-                'blocklanguages' => [
-                    'except_pages' => [
-                        'category',
-                        'product',
+                [
+                    'blocklanguages' => [
+                        'except_pages' => [
+                            'category',
+                            'product',
+                        ],
                     ],
                 ],
             ],
@@ -84,6 +106,141 @@ class HookConfiguratorTest extends TestCase
                     'except_pages' => [
                         'category',
                         'product',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testModuleWithExceptionsIsHookedFromAParsedThemeYaml()
+    {
+        $hooks = Yaml::parse(
+            "displayTop:\n"
+            . "  - ~\n"
+            . "  - blocklanguages:\n"
+            . "      except_pages:\n"
+            . "        - category\n"
+            . "        - product\n"
+        );
+        // A mapping cannot be written next to the `~` placeholder in one sequence, so the
+        // module carrying settings arrives under a position and not under its own name.
+        $this->assertSame([0, 1], array_keys($hooks['displayTop']));
+
+        $this->setCurrentDisplayHooksConfiguration([
+            'displayTop' => [
+                'block_already_here',
+            ],
+        ]);
+
+        $expected = [
+            'displayTop' => [
+                'block_already_here',
+                [
+                    'blocklanguages' => [
+                        'except_pages' => [
+                            'category',
+                            'product',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->hookConfigurator->getThemeHooksConfiguration($hooks));
+    }
+
+    public function testModuleWithExceptionsIsReadableByTheRepository()
+    {
+        // HookRepository::persistHooksConfiguration() takes the name with key() and the
+        // settings with current(). The two halves used to disagree on where the name lives.
+        $this->setCurrentDisplayHooksConfiguration([
+            'displayTop' => [],
+        ]);
+
+        $configuration = $this->hookConfigurator->getThemeHooksConfiguration([
+            'displayTop' => [
+                [
+                    'blocklanguages' => [
+                        'except_pages' => [
+                            'category',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = $configuration['displayTop'][0];
+        $this->assertSame('blocklanguages', key($entry));
+        $this->assertSame(['category'], current($entry)['except_pages']);
+    }
+
+    public function testModuleWithExceptionsRemovedFromDiskIsSkipped()
+    {
+        $this->setCurrentDisplayHooksConfiguration([
+            'displayTop' => [],
+        ]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        // The warning has to name the module. Naming the list position instead is where the
+        // "Module 1 was removed from disk" line in the reports comes from.
+        $logger
+            ->expects($this->once())
+            ->method('warning')
+            ->with('Module removed_from_disk was removed from disk, impossible to hook it');
+
+        $hookConfigurator = new HookConfigurator($this->hookRepository, $logger, $this->moduleManager);
+
+        $configuration = $hookConfigurator->getThemeHooksConfiguration([
+            'displayTop' => [
+                [
+                    'removed_from_disk' => [
+                        'except_pages' => [
+                            'category',
+                        ],
+                    ],
+                ],
+                'blocklanguages',
+            ],
+        ]);
+
+        $this->assertEquals(['displayTop' => ['blocklanguages']], $configuration);
+    }
+
+    public function testModuleWithExceptionsIsUnhookedFromItsCurrentHook()
+    {
+        $this->setCurrentDisplayHooksConfiguration([
+            'displayTop' => [
+                'blocklanguages',
+            ],
+            'displayNav' => [
+                'block_already_here',
+            ],
+        ]);
+
+        $expected = [
+            'displayTop' => [],
+            'displayNav' => [
+                'block_already_here',
+                [
+                    'blocklanguages' => [
+                        'except_pages' => [
+                            'category',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $actual = $this->hookConfigurator->getThemeHooksConfiguration([
+            'displayNav' => [
+                null,
+                [
+                    'blocklanguages' => [
+                        'except_pages' => [
+                            'category',
+                        ],
                     ],
                 ],
             ],
@@ -239,6 +396,71 @@ class HookConfiguratorTest extends TestCase
         $expected = [
             'displayTop' => [
             ],
+            'displayNav' => [
+                'blocklanguages',
+            ],
+        ];
+
+        $actual = $this->hookConfigurator->getThemeHooksConfiguration([
+            'displayNav' => [
+                'blocklanguages',
+            ],
+        ]);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testExistingModuleWithExceptionsIsKeptByThePlaceholder()
+    {
+        // A module already hooked with exceptions comes back from the repository keyed by its own
+        // name. Taking the value as the name handed the module manager an array, which is fatal.
+        $this->setCurrentDisplayHooksConfiguration([
+            'displayTop' => [
+                'blocklanguages' => [
+                    'except_pages' => [
+                        'category',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expected = [
+            'displayTop' => [
+                [
+                    'blocklanguages' => [
+                        'except_pages' => [
+                            'category',
+                        ],
+                    ],
+                ],
+                'blockcurrencies',
+            ],
+        ];
+
+        $actual = $this->hookConfigurator->getThemeHooksConfiguration([
+            'displayTop' => [
+                null,
+                'blockcurrencies',
+            ],
+        ]);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testExistingModuleWithExceptionsIsUnhookedWhenTheThemeMovesIt()
+    {
+        $this->setCurrentDisplayHooksConfiguration([
+            'displayTop' => [
+                'blocklanguages' => [
+                    'except_pages' => [
+                        'category',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expected = [
+            'displayTop' => [],
             'displayNav' => [
                 'blocklanguages',
             ],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `theme.yml` module exceptions have never been applied. A hook list is a YAML sequence, so a module carrying settings can only be written as a list item - `- blocklanguages: {except_pages: [...]}` - which is also the only form that can sit beside the `~` placeholder every shipped theme uses. Parsing that yields `[0 => null, 1 => ['blocklanguages' => [...]]]`, so the module name is inside the entry and its key is a position.<br><br>`HookConfigurator::getThemeHooksConfiguration()` read the name from the position instead. It asked the module manager whether a module called `1` was on disk, got no, logged `Module 1 was removed from disk, impossible to hook it` and dropped the entry, so the module was not hooked at all. Writing the name as an array key instead avoids that, but then `HookRepository::persistHooksConfiguration()` runs `key()` on the settings and looks for a module named `except_pages`. Neither form worked end to end.<br><br>The same mistake is made three more times on the other side of the method, where `getDisplayHooksWithModules()` returns a module without exceptions as a list value but one **with** exceptions under its own name. Reading the value as a name there means: `getUniqueModuleToHookList()` collected whole entries, so the `in_array()` that clears a module from its current hook compared a name against an array and never matched; a module already hooked with exceptions was never unhooked when a theme moved it, ending up hooked twice; and carrying existing modules over for the `~` placeholder passed that array straight to `ModuleManager::isOnDisk(string $name)`, which is a **fatal TypeError**. That last one fires on any shop where a single module is hooked with exceptions and the theme uses `~`, which every shipped theme does.<br><br>Every one of these is the same defect: the module name was read from the position, or from the value, rather than from the entry that carries it. One private decoder now resolves all the shapes, and entries are normalised to the list form the repository already reads back. Settings on carried-over modules are preserved instead of being lost.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `tests/Unit/Core/Module/HookConfiguratorTest.php` covers it. The suite now injects a `ModuleManager` that answers for a fixed set of module names, which is what makes the on-disk lookup meaningful: both service definitions inject the manager in production, so the guard runs there, while the tests previously constructed the configurator without one and never exercised it.<br><br>Seven cases: a hook list parsed from real YAML with `Yaml::parse()`, the array-key form, the entry as the repository reads it back, a module missing from disk, a module moved to another hook, an already-excepted module carried over by `~`, and an already-excepted module moved by the theme. With the fix reverted the suite reports 2 errors and 5 failures; all pass with it.<br><br>Manually: add `- blocklanguages: {except_pages: [category, product]}` under a hook in a theme's `modules_to_hook`, next to the usual `- ~`, and install the theme. Before: the module is not hooked and the log reads `Module 1 was removed from disk, impossible to hook it`. After: it is hooked, and it does not display on the category and product pages.<br><br>For the fatal: with that module hooked and carrying exceptions, install a theme whose hook list contains `- ~`. Before: `TypeError: ModuleManager::isOnDisk(): Argument #1 ($name) must be of type string, array given`. After: the module is carried over with its exceptions intact.
| UI Tests          | Not run. The change is covered by unit tests on the hook configurator and touches no UI flow; a campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #9904
| Related PRs       |
| Sponsor company   |

### Why the list form

`HookRepository::persistHooksConfiguration()` already reads a settings entry as a list value, taking
the name with `key()` and the settings with `current()`, and the existing integration test
`HookRepositoryTest::testExceptionsTakenIntoAccount` pins exactly that shape:

```php
$this->hookRepository->persistHooksConfiguration([
    'displayTestHookNameWithExceptions' => [
        [
            'ps_emailsubscription' => [
                'except_pages' => ['category', 'product'],
            ],
        ],
    ],
]);
```

So the canonical shape was already settled on the repository side; only the configurator disagreed
with it. This change makes the producer emit what the consumer's own test says it consumes, rather
than introducing a third shape.

The array-key form keeps working - it is normalised to the same entry - so a hand-built configuration
is unaffected.

### Scope

The fatal and the two unhooking defects are not in the report, which is about the exceptions never
applying. They are the same line of reasoning in the same method and share the fix, so splitting them
into a second PR would mean shipping the decoder twice. Each is covered by its own test. Say so if you
would rather see them separately.

### Note on the existing unit test

`testSingleModuleAppendedToHookWithExceptions` asserted the old output, a module name used as an array
key in the returned list. That shape cannot come out of a theme.yml, and `persistHooksConfiguration()`
cannot read it, which is why the test stayed green while the feature did not work. Its expectation is
updated to the normalised entry; its input is left as it was, so the array-key form stays covered.
