### PR TITLE
Allow the stock list to be sorted by reserved quantity

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/products-table.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/products-table.vue
@@ -61,7 +61,13 @@
           </PSSort>
         </th>
         <th class="text-center">
-          {{ trans('title_reserved') }}
+          <PSSort
+            order="reserved_quantity"
+            @sort="sort"
+            :current-sort="currentSort"
+          >
+            {{ trans('title_reserved') }}
+          </PSSort>
         </th>
         <th class="text-center">
           <PSSort

--- a/src/PrestaShopBundle/Api/QueryStockParamsCollection.php
+++ b/src/PrestaShopBundle/Api/QueryStockParamsCollection.php
@@ -54,6 +54,7 @@ class QueryStockParamsCollection extends QueryParamsCollection
             'supplier',
             'available_quantity',
             'physical_quantity',
+            'reserved_quantity',
             'active',
             'low_stock',
         ];

--- a/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
@@ -349,6 +349,7 @@ abstract class StockManagementRepository
             '{supplier}' => 'supplier_name',
             '{available_quantity}' => 'product_available_quantity',
             '{physical_quantity}' => 'product_physical_quantity',
+            '{reserved_quantity}' => 'product_reserved_quantity',
             '{id_stock_mvt}' => 'id_stock_mvt',
             '{date_add}' => 'date_add',
             '{product_low_stock_alert}' => 'product_low_stock_alert',

--- a/tests/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
@@ -100,6 +100,12 @@ class StockManagementControllerTest extends ApiTestCase
                 24,
             ],
             [
+                // A sortable column has to be both allowed and mapped to a real one, otherwise the
+                // token reaches the query unreplaced and the request fails.
+                ['order' => 'reserved_quantity desc', 'page_index' => 1, 'page_size' => 2],
+                24,
+            ],
+            [
                 ['supplier_id' => 1, 'page_index' => 2, 'page_size' => 2],
                 0,
             ],

--- a/tests/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
+++ b/tests/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
@@ -191,6 +191,20 @@ class QueryParamsCollectionTest extends TestCase
                     'first_result' => 4,
                 ],
             ]],
+            ['reserved_quantity', null, null, [
+                'ORDER BY {reserved_quantity} ',
+                [
+                    'max_results' => 100,
+                    'first_result' => 0,
+                ],
+            ]],
+            ['reserved_quantity DESC', null, null, [
+                'ORDER BY {reserved_quantity} DESC ',
+                [
+                    'max_results' => 100,
+                    'first_result' => 0,
+                ],
+            ]],
             ['physical_quantity', '3', '3', [
                 'ORDER BY {physical_quantity} ',
                 [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On Sell > Stock the Physical and Available columns can be sorted and Reserved cannot, which is what the report shows.<br><br>It is not only a missing header control. Sorting on that page travels through three places and the column is absent from two of them: `QueryStockParamsCollection::getValidOrderParams()` does not list `reserved_quantity`, so `parseOrderParams()` silently drops it and falls back to the default order, and `StockManagementRepository::orderBy()` has no `{reserved_quantity}` entry in its token to column map. The value itself is already selected, as `sa.reserved_quantity AS product_reserved_quantity`.<br><br>The two are added together on purpose. Allowing the parameter without mapping it lets `getSqlOrder()` emit `{reserved_quantity}`, `strtr()` leaves it untouched and the query runs with `ORDER BY {reserved_quantity}`, which fails. The header control is then added to `products-table.vue` next to the two that already have one.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Two levels, because the halves fail differently.<br><br>`QueryParamsCollectionTest` gains two data sets asserting `reserved_quantity` and `reserved_quantity DESC` survive parsing and produce `ORDER BY {reserved_quantity}`. Removing the allowed-parameter entry fails 4 of its cases.<br><br>`StockManagementControllerTest` gains a list request ordered by `reserved_quantity desc`. This is the one that covers the mapping: with the allowed parameter present but the map entry removed, the unit test still passes while this returns **HTTP 500** and reports `Failed asserting that 500 matches expected 200`. Measured both ways.<br><br>Manually: open Sell > Stock and click the Reserved column header. Before: no control. After: it sorts, and the arrow behaves like the Physical and Available ones.
| UI Tests          | Not run. The change is covered by the unit and integration tests above; a campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #10827
| Related PRs       |
| Sponsor company   |

### Why the integration test is there

The interesting failure is not the missing header, it is that the sortable-column contract is spread over a whitelist in one class and a token map in another, with nothing tying them together. A change that satisfies only the whitelist looks correct in unit tests and breaks the page. The list request added to `StockManagementControllerTest` is the cheapest thing that fails when the two drift apart.

If you would rather have that invariant enforced rather than tested, the map could move next to the whitelist so a column is declared once. That is a wider change than this report needs, so I have not done it here.
