### PR TITLE
Keep the customer address the invoice was issued with

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -63,6 +63,9 @@ class OrderInvoiceCore extends ObjectModel
     /** @var string shop address */
     public $shop_address;
 
+    /** @var string|null Invoice address of the customer, as printed when the invoice was issued */
+    public $customer_address;
+
     /** @var string note */
     public $note;
 
@@ -101,6 +104,7 @@ class OrderInvoiceCore extends ObjectModel
             'total_wrapping_tax_excl' => ['type' => self::TYPE_FLOAT],
             'total_wrapping_tax_incl' => ['type' => self::TYPE_FLOAT],
             'shop_address' => ['type' => self::TYPE_HTML, 'validate' => 'isCleanHtml', 'size' => FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4],
+            'customer_address' => ['type' => self::TYPE_HTML, 'validate' => 'isCleanHtml', 'size' => FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4],
             'note' => ['type' => self::TYPE_HTML, 'size' => FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4],
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
         ],
@@ -111,6 +115,7 @@ class OrderInvoiceCore extends ObjectModel
         $order = new Order($this->id_order);
 
         $this->shop_address = OrderInvoice::getCurrentFormattedShopAddress($order->id_shop);
+        $this->customer_address = OrderInvoice::getFormattedCustomerAddress((int) $order->id_address_invoice);
 
         return parent::add();
     }
@@ -889,6 +894,30 @@ class OrderInvoiceCore extends ObjectModel
         $address->id_country = (int) Configuration::get('PS_SHOP_COUNTRY_ID', null, null, $id_shop);
 
         return AddressFormat::generateAddress($address, [], '<br />', ' ');
