### PR TITLE
Import an image caption into the language being imported

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -908,6 +908,45 @@ class AdminImportControllerCore extends AdminController
         return $tab;
     }
 
+    /**
+     * Builds the language values for an imported image caption.
+     *
+     * `createMultiLangField()` puts the same text in every language, so importing the French file
+     * writes a French caption into English too, and the next import in another language looks like it
+     * overwrote everything. The caption belongs to the language being imported.
+     *
+     * This applies the rule `fillInfo()` already uses for the other multilingual fields: the chosen
+     * language gets the value, the rest are left alone. Without a language chosen the previous
+     * behaviour is kept, since there is nothing to single out.
+     *
+     * @param string $field
+     *
+     * @return array
+     */
+    protected static function createMultiLangFieldForImportedLanguage($field)
+    {
+        $values = self::createMultiLangField($field);
+        $isoLang = Tools::getValue('iso_lang');
+
+        if (!$isoLang) {
+            return $values;
+        }
+
+        $idLang = (int) Language::getIdByIso($isoLang);
+
+        if (!$idLang) {
+            return $values;
+        }
+
+        foreach (array_keys($values) as $idLangValue) {
+            if ((int) $idLangValue !== $idLang) {
+                $values[$idLangValue] = '';
+            }
+        }
+
+        return $values;
+    }
+
     protected static function createMultiLangField($field)
     {
         $res = [];
@@ -2007,7 +2046,7 @@ class AdminImportControllerCore extends AdminController
                         $image->cover = (!$key && !$product_has_images) ? true : false;
                         $alt = $product->image_alt[$key];
                         if (strlen($alt) > 0) {
-                            $image->legend = self::createMultiLangField($alt);
+                            $image->legend = self::createMultiLangFieldForImportedLanguage($alt);
                         }
                         // file_exists doesn't work with HTTP protocol
                         if (($field_error = $image->validateFields(UNFRIENDLY_ERROR, true)) === true
@@ -2254,7 +2293,7 @@ class AdminImportControllerCore extends AdminController
                     if (isset($info['image_alt'])) {
                         $alt = self::split($info['image_alt']);
                         if (isset($alt[$key]) && strlen($alt[$key]) > 0) {
-                            $alt = self::createMultiLangField($alt[$key]);
+                            $alt = self::createMultiLangFieldForImportedLanguage($alt[$key]);
                             $image->legend = $alt;
                         }
                     }

--- a/tests/Integration/Classes/ImportImageCaptionLanguageTest.php
+++ b/tests/Integration/Classes/ImportImageCaptionLanguageTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use AdminImportControllerCore;
+use Db;
+use Language;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * An imported image caption belongs to the language being imported. Writing it into every language is
+ * what made a second import in another language look like it overwrote the first.
+ */
+class ImportImageCaptionLanguageTest extends TestCase
+{
+    /** @var mixed */
+    private $previousIsoLang;
+
+    /** @var int */
+    private int $addedLanguageId = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousIsoLang = $_GET['iso_lang'] ?? null;
+
+        // The test shop ships a single language, and one language cannot show whether a caption stayed
+        // out of the others. Add a second one for the duration of the test.
+        if (count(Language::getIDs(false)) < 2) {
+            Db::getInstance()->insert('lang', [
+                'name' => 'Test language',
+                'active' => 1,
+                'iso_code' => 'zz',
+                'language_code' => 'zz-zz',
+                'locale' => 'zz-ZZ',
+                'date_format_lite' => 'Y-m-d',
+                'date_format_full' => 'Y-m-d H:i:s',
+                'is_rtl' => 0,
+            ]);
+            $this->addedLanguageId = (int) Db::getInstance()->Insert_ID();
+            Db::getInstance()->insert('lang_shop', ['id_lang' => $this->addedLanguageId, 'id_shop' => 1]);
+            $this->forgetTheLanguageCache();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousIsoLang === null) {
+            unset($_GET['iso_lang']);
+        } else {
+            $_GET['iso_lang'] = $this->previousIsoLang;
+        }
+
+        if ($this->addedLanguageId) {
+            Db::getInstance()->delete('lang_shop', 'id_lang = ' . $this->addedLanguageId);
+            Db::getInstance()->delete('lang', 'id_lang = ' . $this->addedLanguageId);
+            $this->addedLanguageId = 0;
+            $this->forgetTheLanguageCache();
+        }
+
+        parent::tearDown();
+    }
+
+    private function forgetTheLanguageCache(): void
+    {
+        $cache = new ReflectionProperty(Language::class, '_LANGUAGES');
+        $cache->setAccessible(true);
+        $cache->setValue(null, null);
+    }
+
+    public function testTheCaptionOnlyLandsInTheImportedLanguage(): void
+    {
+        $languages = Language::getIDs(false);
+
+        $this->assertGreaterThan(1, count($languages), 'the setup must provide a second language');
+
+        $idLang = (int) Language::getIdByIso('en');
+        $this->assertNotEmpty($idLang, 'the shop is expected to have English installed');
+
+        $_GET['iso_lang'] = 'en';
+
+        $values = $this->buildCaption('A printed t-shirt');
+
+        $this->assertSame('A printed t-shirt', $values[$idLang]);
+
+        foreach ($values as $id => $value) {
+            if ((int) $id !== $idLang) {
+                $this->assertSame('', $value, 'a language that was not imported must be left empty');
+            }
+        }
+    }
+
+    public function testWithoutAChosenLanguageEveryLanguageIsStillFilled(): void
+    {
+        unset($_GET['iso_lang']);
+
+        $values = $this->buildCaption('A printed t-shirt');
+
+        $this->assertNotEmpty($values);
+
+        foreach ($values as $value) {
+            $this->assertSame('A printed t-shirt', $value, 'the previous behaviour is kept when no language is chosen');
+        }
+    }
+
+    private function buildCaption(string $caption): array
+    {
+        $method = new ReflectionMethod(AdminImportControllerCore::class, 'createMultiLangFieldForImportedLanguage');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $caption);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Importing image captions per language does not keep them apart: whichever language file is imported last ends up in every language, which is what @liviu-v describes on 8.1.7 and the original report on 1.7.5.<br><br>The importer builds the caption with `createMultiLangField()`, and that helper writes the same string into every installed language:<br><br>`foreach (Language::getIDs(false) as $id_lang) { $res[$id_lang] = $field; }`<br><br>so a French import also writes the French caption into English. The other multilingual fields do not behave that way because they go through `fillInfo()`, which reads the `iso_lang` chosen on the import form and only fills the language it names.<br><br>Image captions now follow the same rule. Without a language chosen the previous behaviour is kept, since there is nothing to single out.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `ImportImageCaptionLanguageTest` adds a second language for the duration of the test, because one language cannot show whether a caption stayed out of the others, and asserts the caption lands only in the imported language, and that with no language chosen every language is still filled. Reverting the helper fails the first.<br><br>Manually: import a CSV of `id` and `image_alt` with the language set to English, then the same for another language. Before: the second import's text appears under both. After: each language keeps its own.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #14934
| Related PRs       |
| Sponsor company   |

### The decision, and what I rejected

**Taken: apply the rule the importer already has.** `fillInfo()` decides this for every other multilingual field, so the captions follow it rather than getting a rule of their own.

**Rejected: registering `image_alt` in `self::$validators` so `fillInfo()` handles it.** That looks tidier and it is where the rule lives, but the captions are not assigned through `fillInfo()`: they are built inside the image loops, one per image URL, from a value that has already been split on the multiple-value separator. Routing them through the generic path would mean restructuring how images are read, for the same result.

**Rejected: filling the other languages with the value when they are empty**, which is what `fillInfo()` does for a field being updated. An image created by the import has no captions at all, so "empty" is every other language, and it would put the imported text back into all of them - the behaviour being fixed.
