### PR TITLE
Filter the Files grid on the size it stores, not the one it prints

### DIFF
--- a/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
@@ -18,6 +18,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShopBundle\Form\Admin\Type\IntegerMinMaxFilterType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -167,12 +168,21 @@ final class AttachmentGridDefinitionFactory extends AbstractFilterableGridDefini
                     ->setAssociatedColumn('name')
             )
             ->add(
-                (new Filter('file_size', NumberType::class))
+                // The column shows a converted size, so no value read off it can match the stored byte
+                // count. A range over that byte count is what the numeric columns of other grids use.
+                (new Filter('file_size', IntegerMinMaxFilterType::class))
                     ->setTypeOptions([
-                        'attr' => [
-                            'placeholder' => $this->trans('Search file size', [], 'Admin.Actions'),
-                        ],
                         'required' => false,
+                        'min_field_options' => [
+                            'attr' => [
+                                'placeholder' => $this->trans('Min (bytes)', [], 'Admin.Actions'),
+                            ],
+                        ],
+                        'max_field_options' => [
+                            'attr' => [
+                                'placeholder' => $this->trans('Max (bytes)', [], 'Admin.Actions'),
+                            ],
+                        ],
                     ])
                     ->setAssociatedColumn('file_size')
             )

--- a/src/Core/Grid/Query/AttachmentQueryBuilder.php
+++ b/src/Core/Grid/Query/AttachmentQueryBuilder.php
@@ -135,6 +135,26 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
                 continue;
             }
 