+    }
+
+    /**
+     * Formats the invoice address of an order the way the invoice prints it, so the document keeps the
+     * address it carried when it was issued.
+     *
+     * `shop_address` above already does this for the merchant's own address; editing a customer address
+     * afterwards used to rewrite invoices that had been sent.
+     *
+     * @param int $idAddress
+     *
+     * @return string|null null when the address is gone, so the caller falls back to the live one
+     */
+    public static function getFormattedCustomerAddress($idAddress)
+    {
+        $address = new Address((int) $idAddress);
+
+        if (!Validate::isLoadedObject($address)) {
+            return null;
+        }
+
+        $patternRules = json_decode(Configuration::get('PS_INVCE_INVOICE_ADDR_RULES'), true);
+
+        return AddressFormat::generateAddress($address, is_array($patternRules) ? $patternRules : [], '<br />', ' ');
     }
 
     /**

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -151,7 +151,11 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
 
         $invoice_address = new Address((int) $this->order->id_address_invoice);
         $country = new Country((int) $invoice_address->id_country);
-        $formatted_invoice_address = AddressFormat::generateAddress($invoice_address, $invoiceAddressPatternRules, '<br />', ' ');
+        // Invoices issued before this column existed, and orders whose address has since been removed,
+        // fall back to the live one exactly as they did before.
+        $formatted_invoice_address = !empty($this->order_invoice->customer_address)
+            ? $this->order_invoice->customer_address
+            : AddressFormat::generateAddress($invoice_address, $invoiceAddressPatternRules, '<br />', ' ');
 
         $delivery_address = null;
         $formatted_delivery_address = '';

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1348,6 +1348,7 @@ CREATE TABLE `PREFIX_order_invoice` (
   `total_wrapping_tax_excl` decimal(20, 6) NOT NULL DEFAULT '0.00',
   `total_wrapping_tax_incl` decimal(20, 6) NOT NULL DEFAULT '0.00',
   `shop_address` MEDIUMTEXT DEFAULT NULL,
+  `customer_address` MEDIUMTEXT DEFAULT NULL,
   `note` MEDIUMTEXT,
   `date_add` datetime NOT NULL,
   PRIMARY KEY (`id_order_invoice`),

--- a/tests/Integration/Classes/OrderInvoiceCustomerAddressTest.php
+++ b/tests/Integration/Classes/OrderInvoiceCustomerAddressTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\Classes;
+
+use Address;
+use Db;
+use Order;
+use OrderInvoice;
+use PHPUnit\Framework\TestCase;
+
+class OrderInvoiceCustomerAddressTest extends TestCase
+{
+    /** @var int */
+    private $idOrderInvoice = 0;
+
+    protected function tearDown(): void
+    {
+        if ($this->idOrderInvoice) {
+            Db::getInstance()->delete('order_invoice', 'id_order_invoice = ' . (int) $this->idOrderInvoice);
+            $this->idOrderInvoice = 0;
+        }
+
+        parent::tearDown();
+    }
+
+    public function testItFormatsTheAddressOfAnOrder(): void
+    {
+        $idAddress = (int) Db::getInstance()->getValue('SELECT id_address FROM ' . _DB_PREFIX_ . 'address WHERE deleted = 0');
+        $address = new Address($idAddress);
+
+        $formatted = OrderInvoice::getFormattedCustomerAddress($idAddress);
+
+        $this->assertNotEmpty($formatted);
+        $this->assertStringContainsString($address->address1, $formatted);
+    }
+
+    public function testItReturnsNullWhenTheAddressIsGone(): void
+    {
+        $this->assertNull(OrderInvoice::getFormattedCustomerAddress(0));
+    }
+
+    /**
+     * The point of the change: an invoice keeps the address it was issued with, so editing the
+     * customer address afterwards no longer rewrites a document already sent.
+     */
+    public function testAnIssuedInvoiceKeepsTheAddressItWasCreatedWith(): void
+    {
+        $idOrder = (int) Db::getInstance()->getValue('SELECT id_order FROM ' . _DB_PREFIX_ . 'orders');
+        $order = new Order($idOrder);
+        $address = new Address((int) $order->id_address_invoice);
+
+        $originalCity = $address->city;
+
+        $invoice = new OrderInvoice();
+        $invoice->id_order = $idOrder;
+        $invoice->number = 0;
+        $invoice->add();
+        $this->idOrderInvoice = (int) $invoice->id;
+
+        $this->assertNotEmpty($invoice->customer_address, 'the invoice stores the address when it is created');
+        $this->assertStringContainsString($originalCity, $invoice->customer_address);
+
+        $address->city = $originalCity . ' Renamed';
+        $address->update();
+
+        try {
+            $reloaded = new OrderInvoice($this->idOrderInvoice);
+
+            $this->assertStringContainsString(
+                $originalCity,
+                $reloaded->customer_address,
+                'the issued invoice must not follow a later edit of the address'
+            );
+            $this->assertStringNotContainsString('Renamed', $reloaded->customer_address);
+        } finally {
+            $address->city = $originalCity;
+            $address->update();
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Editing a customer address rewrites invoices that were already issued and sent, so one order can have two different documents. `HTMLTemplateInvoice` looks the address up live, `Address::update()` writes in place and has no versioning, and only `Address::delete()` protects order history, soft-deleting an address used by an order with the comment "We must absolutely retain all the business data for the order". Deletion preserves history; editing does not.<br><br>The invoice already solves this for the other party. `ps_order_invoice` carries a `shop_address` column that `OrderInvoice::add()` fills at creation, and the template falls back to the current shop address only when it is empty, a mechanism that was backfilled by an upgrade script in 1.6.1.1. The customer side never got it.<br><br>This adds `customer_address` beside it, filled the same way, preferred by the template. Invoices created before the column exists, and orders whose address has since been removed, fall back to the live lookup exactly as they do today.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `OrderInvoiceCustomerAddressTest`, three cases: the formatter renders an order's invoice address, it returns null when the address is gone so the caller can fall back, and an issued invoice keeps the address it was created with after that address is edited. Removing the line that stores it fails the third with `Failed asserting that a NULL is not empty`.<br><br>Manually: place an order, generate its invoice, then change the customer's address and open the invoice again. Before: the PDF shows the new address. After: it shows the address as it was, and the customer's address is still editable for anything that follows.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #12394
| Related PRs       | An upgrade script is needed for existing shops. Since 9.x those live in PrestaShop/autoupgrade rather than core, so it is not in this diff: `ALTER TABLE PREFIX_order_invoice ADD COLUMN customer_address MEDIUMTEXT DEFAULT NULL;`. Without it nothing breaks, existing shops simply keep the current behaviour through the fallback. I will open that PR once the direction here is accepted.
| Sponsor company   |

### The decision, and what I rejected

The thread has been open since 2019 with three approaches on the table, so this states which one this PR takes.

**Taken: freeze the address on the invoice.** It extends a decision the project has already made in the same table for the same reason, needs no new setting, and leaves the merchant free to correct an address for everything that follows.

**Rejected: block address edits once an invoice is sent**, which is the TODO in the report. @BenTen's objection stands - a merchant then has no way to fix a typo - and it would need new UI to express the exception.

**Rejected: annul the invoice and issue a new one** (@hanuchin). That is the right answer for a genuine change of substance, but making it the only way to correct a misspelt street is disproportionate, and it is a merchant decision rather than something the code should force.

**Rejected: version addresses on update**, creating a new row and soft-deleting the old one as `delete()` already does. It gives the same outcome but changes `id_address` for carts, default addresses and any module holding one, which is a much wider blast radius than the reported problem.

### What this does not fix

@khouloudbelguith's #14622 is the same class of problem on the ecotax, a different field with its own storage. And @hanuchin is right that a module hooked into the PDF can still alter an old invoice at render time; freezing the address does not address that.
