### PR TITLE
Stop the combination price conversion overwriting the typed price

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/update-origin-tracker.ts
+++ b/admin-dev/themes/new-theme/js/components/form/update-origin-tracker.ts
@@ -1,0 +1,44 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * Remembers which field an update cycle started from, so that values derived from it are never
+ * written back onto it.
+ *
+ * Assigning a mapped value re-enters the same update handler, so a pair of fields that convert
+ * into each other echoes: `12` typed as a tax included price becomes `9.756098` tax excluded at
+ * the form's precision, and converting that back gives `12.000001`, which replaced what had just
+ * been typed. The conversion is lossy in both directions, so the field being edited has to win.
+ */
+export default class UpdateOriginTracker {
+  private origin: string | null = null;
+
+  /**
+   * Runs an update cycle for a field. Cycles started while one is already running belong to it,
+   * so a chain of derived updates keeps the field the user actually edited as its origin.
+   */
+  run(modelKey: string, update: () => void): void {
+    const isOutermostUpdate = this.origin === null;
+
+    if (isOutermostUpdate) {
+      this.origin = modelKey;
+    }
+
+    try {
+      update();
+    } finally {
+      if (isOutermostUpdate) {
+        this.origin = null;
+      }
+    }
+  }
+
+  /**
+   * @returns {boolean} whether this field is the one the running update cycle started from
+   */
+  isOrigin(modelKey: string): boolean {
+    return this.origin === modelKey;
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/product/combination/form/combination-form-model.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/form/combination-form-model.ts
@@ -8,8 +8,11 @@ import CombinationFormMapping from '@pages/product/combination/form/combination-
 import {EventEmitter} from 'events';
 import BigNumber from '@node_modules/bignumber.js';
 import {NumberFormatter} from '@app/cldr';
+import UpdateOriginTracker from '@components/form/update-origin-tracker';
 
 export default class CombinationFormModel {
+  private updateOrigin: UpdateOriginTracker = new UpdateOriginTracker();
+
   private eventEmitter: EventEmitter;
 
   private mapper: ObjectFormMapper;
@@ -78,17 +81,21 @@ export default class CombinationFormModel {
       return;
     }
 
+    this.updateOrigin.run(event.modelKey, () => this.applyPriceConversions(event, taxRatio));
+  }
+
+  private applyPriceConversions(event: FormUpdateEvent, taxRatio: BigNumber): void {
     // eslint-disable-next-line default-case
     switch (event.modelKey) {
       // Regular retail price
       case 'impact.priceTaxIncluded': {
         const priceTaxIncluded = this.mapper.getBigNumber('impact.priceTaxIncluded') ?? new BigNumber(0);
-        this.mapper.set('impact.priceTaxExcluded', priceTaxIncluded.dividedBy(taxRatio).toFixed(this.precision));
+        this.setDerivedPrice('impact.priceTaxExcluded', priceTaxIncluded.dividedBy(taxRatio).toFixed(this.precision));
         break;
       }
       case 'impact.priceTaxExcluded': {
         const priceTaxExcluded = this.mapper.getBigNumber('impact.priceTaxExcluded') ?? new BigNumber(0);
-        this.mapper.set('impact.priceTaxIncluded', priceTaxExcluded.times(taxRatio).toFixed(this.precision));
+        this.setDerivedPrice('impact.priceTaxIncluded', priceTaxExcluded.times(taxRatio).toFixed(this.precision));
         break;
       }
 
@@ -97,7 +104,10 @@ export default class CombinationFormModel {
         // Only this update is needed here, the rest will be updated via the trigger for price.ecotaxTaxExcluded
         const ecoTaxRatio = this.getEcoTaxRatio();
         const combinationEcotaxTaxIncluded = this.mapper.getBigNumber('price.ecotaxTaxIncluded') ?? new BigNumber(0);
-        this.mapper.set('price.ecotaxTaxExcluded', combinationEcotaxTaxIncluded.dividedBy(ecoTaxRatio).toFixed(this.precision));
+        this.setDerivedPrice(
+          'price.ecotaxTaxExcluded',
+          combinationEcotaxTaxIncluded.dividedBy(ecoTaxRatio).toFixed(this.precision),
+        );
 
         break;
       }
@@ -114,7 +124,7 @@ export default class CombinationFormModel {
         this.updateImpactForEcotax(ecotaxTaxIncluded);
 
         // Finally, we can update the price.ecotaxTaxIncluded
-        this.mapper.set('price.ecotaxTaxIncluded', combinationEcotaxTaxIncluded.toFixed(this.precision));
+        this.setDerivedPrice('price.ecotaxTaxIncluded', combinationEcotaxTaxIncluded.toFixed(this.precision));
 
         break;
       }
@@ -122,17 +132,30 @@ export default class CombinationFormModel {
       // Unit price
       case 'impact.unitPriceTaxIncluded': {
         const unitPriceTaxIncluded = this.mapper.getBigNumber('impact.unitPriceTaxIncluded') ?? new BigNumber(0);
-        this.mapper.set('impact.unitPriceTaxExcluded', unitPriceTaxIncluded.dividedBy(taxRatio).toFixed(this.precision));
+        this.setDerivedPrice('impact.unitPriceTaxExcluded', unitPriceTaxIncluded.dividedBy(taxRatio).toFixed(this.precision));
         break;
       }
       case 'impact.unitPriceTaxExcluded': {
         const unitPriceTaxExcluded = this.mapper.getBigNumber('impact.unitPriceTaxExcluded') ?? new BigNumber(0);
-        this.mapper.set('impact.unitPriceTaxIncluded', unitPriceTaxExcluded.times(taxRatio).toFixed(this.precision));
+        this.setDerivedPrice('impact.unitPriceTaxIncluded', unitPriceTaxExcluded.times(taxRatio).toFixed(this.precision));
         break;
       }
     }
 
     this.updateFinalPrices();
+  }
+
+  /**
+   * Assigns a price computed from another field. The field the update started from is left alone:
+   * a tax included price converted to tax excluded and back does not return the value that was
+   * typed, so echoing it would replace the merchant's own input.
+   */
+  private setDerivedPrice(modelKey: string, value: string): void {
+    if (this.updateOrigin.isOrigin(modelKey)) {
+      return;
+    }
+
+    this.mapper.set(modelKey, value);
   }
 
   /**
@@ -149,7 +172,7 @@ export default class CombinationFormModel {
       .minus(productPriceTaxIncluded);
 
     // Finally update the impact on price (without taxes)
-    this.mapper.set('impact.priceTaxExcluded', impactPriceTaxIncluded.dividedBy(taxRatio).toFixed(this.precision));
+    this.setDerivedPrice('impact.priceTaxExcluded', impactPriceTaxIncluded.dividedBy(taxRatio).toFixed(this.precision));
   }
 
   private updateFinalPrices(): void {

--- a/admin-dev/themes/new-theme/tests/components/form/update-origin-tracker.spec.js
+++ b/admin-dev/themes/new-theme/tests/components/form/update-origin-tracker.spec.js
@@ -1,0 +1,144 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+import {expect} from 'chai';
+import BigNumber from 'bignumber.js';
+import UpdateOriginTracker from '../../../js/components/form/update-origin-tracker';
+
+describe('UpdateOriginTracker', () => {
+  it('reports no origin outside an update', () => {
+    const tracker = new UpdateOriginTracker();
+
+    expect(tracker.isOrigin('impact.priceTaxIncluded')).to.equal(false);
+  });
+
+  it('reports the edited field as the origin while it is being updated', () => {
+    const tracker = new UpdateOriginTracker();
+    let seen = null;
+
+    tracker.run('impact.priceTaxIncluded', () => {
+      seen = tracker.isOrigin('impact.priceTaxIncluded');
+    });
+
+    expect(seen).to.equal(true);
+  });
+
+  it('does not report a field the update only derives', () => {
+    const tracker = new UpdateOriginTracker();
+    let seen = null;
+
+    tracker.run('impact.priceTaxIncluded', () => {
+      seen = tracker.isOrigin('impact.priceTaxExcluded');
+    });
+
+    expect(seen).to.equal(false);
+  });
+
+  it('keeps the outermost origin when a derived update starts its own cycle', () => {
+    // This is the echo: writing the tax excluded price re-enters the handler, which converts it
+    // back and would assign the tax included one the merchant just typed.
+    const tracker = new UpdateOriginTracker();
+    const written = [];
+
+    const write = (modelKey) => {
+      if (!tracker.isOrigin(modelKey)) {
+        written.push(modelKey);
+      }
+    };
+
+    tracker.run('impact.priceTaxIncluded', () => {
+      write('impact.priceTaxExcluded');
+
+      tracker.run('impact.priceTaxExcluded', () => {
+        write('impact.priceTaxIncluded');
+      });
+    });
+
+    expect(written).to.deep.equal(['impact.priceTaxExcluded']);
+  });
+
+  it('releases the origin once the outermost update finishes', () => {
+    const tracker = new UpdateOriginTracker();
+
+    tracker.run('impact.priceTaxIncluded', () => {
+      tracker.run('impact.priceTaxExcluded', () => {});
+    });
+
+    expect(tracker.isOrigin('impact.priceTaxIncluded')).to.equal(false);
+    expect(tracker.isOrigin('impact.priceTaxExcluded')).to.equal(false);
+  });
+
+  it('releases the origin when the update throws', () => {
+    const tracker = new UpdateOriginTracker();
+
+    expect(() => tracker.run('impact.priceTaxIncluded', () => {
+      throw new Error('conversion failed');
+    })).to.throw('conversion failed');
+
+    expect(tracker.isOrigin('impact.priceTaxIncluded')).to.equal(false);
+  });
+
+  describe('the conversion it protects', () => {
+    const PRECISION = 6;
+    const TAX_RATIO = new BigNumber(1.23);
+
+    // The two halves of the combination form's price conversion, as the model runs them.
+    const convert = (modelKey, fields) => (modelKey === 'priceTaxIncluded'
+      ? ['priceTaxExcluded', new BigNumber(fields.priceTaxIncluded).dividedBy(TAX_RATIO).toFixed(PRECISION)]
+      : ['priceTaxIncluded', new BigNumber(fields.priceTaxExcluded).times(TAX_RATIO).toFixed(PRECISION)]);
+
+    const edit = (tracker, fields, modelKey, typed) => {
+      const apply = (key) => {
+        const [derivedKey, derivedValue] = convert(key, fields);
+
+        if (tracker && tracker.isOrigin(derivedKey)) {
+          return;
+        }
+
+        if (fields[derivedKey] === derivedValue) {
+          return;
+        }
+
+        fields[derivedKey] = derivedValue;
+        apply(derivedKey);
+      };
+
+      fields[modelKey] = typed;
+
+      if (tracker) {
+        tracker.run(modelKey, () => apply(modelKey));
+      } else {
+        apply(modelKey);
+      }
+    };
+
+    it('drifts without the tracker, which is the reported defect', () => {
+      const fields = {priceTaxIncluded: '0', priceTaxExcluded: '0'};
+
+      edit(null, fields, 'priceTaxIncluded', '12');
+
+      expect(fields.priceTaxIncluded).to.equal('12.000001');
+    });
+
+    it('leaves the typed price alone with the tracker', () => {
+      const tracker = new UpdateOriginTracker();
+      const fields = {priceTaxIncluded: '0', priceTaxExcluded: '0'};
+
+      edit(tracker, fields, 'priceTaxIncluded', '12');
+
+      expect(fields.priceTaxIncluded).to.equal('12');
+      expect(fields.priceTaxExcluded).to.equal('9.756098');
+    });
+
+    it('still converts in the other direction', () => {
+      const tracker = new UpdateOriginTracker();
+      const fields = {priceTaxIncluded: '0', priceTaxExcluded: '0'};
+
+      edit(tracker, fields, 'priceTaxExcluded', '10');
+
+      expect(fields.priceTaxExcluded).to.equal('10');
+      expect(fields.priceTaxIncluded).to.equal('12.300000');
+    });
+  });
+});


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Impact on price tax excluded and tax included are two mapped fields that convert into each other, and `FormObjectMapper::set()` goes through the same update path as a real edit, so assigning one re-enters the handler that converts the other way.<br><br>The conversion is lossy at the form's precision, so the return trip does not land back on the entered value. Typing `12` as a tax included impact at a 23% rate stores `12 / 1.23 = 9.756098` tax excluded; the echo converts that back to `9.756098 * 1.23 = 12.000001` and writes it over the `12` that was just typed. That is the value in the reproduction on the issue.<br><br>The same echo exists on the two other converted pairs in this model, the ecotax and the unit price.<br><br>A value derived from another field is now refused on the field the update started from. The edited field keeps what was typed, the other one follows, and cascades that target a third field are unaffected - which matters for the ecotax branch, whose ordering is deliberate.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `admin-dev/themes/new-theme/tests/components/form/update-origin-tracker.spec.js`, run with `npm test` in `admin-dev/themes/new-theme`. Nine cases: the tracker's contract, including that it releases the origin when an update throws, and a replay of the price conversion itself. One of them asserts the drift with no guard and reads `12.000001`, the reported value; another asserts `12` survives with it, and a third that entering a tax excluded price still fills the tax included one. Four fail with the guard neutralised.<br><br>Manually: create a 23% tax rule, a product with combinations priced 10 tax excluded, then edit a combination and enter `12` in impact on price tax included and click outside. Before: it becomes `12.000001`. After: it stays `12`, with `9.756098` tax excluded.
| UI Tests          | Not run. `11_combinationTab.ts` and `03_CRUDProductWithCombinations.ts` cover this tab and would exercise the change; a campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #9972
| Related PRs       | #25749 changed when this conversion is triggered (blur rather than input) and reduced how often the echo is seen, without removing it. #23929 and #20144 were closed attempts at neighbouring decimal-loss reports.
| Sponsor company   |

### On the shape of the test

There is no DOM harness in this theme's test suite - every existing spec covers a module with no jQuery in it - and `jsdom` is present only as a transitive dependency of `webpack-font-preload-plugin`, so a spec that drove the real model would rest on a package nothing declares. The guard is therefore a small module of its own, unit tested directly, with the conversion replayed beside it so the reported value is pinned by a test rather than only by prose. The wiring into `CombinationFormModel` is three lines and is what the UI campaigns above exercise.

### Same pattern elsewhere

`ProductFormModel::updateProductPrices()` converts `price.priceTaxIncluded` and `price.priceTaxExcluded` into each other the same way, so it drifts the same way. It is left alone here because it belongs to a different form and has no open report - #12078 covers it but was closed as fixed for the form that preceded this one. Say the word and I will apply the same guard there in this PR.