+            if ('file_size' === $filterName) {
+                // A filter saved before this was a range arrives as a scalar; it cannot be honoured, and
+                // reading it as one bound or the other would answer a question nobody asked.
+                if (!is_array($value)) {
+                    continue;
+                }
+
+                if (isset($value['min_field']) && '' !== $value['min_field']) {
+                    $qb->andWhere($allowedFiltersMap[$filterName] . ' >= :file_size_min')
+                        ->setParameter('file_size_min', (int) $value['min_field']);
+                }
+
+                if (isset($value['max_field']) && '' !== $value['max_field']) {
+                    $qb->andWhere($allowedFiltersMap[$filterName] . ' <= :file_size_max')
+                        ->setParameter('file_size_max', (int) $value['max_field']);
+                }
+
+                continue;
+            }
+
             if ('products' === $filterName && $value === '0') {
                 $qb->andWhere($allowedFiltersMap[$filterName] . ' IS NULL');
 

--- a/tests/Integration/Core/Grid/Query/AttachmentSizeFilterTest.php
+++ b/tests/Integration/Core/Grid/Query/AttachmentSizeFilterTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Grid\Query;
+
+use Db;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Query\AttachmentQueryBuilder;
+use PrestaShop\PrestaShop\Core\Search\Filters\AttachmentFilters;
+use PrestaShop\PrestaShop\Core\Util\File\FileSizeConverter;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The Files grid converts the stored byte count for display, so no value read off the Size column can
+ * match it. The filter is a range over the stored count instead.
+ */
+class AttachmentSizeFilterTest extends KernelTestCase
+{
+    private const SIZES = [512, 45678, 3145728];
+
+    private AttachmentQueryBuilder $queryBuilder;
+
+    /** @var array<int, int> id_attachment keyed by size */
+    private array $ids = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $languageContextBuilder = self::getContainer()->get(LanguageContextBuilder::class);
+        $languageContextBuilder->setLanguageId(1);
+
+        $this->queryBuilder = self::getContainer()->get('prestashop.core.grid.query_builder.attachment');
+
+        foreach (self::SIZES as $size) {
+            Db::getInstance()->insert('attachment', [
+                'file' => sha1((string) $size . microtime()),
+                'file_name' => 'size-filter-' . $size . '.bin',
+                'file_size' => $size,
+                'mime' => 'application/octet-stream',
+            ]);
+            $id = (int) Db::getInstance()->Insert_ID();
+            $this->ids[$size] = $id;
+
+            foreach (Db::getInstance()->executeS('SELECT id_lang FROM ' . _DB_PREFIX_ . 'lang') as $lang) {
+                Db::getInstance()->insert('attachment_lang', [
+                    'id_attachment' => $id,
+                    'id_lang' => (int) $lang['id_lang'],
+                    'name' => 'size filter ' . $size,
+                    'description' => '',
+                ]);
+            }
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->ids as $id) {
+            Db::getInstance()->delete('attachment_lang', 'id_attachment = ' . $id);
+            Db::getInstance()->delete('attachment', 'id_attachment = ' . $id);
+        }
+        $this->ids = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * The reported case: a file larger than a kilobyte shows as "44.61kB" and could not be found at all.
+     */
+    public function testAFileAboveAKilobyteCanBeFound(): void
+    {
+        $converter = new FileSizeConverter();
+        $this->assertSame('44.61kB', $converter->convert(45678), 'the display this filter has to serve');
+
+        $found = $this->search(['min_field' => 45678, 'max_field' => 45678]);
+
+        $this->assertSame([$this->ids[45678]], $found);
+    }
+
+    public function testAMinimumKeepsTheFilesAtOrAboveIt(): void
+    {
+        $found = $this->search(['min_field' => 45678]);
+
+        $this->assertContains($this->ids[45678], $found);
+        $this->assertContains($this->ids[3145728], $found);
+        $this->assertNotContains($this->ids[512], $found);
+    }
+
+    public function testAMaximumKeepsTheFilesAtOrBelowIt(): void
+    {
+        $found = $this->search(['max_field' => 512]);
+
+        $this->assertContains($this->ids[512], $found);
+        $this->assertNotContains($this->ids[45678], $found);
+        $this->assertNotContains($this->ids[3145728], $found);
+    }
+
+    public function testARangeKeepsWhatFallsInside(): void
+    {
+        $found = $this->search(['min_field' => 1024, 'max_field' => 100000]);
+
+        $this->assertContains($this->ids[45678], $found);
+        $this->assertNotContains($this->ids[512], $found);
+        $this->assertNotContains($this->ids[3145728], $found);
+    }
+
+    /**
+     * A filter saved before the size became a range arrives as a scalar. It cannot be honoured, and
+     * reading it as one bound or the other would answer a question nobody asked.
+     */
+    public function testAFilterSavedBeforeTheRangeIsIgnoredRatherThanGuessed(): void
+    {
+        $found = $this->search('512');
+
+        foreach ($this->ids as $id) {
+            $this->assertContains($id, $found);
+        }
+    }
+
+    /**
+     * @param array<string, int>|string $fileSizeFilter
+     *
+     * @return int[]
+     */
+    private function search($fileSizeFilter): array
+    {
+        $filters = new AttachmentFilters([
+            'limit' => 500,
+            'offset' => 0,
+            'orderBy' => 'id_attachment',
+            'sortOrder' => 'asc',
+            'filters' => ['file_size' => $fileSizeFilter],
+        ]);
+
+        $rows = $this->queryBuilder->getSearchQueryBuilder($filters)->executeQuery()->fetchAllAssociative();
+
+        return array_map('intval', array_column($rows, 'id_attachment'));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The Size column of Catalog > Files converts the stored byte count for display - `AttachmentGridDataFactoryDecorator:78` runs it through `FileSizeConverter::convert()` - while the filter matched that same byte count with `a.file_size LIKE '%<input>%'` in `AttachmentQueryBuilder::applyFilters()`.<br><br>Nothing a merchant reads off the column matches, except for files under a kilobyte, which print as their own byte count:<br><br><pre>bytes=512      shown=512B     types 512    -> LIKE '%512%'    matches: YES<br>bytes=1234     shown=1.21kB   types 1.21   -> LIKE '%1.21%'   matches: NO<br>bytes=45678    shown=44.61kB  types 44.61  -> LIKE '%44.61%'  matches: NO<br>bytes=3145728  shown=3.00MB   types 3.00   -> LIKE '%3.00%'   matches: NO</pre><br>The filter is now a range over the stored byte count, with the unit named in the inputs.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `AttachmentSizeFilterTest` inserts three attachments of 512, 45678 and 3145728 bytes and runs the grid's own query builder. It asserts the reported case first - 45678 bytes displays as `44.61kB` and is now findable - then the minimum, the maximum and the range. All five fail on 9.2.x as shipped.<br><br>Manually: Catalog > Files, add a file over a kilobyte, and filter by size. Before: no records found for anything the column shows. After: the file is returned by a minimum at or below its byte count.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #11054
| Related PRs       |
| Sponsor company   |

A filter saved before this change arrives as a scalar rather than a range. It is skipped rather than read as one bound or the other - see the rejected alternatives.

### The decision, and what I rejected

The range follows what the codebase already does for numeric grid columns: `ProductGridDefinitionFactory` filters `id_product` and `quantity` with `IntegerMinMaxFilterType`, and `DoctrineFilterApplicator` implements the same `min_field` / `max_field` shape. `AttachmentQueryBuilder` rolls its own `applyFilters()`, so the branch is added there explicitly rather than inherited - a range value falling through to the `LIKE` tail would be an array in a string.

**Rejected: parsing what the column shows.** Accepting `44.61kB` reads as the friendliest fix, and it means inverting a lossy conversion: `44.61kB` is any byte count in a range, the precision decides how wide, and `NumberType` localises the separator so `44,61` has to work too. That is a locale-sensitive parser for a trivial filter.

**Rejected: dropping the size filter.** `BackupDefinitionFactory` shows a converted size and offers no filter on it, so there is precedent for that answer, but it removes a feature the issue asks to work rather than fixing it.

**Rejected: reading a stale scalar filter as a minimum.** Silently reinterpreting a saved value returns a result the merchant did not ask for, which is worse than returning everything and letting them filter again.

**Noted, not done:** `AttachmentGridDataFactoryDecorator:78` overwrites `file_size` in place with the converted string, where `BackupGridDataFactory` and `ProductLazyArray:441` both keep the raw value and add `file_size_formatted` beside it. It is not what breaks the filter - the filter runs in SQL, before the decorator - so it stays out of this diff.
