### PR TITLE
Offer no shipment for a cart holding a product nothing can deliver

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2755,8 +2755,19 @@ class CartCore extends ObjectModel
                 $this
             );
 
-            // Apply fallback if no carrier is found
             if (empty($product['carrier_list'])) {
+                if (empty($product['is_virtual'])) {
+                    /*
+                     * Nothing can deliver this product to this address. The placeholder below used to be
+                     * applied here too, which put the product in a package of its own because no other
+                     * product shares that carrier list - and one package is one order, so the cart was
+                     * paid for as two. There is no set of packages that delivers this cart, so there is
+                     * none to return, and the delivery step has nothing to offer.
+                     */
+                    return [];
+                }
+
+                // A virtual product has no carrier by nature and still belongs in a package.
                 $product['carrier_list'] = [0 => 0];
             }
 

--- a/tests/Integration/Classes/Cart/UnshippablePackagingTest.php
+++ b/tests/Integration/Classes/Cart/UnshippablePackagingTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Cart;
+
+use Carrier;
+use Cart;
+use Configuration;
+use Context;
+use Country;
+use Currency;
+use Db;
+use Language;
+use Product;
+use StockAvailable;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tools;
+
+/**
+ * A product no carrier can deliver to the chosen address is given a placeholder carrier list, which makes
+ * it group into a package of its own. One package is one order, so the cart is paid for as two orders.
+ */
+class UnshippablePackagingTest extends KernelTestCase
+{
+    private Carrier $carrier;
+
+    private Product $shippable;
+
+    private Product $unshippable;
+
+    private Cart $cart;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+        global $kernel;
+        $kernel = self::$kernel;
+
+        $context = Context::getContext();
+        $context->currency = Currency::getDefaultCurrency();
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'));
+
+        Configuration::updateValue('PS_ORDER_OUT_OF_STOCK', true);
+
+        // A carrier that serves no zone, so nothing it is restricted to can be delivered anywhere.
+        $this->carrier = new Carrier();
+        $this->carrier->name = 'unshippable packaging test';
+        $this->carrier->delay = [(int) Configuration::get('PS_LANG_DEFAULT') => 'never'];
+        $this->carrier->active = true;
+        $this->carrier->shipping_method = Carrier::SHIPPING_METHOD_FREE;
+        $this->carrier->range_behavior = 0;
+        $this->carrier->add();
+        Db::getInstance()->delete('carrier_zone', 'id_carrier = ' . (int) $this->carrier->id);
+
+        $this->shippable = $this->createProduct('unshippable packaging shippable');
+        $this->unshippable = $this->createProduct('unshippable packaging restricted');
+        // Carrier::add() writes id_reference straight to the row and leaves the property alone, and after
+        // an insert the reference is the id.
+        Db::getInstance()->insert('product_carrier', [
+            'id_product' => (int) $this->unshippable->id,
+            'id_carrier_reference' => (int) $this->carrier->id,
+            'id_shop' => 1,
+        ]);
+
+        $idCustomer = (int) Db::getInstance()->getValue(
+            'SELECT id_customer FROM ' . _DB_PREFIX_ . 'customer WHERE deleted = 0 AND is_guest = 0 ORDER BY id_customer ASC'
+        );
+        $idAddress = (int) Db::getInstance()->getValue(
+            'SELECT id_address FROM ' . _DB_PREFIX_ . 'address WHERE id_customer = ' . $idCustomer . ' AND deleted = 0 ORDER BY id_address ASC'
+        );
+
+        $this->cart = new Cart();
+        $this->cart->id_customer = $idCustomer;
+        $this->cart->id_address_delivery = $idAddress;
+        $this->cart->id_address_invoice = $idAddress;
+        $this->cart->id_lang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $this->cart->id_currency = (int) Currency::getDefaultCurrency()->id;
+        $this->cart->id_shop = 1;
+        $this->cart->add();
+        $context->cart = $this->cart;
+
+        $this->cart->updateQty(1, (int) $this->shippable->id);
+        $this->cart->updateQty(1, (int) $this->unshippable->id);
+    }
+
+    protected function tearDown(): void
+    {
+        Db::getInstance()->delete('cart_product', 'id_cart = ' . (int) $this->cart->id);
+        $this->cart->delete();
+        Db::getInstance()->delete('product_carrier', 'id_product = ' . (int) $this->unshippable->id);
+        foreach ([$this->shippable, $this->unshippable] as $product) {
+            Db::getInstance()->delete('category_product', 'id_product = ' . (int) $product->id);
+            $product->delete();
+        }
+        $this->carrier->delete();
+
+        parent::tearDown();
+    }
+
+    public function testACartHoldingAnUndeliverableProductOffersNoPackageToShip(): void
+    {
+        $this->assertSame(
+            [],
+            Carrier::getAvailableCarrierList(new Product((int) $this->unshippable->id), 0, (int) $this->cart->id_address_delivery, null, $this->cart),
+            'the fixture has to leave this product with no carrier at all'
+        );
+
+        $this->assertSame(0, $this->countPackages($this->cart), 'one package is one order');
+        $this->assertSame([], $this->cart->getDeliveryOptionList(null, true));
+    }
+
+    /**
+     * The same cart without that product is untouched: this must block the carts it has to, and no others.
+     */
+    public function testACartWhoseProductsCanAllBeDeliveredIsUnaffected(): void
+    {
+        $this->cart->deleteProduct((int) $this->unshippable->id);
+
+        $this->assertSame(1, $this->countPackages($this->cart));
+        $this->assertNotSame([], $this->cart->getDeliveryOptionList(null, true));
+    }
+
+    /**
+     * A virtual product has no carrier by nature. It has always been packaged through the placeholder and
+     * has to stay orderable.
+     */
+    public function testAVirtualProductIsStillPackaged(): void
+    {
+        $this->cart->deleteProduct((int) $this->unshippable->id);
+
+        $virtual = $this->createProduct('unshippable packaging virtual');
+        $virtual->is_virtual = true;
+        $virtual->product_type = 'virtual';
+        $virtual->update();
+        $this->cart->updateQty(1, (int) $virtual->id);
+
+        $packages = $this->countPackages($this->cart);
+
+        $this->cart->deleteProduct((int) $virtual->id);
+        Db::getInstance()->delete('category_product', 'id_product = ' . (int) $virtual->id);
+        $virtual->delete();
+
+        $this->assertSame(1, $packages);
+    }
+
+    private function countPackages(Cart $cart): int
+    {
+        $packages = 0;
+        foreach ($cart->getPackageList(true) as $byAddress) {
+            $packages += count($byAddress);
+        }
+
+        return $packages;
+    }
+
+    private function createProduct(string $name): Product
+    {
+        $product = new Product();
+        $product->id_category_default = 2;
+        $product->name = [(int) Configuration::get('PS_LANG_DEFAULT') => $name];
+        $product->link_rewrite = [(int) Configuration::get('PS_LANG_DEFAULT') => Tools::str2url($name)];
+        $product->price = 10;
+        $product->id_tax_rules_group = 1;
+        $product->add();
+        $product->addToCategories([2]);
+        StockAvailable::setQuantity((int) $product->id, 0, 100);
+
+        return $product;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Cart::getPackageList()` gives a product no carrier can deliver to the chosen address a placeholder carrier list of `[0 => 0]`. Packages are grouped by that list, no other product shares it, so the product forms a package of its own - and `PaymentModule::validateOrder()` builds one order per package. The cart is paid for as two orders, one of them holding an item that cannot be shipped.<br><br>Measured on 9.2.x with a carrier restricted to a product and serving no zone: the cart yields **2 packages**. There is no set of packages that delivers such a cart, so none is returned. `CheckoutDeliveryStep` completes only when there are delivery options, so checkout stops rather than splitting.<br><br>A virtual product has no carrier by nature and keeps the placeholder.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `UnshippablePackagingTest` builds a carrier that serves no zone, restricts a product to it, and puts that product in a cart beside a normal one. It asserts no package and no delivery option. Two controls guard against over-blocking: the same cart without that product still yields one package and its delivery options, and a virtual product is still packaged.<br><br>On 9.2.x the first case fails with 2 packages; both controls pass on either side.<br><br>Behat `cart` suite: 242 scenarios, 3537 steps, all passing.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #15304
| Related PRs       | #25407 by @justeen35
| Sponsor company   |

### The decision, and what I rejected

**Builds on #25407 by @justeen35**, closed as stale by @matks in 2021 under the 30-day review guideline rather than on merit. It carried the same discrimination - a non-virtual product with an empty carrier list - and applied it further down, inside the grouping loop. This puts it where the placeholder is applied, which is the line that causes the split, so the two branches sit together and the reason the placeholder exists for virtual products is visible at the same place.

**Rejected: merging the undeliverable product into the other package.** It gives the merchant one order, which reads like the fix the title asks for, and it would quietly accept an order for something the shop cannot ship. The split is a symptom; the cart being undeliverable is the fact.

**Rejected: dropping the placeholder entirely.** It exists for virtual products, which have no carrier by nature and must stay orderable. That is the case the discrimination protects, and it has its own test here.

**Rejected: naming the offending product in a checkout message.** The issue asks for the customer to be told which item is at fault, and that belongs in the theme rather than in the cart, so it is a separate change in the theme repositories. What this fixes is the wrong order being created; the message is worth a follow-up.

**Worth naming, not changed here:** `PaymentModule::validateOrder()` iterates the package list without asserting it is non-empty. A payment module that calls it on a cart with no delivery options - which is already reachable today, for instance when a shop has no carrier at all - creates no order. This PR does not widen that, but it does make one more cart reach that state.
