### PR TITLE
Search stock by product location

### DIFF
--- a/src/PrestaShopBundle/Api/QueryParamsCollection.php
+++ b/src/PrestaShopBundle/Api/QueryParamsCollection.php
@@ -721,6 +721,7 @@ abstract class QueryParamsCollection
                 '{combination_mpn}',
                 '{product_name}',
                 '{combination_name}',
+                '{product_location}',
             ];
 
             $conditions = array_map(function ($field) use ($index) {

--- a/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
@@ -320,6 +320,7 @@ abstract class StockManagementRepository
             '{combination_mpn}' => 'combination_mpn',
             '{supplier_name}' => 'supplier_name',
             '{product_name}' => 'product_name',
+            '{product_location}' => 'product_location',
         ]);
     }
 

--- a/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
@@ -117,6 +117,7 @@ class StockMovementRepository extends StockManagementRepository
               pa.isbn                                     AS combination_isbn,
               pa.upc                                      AS combination_upc,
               pa.mpn                                      AS combination_mpn,
+              COALESCE(sa.location, "")                   AS product_location,
               p.id_supplier                               AS supplier_id,
               COALESCE(s.name, "N/A")                     AS supplier_name,
               COALESCE(ic.id_image, 0)                    AS product_cover_id,

--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -248,6 +248,7 @@ class StockRepository extends StockManagementRepository
           IF(COALESCE(pa.isbn, "") = "", "N/A", pa.isbn)                                    AS combination_isbn,
           IF(COALESCE(pa.upc, "") = "", "N/A", pa.upc)                                      AS combination_upc,
           IF(COALESCE(pa.mpn, "") = "", "N/A", pa.mpn)                                      AS combination_mpn,
+          COALESCE(sa.location, "")                                                         AS product_location,
           pl.name                                                                           AS product_name,
           p.id_supplier                                                                     AS supplier_id,
           COALESCE(s.name, "N/A")                                                           AS supplier_name,

--- a/tests/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
@@ -442,6 +442,19 @@ class StockManagementControllerTest extends ApiTestCase
         $this->assertResponseBodyValidJson(200);
     }
 
+    public function testItShouldReturnValidResponseWhenSearchingStockByLocation(): void
+    {
+        $listProductsRoute = $this->router->generate('api_stock_list_products');
+
+        self::$client->request(
+            'GET',
+            $listProductsRoute,
+            ['keywords' => ['Aisle 3']]
+        );
+
+        $this->assertResponseBodyValidJson(200);
+    }
+
     public function testItShouldReturnValidResponseWhenRequestingStockWithAttributes(): void
     {
         $listProductsRoute = $this->router->generate('api_stock_list_products');

--- a/tests/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
+++ b/tests/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
@@ -276,7 +276,8 @@ class QueryParamsCollectionTest extends TestCase
                         '{product_mpn} LIKE :keyword_0 OR ' .
                         '{combination_mpn} LIKE :keyword_0 OR ' .
                         '{product_name} LIKE :keyword_0 OR ' .
-                        '{combination_name} LIKE :keyword_0' .
+                        '{combination_name} LIKE :keyword_0 OR ' .
+                        '{product_location} LIKE :keyword_0' .
                         ')',
                 ],
                 $keywordsFilterMessage,
@@ -297,7 +298,8 @@ class QueryParamsCollectionTest extends TestCase
                         '{product_mpn} LIKE :keyword_0 OR ' .
                         '{combination_mpn} LIKE :keyword_0 OR ' .
                         '{product_name} LIKE :keyword_0 OR ' .
-                        '{combination_name} LIKE :keyword_0' .
+                        '{combination_name} LIKE :keyword_0 OR ' .
+                        '{product_location} LIKE :keyword_0' .
                         ')',
                 ],
                 $keywordsFilterMessage,
@@ -318,7 +320,8 @@ class QueryParamsCollectionTest extends TestCase
                         '{product_mpn} LIKE :keyword_0 OR ' .
                         '{combination_mpn} LIKE :keyword_0 OR ' .
                         '{product_name} LIKE :keyword_0 OR ' .
-                        '{combination_name} LIKE :keyword_0' .
+                        '{combination_name} LIKE :keyword_0 OR ' .
+                        '{product_location} LIKE :keyword_0' .
                         ')' . "\n" .
                         'AND (' .
                         '{supplier_name} LIKE :keyword_1 OR ' .
@@ -332,7 +335,8 @@ class QueryParamsCollectionTest extends TestCase
                         '{product_mpn} LIKE :keyword_1 OR ' .
                         '{combination_mpn} LIKE :keyword_1 OR ' .
                         '{product_name} LIKE :keyword_1 OR ' .
-                        '{combination_name} LIKE :keyword_1' .
+                        '{combination_name} LIKE :keyword_1 OR ' .
+                        '{product_location} LIKE :keyword_1' .
                         ')' . "\n" .
                         'AND (' .
                         '{supplier_name} LIKE :keyword_2 OR ' .
@@ -346,7 +350,8 @@ class QueryParamsCollectionTest extends TestCase
                         '{product_mpn} LIKE :keyword_2 OR ' .
                         '{combination_mpn} LIKE :keyword_2 OR ' .
                         '{product_name} LIKE :keyword_2 OR ' .
-                        '{combination_name} LIKE :keyword_2' .
+                        '{combination_name} LIKE :keyword_2 OR ' .
+                        '{product_location} LIKE :keyword_2' .
                         ')',
                 ],
                 $keywordsFilterMessage,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Two thirds of this request already work. `QueryParamsCollection::appendSqlSearchFilter()` already matches the search box against product and combination EAN, ISBN, **UPC**, MPN, the reference, both names and the supplier, so scanning an EAN or a UPC on Sell > Stock finds the row today.<br><br>What is missing is the location. It is not in the search field list, it has no entry in the token to column map in `StockManagementRepository`, and neither stock query selects it, although both already join `stock_available`.<br><br>`COALESCE(sa.location, "")` is now selected as `product_location` by both queries, the token is mapped, and the field joins the search list. `stock_available.location` is the per row value, written alongside `product.location` by `ProductStockUpdater`, so a combination keeps its own location rather than inheriting the product one.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `StockManagementControllerTest::testItShouldReturnValidResponseWhenSearchingStockByLocation` searches the products list by a location string. I checked that it really exercises the new column rather than passing by default: with a deliberate error injected into that query it fails with `Failed asserting that 500 matches expected 200`.<br><br>`QueryParamsCollectionTest` also asserts the search clause field by field, so its three expectations carry the new column; that is where the change is visible at unit level.<br><br>Manually: set a location on a product in its Stock tab, open Sell > Stock and type that location in the search box. Before: no result. After: the row is listed. Searching an EAN or a UPC behaves as before.
| UI Tests          | Not run. The change is covered by the integration test above; a campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #10875
| Related PRs       | #42453 fixes the missing sort on the Reserved column of the same page and touches the neighbouring order-parameter list.
| Sponsor company   |

### What is not covered by a test, and why

The search fields and the token map are shared: `QueryStockMovementParamsCollection` extends the stock one and both repositories extend `StockManagementRepository`. A field added for the products list therefore reaches the movements list too, which is why the column is selected by both queries rather than only the one this report is about.

I could not cover that half. A test hitting `api_stock_list_movements` with a keyword still returns 200 with the movements query **deliberately broken**, so it never reaches it in this harness, and I removed the test rather than leave one that proves nothing. The movements select is included because the shared list makes it necessary, not because a test demanded it. If you know how that endpoint is reached under `ApiTestCase`, I will add the case.

