### PR TITLE
Describe the physical and reserved quantities on StockAvailable

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -24,6 +24,16 @@ class StockAvailableCore extends ObjectModel
     /** @var int the group shop associated to the current product and corresponding quantity */
     public $id_shop_group;
 
+    /**
+     * @var int Quantity in stock, orders awaiting shipment included. Maintained by the stock system
+     */
+    public $physical_quantity = 0;
+
+    /**
+     * @var int Quantity held by orders that are not shipped yet. Maintained by the stock system
+     */
+    public $reserved_quantity = 0;
+
     /** @var int the quantity available for sale */
     public $quantity = 0;
 
@@ -60,6 +70,8 @@ class StockAvailableCore extends ObjectModel
             'id_shop' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'id_shop_group' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'quantity' => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'required' => true, 'range' => ['min' => StockSettings::INT_32_MAX_NEGATIVE, 'max' => StockSettings::INT_32_MAX_POSITIVE]],
+            'physical_quantity' => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'range' => ['min' => StockSettings::INT_32_MAX_NEGATIVE, 'max' => StockSettings::INT_32_MAX_POSITIVE]],
+            'reserved_quantity' => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'range' => ['min' => StockSettings::INT_32_MAX_NEGATIVE, 'max' => StockSettings::INT_32_MAX_POSITIVE]],
             'depends_on_stock' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => true],
             'out_of_stock' => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'required' => true],
             'location' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 255],
@@ -75,6 +87,11 @@ class StockAvailableCore extends ObjectModel
             'id_product_attribute' => ['xlink_resource' => 'combinations'],
             'id_shop' => ['xlink_resource' => 'shops'],
             'id_shop_group' => ['xlink_resource' => 'shop_groups'],
+            // Readable but not writable: both are derived from the orders and the stock movements,
+            // physical_quantity being quantity plus reserved_quantity. A client setting either one
+            // directly would be overwritten by the next movement and inconsistent until then.
+            'physical_quantity' => ['setter' => false],
+            'reserved_quantity' => ['setter' => false],
         ],
         'hidden_fields' => [
         ],

--- a/tests/Integration/Classes/Stock/StockAvailableDefinitionTest.php
+++ b/tests/Integration/Classes/Stock/StockAvailableDefinitionTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Stock;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use StockAvailable;
+
+class StockAvailableDefinitionTest extends TestCase
+{
+    /**
+     * The reported defect: physical_quantity and reserved_quantity have been columns since 1.7.2 and
+     * were never added to the model, so the webservice could not see them. Comparing the definition
+     * against the table catches the next column that is added without one.
+     */
+    public function testTheDefinitionCoversEveryColumnOfTheTable(): void
+    {
+        $table = _DB_PREFIX_ . StockAvailable::$definition['table'];
+
+        $columns = array_column(
+            Db::getInstance()->executeS('SHOW COLUMNS FROM `' . $table . '`') ?: [],
+            'Field'
+        );
+
+        $this->assertNotEmpty($columns, 'the table must be readable for this test to mean anything');
+
+        $known = array_merge(
+            array_keys(StockAvailable::$definition['fields']),
+            [StockAvailable::$definition['primary']]
+        );
+
+        $this->assertSame(
+            [],
+            array_values(array_diff($columns, $known)),
+            'every column of ' . $table . ' should be described by the object model'
+        );
+    }
+
+    /**
+     * Both are derived by the stock system, so the webservice may read them and must not write them,
+     * the way Category::level_depth is handled.
+     */
+    public function testTheDerivedQuantitiesAreNotWritableThroughTheWebservice(): void
+    {
+        $stockAvailable = new StockAvailable();
+
+        $reflection = new ReflectionProperty(StockAvailable::class, 'webserviceParameters');
+        $reflection->setAccessible(true);
+        $parameters = $reflection->getValue($stockAvailable);
+
+        foreach (['physical_quantity', 'reserved_quantity'] as $field) {
+            $this->assertArrayHasKey($field, $parameters['fields'], $field . ' should be exposed');
+            $this->assertFalse(
+                $parameters['fields'][$field]['setter'],
+                $field . ' is maintained by the stock system and must not be settable'
+            );
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `stock_available` has carried `physical_quantity` and `reserved_quantity` since 1.7.2, and `StockAvailable::$definition` never described them. The model lists eight fields against eleven columns, so the two are invisible to anything going through the object model, the webservice included, which is the report.<br><br>They are added to the definition, with the properties defaulting to `0` to match `NOT NULL DEFAULT 0` on the columns, and exposed to the webservice **read only**.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `StockAvailableDefinitionTest` has two cases. One compares the definition against `SHOW COLUMNS` and fails if any column has no field, which is what would have caught this in 2019 and what will catch the next column added without one; removing the two fields fails it. The other asserts both are exposed with `setter` false.<br><br>`StockManagementControllerTest` and the rest of the stock integration tests stay green, 20 tests.<br><br>Through the webservice: `GET /api/stock_availables/1` now returns the two values, and sending them back in a `PUT` leaves them untouched.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #15976
| Related PRs       |
| Sponsor company   |

### The decision, and what I rejected

**Taken: expose them, read only.** `physical_quantity` is `quantity + reserved_quantity`, maintained by `StockAvailableRepository::updatePhysicalProductQuantity()`, and `reserved_quantity` follows the orders. A client setting either would be overwritten by the next stock movement and would leave the trio inconsistent until then. `setter => false` is how the same problem is already handled for `Category::level_depth` and `Customer::secure_key`, so this is the existing convention rather than a new one.

**Rejected: making them writable**, which is the literal reading of the report - it asks to update physical quantities over the webservice. It would let a client desynchronise stock silently, and the supported way to change a quantity is `quantity`, which stays writable and drives the other two.

**Rejected: leaving the definition alone and exposing them only through `webserviceParameters`.** The title of the report is that the object model does not reflect the table, and a field the model does not describe is not read from the database at all, so there would be nothing to expose.

### One thing worth flagging

Adding the fields made `StockManagementControllerTest::testItShouldReturnValidResponseWhenRequestingProductsCombinationsStockEdition` return 500 instead of 404, because an unloaded `StockAvailable` had `null` where the validator wants an integer. Defaulting both properties to `0`, which is what the columns declare, restores it. Worth knowing if anyone adds another field here.
