### PR TITLE
Do not require a customer field the shop does not collect

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -221,6 +221,37 @@ class CustomerCore extends ObjectModel
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
+    /**
+     * {@inheritdoc}
+     *
+     * Partner offers and the birthdate are each hidden by a setting of their own, while whether they
+     * are required is decided on a different screen, so the two can disagree. When they do, the field
+     * is never rendered and never submitted, and requiring it makes registration impossible: the form
+     * cannot show it and validation refuses the account without it.
+     *
+     * A field the shop does not collect is therefore dropped from the required list.
+     */
+    public function getCachedFieldsRequiredDatabase($all = false)
+    {
+        $requiredFields = parent::getCachedFieldsRequiredDatabase($all);
+
+        if ($all) {
+            return $requiredFields;
+        }
+
+        $notCollected = [];
+
+        if (!Configuration::get('PS_CUSTOMER_OPTIN')) {
+            $notCollected[] = 'optin';
+        }
+
+        if (!Configuration::get('PS_CUSTOMER_BIRTHDATE')) {
+            $notCollected[] = 'birthday';
+        }
+
+        return $notCollected === [] ? $requiredFields : array_diff($requiredFields, $notCollected);
+    }
+
     public function add($autoDate = true, $nullValues = true)
     {
         $this->id_shop = ($this->id_shop) ? $this->id_shop : Context::getContext()->shop->id;

--- a/tests/Integration/Classes/CustomerRequiredFieldsTest.php
+++ b/tests/Integration/Classes/CustomerRequiredFieldsTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Customer;
+use Db;
+use ObjectModel;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * Marking a field required while the setting that shows it is off used to make registration
+ * impossible: the form never renders the field, nothing is submitted for it, and
+ * ObjectModel::validateFieldsRequiredDatabase() refuses the account.
+ */
+class CustomerRequiredFieldsTest extends TestCase
+{
+    /** @var array<string, mixed> */
+    private array $previousConfiguration = [];
+
+    /** @var int[] */
+    private array $insertedRequiredFields = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (['PS_CUSTOMER_OPTIN', 'PS_CUSTOMER_BIRTHDATE'] as $key) {
+            $this->previousConfiguration[$key] = Configuration::get($key);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->previousConfiguration as $key => $value) {
+            Configuration::updateValue($key, $value);
+        }
+
+        foreach ($this->insertedRequiredFields as $id) {
+            Db::getInstance()->delete('required_field', 'id_required_field = ' . (int) $id);
+        }
+        $this->insertedRequiredFields = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider hiddenFields
+     */
+    public function testAFieldTheShopDoesNotCollectIsNotRequired(string $field, string $setting): void
+    {
+        $this->requireField($field);
+
+        Configuration::updateValue($setting, 0);
+        $this->forgetTheRequiredFieldCache();
+        $this->assertNotContains(
+            $field,
+            (new Customer())->getCachedFieldsRequiredDatabase(),
+            $field . ' cannot be required while ' . $setting . ' hides it'
+        );
+
+        Configuration::updateValue($setting, 1);
+        $this->forgetTheRequiredFieldCache();
+        $this->assertContains(
+            $field,
+            (new Customer())->getCachedFieldsRequiredDatabase(),
+            $field . ' stays required once the shop collects it again'
+        );
+    }
+
+    public function hiddenFields(): array
+    {
+        return [
+            'partner offers' => ['optin', 'PS_CUSTOMER_OPTIN'],
+            'birthdate' => ['birthday', 'PS_CUSTOMER_BIRTHDATE'],
+        ];
+    }
+
+    /**
+     * The required fields are cached in a static, so a row inserted by this test is invisible until
+     * the cache is dropped.
+     */
+    private function forgetTheRequiredFieldCache(): void
+    {
+        $cache = new ReflectionProperty(ObjectModel::class, 'fieldsRequiredDatabase');
+        $cache->setAccessible(true);
+        $cache->setValue(null, null);
+    }
+
+    private function requireField(string $field): void
+    {
+        $existing = (int) Db::getInstance()->getValue(
+            'SELECT id_required_field FROM ' . _DB_PREFIX_ . "required_field
+             WHERE object_name = 'Customer' AND field_name = '" . pSQL($field) . "'"
+        );
+
+        if ($existing) {
+            return;
+        }
+
+        Db::getInstance()->insert('required_field', ['object_name' => 'Customer', 'field_name' => $field]);
+        $this->insertedRequiredFields[] = (int) Db::getInstance()->Insert_ID();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | With "Enable partner offers" off and `optin` marked as a required field, nobody can create an account or check out as a guest.<br><br>The two switches live on different screens and nothing ties them together. `CustomerFormatter` adds the `optin` field only `if ($this->ask_for_partner_optin)`, which is `PS_CUSTOMER_OPTIN`, so with the setting off the checkbox is never rendered and nothing is submitted for it. `ObjectModel::validateFieldsRequiredDatabase()` then reads `Tools::getValue('optin', null)`, gets `null`, and returns "The field is required". The field cannot be filled in and the account cannot be created.<br><br>`birthday` has exactly the same shape behind `PS_CUSTOMER_BIRTHDATE`, so it is fixed with it rather than left for the next report.<br><br>`Customer` now drops from its required list any field the shop does not collect.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `CustomerRequiredFieldsTest` covers both fields: with the setting off the field is not required, with it on it is required again. Removing the filter fails both with `Failed asserting that an array does not contain 'optin'` and the same for `birthday`.<br><br>Manually: the steps in the report. Shop Parameters > Customer Settings, turn off "Enable partner offers"; Customers > set Partner offers as required; then register from the front office. Before: "Receive offers from our partners is required" and no account. After: the account is created. Turning the setting back on makes the checkbox appear and required again.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #16196
| Related PRs       |
| Sponsor company   |

### The decision, and what I rejected

**Taken: the class that owns the field decides whether it can be required.** `Customer::getCachedFieldsRequiredDatabase()` is the one place `validateFieldsRequiredDatabase()` reads, so filtering there fixes existing shops immediately and keeps the rule next to the fields it is about.

**Rejected: filtering in `ObjectModel`.** It is the generic base and knows nothing about `PS_CUSTOMER_OPTIN`; putting a customer setting there would be the wrong layer.

**Rejected: preventing the field being marked required in the back office.** Worth doing on its own, but it does nothing for a shop already in this state, which is every shop that hit this report.

**Rejected: submitting a default value for the hidden field.** It would make validation pass by writing data the customer never agreed to, and for partner offers that is a consent flag.

### Scope

`optin` and `birthday` are the two customer fields with a setting that hides them; the rest are always collected. If another one gains such a setting, it belongs in the same list.
