### PR TITLE
Order cart rules of equal priority deterministically

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -480,7 +480,7 @@ class CartCore extends ObjectModel
                     ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
                     ' . ($filter == CartRule::FILTER_ACTION_GIFT ? 'AND gift_product != 0' : '') . '
                     ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '')
-                    . ' ORDER by cr.priority ASC, cr.gift_product DESC'
+                    . ' ORDER by cr.priority ASC, cr.gift_product DESC, cr.date_add ASC, cr.id_cart_rule ASC'
                 );
 
                 // Sort by the new 3-level priority system (Type → Priority Field → Creation Date)
@@ -498,7 +498,7 @@ class CartCore extends ObjectModel
                     ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
                     ' . ($filter == CartRule::FILTER_ACTION_GIFT ? 'AND gift_product != 0' : '') . '
                     ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '')
-                    . ' ORDER by cr.priority ASC, cr.gift_product DESC'
+                    . ' ORDER by cr.priority ASC, cr.gift_product DESC, cr.date_add ASC, cr.id_cart_rule ASC'
                 );
             }
 
@@ -597,7 +597,7 @@ class CartCore extends ObjectModel
                     ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
                     ' . ($filter == CartRule::FILTER_ACTION_GIFT ? 'AND gift_product != 0' : '') . '
                     ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '')
-                    . ' ORDER by cr.priority ASC, cr.gift_product DESC'
+                    . ' ORDER by cr.priority ASC, cr.gift_product DESC, cr.date_add ASC, cr.id_cart_rule ASC'
                 );
             }
 

--- a/tests/Integration/Classes/CartRuleOrderingTest.php
+++ b/tests/Integration/Classes/CartRuleOrderingTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\Classes;
+
+use Cart;
+use CartRule;
+use Configuration;
+use Context;
+use Currency;
+use Db;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class CartRuleOrderingTest extends KernelTestCase
+{
+    /** @var Cart|null */
+    private $cart;
+
+    /** @var CartRule[] */
+    private $cartRules = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Cart::getCartRules() resolves the discount feature flag through ContainerFinder, which reads
+        // the global $kernel that bootKernel() does not set by itself.
+        self::bootKernel();
+        global $kernel;
+        $kernel = self::$kernel;
+
+        $context = Context::getContext();
+        // Cart price computation reads the currency precision off the context.
+        $context->currency = Currency::getDefaultCurrency();
+
+        $this->cart = new Cart();
+        $this->cart->id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $this->cart->id_lang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $this->cart->id_shop = (int) $context->shop->id;
+        $this->cart->add();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cartRules as $cartRule) {
+            $cartRule->delete();
+        }
+        $this->cartRules = [];
+
+        if ($this->cart && $this->cart->id) {
+            Db::getInstance()->delete('cart_cart_rule', 'id_cart = ' . (int) $this->cart->id);
+            $this->cart->delete();
+        }
+        $this->cart = null;
+
+        parent::tearDown();
+    }
+
+    /**
+     * Every rule a merchant creates without touching the priority field shares the schema default of 1,
+     * so ordering on priority alone leaves them tied and the database free to return any order. The
+     * reported symptom is a discount dropping to 0 when the row set changes and the order flips.
+     */
+    public function testRulesOfEqualPriorityAreOrderedByCreationDate(): void
+    {
+        // Created in one order, dated in the opposite one, so id order and date order disagree.
+        $names = ['first created', 'second created', 'third created'];
+        $ids = [];
+
+        foreach ($names as $name) {
+            $cartRule = new CartRule();
+            $cartRule->id_customer = 0;
+            $cartRule->date_from = date('Y-m-d H:i:s', strtotime('-1 day'));
+            $cartRule->date_to = date('Y-m-d H:i:s', strtotime('+1 day'));
+            $cartRule->quantity = 10;
+            $cartRule->quantity_per_user = 10;
+            $cartRule->reduction_percent = 5;
+            $cartRule->active = 1;
+            $cartRule->name = [(int) Configuration::get('PS_LANG_DEFAULT') => $name];
+            $cartRule->add();
+
+            $this->cartRules[] = $cartRule;
+            $ids[] = (int) $cartRule->id;
+
+            Db::getInstance()->insert('cart_cart_rule', [
+                'id_cart' => (int) $this->cart->id,
+                'id_cart_rule' => (int) $cartRule->id,
+            ]);
+        }
+
+        $this->assertSame(
+            [1, 1, 1],
+            array_map(static function (CartRule $rule): int { return (int) $rule->priority; }, $this->cartRules),
+            'the rules must share a priority for this to test anything'
+        );
+
+        // Date them in reverse, so following the dates cannot be mistaken for following the ids.
+        foreach (array_reverse($ids) as $offset => $idCartRule) {
+            Db::getInstance()->update(
+                'cart_rule',
+                ['date_add' => date('Y-m-d H:i:s', strtotime(sprintf('-%d hours', 10 - $offset)))],
+                'id_cart_rule = ' . (int) $idCartRule
+            );
+        }
+
+        $cart = new Cart((int) $this->cart->id);
+
+        $returned = array_map(
+            static function (array $row): int { return (int) $row['id_cart_rule']; },
+            // Second argument off: automatically adding rules needs the kernel container.
+            $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false)
+        );
+
+        $this->assertSame(
+            array_reverse($ids),
+            $returned,
+            'equal priorities must fall back to the creation date, not to whatever the database returns'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The three queries that read a cart's rules order them with `ORDER by cr.priority ASC, cr.gift_product DESC`. `priority` is `NOT NULL DEFAULT 1` in the schema, so every rule a merchant creates without opening that field is tied, and among tied rows the database is free to return any order.<br><br>That is what the report describes. Adding a product to the order changes the row set, the order the rules are applied in flips, and a discount that previously had a share of the total is evaluated last against what is left, which is nothing. It is intermittent because it depends on the plan, which is also why @matks could reproduce it by hand and not in Behat.<br><br>The three queries now fall back to `cr.date_add ASC, cr.id_cart_rule ASC`. Priority still decides; ties resolve by creation date, and the id makes the order total so it cannot drift at all.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `CartRuleOrderingTest` creates three rules of equal priority, dates them in the reverse of their id order so following the dates cannot be mistaken for following the ids, and asserts `getCartRules()` returns them by date. Removing the tiebreak fails it with `Failed asserting that two arrays are identical` - the database returns id order instead.<br><br>`CartTest`, `CartRuleTest` and the new file run green together, 20 tests.<br><br>Manually: the scenario in the report. Two discounts on an order, then add the product carrying the 500 EUR rule; the earlier discounts keep their amounts.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #20397
| Related PRs       |
| Sponsor company   |

### The decision, and what I rejected

@MatShir's reading in 2020 was that ordering should follow the priority and be consistent, and closed on "the cart rule order should be done by the priority". It already is; what was missing is what happens when priorities are equal, which on a default install is every time.

**Taken: date then id as the tiebreak.** It is what the project has already chosen elsewhere. `DiscountPriority::sortByPriority()`, used by `sortCartRulesByPriority()` in the new discount system, orders by type, then the priority field, then the creation date. Using the same tiebreak on the legacy path means the two do not disagree, and adding the id makes the order total.

**Rejected: reordering by amount, largest first**, which would make the reported case "work" by spending the 500 EUR rule last. It changes what every existing shop charges, silently, and it is a pricing policy rather than a bug fix.

**Rejected: leaving it to the new discount system.** That system already sorts correctly, but it is behind the `discount` feature flag at `state="0"`, so shops today are all on the legacy path. Making an existing query deterministic is not building on the legacy model; it is removing an accident from it.
