### PR TITLE
Remove the imported specific price when the CSV carries a zero discount

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1909,7 +1909,14 @@ class AdminImportControllerCore extends AdminController
                 }
             }
 
-            if ((isset($info['reduction_price']) && $info['reduction_price'] > 0) || (isset($info['reduction_percent']) && $info['reduction_percent'] > 0)) {
+            if (self::csvRemovesTheDiscount($info)) {
+                // An explicit zero means "no discount any more". Only the row this importer creates is
+                // removed, matched on the exact scope written below, so specific prices a merchant set
+                // for a customer, group, currency, country or quantity tier are left alone.
+                if (!$validateOnly) {
+                    $this->deleteImportedSpecificPrices((int) $product->id, $id_shop_list);
+                }
+            } elseif ((isset($info['reduction_price']) && $info['reduction_price'] > 0) || (isset($info['reduction_percent']) && $info['reduction_percent'] > 0)) {
                 foreach ($id_shop_list as $id_shop) {
                     $specific_price = SpecificPrice::getSpecificPrice($product->id, $id_shop, 0, 0, 0, 1, 0, 0, 0, 0);
 
@@ -4081,6 +4088,68 @@ class AdminImportControllerCore extends AdminController
         $iso_lang = trim(Tools::getValue('iso_lang'));
         setlocale(LC_COLLATE, strtolower($iso_lang) . '_' . strtoupper($iso_lang) . '.UTF-8');
         setlocale(LC_CTYPE, strtolower($iso_lang) . '_' . strtoupper($iso_lang) . '.UTF-8');
+    }
+
+    /**
+     * Whether the row asks for the discount to be removed.
+     *
+     * Only an explicit zero does. An empty cell means the column was left alone and must not be read
+     * as "delete", which is the difference between updating one column of a catalogue and wiping the
+     * discounts off every product in the file. The empty check is kept explicit rather than left to
+     * the comparison: `'' == 0` is false on PHP 8 but was true before it, and the intent should not
+     * depend on that.
+     *
+     * @param array $info
+     *
+     * @return bool
+     */
+    protected static function csvRemovesTheDiscount(array $info)
+    {
+        foreach (['reduction_price', 'reduction_percent'] as $field) {
+            if (!isset($info[$field]) || $info[$field] === '') {
+                continue;
+            }
+
+            if ($info[$field] == 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Removes the specific price this importer owns for a product, on the given shops.
+     *
+     * The scope is the one written when a discount is imported: no combination, currency, country,
+     * group or customer, quantity 1, not produced by a catalog price rule. Anything else on the
+     * product was configured elsewhere and is left untouched.
+     *
+     * @param int $idProduct
+     * @param array $idShopList
+     */
+    protected function deleteImportedSpecificPrices($idProduct, array $idShopList)
+    {
+        foreach ($idShopList as $idShop) {
+            $query = new DbQuery();
+            $query->select('id_specific_price')
+                ->from('specific_price')
+                ->where('id_product = ' . (int) $idProduct)
+                ->where('id_shop = ' . (int) $idShop)
+                ->where('id_product_attribute = 0')
+                ->where('id_currency = 0')
+                ->where('id_country = 0')
+                ->where('id_group = 0')
+                ->where('id_customer = 0')
+                ->where('from_quantity = 1')
+                ->where('id_specific_price_rule = 0')
+                ->where('price = -1');
+
+            foreach (Db::getInstance()->executeS($query) ?: [] as $row) {
+                $specificPrice = new SpecificPrice((int) $row['id_specific_price']);
+                $specificPrice->delete();
+            }
+        }
     }
 
     protected function addProductWarning($product_name, $product_id = null, $message = '')

--- a/tests/Integration/Classes/SpecificPriceImportDeletionTest.php
+++ b/tests/Integration/Classes/SpecificPriceImportDeletionTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use AdminImportControllerCore;
+use Db;
+use ReflectionClass;
+use ReflectionMethod;
+use SpecificPrice;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Importing a zero discount removes the specific price the importer owns, and only that one.
+ */
+class SpecificPriceImportDeletionTest extends KernelTestCase
+{
+    private const PRODUCT_ID = 1;
+    private const SHOP_ID = 1;
+
+    /** @var int[] */
+    private array $createdIds = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdIds as $id) {
+            $specificPrice = new SpecificPrice($id);
+            if ($specificPrice->id) {
+                $specificPrice->delete();
+            }
+        }
+        $this->createdIds = [];
+        parent::tearDown();
+    }
+
+    public function testItRemovesTheOneTheImporterWroteAndLeavesTheOthers(): void
+    {
+        $imported = $this->createSpecificPrice([]);
+        $forACustomer = $this->createSpecificPrice(['id_customer' => 1]);
+        $forAQuantity = $this->createSpecificPrice(['from_quantity' => 10]);
+        $fromARule = $this->createSpecificPrice(['id_specific_price_rule' => 1]);
+
+        $this->deleteImported();
+
+        // demo data carries an all-shops price on this product (id_shop = 0); the importer never
+        // writes one, so the delete must not reach it
+        $allShops = (int) Db::getInstance()->getValue(
+            'SELECT id_specific_price FROM ' . _DB_PREFIX_ . 'specific_price
+             WHERE id_product = ' . self::PRODUCT_ID . ' AND id_shop = 0'
+        );
+
+        $this->assertFalse($this->exists($imported), 'the imported specific price was not removed');
+        if ($allShops) {
+            $this->assertTrue($this->exists($allShops), 'an all-shops specific price was removed');
+        }
+        $this->assertTrue($this->exists($forACustomer), 'a customer specific price was removed');
+        $this->assertTrue($this->exists($forAQuantity), 'a quantity tier was removed');
+        $this->assertTrue($this->exists($fromARule), 'a catalog price rule price was removed');
+    }
+
+    /**
+     * @dataProvider discountRemovalRows
+     */
+    public function testItOnlyTreatsAnExplicitZeroAsRemoval(array $row, bool $expected, string $message): void
+    {
+        $method = new ReflectionMethod(AdminImportControllerCore::class, 'csvRemovesTheDiscount');
+        $method->setAccessible(true);
+
+        $this->assertSame($expected, $method->invoke(null, $row), $message);
+    }
+
+    public function discountRemovalRows(): array
+    {
+        return [
+            [['reduction_percent' => '0'], true, 'a zero percent asks for the discount to go'],
+            [['reduction_percent' => 0], true, 'the same written as an integer'],
+            [['reduction_price' => '0.00'], true, 'a zero amount asks for it too'],
+            [['reduction_percent' => ''], false, 'an empty cell means the column was left alone'],
+            [['reduction_price' => ''], false, 'an empty amount means the same'],
+            [[], false, 'a file without the column must never delete anything'],
+            [['reduction_percent' => '25'], false, 'a real discount is not a removal'],
+            [['reduction_price' => '9.99'], false, 'nor is a real amount'],
+            [['reduction_percent' => '', 'reduction_price' => '0'], true, 'one explicit zero is enough'],
+        ];
+    }
+
+    public function testItRemovesAPriceThatNeverExpires(): void
+    {
+        // what the importer writes when the CSV carries no discount dates, and what a delete filtered
+        // on "to >= now()" would miss
+        $endless = $this->createSpecificPrice(['from' => '0000-00-00 00:00:00', 'to' => '0000-00-00 00:00:00']);
+
+        $this->deleteImported();
+
+        $this->assertFalse($this->exists($endless));
+    }
+
+    private function deleteImported(): void
+    {
+        $method = new ReflectionMethod(AdminImportControllerCore::class, 'deleteImportedSpecificPrices');
+        $method->setAccessible(true);
+        $method->invoke(
+            (new ReflectionClass(AdminImportControllerCore::class))->newInstanceWithoutConstructor(),
+            self::PRODUCT_ID,
+            [self::SHOP_ID]
+        );
+    }
+
+    private function createSpecificPrice(array $overrides): int
+    {
+        $specificPrice = new SpecificPrice();
+        $specificPrice->id_product = self::PRODUCT_ID;
+        $specificPrice->id_shop = self::SHOP_ID;
+        $specificPrice->id_product_attribute = 0;
+        $specificPrice->id_currency = 0;
+        $specificPrice->id_country = 0;
+        $specificPrice->id_group = 0;
+        $specificPrice->id_customer = 0;
+        $specificPrice->id_specific_price_rule = 0;
+        $specificPrice->price = -1;
+        $specificPrice->from_quantity = 1;
+        $specificPrice->reduction = 0.25;
+        $specificPrice->reduction_type = 'percentage';
+        $specificPrice->reduction_tax = 1;
+        $specificPrice->from = '0000-00-00 00:00:00';
+        $specificPrice->to = '0000-00-00 00:00:00';
+
+        foreach ($overrides as $field => $value) {
+            $specificPrice->{$field} = $value;
+        }
+
+        $specificPrice->add();
+        $this->createdIds[] = (int) $specificPrice->id;
+
+        return (int) $specificPrice->id;
+    }
+
+    private function exists(int $id): bool
+    {
+        return (bool) Db::getInstance()->getValue(
+            'SELECT id_specific_price FROM ' . _DB_PREFIX_ . 'specific_price WHERE id_specific_price = ' . $id
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Importing a product CSV with `0` in the discount column leaves the existing specific price in place, so a catalogue that uses discounts cannot be updated in bulk. The importer creates and updates a specific price but never removes one.<br><br>This has been attempted before. #39473 was approved three times and then closed after QA reported the prices were still not deleted; the branch was left on `9.0.x` and never retargeted. Its delete filtered on the discount window:<br><br>`->where('sp.\`from\` <= now()')` and `->where('sp.\`to\` >= now()')`<br><br>but when the CSV carries no dates the importer writes `to = '0000-00-00 00:00:00'`, and `'0000-00-00 00:00:00' >= now()` is false. The one row the importer had just created was the one row that delete could never match, which is exactly what the QA video shows.<br><br>This removes on the scope the create branch writes instead, per shop and with no date condition: no combination, currency, country, group or customer, quantity 1, not produced by a catalog price rule. A specific price a merchant set for a customer, a group, a currency, a country or a quantity tier is left alone, as are the all-shops rows the demo data ships with, which the importer never writes.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `SpecificPriceImportDeletionTest`, 11 cases.<br><br>Two cover the delete scope: the imported row is removed while a customer-specific price on the same product survives, and a price with no end date is removed. Restoring #39473's date filter fails both, which is the regression that closed it.<br><br>Nine cover the decision to delete at all, `AdminImportController::csvRemovesTheDiscount()`. An explicit `0`, `0` as an integer and `0.00` remove; an empty cell, a missing column and a real discount do not. Dropping the zero comparison fails two of them. This one matters more than it looks: reading an empty cell as a zero would wipe the discounts off every product in a file that simply does not carry the column.<br><br>Manually: import a CSV giving a product a 25% discount, then import the same file with `0` in that column. Before: the product keeps 25%. After: the discount is gone and any customer or group price on it is untouched.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #12867
| Related PRs       | Builds on #39473 by @MattKelvin, which carried the same intent and the same entry point. That PR was closed on 2026-03-25 when `9.0.x` stopped being the development branch and has had no author activity since, so this reopens the work on `9.2.x` with the QA failure diagnosed and covered.
| Sponsor company   |

### What is not covered

The tests reach `csvRemovesTheDiscount()` and `deleteImportedSpecificPrices()` by reflection. There is no
harness in the repository that drives `AdminImportController::productImport()` end to end, so the line that
connects the two is not exercised by a test: replacing the call with `if (false)` leaves the suite green.
I would rather say that than imply a coverage I do not have. If an import harness exists that I have
missed, point me at it and I will add the case.
