### PR TITLE
Fix product ID type in product grid decorator

### DIFF
--- a/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
+++ b/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
@@ -234,7 +234,7 @@ class ProductGridDataFactoryDecorator implements GridDataFactoryInterface
                 } else {
                     $shopId = new ShopId((int) $products[$i]['id_shop_default']);
                 }
-                $packQuantity = $this->productPackRepository->getDynamicPackQuantity(new ProductId($products[$i]['id_product']), $shopId);
+                $packQuantity = $this->productPackRepository->getDynamicPackQuantity(new ProductId((int) $products[$i]['id_product']), $shopId);
                 if (null !== $packQuantity) {
                     $products[$i]['quantity'] = $packQuantity;
                 }

--- a/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
@@ -216,7 +216,7 @@ class ProductPackRepository extends AbstractObjectModelRepository
         if ($packStockType === PackStockType::STOCK_TYPE_PACK_ONLY) {
             try {
                 $stockAvailable = $this->stockAvailableRepository->getForProduct($productId, $shopId);
-                $packQuantity = $stockAvailable->quantity;
+                $packQuantity = (int) $stockAvailable->quantity;
             } catch (StockAvailableNotFoundException) {
                 $packQuantity = 0;
             }
@@ -240,7 +240,7 @@ class ProductPackRepository extends AbstractObjectModelRepository
                         $packedItemStockAvailable = $this->stockAvailableRepository->getForCombination(new CombinationId($packedItemCombinationId), $shopId);
                     }
 
-                    $packedItemStock = $packedItemStockAvailable->quantity;
+                    $packedItemStock = (int) $packedItemStockAvailable->quantity;
                 } catch (StockAvailableNotFoundException) {
                     $packedItemStock = 0;
                 }

