### PR TITLE
File webservice images under the collection they belong to in JSON

### DIFF
--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -25,6 +25,12 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
      */
     protected $content = [];
 
+    /**
+     * @var string Name of the collection currently being opened, used when no resource configuration
+     *             supplies one. The images resource renders its own nodes and passes no parameters.
+     */
+    protected $currentCollectionNodeName = '';
+
     public function __construct($languages = [])
     {
         $this->languages = $languages;
@@ -103,8 +109,19 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
         if ($isAPICall && !in_array($node_name, ['description', 'schema', 'api'])) {
             $this->content[] = $node_name;
         }
+        // A resource rendered from a configuration names its collection in the parameters. The images
+        // resource builds its nodes itself and passes none, so remember the collection it opened and
+        // use that instead of indexing a key that is not there.
+        if ($has_child && $more_attr === null) {
+            $this->currentCollectionNodeName = $node_name;
+        }
+
         if (isset($more_attr, $more_attr['id'])) {
-            $this->content[$params['objectsNodeName']][] = ['id' => $more_attr['id']];
+            $objectsNodeName = $params['objectsNodeName'] ?? $this->currentCollectionNodeName;
+
+            if ($objectsNodeName !== '') {
+                $this->content[$objectsNodeName][] = ['id' => $more_attr['id']];
+            }
         }
 
         return '';

--- a/tests/Unit/Classes/webservice/WebserviceOutputJsonImagesTest.php
+++ b/tests/Unit/Classes/webservice/WebserviceOutputJsonImagesTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Webservice;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use WebserviceOutputJSONCore;
+
+/**
+ * The images resource renders its own nodes and passes no parameters, so the JSON renderer used to
+ * index objectsNodeName on an empty array: a PHP notice, and every entry filed under an empty key.
+ */
+class WebserviceOutputJsonImagesTest extends TestCase
+{
+    public function testTheImagesAreFiledUnderTheCollectionThatWasOpened(): void
+    {
+        $renderer = new WebserviceOutputJSONCore();
+
+        // What WebserviceSpecificManagementImages does: open the collection, then one node per image.
+        $renderer->renderNodeHeader('images', []);
+        $renderer->renderNodeHeader('image', [], ['id' => 221], false);
+        $renderer->renderNodeHeader('image', [], ['id' => 711], false);
+
+        $content = $this->contentOf($renderer);
+
+        $this->assertArrayNotHasKey('', $content, 'nothing may be filed under an empty key');
+        $this->assertSame(
+            [['id' => 221], ['id' => 711]],
+            $content['images'] ?? null
+        );
+    }
+
+    public function testAConfiguredResourceStillUsesItsOwnCollectionName(): void
+    {
+        $renderer = new WebserviceOutputJSONCore();
+
+        $renderer->renderNodeHeader('images', []);
+        $renderer->renderNodeHeader('product', ['objectsNodeName' => 'products'], ['id' => 1], false);
+
+        $content = $this->contentOf($renderer);
+
+        $this->assertSame([['id' => 1]], $content['products'] ?? null, 'the parameters still win');
+        $this->assertArrayNotHasKey('images', $content);
+    }
+
+    private function contentOf(WebserviceOutputJSONCore $renderer): array
+    {
+        $content = new ReflectionProperty(WebserviceOutputJSONCore::class, 'content');
+        $content->setAccessible(true);
+
+        return $content->getValue($renderer);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `GET /api/images/products/<id>?output_format=JSON` returns a PHP notice and files every image under an empty key:<br><br>`{"":[{"id":"221"},{"id":"711"}],"errors":[{"code":5,"message":"[PHP Notice #8] Undefined index: objectsNodeName ..."}]}`<br><br>A resource rendered from a configuration names its collection in the parameters. The images resource is not one of those: `WebserviceSpecificManagementImages` builds its own nodes and calls `renderNodeHeader('images', [])` then `renderNodeHeader('image', [], ['id' => …], false)`, with no parameters at all. `WebserviceOutputJSON::renderNodeHeader()` then indexes `$params['objectsNodeName']` without checking, which is the notice, and the empty result becomes the array key. XML is unaffected because it renders from the node name it is given.<br><br>The renderer now remembers the collection it opened and uses that when the parameters do not name one. `getNodeName()` and `renderNodeFooter()` right below already guard the neighbouring key the same way.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `WebserviceOutputJsonImagesTest` replays what the images resource does and asserts the entries land under `images` with nothing under an empty key, and that a resource which does name its collection still wins. Restoring the unguarded index fails the first.<br><br>Manually: `GET /api/images/products/<id>?output_format=JSON`. Before: the notice above and `{"":[…]}`. After: `{"images":[{"id":…}]}`. The XML output is unchanged.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #15499
| Related PRs       | #27366 by @KminekMatej covered this as part of a rework of the whole webservice output layer, 10 files and +813/-649. It was closed after a long review; this does not reopen it.
| Sponsor company   |

### The decision, and what I rejected

@paulnoelcholot's note on the issue is that this will not be fixed by the team and that a pull request is welcome, so this is that, kept as small as the report allows.

**Rejected: reviving #27366.** It is the obvious candidate, and it does fix this, but it replaces the output builder, both renderers and the images manager at once. It was closed after three years of review rather than through neglect, so bringing it back is a decision about the webservice layer and not about this notice.

**Rejected: giving the images resource an `objectsNodeName` in its parameters.** It reads as the tidier fix, but that resource renders several different collections in one response - `image_types`, `languages`, `images`, `declination` - so a single name in the parameters would be wrong for most of them. The name is already passed correctly as the node name; the renderer just was not using it.

**Rejected: only silencing the notice** with a null coalesce to an empty string. It removes the warning and keeps the entries filed under `""`, which is the part that actually breaks a client.
