### PR TITLE
Say that module permissions narrow rather than grant

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Permission/Blocks/profile_tab_contents.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Permission/Blocks/profile_tab_contents.html.twig
@@ -92,6 +92,9 @@
               data-empty="{{ 'No module'|trans({}, 'Admin.Advparameters.Feature')|escape }}"
             >
             </div>
+            <p class="form-text text-muted mt-2">
+              {{ 'These permissions narrow what a profile may do with an individual module, they do not grant access on their own. Configure also requires the Edit permission on the "Modules and Services" page, and Uninstall requires Delete.'|trans({}, 'Admin.Advparameters.Help') }}
+            </p>
           </div>
         {% endif %}
       </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `AdminModuleDataProvider::isAllowedAccess()` gates every module action on a tab permission first, and only then on the per-module one:<br><br>`return $this->employee->can('edit', 'AdminModulessf') && $this->moduleProvider->can('configure', $name);`<br><br>and for uninstall, `can('delete', 'AdminModulessf') && $this->moduleProvider->can('uninstall', $name)`. So the per-module columns are an additional requirement, never a substitute. A profile with Modules and Services set to View and Add but not Edit cannot configure any module however many Configure boxes are ticked, which is the report.<br><br>The permissions screen shows the two sets side by side with nothing saying one depends on the other. This adds that sentence under the module table.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Advanced Parameters > Team > Permissions, pick a non-administrator profile: the note now sits under the module permission table. Behaviour is unchanged; nothing is granted or removed by this PR.<br><br>To see what it describes, set Modules and Services to View only for a profile, tick Configure for a module, and log in as an employee with that profile: the module still cannot be configured, and the screen now says why.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #9786
| Related PRs       | #12101, #16338 and #30788 come back to the same conjunct.
| Sponsor company   |

### The decision, and what I rejected

The code supports two readings and they lead to opposite changes, so this states which one it takes.

**Taken: the per-module matrix narrows a permission that has already been granted, and the screen was the thing that was wrong.** It matches what the code does today, it changes no behaviour, and it answers the reporter's actual complaint, which is that ticking Configure appeared to do nothing and gave no explanation.

**Rejected: dropping the `can('edit', 'AdminModulessf') &&` conjunct so Configure stands on its own.** That is the other defensible reading, and it is a one-line change, but it **widens access on every existing installation**: any profile that already has a Configure box ticked without tab Edit would gain access it does not have today. A permission check is not something to loosen as a side effect of a bug report, and if it is wanted it should be a deliberate, announced change rather than this PR.

I would rather be overruled on this than have widened a permission quietly. If the product decision is that Configure should stand alone, the conjunct is the line to change and I will do it.

### Not covered

The per-module `view` column is not read by `isAllowedAccess()` at all, so I have said nothing about it in the note rather than guess at its meaning.
