### PR TITLE
Let admin overrides win for included templates

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -476,10 +476,26 @@ class AdminControllerCore extends Controller
                 $this->bo_css = 'theme.css';
             }
 
-            $this->context->smarty->setTemplateDir([
-                _PS_BO_ALL_THEMES_DIR_ . $this->bo_theme . DIRECTORY_SEPARATOR . 'template',
-                _PS_OVERRIDE_DIR_ . 'controllers' . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'templates',
-            ]);
+            $themeTemplateDir = _PS_BO_ALL_THEMES_DIR_ . $this->bo_theme . DIRECTORY_SEPARATOR . 'template';
+            $overrideTemplateDir = _PS_OVERRIDE_DIR_ . 'controllers' . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'templates';
+
+            /*
+             * Smarty resolves a template in registration order, so a partial pulled in with {include}
+             * only picks up an override when the override directory is registered first. The numeric
+             * keys stay as they were, 0 for the theme and 1 for the override, because the admin reads
+             * them positionally in several places; assigning each directory with its own key keeps
+             * those readings intact while changing the order Smarty searches.
+             */
+            $templateDirs = Configuration::get('PS_DISABLE_OVERRIDES')
+                ? [0 => $themeTemplateDir, 1 => $overrideTemplateDir]
+                : [1 => $overrideTemplateDir, 0 => $themeTemplateDir];
+
+            $this->context->smarty->setTemplateDir([]);
+            foreach ($templateDirs as $templateDirKey => $templateDir) {
+                // Cast for the declared string|null parameter; PHP turns a numeric string key back
+                // into the integer one, so getTemplateDir(0) and (1) keep answering as before.
+                $this->context->smarty->addTemplateDir($templateDir, (string) $templateDirKey);
+            }
         }
 
         $this->id = Tab::getIdFromClassName($this->controller_name);

--- a/tests/Unit/Classes/controller/AdminTemplateDirOrderTest.php
+++ b/tests/Unit/Classes/controller/AdminTemplateDirOrderTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Smarty;
+
+/**
+ * The admin registers two template directories and Smarty resolves {include} in registration order,
+ * so an override only wins when its directory comes first. The keys have to stay 0 for the theme and
+ * 1 for the override, because Tree, TreeToolbar, TreeToolbarButton, HelperUploader, Helper and
+ * AdminController itself read them positionally.
+ */
+class AdminTemplateDirOrderTest extends TestCase
+{
+    private const THEME_DIR = '/tmp/ps-test-theme';
+    private const OVERRIDE_DIR = '/tmp/ps-test-override';
+
+    /**
+     * @dataProvider registrationOrders
+     */
+    public function testKeysStayPutWhicheverOrderIsRegistered(array $dirs, string $expectedFirst): void
+    {
+        $smarty = new Smarty();
+        $smarty->setTemplateDir([]);
+
+        foreach ($dirs as $key => $dir) {
+            $smarty->addTemplateDir($dir, $key);
+        }
+
+        $registered = $smarty->getTemplateDir();
+
+        $this->assertSame(
+            $expectedFirst,
+            rtrim((string) reset($registered), '/'),
+            'Smarty searches the directories in registration order'
+        );
+        $this->assertSame(
+            self::THEME_DIR,
+            rtrim((string) $smarty->getTemplateDir(0), '/'),
+            'index 0 must stay the theme directory whatever the order'
+        );
+        $this->assertSame(
+            self::OVERRIDE_DIR,
+            rtrim((string) $smarty->getTemplateDir(1), '/'),
+            'index 1 must stay the override directory whatever the order'
+        );
+    }
+
+    public function registrationOrders(): array
+    {
+        return [
+            'overrides enabled: the override directory is searched first' => [
+                [1 => self::OVERRIDE_DIR, 0 => self::THEME_DIR],
+                self::OVERRIDE_DIR,
+            ],
+            'overrides disabled: the theme is searched first' => [
+                [0 => self::THEME_DIR, 1 => self::OVERRIDE_DIR],
+                self::THEME_DIR,
+            ],
+        ];
+    }
+
+    /**
+     * Guards the assumption the fix rests on: passing the pair as one array loses the keys, because
+     * Smarty appends integer-keyed entries instead of assigning them.
+     */
+    public function testPassingThePairAsOneArrayWouldLoseTheKeys(): void
+    {
+        $smarty = new Smarty();
+        $smarty->setTemplateDir([1 => self::OVERRIDE_DIR, 0 => self::THEME_DIR]);
+
+        $this->assertSame(
+            self::OVERRIDE_DIR,
+            rtrim((string) $smarty->getTemplateDir(0), '/'),
+            'the array form renumbers, which is why the directories are added one at a time'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | An admin template placed in `override/controllers/admin/templates` is used when it is the template being rendered, because `AdminController::createTemplate()` looks there explicitly. A partial pulled in with `{include}` is resolved by Smarty instead, which searches the registered directories in order, and the admin registered them theme first:<br><br>`setTemplateDir([theme, override])`<br><br>so core always won and the override was never reached.<br><br>The override directory is now registered first, and last instead when `PS_DISABLE_OVERRIDES` is set, so disabling overrides keeps working. Both directories are still registered in either case.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `AdminTemplateDirOrderTest` covers the two orders and asserts that `getTemplateDir(0)` is the theme and `getTemplateDir(1)` the override in both, which is the property the rest of the admin depends on. A third case pins why the directories are added one at a time.<br><br>Manually: copy an admin partial that is reached through `{include}`, for instance `helpers/list/list_header.tpl`, into `override/controllers/admin/templates/`, change something visible, and open a list page. Before: the core version. After: the override.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #9952
| Related PRs       |
| Sponsor company   |

### The decision, and what I rejected

**Rejected: swapping the two entries in the array.** That is the obvious fix and it is what I assumed this issue needed. It does not work as a small change: `Smarty::addTemplateDir()` treats an array with integer keys as *append*, not assign, so passing `[1 => override, 0 => theme]` renumbers straight back to `[0 => override, 1 => theme]`. Every positional read then means the opposite of what it did - and there are **32** of them, in `Tree`, `TreeToolbar`, `TreeToolbarButton`, `HelperUploader`, `Helper` and `AdminController`. Rewriting all of them changes what `getTemplateDir(0)` returns for module code as well, which is a break for anything outside core that reads it.

**Taken: add the directories one at a time with an explicit key.** With a scalar and a key, Smarty assigns rather than appends, so the array becomes `[1 => override, 0 => theme]`: Smarty searches the override first, while `getTemplateDir(0)` and `getTemplateDir(1)` answer exactly as they did. No caller changes, nothing outside core changes, and the test asserts that property directly so the two cannot drift apart later.

The key is cast to string because the parameter is declared `string|null`; PHP turns a numeric string key back into the integer one, which the test also covers.

### Not covered

The same order applies in `ModuleController::configureModuleAction()`, and the lookup helper in `Tree`, `TreeToolbar`, `TreeToolbarButton` and `HelperUploader` is four near-identical copies that check the theme before the override on their own. Both are worth tidying and neither is this report, so they are left alone rather than bundled in.
