### PR TITLE
Refresh the module version shown after an upgrade

### DIFF
--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -400,6 +400,18 @@ export default class ModuleCard {
         } else if (action === 'update' || action === 'upgrade') { // because the action is update on ModuleManager button and upgrade on bulk actions
           mainElement = jqElementObj.closest(`.${alteredSelector}`);
 
+          // The version sits outside the action menu, so it survives the replacement below and would
+          // keep showing the number the module had before the upgrade until the page is reloaded.
+          const upgraded = result[moduleTechName];
+
+          if (upgraded.version !== undefined) {
+            mainElement.attr('data-version', upgraded.version);
+          }
+
+          if (upgraded.version_html !== undefined) {
+            mainElement.find('.js-module-version').html(upgraded.version_html);
+          }
+
           this.eventEmitter.emit('Module Upgraded', mainElement);
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -286,6 +286,15 @@ class ModuleController extends ModuleAbstractController
                     'level' => $this->getAuthorizationLevel(self::CONTROLLER_NAME),
                 ]
             );
+
+            // The card shows the version outside the action menu, so replacing the menu alone leaves
+            // the old number on screen after an upgrade. Send the line back rendered rather than
+            // reloading the page: bulk upgrades run one after another and a reload would drop the
+            // ones still queued.
+            $response[$moduleName]['version'] = $collectionPresented[0]->attributes->get('version');
+            $response[$moduleName]['version_html'] = $this->twig->load(
+                '@PrestaShop/Admin/Module/Includes/card_manage_installed.html.twig'
+            )->renderBlock('addon_version', ['module' => $collectionPresented[0]]);
         } else {
             $response[$moduleName]['msg'] = $this->trans(
                 'Cannot %action% module %module%. %error_details%',

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -46,7 +46,7 @@
           </h3>
         </div>
         <div class="col-md-2">
-          <div class="text-ellipsis small-text">
+          <div class="text-ellipsis small-text js-module-version">
             {% block addon_version %}
               {% if module.attributes.productType == 'service' %}
                 {{ 'Service by %author%'|trans({'%author%': '<b>' ~ module.attributes.author ~ '</b>'}, 'Admin.Modules.Feature')|raw_purified }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Upgrading a module from the Module Manager leaves the old version number on the card until the page is reloaded by hand.<br><br>The action response carries `action_menu_html`, and `module-card.ts` replaces the action menu with it. The version is rendered outside that menu, in the `addon_version` block of `card_list.html.twig`, so nothing touches it. A reload does happen, but only when the response sets `refresh_needed`, and for an upgrade that falls through to `moduleNeedsReload()`, which is true only for a module that has admin tabs or hooks `actionListModules`. Anything else keeps the stale number.<br><br>The response now also carries the re-rendered version line, and the card writes it into a `js-module-version` hook on the container the `addon_version` block already lives in, so every card template inherits it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Module Manager with a module that has an update available and no admin tab, for example a plain display module. Click Update. Before: the notification says the update finished and the card still reads the old `v…`. After: the version line updates with it, without a page reload.<br><br>Bulk upgrade of several modules at once still runs them all.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #16066
| Related PRs       |
| Sponsor company   |

### The decision, and what I rejected

**Rejected: setting `refresh_needed` for upgrades**, which is a one-line server change, is what the existing mechanism is for, and is literally what the report asks for - "the page is reloaded to display the correct version number". It breaks bulk upgrades. `controller.js` chains the queued modules through `unstackModulesActions`, one request at a time, so the first module to report `refresh_needed` reloads the page and everything still queued is lost. That already happens today for modules with admin tabs; making it the rule for every upgrade would turn a ten-module bulk upgrade into a one-module upgrade.

**Taken: send the version back and update it in place.** It is the same shape as `action_menu_html`, which the response already does for the part of the card that does get refreshed, so this extends an existing mechanism rather than adding one. Bulk is unaffected.

### Not covered by a test

There is no harness here for a controller response feeding a jQuery card update, and I have not added a UI test since the campaign is paused. The pieces are checked individually - `lint:twig`, ESLint and `tsc` on the changed files, PHPStan and php-cs-fixer on the controller - but the round trip itself is only covered by the manual steps above. Saying so rather than implying more.
