### PR TITLE
Show payment module order messages in the Back Office

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -457,6 +457,11 @@ abstract class PaymentModuleCore extends Module
                     $msg->id_order = (int) $order->id;
                     $msg->private = true;
                     $msg->add();
+
+                    // The order page reads customer messages, never `message` rows, so a message
+                    // left only in the latter is not visible anywhere in the Back Office. Keep it
+                    // private: it is addressed to the merchant, not to the customer.
+                    $this->copyMessageIntoCustomerThread($order, $msg->message, true);
                 }
             }
 
@@ -578,26 +583,7 @@ abstract class PaymentModuleCore extends Module
                 $update_message->update();
 
                 // Add this message in the customer thread
-                $customer_thread = new CustomerThread();
-                $customer_thread->id_contact = 0;
-                $customer_thread->id_customer = (int) $order->id_customer;
-                $customer_thread->id_shop = (int) $this->context->shop->id;
-                $customer_thread->id_order = (int) $order->id;
-                $customer_thread->id_lang = (int) $this->context->language->id;
-                $customer_thread->email = $this->context->customer->email;
-                $customer_thread->status = 'open';
-                $customer_thread->token = Tools::passwdGen(12);
-                $customer_thread->add();
-
-                $customer_message = new CustomerMessage();
-                $customer_message->id_customer_thread = $customer_thread->id;
-                $customer_message->id_employee = 0;
-                $customer_message->message = $update_message->message;
-                $customer_message->private = false;
-
-                if (!$customer_message->add()) {
-                    $this->_errors[] = $this->trans('An error occurred while saving message', [], 'Admin.Payment.Notification');
-                }
+                $this->copyMessageIntoCustomerThread($order, $update_message->message, false);
             }
 
             if (self::DEBUG_MODE) {
@@ -1398,6 +1384,54 @@ abstract class PaymentModuleCore extends Module
             }
         }
         $orderShipmentCreator->addShipmentOrder($order, $physicalProductsByCarrier);
+    }
+
+    /**
+     * Copies a message attached to an order into that order's customer thread, which is what the
+     * Back Office order page displays.
+     *
+     * The thread is looked up by order rather than kept on the instance: validateOrder() runs this
+     * once per order, and a cart split across several carriers produces several orders, so a
+     * remembered thread would collect the messages of every order after the first.
+     *
+     * @param bool $private true for a message only employees should see
+     */
+    private function copyMessageIntoCustomerThread(Order $order, string $message, bool $private): void
+    {
+        $idCustomerThread = (int) CustomerThread::getIdCustomerThreadByEmailAndIdOrder(
+            $this->context->customer->email,
+            (int) $order->id
+        );
+
+        if (!$idCustomerThread) {
+            $customerThread = new CustomerThread();
+            $customerThread->id_contact = 0;
+            $customerThread->id_customer = (int) $order->id_customer;
+            $customerThread->id_shop = (int) $this->context->shop->id;
+            $customerThread->id_order = (int) $order->id;
+            $customerThread->id_lang = (int) $this->context->language->id;
+            $customerThread->email = $this->context->customer->email;
+            $customerThread->status = 'open';
+            $customerThread->token = Tools::passwdGen(12);
+
+            if (!$customerThread->add()) {
+                $this->_errors[] = $this->trans('An error occurred while saving message', [], 'Admin.Payment.Notification');
+
+                return;
+            }
+
+            $idCustomerThread = (int) $customerThread->id;
+        }
+
+        $customerMessage = new CustomerMessage();
+        $customerMessage->id_customer_thread = $idCustomerThread;
+        $customerMessage->id_employee = 0;
+        $customerMessage->message = $message;
+        $customerMessage->private = $private;
+
+        if (!$customerMessage->add()) {
+            $this->_errors[] = $this->trans('An error occurred while saving message', [], 'Admin.Payment.Notification');
+        }
     }
 
     private function isFeatureFlagIsEnabledForMultiShipment()

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -9,6 +9,8 @@ namespace Tests\Integration\Behaviour\Features\Context;
 use AdminKernel;
 use Behat\Gherkin\Node\TableNode;
 use Configuration;
+use Customer;
+use CustomerThread;
 use Exception;
 use Order;
 use OrderCarrier;
@@ -30,8 +32,9 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
 
     /**
      * @When /^I validate my cart using payment module (fake)$/
+     * @When /^I validate my cart using payment module (fake) with message "(.+)"$/
      */
