### PR TITLE
Compute the reserved quantity once instead of once per stock line

### DIFF
--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -149,25 +149,48 @@ class StockManager
             ? 'o.id_shop_group = :stock_shop_group_id'
             : 'o.id_shop = :stock_shop_id';
 
+        /*
+         * The sum used to sit in the SET as a correlated subquery, which MySQL reports as a DEPENDENT
+         * SUBQUERY and runs once per updated row. It is computed once here instead, over the same rows:
+         * the narrowing that bounds which stock lines are updated is repeated inside, so an update for a
+         * single order or product still reads only that order's or product's lines.
+         */
+        $reservedJoin = '';
+        if ($idOrder) {
+            $reservedJoin = '
+                INNER JOIN (
+                    SELECT product_id
+                    FROM {table_prefix}order_detail
+                    WHERE id_order = :order_id
+                ) od3
+                ON od3.product_id = od.product_id';
+        }
+
+        $reservedCondition = $idProduct ? ' AND od.product_id = :product_id' : '';
+
         $updateReservedQuantityQuery .= '
-            SET sa.reserved_quantity = (
-                SELECT SUM(od.product_quantity - od.product_quantity_refunded)
+            LEFT JOIN (
+                SELECT
+                    od.product_id,
+                    od.product_attribute_id,
+                    SUM(od.product_quantity - od.product_quantity_refunded) AS reserved_quantity
                 FROM {table_prefix}orders o
                 INNER JOIN {table_prefix}order_detail od ON od.id_order = o.id_order
-                INNER JOIN {table_prefix}order_state os ON os.id_order_state = o.current_state
-                WHERE ' . $orderScopeCondition . ' AND
+                INNER JOIN {table_prefix}order_state os ON os.id_order_state = o.current_state' . $reservedJoin . '
+                WHERE ' . $orderScopeCondition . $reservedCondition . ' AND
                 os.shipped != 1 AND (
                     o.valid = 1 OR (
                         os.id_order_state != :error_state AND
                         os.id_order_state != :cancellation_state
                     )
-                ) AND sa.id_product = od.product_id AND
-                sa.id_product_attribute = od.product_attribute_id
+                )
                 GROUP BY od.product_id, od.product_attribute_id
-            )
+            ) reserved
+            ON reserved.product_id = sa.id_product AND reserved.product_attribute_id = sa.id_product_attribute
+            SET sa.reserved_quantity = COALESCE(reserved.reserved_quantity, 0)
             WHERE
