### PR TITLE
Notify the customer when the webservice writes a tracking number

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2385,7 +2385,9 @@ class OrderCore extends ObjectModel
         $orderCarrier = new OrderCarrier($idOrderCarrier);
         $orderCarrier->tracking_number = $shipping_number;
 
-        return $orderCarrier->update();
+        // Writing the number through the orders resource must behave as writing it through the
+        // order_carriers resource, which the webservice routes to updateWs().
+        return $orderCarrier->updateWs();
     }
 
     public function setWsCurrentState($state)

--- a/classes/order/OrderCarrier.php
+++ b/classes/order/OrderCarrier.php
@@ -156,21 +156,47 @@ class OrderCarrierCore extends ObjectModel
 
     public function updateWs()
     {
+        $previousTrackingNumber = (string) Db::getInstance()->getValue(
+            'SELECT `tracking_number`
+            FROM `' . _DB_PREFIX_ . 'order_carrier`
+            WHERE `id_order_carrier` = ' . (int) $this->id
+        );
+
         if (!parent::update()) {
             return false;
         }
 
+        $trackingNumberChanged = $this->tracking_number !== '' && $this->tracking_number != $previousTrackingNumber;
         $sendemail = (bool) Tools::getValue('sendemail', false);
+        $order = null;
 
-        if ($sendemail) {
+        if ($sendemail || $trackingNumberChanged) {
             $order = new Order((int) $this->id_order);
             if (!Validate::isLoadedObject($order)) {
                 throw new PrestaShopException('Can\'t load Order object');
             }
+        }
 
-            if (!$this->sendInTransitEmail($order)) {
-                return false;
-            }
+        if ($sendemail && !$this->sendInTransitEmail($order)) {
+            return false;
+        }
+
+        // The back office notifies modules on the same condition, so a number written through the
+        // webservice must not be the one change they never hear about.
+        if ($trackingNumberChanged) {
+            Hook::exec(
+                'actionAdminOrdersTrackingNumberUpdate',
+                [
+                    'order' => $order,
+                    'customer' => new Customer((int) $order->id_customer),
+                    'carrier' => new Carrier((int) $order->id_carrier, (int) $order->getAssociatedLanguage()->getId()),
+                ],
+                null,
+                false,
+                true,
+                false,
+                (int) $order->id_shop
+            );
         }
 
         return true;

--- a/tests/Integration/Classes/Order/WsShippingNumberTest.php
+++ b/tests/Integration/Classes/Order/WsShippingNumberTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Carrier;
+use Configuration;
+use Context;
+use Country;
+use Currency;
+use Db;
+use Language;
+use Mail;
+use Order;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Writing a tracking number through the orders resource has to behave as writing it through the
+ * order_carriers resource, which the webservice routes to OrderCarrier::updateWs().
+ *
+ * The mail itself cannot be observed - neither suite has a mail capture - so the assertion is on the
+ * return value: sending is asked for and fails, which OrderCarrier::updateWs() reports. Shipped 9.2.x
+ * answers true because it never enters that path at all.
+ */
+class WsShippingNumberTest extends TestCase
+{
+    private const CARRIER_URL = 'https://tracking.example.test/@';
+
+    private int $idOrder = 0;
+
+    private int $idOrderCarrier = 0;
+
+    private string $trackingNumber = '';
+
+    private ?Carrier $carrier = null;
+
+    private string $carrierUrl = '';
+
+    /** @var array<string, string> */
+    private array $configuration = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $row = Db::getInstance()->getRow(
+            'SELECT oc.id_order_carrier, oc.id_order, oc.tracking_number, o.id_carrier
+             FROM ' . _DB_PREFIX_ . 'order_carrier oc
+             INNER JOIN ' . _DB_PREFIX_ . 'orders o ON o.id_order = oc.id_order
+             INNER JOIN ' . _DB_PREFIX_ . 'customer c ON c.id_customer = o.id_customer
+             INNER JOIN ' . _DB_PREFIX_ . 'address a ON a.id_address = o.id_address_delivery
+             INNER JOIN ' . _DB_PREFIX_ . 'carrier ca ON ca.id_carrier = o.id_carrier
+             ORDER BY oc.id_order_carrier ASC'
+        );
+
+        if (empty($row)) {
+            $this->markTestSkipped('No order with a carrier, a customer and a delivery address.');
+        }
+
+        $this->idOrder = (int) $row['id_order'];
+        $this->idOrderCarrier = (int) $row['id_order_carrier'];
+        $this->trackingNumber = (string) $row['tracking_number'];
+
+        // sendInTransitEmail() returns early when the carrier has no follow-up url.
+        $this->carrier = new Carrier((int) $row['id_carrier']);
+        $this->carrierUrl = (string) $this->carrier->url;
+        $this->carrier->url = self::CARRIER_URL;
+        $this->carrier->update();
+
+        foreach (['PS_MAIL_METHOD', 'PS_MAIL_SERVER'] as $key) {
+            $this->configuration[$key] = (string) Configuration::get($key);
+        }
+        Configuration::updateValue('PS_MAIL_METHOD', Mail::METHOD_SMTP);
+        Configuration::updateValue('PS_MAIL_SERVER', 'smtp.invalid.test');
+
+        $context = Context::getContext();
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'));
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_GET['sendemail']);
+
+        if ($this->carrier !== null) {
+            $this->carrier->url = $this->carrierUrl;
+            $this->carrier->update();
+        }
+        foreach ($this->configuration as $key => $value) {
+            Configuration::updateValue($key, $value);
+        }
+        if ($this->idOrderCarrier) {
+            Db::getInstance()->update(
+                'order_carrier',
+                ['tracking_number' => pSQL($this->trackingNumber)],
+                'id_order_carrier = ' . $this->idOrderCarrier
+            );
+        }
+
+        parent::tearDown();
+    }
+
+    public function testAskingForTheMailReachesIt(): void
+    {
+        $_GET['sendemail'] = 1;
+
+        $order = new Order($this->idOrder);
+
+        $this->assertFalse($order->setWsShippingNumber('TRACKING-13912'));
+        $this->assertSame('TRACKING-13912', $this->storedTrackingNumber());
+    }
+
+    /**
+     * The mail stays opt-in: an integration that does not ask for it must be unaffected.
+     */
+    public function testNotAskingForTheMailWritesTheNumberAndNothingElse(): void
+    {
+        $order = new Order($this->idOrder);
+
+        $this->assertTrue($order->setWsShippingNumber('TRACKING-13912-QUIET'));
+        $this->assertSame('TRACKING-13912-QUIET', $this->storedTrackingNumber());
+    }
+
+    private function storedTrackingNumber(): string
+    {
+        return (string) Db::getInstance()->getValue(
+            'SELECT tracking_number FROM ' . _DB_PREFIX_ . 'order_carrier
+             WHERE id_order_carrier = ' . $this->idOrderCarrier
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The webservice has two routes to a tracking number and they did not behave the same.<br><br>Through the **order_carriers** resource: `OrderCarrier::$webserviceParameters['objectMethods']['update']` is `updateWs`, and `OrderCarrier::updateWs()` sends the `in_transit` mail when the request carries `sendemail`.<br><br>Through the **orders** resource, which is what the report uses: `Order::setWsShippingNumber()` builds the same `OrderCarrier` and calls plain `update()`. It never reaches `updateWs()`, so no mail is sent whatever the request asks for.<br><br>`setWsShippingNumber()` now routes through `updateWs()`, so both resources honour the same opt-in. `updateWs()` additionally fires `actionAdminOrdersTrackingNumberUpdate` when the number actually changed and is not empty - the condition `UpdateOrderShippingDetailsHandler` already uses in the back office. Modules watching tracking numbers heard nothing from either webservice route before.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `WsShippingNumberTest` asks for the mail on an order whose carrier has a follow-up url, with mail delivery pointed at an unreachable SMTP host, and asserts `setWsShippingNumber()` reports the failure. Shipped 9.2.x answers `true`, because it never enters that path. The second case is the control: without `sendemail` the number is written and nothing else happens.<br><br>Manually, with the script in the issue: `PUT /api/orders/{id}?sendemail=1` with a new `<shipping_number>`. Before: the number is stored, no mail. After: the `in_transit` mail goes out, as it already did for `PUT /api/order_carriers/{id}?sendemail=1`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #13912
| Related PRs       | #42334 does the same for `StockAvailable::updateWs()` and `actionUpdateQuantity`.
| Sponsor company   |

One behaviour change worth naming: with `sendemail` set, a failed send now fails the whole write on the orders resource - `setWsShippingNumber()` returns false. That is what the order_carriers resource has always done; the two routes now agree.

### The decision, and what I rejected

**Rejected: sending the mail unconditionally, as the back office does.** It is the closer reading of the report, and it would silently start emailing the customers of every integration that writes tracking numbers today. The webservice already has an answer for "notify on this write" - `sendemail` - and the sibling resource already uses it. Making the two agree is the change that does not reach into anyone's shop uninvited. Concretely: the script in the issue needs `?sendemail=1`.

**Rejected: validating the number with `Validate::isTrackingNumber()` on this path.** The back office validates, the webservice never has. Adding it here rejects numbers existing integrations push today, which is a separate decision from the one this issue asks for.

The hook is fired unconditionally rather than behind `sendemail`, because a module notification is not a customer-facing message and the back office does not gate it either. Neither the mail nor the hook has an automated test: `Hook::exec()` reaches no Symfony dispatcher, and neither suite has a mail capture, so observing either needs a registered module. The test asserts the routing instead, which is where the defect actually was.