-    public function validateCartWithPaymentModule($paymentModuleName)
+    public function validateCartWithPaymentModule($paymentModuleName, $message = null)
     {
         switch ($paymentModuleName) {
             case 'fake':
@@ -56,7 +59,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
             (int) Configuration::get('PS_OS_CHEQUE'), // PS_OS_PAYMENT for payment-validated order
             0,
             'Unknown',
-            null,
+            $message,
             [],
             null,
             false,
@@ -67,6 +70,39 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
         $this->orders[] = $order;
 
         $kernel = $previousKernel;
+    }
+
+    /**
+     * @Then /^the order should have a private customer message "(.+)"$/
+     */
+    public function checkOrderHasPrivateCustomerMessage($expectedMessage)
+    {
+        $order = $this->getCurrentCartOrder();
+        $customer = new Customer((int) $order->id_customer);
+        $idCustomerThread = (int) CustomerThread::getIdCustomerThreadByEmailAndIdOrder(
+            $customer->email,
+            (int) $order->id
+        );
+
+        if (!$idCustomerThread) {
+            throw new RuntimeException(sprintf('No customer thread was created for order %d', $order->id));
+        }
+
+        foreach (CustomerThread::getMessageCustomerThreads($idCustomerThread) as $customerMessage) {
+            if ($customerMessage['message'] === $expectedMessage) {
+                Assert::assertEquals(
+                    1,
+                    (int) $customerMessage['private'],
+                    'A message left by a payment module is addressed to the merchant and must stay private'
+                );
+
+                return;
+            }
+        }
+
+        throw new RuntimeException(
+            sprintf('Order %d has no customer message "%s"', $order->id, $expectedMessage)
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/cart_to_order.feature
@@ -344,3 +344,24 @@ Feature: Check cart to order data copy
     Then current cart order shipping fees should be 7.0 tax excluded
     Then current cart order should have a discount in position 1 with an amount of 36.989680 tax included and 35.567000 tax excluded
     Then customer "customer1" should have 0 cart rules that apply to him
+
+  Scenario: A message left by the payment module is visible in the Back Office
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    And I create carrier "carrier1" with specified properties:
+      | name | carrier 1 |
+      | zones| zone1     |
+    Then I set ranges for carrier "carrier1" with specified properties for all shops:
+      | id_zone | range_from | range_to | range_price |
+      | zone1   | 0          | 10000    | 5.0         |
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake with message "Transaction 4242 was authorised"
+    Then the order should have a private customer message "Transaction 4242 was authorised"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A payment module can attach a message to the order it validates, by passing one to `PaymentModule::validateOrder()`. That message is stored in `message` and nowhere else, while the Back Office order page reads customer messages: `GetOrderForViewingHandler::getOrderMessages()` calls `getCustomerMessages()` and there is no read of `message` anywhere in the order view. The message is therefore visible on no page in the Back Office - not the order, not the customer, not customer service.<br><br>The customer's own checkout message already avoids this: `validateOrder()` links it to the order and then copies it into a customer thread. This applies the same treatment to a module message, marked **private** so it stays visible to the merchant only.<br><br>The direction is the one @matks proposed on the issue in 2021, with a draft in #24229 that was closed unfinished ("feel free to use my work to submit a contribution"). One difference: that draft remembered the thread on the module instance. `validateOrder()` runs this block once per order and a cart split across carriers produces one order per package, so a remembered thread would collect the messages of every order after the first. The thread is looked up per order instead, which also means the module message and the customer's checkout message share one thread rather than creating two.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | A Behat scenario is added to `cart_to_order.feature`, driving the real `validateOrder()` path: it validates a cart with a payment module message and asserts the order has a private customer message with that text. `I validate my cart using payment module fake` gains an optional message, so the existing scenarios are unchanged.<br><br>Reverting the fix fails it with `No customer thread was created for order N`. The whole `cart` suite passes with the change: **243 scenarios, 3559 steps**, against 242/3537 on the base.<br><br>Manually: make a payment module pass a non-empty `$message` to `validateOrder()` (the fifth argument), place an order through it, then open that order in the Back Office. Before: the message appears nowhere. After: it is listed in the order's messages, flagged private.
| UI Tests          | Not run. The change is covered by an integration scenario on order validation; a campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #9783
| Related PRs       | #24229 is @matks' closed draft this builds on. #42056 edits the same two blocks of `validateOrder()`; a real merge test against its head `afc35ca1` reports `Automatic merge went well`, so the two do not conflict, and this PR can be rebased on it if it merges first.
| Sponsor company   |

### One consequence worth naming

Threads are now looked up before being created, so an order whose customer left a checkout message **and** whose payment module left one ends up with a single thread holding both, where the previous code would have created a thread per message. That is the behaviour the customer service page already assumes - it lists one thread per order - and it is what makes the split-order case correct.