--- a/tests/Integration/Adapter/Product/ProductGridDataFactoryDecoratorTest.php
+++ b/tests/Integration/Adapter/Product/ProductGridDataFactoryDecoratorTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Product\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Adapter\Product\Grid\Data\Factory\ProductGridDataFactoryDecorator;
+use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
+use PrestaShop\PrestaShop\Adapter\Product\Pack\Repository\ProductPackRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository;
+use PrestaShop\PrestaShop\Adapter\Tax\TaxComputer;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Grid\Data\Factory\GridDataFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
+use PrestaShop\PrestaShop\Core\Search\Filters\ProductFilters;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The decorator reads grid rows straight out of the database layer, and whether that layer hands back
+ * `1` or `'1'` depends on the driver: with native prepared statements the value arrives as an integer,
+ * with emulated prepares (and on some MariaDB setups) every column arrives as a string. The typed
+ * value objects it builds from those rows therefore have to cast, or the product list dies with a
+ * TypeError on hosts that return strings.
+ */
+class ProductGridDataFactoryDecoratorTest extends KernelTestCase
+{
+    private const PACK_QUANTITY = 42;
+
+    public function testItBuildsPackQuantityFromStringTypedProductId(): void
+    {
+        self::bootKernel();
+
+        $stringTypedPackRow = [
+            'id_product' => '7',
+            'id_shop_default' => '1',
+            'id_image' => '0',
+            'legend' => '',
+            'name' => 'A pack whose columns all came back as strings',
+            'reference' => '',
+            'price' => '10.000000',
+            'id_tax_rules_group' => '0',
+            'quantity' => '3',
+            'product_type' => ProductType::TYPE_PACK,
+        ];
+
+        // The repository is stubbed so the assertion is about the value object the decorator builds,
+        // not about which fixture products happen to be packs.
+        $packRepository = $this->createMock(ProductPackRepository::class);
+        $packRepository
+            ->expects(self::once())
+            ->method('getDynamicPackQuantity')
+            ->with(
+                self::callback(static fn (ProductId $productId): bool => $productId->getValue() === 7),
+                self::anything()
+            )
+            ->willReturn(self::PACK_QUANTITY);
+
+        $decorator = $this->buildDecorator($stringTypedPackRow, $packRepository);
+
+        // Before the cast this threw:
+        // ProductId::__construct(): Argument #1 ($productId) must be of type int, string given
+        $gridData = $decorator->getData(new ProductFilters(ShopConstraint::shop(1)));
+
+        $records = $gridData->getRecords()->all();
+        self::assertCount(1, $records);
+        self::assertSame(self::PACK_QUANTITY, $records[0]['quantity']);
+    }
+
+    private function buildDecorator(
+        array $productRow,
+        ProductPackRepository $packRepository
+    ): ProductGridDataFactoryDecorator {
+        $container = self::getContainer();
+
+        $innerFactory = new class($productRow) implements GridDataFactoryInterface {
+            public function __construct(private array $productRow)
+            {
+            }
+
+            public function getData(SearchCriteriaInterface $searchCriteria): GridData
+            {
+                return new GridData(new RecordCollection([$this->productRow]), 1, '');
+            }
+        };
+
+        $configuration = $container->get(Configuration::class);
+        $legacyContext = $container->get(LegacyContext::class);
+
+        return new ProductGridDataFactoryDecorator(
+            $innerFactory,
+            $container->get(LocaleRepository::class),
+            $legacyContext->getContext()->language->getLocale(),
+            (int) $configuration->get('PS_CURRENCY_DEFAULT'),
+            $container->get(TaxComputer::class),
+            (int) $legacyContext->getContext()->country->id,
+            $container->get(ProductImagePathFactory::class),
+            $container->get(TranslatorInterface::class),
+            $configuration->getBoolean('PS_TAX'),
+            $configuration->getBoolean('PS_USE_ECOTAX'),
+            $configuration->getInt('PS_ECOTAX_TAX_RULES_GROUP_ID'),
+            $container->get(ShopRepository::class),
+            $container->get(ProductRepository::class),
+            $packRepository,
+        );
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | This PR fixes #42447 by explicitly casting the product ID to int before creating the ProductId value object in ProductGridDataFactoryDecorator.<br><br>Depending on the database/PDO environment, id_product returned by the product grid query may be a string instead of an integer. Since the decorator uses strict types, passing this value directly to ProductId can trigger a TypeError.<br><br>The fix normalizes the value with an explicit (int) cast, consistently with the other IDs handled in the same decorator.
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | see below 👇 
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/33363260578
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42447
| Related PRs       |
| Sponsor company   | Codencode snc

---

## How to test

1. Go to the **BO > Catalog > Products** page and make sure at least one pack product exists.
2. On a fresh installation, product ID `15` is a pack product, so you can simply use that product to reproduce the issue.
3. Open the product list and verify that pack products are displayed without any error.
4. Verify that the pack quantity is correctly displayed in the product grid.

### Reproducing the affected PDO behavior

This issue occurs on environments where PDO returns numeric database values as strings.

If your environment already reproduces this behavior, no additional setup is required.

If your environment uses `mysqlnd` and numeric values are returned as native PHP types, you can temporarily simulate the affected behavior.

In `classes/db/DbPDO.php`, inside the `getPDO()` method, replace:

```php id="3mnhyc"
return new PDO(
    $dsn,
    $user,
    $password,
    $options
);
```

with:

```php id="dg61qs"
$pdo = new PDO(
    $dsn,
    $user,
    $password,
    $options
);

$pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);

return $pdo;
```

> [!IMPORTANT]
> This modification is only required to simulate the affected PDO behavior and must not be committed.

With `PDO::ATTR_STRINGIFY_FETCHES` enabled:

* Without this PR, opening **BO > Catalog > Products** with a pack product should reproduce the `TypeError`.
* With this PR applied, the product grid should load correctly and the pack quantity should be displayed without type-related errors.

After testing, revert the temporary modification in `classes/db/DbPDO.php`.
