### PR TITLE
Apply position_in_category once the category association exists

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -45,6 +45,13 @@ class ProductCore extends ObjectModel
     /** @var int default Category identifier */
     public $id_category_default;
 
+    /**
+     * Position asked for through the webservice while the category association did not exist yet.
+     *
+     * @var int|null
+     */
+    protected $ws_position_in_category;
+
     /** @var int default Shop identifier */
     public $id_shop_default;
 
@@ -6801,6 +6808,12 @@ class ProductCore extends ObjectModel
             );
         }
 
+        if ($return && $this->ws_position_in_category !== null) {
+            $position = $this->ws_position_in_category;
+            $this->ws_position_in_category = null;
+            $this->setWsPositionInCategory($position);
+        }
+
         Hook::exec('actionProductUpdate', ['id_product' => (int) $this->id]);
 
         return $return;
@@ -7001,9 +7014,17 @@ class ProductCore extends ObjectModel
             'ORDER BY `position`'
         );
 
-        $sizeResult = count($result);
+        foreach ($result as &$value) {
+            $value = (int) $value['id_product'];
+        }
+        unset($value);
 
-        if ($position > $sizeResult && $sizeResult > 0) {
+        $sizeResult = count($result);
+        $isInCategory = in_array((int) $this->id, $result, true);
+        // A product that is not in the category yet adds a slot to it, so the last free position is one further.
+        $lastPosition = $isInCategory ? $sizeResult : $sizeResult + 1;
+
+        if ($position > $lastPosition && $sizeResult > 0) {
             WebserviceRequest::getInstance()->setError(
                 500,
                 $this->trans(
@@ -7017,19 +7038,30 @@ class ProductCore extends ObjectModel
             return false;
         }
 
-        foreach ($result as &$value) {
-            $value = $value['id_product'];
+        if (!$isInCategory) {
+            /*
+             * The webservice runs the field setters before it saves the object and before it applies the
+             * associations, so on a creation the category link this position refers to does not exist yet.
+             * Keep the request and let setWsCategories() apply it once the rows are in place; reordering
+             * the rest of the category here would rewrite other products' positions for nothing.
+             */
+            $this->ws_position_in_category = (int) $position;
+
+            return true;
         }
+
         // result is indexed by recordset order and not position. positions start at index 1 so we need an empty element
         array_unshift($result, null);
 
-        $current_position = $this->getWsPositionInCategory();
-
-        if ($current_position && isset($result[$current_position])) {
-            $save = $result[$current_position];
-            unset($result[$current_position]);
-            array_splice($result, (int) $position, 0, $save);
-        }
+        /*
+         * The product is located by its place in the ordered list rather than by the position stored
+         * against it: dropping a category from a product's associations vacates a position without
+         * renumbering the rest, and after that the stored value no longer indexes the list.
+         */
+        $current_index = array_search((int) $this->id, $result, true);
+        $save = $result[$current_index];
+        unset($result[$current_index]);
+        array_splice($result, (int) $position, 0, $save);
 
         foreach ($result as $position => $id_product) {
             Db::getInstance()->update('category_product', [

--- a/tests/Integration/Classes/Product/WsPositionInCategoryTest.php
+++ b/tests/Integration/Classes/Product/WsPositionInCategoryTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Category;
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+use Tools;
+
+/**
+ * The webservice runs a resource's field setters before it saves the object and before it applies the
+ * associations, so on a creation position_in_category is asked for while the category link it refers to
+ * does not exist yet. Each test replays that order rather than calling the setter on a ready product.
+ *
+ * @see \WebserviceRequestCore::saveEntityFromXml()
+ */
+class WsPositionInCategoryTest extends TestCase
+{
+    private const SIZE = 5;
+
+    private Category $category;
+
+    private Category $otherCategory;
+
+    /** @var Product[] */
+    private array $products = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->category = $this->createCategory('ws position');
+        $this->otherCategory = $this->createCategory('ws position elsewhere');
+
+        for ($i = 0; $i < self::SIZE; ++$i) {
+            $product = $this->createProduct('ws position product ' . $i);
+            $product->add();
+            $product->addToCategories([$this->category->id]);
+            $this->products[] = $product;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->products as $product) {
+            if ($product->id) {
+                Db::getInstance()->delete('category_product', 'id_product = ' . (int) $product->id);
+                $product->delete();
+            }
+        }
+        $this->category->delete();
+        $this->otherCategory->delete();
+        $this->products = [];
+
+        parent::tearDown();
+    }
+
+    public function testACreatedProductLandsAtTheRequestedPosition(): void
+    {
+        $product = $this->saveThroughWebservice($this->createProduct('ws position created'), 3);
+
+        $this->assertSame('3', (string) $product->getWsPositionInCategory());
+        $this->assertSame((int) $product->id, $this->productAt(3));
+    }
+
+    /**
+     * Nothing may be reordered on behalf of a product that is not in the category yet. The category is
+     * given a gap first, because renumbering a contiguous one writes back what was already there.
+     */
+    public function testAskingBeforeTheAssociationExistsLeavesTheCategoryAlone(): void
+    {
+        $this->products[1]->setWsCategories([['id' => (string) $this->otherCategory->id]]);
+        $before = $this->positions();
+        $this->assertSame([1, 3, 4, 5], array_keys($before));
+
+        $product = $this->createProduct('ws position pending');
+        $product->setWsPositionInCategory('3');
+
+        $this->assertSame($before, $this->positions());
+    }
+
+    /**
+     * A product joining the category adds a slot to it, so the position after the last one is free.
+     */
+    public function testACreatedProductMayTakeTheSlotAfterTheLastOne(): void
+    {
+        $product = $this->saveThroughWebservice($this->createProduct('ws position appended'), self::SIZE + 1);
+
+        $this->assertSame((string) (self::SIZE + 1), (string) $product->getWsPositionInCategory());
+    }
+
+    /**
+     * Dropping a category from a product's associations vacates a position and renumbers nothing, so the
+     * position stored against a product stops indexing the ordered list.
+     */
+    public function testAVacatedPositionDoesNotDisplaceAnotherProduct(): void
+    {
+        $this->products[1]->setWsCategories([['id' => (string) $this->otherCategory->id]]);
+
+        $moved = $this->products[4];
+        $moved->setWsPositionInCategory('2');
+
+        $this->assertSame((int) $moved->id, $this->productAt(2));
+    }
+
+    public function testAProductAlreadyPlacedStillMoves(): void
+    {
+        $moved = $this->products[3];
+        $moved->setWsPositionInCategory('2');
+
+        $this->assertSame((int) $moved->id, $this->productAt(2));
+    }
+
+    /**
+     * Replays WebserviceRequestCore::saveEntityFromXml(): field setters, then the save, then the
+     * associations.
+     */
+    private function saveThroughWebservice(Product $product, int $position): Product
+    {
+        $product->setWsPositionInCategory((string) $position);
+        $product->add();
+        $product->setWsCategories([['id' => (string) $this->category->id]]);
+        $this->products[] = $product;
+
+        return $product;
+    }
+
+    private function createCategory(string $name): Category
+    {
+        $category = new Category();
+        $category->name = [1 => $name];
+        $category->link_rewrite = [1 => Tools::str2url($name)];
+        $category->id_parent = (int) Configuration::get('PS_HOME_CATEGORY');
+        $category->active = true;
+        $category->add();
+
+        return $category;
+    }
+
+    private function createProduct(string $name): Product
+    {
+        $product = new Product();
+        $product->id_category_default = (int) $this->category->id;
+        $product->name = [1 => $name];
+        $product->link_rewrite = [1 => Tools::str2url($name)];
+        $product->price = 10;
+        $product->id_tax_rules_group = 1;
+
+        return $product;
+    }
+
+    private function productAt(int $position): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT id_product FROM ' . _DB_PREFIX_ . 'category_product
+             WHERE id_category = ' . (int) $this->category->id . ' AND position = ' . $position
+        );
+    }
+
+    /**
+     * @return array<int, int> id_product keyed by position
+     */
+    private function positions(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_product, position FROM ' . _DB_PREFIX_ . 'category_product
+             WHERE id_category = ' . (int) $this->category->id . ' ORDER BY position'
+        );
+
+        $positions = [];
+        foreach ($rows as $row) {
+            $positions[(int) $row['position']] = (int) $row['id_product'];
+        }
+
+        return $positions;
+    }
+}

--- a/tests/UI/campaigns/functional/WS/03_productsCRUD.ts
+++ b/tests/UI/campaigns/functional/WS/03_productsCRUD.ts
@@ -443,8 +443,6 @@ describe('WS - Products : CRUD', async () => {
                 '2',
               );
               expect(objectNodeValueFR).to.eq(createNodeValueFR);
-            } else if (oNode.nodeName === 'position_in_category') {
-              // @todo : https://github.com/PrestaShop/PrestaShop/issues/14903
             } else if (oNode.nodeName === 'associations') {
               // Don't check all associations at the moment
             } else {
@@ -1135,8 +1133,6 @@ describe('WS - Products : CRUD', async () => {
                 '2',
               );
               expect(objectNodeValueFR).to.eq(updateNodeValueFR);
-            } else if (oNode.nodeName === 'position_in_category') {
-              // @todo : https://github.com/PrestaShop/PrestaShop/issues/14903
             } else if (oNode.nodeName === 'associations') {
               // Don't check all associations at the moment
             } else {

--- a/tests/UI/data/xml/product.ts
+++ b/tests/UI/data/xml/product.ts
@@ -12,8 +12,7 @@ function getProductXmlCreate(): string {
     + '    <id_default_image><![CDATA[]]></id_default_image>\n'
     + '    <id_default_combination>0</id_default_combination>\n'
     + '    <id_tax_rules_group>1</id_tax_rules_group>\n'
-    // @todo : https://github.com/PrestaShop/PrestaShop/issues/14903
-    //+ '    <position_in_category>1</position_in_category>\n'
+    + '    <position_in_category>3</position_in_category>\n'
     + '    <type><![CDATA[simple]]></type>\n'
     + '    <id_shop_default>1</id_shop_default>\n'
     + '    <reference><![CDATA[REFERENCE007]]></reference>\n'
@@ -130,8 +129,7 @@ function getProductXmlUpdate(idProduct: string): string {
     + '    <id_default_image><![CDATA[]]></id_default_image>\n'
     + '    <id_default_combination>0</id_default_combination>\n'
     + '    <id_tax_rules_group>2</id_tax_rules_group>\n'
-    // @todo : https://github.com/PrestaShop/PrestaShop/issues/14903
-    //+ '    <position_in_category>2</position_in_category>\n'
+    + '    <position_in_category>2</position_in_category>\n'
     + '    <type><![CDATA[simple]]></type>\n'
     + '    <id_shop_default>1</id_shop_default>\n'
     + '    <reference><![CDATA[UPDATEREFERENCE007]]></reference>\n'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Creating a product through the webservice with `position_in_category` puts it somewhere else. Measured on 9.2.x against a category holding 5 products, asking for position 3: the product comes back at 6.<br><br>`WebserviceRequestCore::saveEntityFromXml()` runs a resource's field setters at line 1588, saves the object at line 1636 and applies the associations at line 1656. So `setWsPositionInCategory()` runs while the product has no id and has no row in the category. It cannot place anything, and the category association that arrives afterwards appends at `MAX(position) + 1`.<br><br>Worse, it does not leave empty-handed: not finding the product in the list, it still ran the renumbering loop and rewrote every other product's position. Measured on a category reading `3@1 4@3 5@4 12@5 13@6 14@7 15@8`, one call that placed nothing left it `3@1 4@2 5@3 12@4 13@5 14@6 15@7`.<br><br>The requested position is now kept until `setWsCategories()` has inserted the rows, and the category is left untouched until there is something to place in it.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `WsPositionInCategoryTest` builds its own category of 5 products and replays the webservice order - setter, `add()`, `setWsCategories()` - rather than calling the setter on a ready product. Four of its five cases fail on 9.2.x as shipped (one error, three failures); the fifth is the control, a product already placed moving normally.<br><br>Manually: `POST /api/products` with `<id_category_default>9</id_category_default>`, `<position_in_category>3</position_in_category>` and category 9 in the associations. Before: the product is last in the category. After: it is third, and the products from third onwards each move down one.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #14903
| Related PRs       | #31342 by @TomLorenzi
| Sponsor company   |

The issue's acceptance criteria are the two skipped assertions in `tests/UI/campaigns/functional/WS/03_productsCRUD.ts`, and this unskips them. The create payload asks for position **3**, not the 1 the commented-out line carried: 1 passes on both sides, because a product the setter cannot place sorts first anyway and lands at 1 by accident. 3 discriminates.

### Two neighbouring defects on the same path

**The bounds check refused the last free slot.** A product joining a category adds a slot to it, so the position after the last one is available. The check counted the category as it stood and rejected it, which is exactly what #31342 by @TomLorenzi fixed. That PR was approved by @kpodemski and @nicosomb and closed in December 2023 with *"No time for this sorry, can be closed then"*; this carries the same idea, in the shape the surrounding code now has. Before the ordering fix above the case was unreachable in practice, since the position was ignored on creation anyway.

**A vacated position displaced the wrong product.** `setWsCategories()` calls `deleteCategories()`, whose `$clean_positions` defaults to false, so dropping a category from a product's associations leaves a hole and renumbers nothing. The stored position then stops indexing the ordered list, and `$result[$current_position]` reaches for someone else. Measured: with a category reading `1, 3, 4, 5, 6`, asking the product at 6 to move to 2 moved the product at 3 instead.

### The decision, and what I rejected

The position is deferred on the object and applied from `setWsCategories()` once the rows exist. It couples two webservice setters, which is worth naming - but the dependency is real rather than introduced: a position inside a category cannot be applied before the product is in that category.

**Rejected: reordering `WebserviceRequest` so associations run before field setters.** It is the direct fix for the cause, and it is the wrong place for it. That order applies to every resource, and any setter that today reads the object's own state before the associations rewrite it would change behaviour with no test naming it.

**Rejected: applying the position from `Product::add()` or `addWs()`.** Both run at line 1636, still before the associations at 1656, so the row is not there yet either.

**Rejected: reviving #31342 on its own.** Its bounds relaxation is needed and is included, but by itself the created product still lands at the end of the category: the position it now accepts is never applied.
