### PR TITLE
Do not list a theme language file that is not there

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -445,7 +445,12 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         // Theme files
         if (!$check || ((string) $iso_from) != 'en') {
-            $files_theme[$tPath_from . 'lang/' . (string) $iso_from . '.php'] = ($copy ? $tPath_to . 'lang/' . (string) $iso_to . '.php' : ++$number);
+            // Listed only when it is there, as every other entry below already does. A theme without a
+            // lang directory, which is every theme shipped since the move to XLIFF, otherwise puts a
+            // source that does not exist into the list and the copy reports it as a failure.
+            if (file_exists($tPath_from . 'lang/' . (string) $iso_from . '.php')) {
+                $files_theme[$tPath_from . 'lang/' . (string) $iso_from . '.php'] = ($copy ? $tPath_to . 'lang/' . (string) $iso_to . '.php' : ++$number);
+            }
 
             // Override for pdf files in the theme
             if (file_exists($pPath_from . 'lang/' . (string) $iso_from . '.php')) {

--- a/tests/Integration/Classes/LanguageFilesListTest.php
+++ b/tests/Integration/Classes/LanguageFilesListTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Language;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Copying a language between themes listed the source theme's lang/<iso>.php whether or not it was
+ * there. No theme shipped since translations moved to XLIFF has that directory, so the copy always
+ * had one source it could not read and reported it as a failure.
+ */
+class LanguageFilesListTest extends TestCase
+{
+    public function testItDoesNotListAThemeLanguageFileThatIsNotThere(): void
+    {
+        $missing = _PS_ROOT_DIR_ . '/themes/classic/lang/cs.php';
+        $this->assertFileDoesNotExist($missing, 'the shipped theme is expected to have no lang directory');
+
+        $files = Language::getFilesList('cs', 'classic', 'cs', 'hummingbird', false, false, true);
+
+        $this->assertArrayNotHasKey($missing, $files, 'a source that is not there must not be listed');
+    }
+
+    /**
+     * Everything listed has to be readable, otherwise the copier reports a failure per entry.
+     */
+    public function testEverythingListedForACopyExists(): void
+    {
+        $files = Language::getFilesList('en', 'classic', 'en', 'hummingbird', false, false, true);
+
+        $unreadable = array_values(array_filter(
+            array_keys($files),
+            static function (string $source): bool {
+                return !file_exists($source);
+            }
+        ));
+
+        $this->assertSame([], $unreadable, 'the copy list must only contain sources that exist');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | International > Translations > Copy fails between themes with `Impossible to copy ".../themes/<from>/lang/<iso>.php" to ".../themes/<to>/lang/<iso>.php"`.<br><br>`Language::getFilesList()` adds the source theme's `lang/<iso>.php` to the list **unconditionally**, while every neighbouring entry is guarded: the theme's pdf override, the theme's module overrides and the module files are each behind a `file_exists()`. No theme shipped since translations moved to XLIFF has a `lang/` directory - neither `classic` nor `hummingbird` does - so the list always carries one source that cannot be read, and `LanguageCopier` reports it.<br><br>That is also why the workaround in the thread works: creating the folder with an empty file makes the source exist.<br><br>The entry is now listed only when the file is there, like the ones around it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `LanguageFilesListTest` asserts that a theme language file that is not there is not listed, and that every source in a copy list exists. Removing the guard fails both.<br><br>Manually: International > Translations, Copy from one theme to another for the same language. Before: the error above. After: the copy completes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #16132
| Related PRs       |
| Sponsor company   |

### The decision, and what I rejected

**Taken: guard the entry, matching the lines around it.** It is the smallest change that removes the failure and it makes the one unguarded entry consistent with the rest of the same method.

**Rejected: creating the destination `lang/` directory and an empty file**, which is the workaround from the thread. It would make the error go away by writing files that nothing reads, and the copy still would not carry any translation.

**Rejected: removing the theme part of the copy altogether.** Measured on a 9.2 install, three of the four things this feature copies no longer exist: `translations/<iso>/{admin,errors,pdf,tabs}.php` is gone, no shipped theme has `lang/`, and no module has a `lang/` directory. Only the mail templates under `mails/<iso>/` are still there. So the feature is largely vestigial and probably deserves a look of its own, but deciding its future is a bigger question than this report, and a custom theme may still ship `lang/` files that this copy is meant to move.

### What this does not fix

@Maofree's follow-up, that the copy runs without error and the translations are still not changed, is the same observation from the other side: with no theme `lang/` files to copy, there is nothing for it to change. That is the vestigial-feature question above rather than a defect in this method.