-                sa.id_shop = :stock_shop_id AND 
-                sa.id_shop_group = :stock_shop_group_id 
+                sa.id_shop = :stock_shop_id AND
+                sa.id_shop_group = :stock_shop_group_id
         ';
 
         $strParams = [

--- a/tests/Integration/Adapter/Stock/ReservedQuantityTest.php
+++ b/tests/Integration/Adapter/Stock/ReservedQuantityTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Stock;
+
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\StockManager;
+use ReflectionMethod;
+
+/**
+ * The reserved quantity is a sum over open order lines. A stock line with no such order has no sum, and
+ * the query used to store that absence as NULL in a NOT NULL column, which only works because
+ * DbPDO::connect() issues SET SESSION sql_mode = ''. Under MySQL's own defaults it is error 1048.
+ */
+class ReservedQuantityTest extends TestCase
+{
+    private StockManager $stockManager;
+
+    private ReflectionMethod $updateReserved;
+
+    private string $sqlMode = '';
+
+    private int $idProduct = 0;
+
+    private int $idStockAvailable = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stockManager = new StockManager();
+        $this->updateReserved = new ReflectionMethod($this->stockManager, 'updateReservedProductQuantity');
+        $this->updateReserved->setAccessible(true);
+
+        $this->sqlMode = (string) Db::getInstance()->getValue('SELECT @@SESSION.sql_mode');
+
+        // a product nobody has ordered, so the sum over open orders has nothing to add up
+        $this->idProduct = 1 + (int) Db::getInstance()->getValue(
+            'SELECT MAX(id_product) FROM ' . _DB_PREFIX_ . 'stock_available'
+        );
+        Db::getInstance()->insert('stock_available', [
+            'id_product' => $this->idProduct,
+            'id_product_attribute' => 0,
+            'id_shop' => 1,
+            'id_shop_group' => 0,
+            'quantity' => 7,
+            'physical_quantity' => 0,
+            'reserved_quantity' => 42,
+            'depends_on_stock' => 0,
+            'out_of_stock' => 0,
+        ]);
+        $this->idStockAvailable = (int) Db::getInstance()->Insert_ID();
+    }
+
+    protected function tearDown(): void
+    {
+        Db::getInstance()->execute("SET SESSION sql_mode = '" . pSQL($this->sqlMode) . "'");
+        if ($this->idStockAvailable) {
+            Db::getInstance()->delete('stock_available', 'id_stock_available = ' . $this->idStockAvailable);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testAStockLineWithNoOpenOrderIsResetToZero(): void
+    {
+        $this->recompute();
+
+        $this->assertSame(0, $this->storedReservedQuantity());
+    }
+
+    /**
+     * The same, with the strictness MySQL applies by default rather than the one PrestaShop turns off.
+     */
+    public function testItDoesNotRelyOnAnEmptySqlMode(): void
+    {
+        Db::getInstance()->execute("SET SESSION sql_mode = 'STRICT_TRANS_TABLES'");
+        $this->assertSame('STRICT_TRANS_TABLES', (string) Db::getInstance()->getValue('SELECT @@SESSION.sql_mode'));
+
+        $this->recompute();
+
+        $this->assertSame(0, $this->storedReservedQuantity());
+    }
+
+    private function recompute(): void
+    {
+        $this->updateReserved->invoke(
+            $this->stockManager,
+            1,
+            (int) Configuration::get('PS_OS_ERROR'),
+            (int) Configuration::get('PS_OS_CANCELED'),
+            $this->idProduct
+        );
+    }
+
+    private function storedReservedQuantity(): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT reserved_quantity FROM ' . _DB_PREFIX_ . 'stock_available
+             WHERE id_stock_available = ' . $this->idStockAvailable
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `StockManager::updateReservedProductQuantity()` carried its sum in the `SET` as a correlated subquery. `EXPLAIN` reports it as a `DEPENDENT SUBQUERY`, so it runs once for every row the statement updates.<br><br>#28854 bounded the order-status path by joining on the order's products, which is why the case in the issue stopped reproducing. What it did not reach is `StockRepository::getData()`, which calls this with **no product and no order** before every Stock Management listing, so opening, filtering or paging that screen recomputes the whole shop.<br><br>The sum is a derived table joined once instead, with the same narrowing repeated inside it so a bounded update still reads only that order's or product's lines.<br><br>It also stops storing an absent sum as `NULL` in a `NOT NULL` column. That works today only because `DbPDO::connect()` issues `SET SESSION sql_mode = ''`; under MySQL's own defaults the same statement is `ERROR 1048 (23000): Column 'reserved_quantity' cannot be null`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `ReservedQuantityTest` recomputes a stock line no order refers to and asserts it lands at `0`. The second case does the same under `SET SESSION sql_mode = 'STRICT_TRANS_TABLES'`, which is where 9.2.x raises `Column 'reserved_quantity' cannot be null`.<br><br>Behat `order` suite: 260 scenarios, 7343 steps, all passing.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #14703
| Related PRs       | #28854 by @tom-combet, merged, bounded the order path. #32066 by @alisamie97, closed for inactivity.
| Sponsor company   |

### Measurements

Seeded to 29,696 `stock_available` rows, 40,007 order lines, 60,005 orders. Medians, 15 runs bounded and 7 unbounded, values compared row by row after each:

| | before | after |
| --- | --- | --- |
| unbounded, what the Stock listing runs | 170.28 ms | **81.87 ms** |
| bounded by one order, what a status change runs | 20.19 ms | 20.82 ms |

The stored values are identical in every row on both paths - that was asserted before the timings, not inferred from them. The bounded difference is inside the run-to-run spread; a single-run measurement had it at 0.9x, and the medians are what that turned into.

Worth naming separately, because this PR does not fix it: on that same data the recompute `StockRepository::getData()` runs before every listing rewrites all 29,696 rows, of which **22** have a non-zero reserved quantity, at a median of 178 ms. Making the statement cheaper halves that; not running it on a read path at all is the larger question, and it needs a stock manager that accepts a set of products rather than one.

### The decision, and what I rejected

**Builds on #32066 by @alisamie97.** It was closed by @kpodemski for inactivity after they wrote that the reserved quantity was where the remaining cost was - which this confirms. That PR narrowed the statement by joining `stock_available` to `order_detail` and `orders`, and **kept the correlated subquery**, so it reduced how many rows paid the per-row cost rather than removing it. It also changed what the statement means: a stock line that no longer appears in any order would stop being reset, leaving a stale reserved quantity behind. Computing the sum once and left-joining it keeps every row reset while paying for the sum a single time.

**Rejected: leaving the `NULL` write alone.** It is masked by `sql_mode = ''` and nothing visibly breaks, but a `NOT NULL` column is being handed a `NULL` and only a session setting decides whether that is a zero or a fatal error. `COALESCE` states the intent in the query.

**Rejected: bounding `StockRepository::getData()` in this PR.** It is the bigger win and it is a design change - the page would have to recompute only the products it is about to show, which means either running the listing twice or teaching `StockManager` to take a list. That belongs in its own discussion rather than inside a query rewrite.
