### PR TITLE
Stop listing a voucher that reduces nothing

### DIFF
--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -441,6 +441,10 @@ class CartLazyArray extends AbstractLazyArray
                     : $discountApplied->getTaxExcluded();
             }
 
+            if ($this->cartVoucherReducesNothing($cartVoucher, $freeShippingOnly, $totalCartVoucherReduction)) {
+                continue;
+            }
+
             $vouchers[$cartVoucher['id_cart_rule']]['id_cart_rule'] = $cartVoucher['id_cart_rule'];
             $vouchers[$cartVoucher['id_cart_rule']]['name'] = $cartVoucher['name'];
             $vouchers[$cartVoucher['id_cart_rule']]['code'] = $cartVoucher['code'];
@@ -485,6 +489,28 @@ class CartLazyArray extends AbstractLazyArray
     private function cartVoucherHasGiftProductReduction(array $cartVoucher): bool
     {
         return !empty($cartVoucher['gift_product']);
+    }
+
+    /**
+     * Whether the rule gives the customer nothing, in which case listing it prints "-0.00".
+     *
+     * A gift rule whose product has been deleted is the reported case: it stays attached to the cart
+     * and reduces nothing. `Cart::getSummaryDetails()` already drops a rule with no value and no free
+     * shipping; this keeps the cart page in step with it.
+     *
+     * @param array $cartVoucher
+     * @param bool $freeShippingOnly
+     * @param float|int|string $reduction
+     *
+     * @return bool
+     */
+    private function cartVoucherReducesNothing(array $cartVoucher, bool $freeShippingOnly, $reduction): bool
+    {
+        if ($freeShippingOnly || !empty($cartVoucher['free_shipping'])) {
+            return false;
+        }
+
+        return (float) $reduction === 0.0;
     }
 
     private function cartVoucherHasFreeShippingOnly(array $cartVoucher): bool

--- a/tests/Unit/Adapter/Presenter/Cart/CartVoucherVisibilityTest.php
+++ b/tests/Unit/Adapter/Presenter/Cart/CartVoucherVisibilityTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Presenter\Cart;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartLazyArray;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * A cart rule that reduces nothing and frees no shipping used to be listed as "-0.00", which is what
+ * a free gift rule looks like once its product has been deleted. `Cart::getSummaryDetails()` already
+ * drops that case; these pin the same rule for the cart page.
+ */
+class CartVoucherVisibilityTest extends TestCase
+{
+    /**
+     * @dataProvider vouchers
+     */
+    public function testItHidesOnlyTheVouchersThatGiveNothing(
+        array $cartVoucher,
+        bool $freeShippingOnly,
+        $reduction,
+        bool $expectedHidden,
+        string $message
+    ): void {
+        $method = new ReflectionMethod(CartLazyArray::class, 'cartVoucherReducesNothing');
+        $method->setAccessible(true);
+
+        $presenter = (new ReflectionClass(CartLazyArray::class))->newInstanceWithoutConstructor();
+
+        $this->assertSame(
+            $expectedHidden,
+            $method->invoke($presenter, $cartVoucher, $freeShippingOnly, $reduction),
+            $message
+        );
+    }
+
+    public function vouchers(): array
+    {
+        return [
+            [['free_shipping' => 0], false, 0, true, 'a gift rule whose product is gone gives nothing'],
+            [['free_shipping' => 0], false, '0.00', true, 'the same when the amount arrives as a string'],
+            [['free_shipping' => 0], false, 5.0, false, 'a real reduction is shown'],
+            [['free_shipping' => 0], false, 0.01, false, 'so is a very small one'],
+            [['free_shipping' => 1], true, 0, false, 'a free shipping rule shows as Free shipping'],
+            [['free_shipping' => 1], false, 0, false, 'free shipping plus a spent reduction still frees the shipping'],
+            [['free_shipping' => 1], false, 5.0, false, 'free shipping with a reduction is shown'],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The fatal in the original report is gone, as @arouiadib found in 2021 and #41050 has since covered the deleted-gift case properly. What is left is the part @Hlavtox raised in the same thread: the voucher is still listed, showing `-0.00`.<br><br>`CartLazyArray::getTemplateVarVouchers()` builds an entry for every rule the calculator returns, with nothing checking whether the rule gave anything. A gift rule whose product has been deleted stays attached to the cart and reduces nothing, so it prints an empty discount line.<br><br>`Cart::getSummaryDetails()` already drops exactly that case - `if ((float) $cart_rule['value_real'] == 0 && (int) $cart_rule['free_shipping'] == 0)`. This applies the same rule on the cart page.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `CartVoucherVisibilityTest`, seven cases on the new predicate: a rule reducing nothing is hidden, whether the amount arrives as `0` or `"0.00"`; a real reduction, however small, is shown; and a rule that frees the shipping is always shown, including when it frees shipping and its reduction has been spent. Making the predicate always return false fails two of them.<br><br>Manually: the scenario in the report. Create a free gift rule, delete the gift product, add something to the cart. Before: a voucher line reading `-€0.00`. After: no line, and the rest of the cart is unchanged.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #15224
| Related PRs       | #41050 by @nicosomb handled the ineligible free gift product itself and is what removed the fatal; this is the display half of the same thread.
| Sponsor company   |

### The decision, and what I rejected

**Taken: hide a voucher that gives nothing, matching what the cart summary already does.** It is not a new policy, it is the same condition the shop already applies one layer down, so the two stop disagreeing about whether an empty rule is worth listing.

**Rejected: removing the rule from the cart instead of hiding the line.** That is tempting and it is what a merchant might expect, but it deletes a customer's voucher as a side effect of rendering a page, and a rule can reduce nothing today and something tomorrow - a cart-total threshold not yet reached, a gift product back in stock. `CartRuleDisablerService` from #41050 is the right place for removal decisions, not the presenter.

**Rejected: keeping the line and showing "no effect" instead of the amount.** More informative in principle, but it needs a new wording and it would list rules the summary does not, which is the disagreement this PR is closing.
