### PR TITLE
Carry the product status into the catalogue export

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -822,6 +822,9 @@ class ProductController extends PrestaShopAdminController
             'price' => $this->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
             'price_final' => $this->trans('Price (tax incl.)', [], 'Admin.Catalog.Feature'),
             'sav_quantity' => $this->trans('Quantity', [], 'Admin.Global'),
+            // The grid shows this column and the importer reads it back as "Active (0/1)", so a catalogue
+            // exported to be edited and imported again has to carry it.
+            'active' => $this->trans('Status', [], 'Admin.Global'),
         ];
 
         $data = [];
@@ -836,6 +839,7 @@ class ProductController extends PrestaShopAdminController
                 'price' => $record['final_price_tax_excluded'],
                 'price_final' => $record['price_tax_included'],
                 'sav_quantity' => $record['quantity'],
+                'active' => $record['active'],
             ];
         }
 

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductExportTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductExportTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Controller\Sell\Catalog;
+
+use Db;
+use Symfony\Component\Routing\RouterInterface;
+use Tests\Integration\Utility\LoginTrait;
+use Tests\TestCase\SymfonyIntegrationTestCase;
+
+/**
+ * The Products grid shows a Status column and the importer reads the field back as "Active (0/1)", so a
+ * catalogue exported to be edited and imported again has to carry it.
+ */
+class ProductExportTest extends SymfonyIntegrationTestCase
+{
+    use LoginTrait;
+
+    private RouterInterface $router;
+
+    /** @var array<int, string> active flag keyed by id_product */
+    private array $originalStatus = [];
+
+    private int $enabledProduct = 0;
+
+    private int $disabledProduct = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loginUser($this->client);
+        $this->router = $this->client->getContainer()->get('router');
+
+        $products = Db::getInstance()->executeS(
+            'SELECT p.id_product, ps.active
+             FROM ' . _DB_PREFIX_ . 'product p
+             INNER JOIN ' . _DB_PREFIX_ . 'product_shop ps ON ps.id_product = p.id_product AND ps.id_shop = 1
+             ORDER BY p.id_product ASC
+             LIMIT 2'
+        );
+        $this->assertCount(2, $products, 'two products are needed to tell the two statuses apart');
+
+        foreach ($products as $product) {
+            $this->originalStatus[(int) $product['id_product']] = (string) $product['active'];
+        }
+
+        [$first, $second] = array_keys($this->originalStatus);
+        $this->enabledProduct = $first;
+        $this->disabledProduct = $second;
+
+        $this->setStatus($this->enabledProduct, 1);
+        $this->setStatus($this->disabledProduct, 0);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalStatus as $idProduct => $active) {
+            $this->setStatus($idProduct, (int) $active);
+        }
+        $this->originalStatus = [];
+
+        parent::tearDown();
+    }
+
+    public function testTheExportCarriesEachProductsRealStatus(): void
+    {
+        $rows = $this->exportedRows();
+
+        $this->assertArrayHasKey($this->enabledProduct, $rows);
+        $this->assertArrayHasKey($this->disabledProduct, $rows);
+
+        // The status is the last column, and it is the stored flag rather than anything derived for display.
+        $this->assertSame('1', end($rows[$this->enabledProduct]));
+        $this->assertSame('0', end($rows[$this->disabledProduct]));
+    }
+
+    /**
+     * @return array<int, string[]> the exported columns keyed by id_product
+     */
+    private function exportedRows(): array
+    {
+        $this->client->request('GET', $this->router->generate('admin_products_export'));
+
+        // The export is a StreamedResponse: the browser kit has already drained it, so the content is on
+        // the internal response and getResponse()->getContent() is empty.
+        $csv = (string) $this->client->getInternalResponse()->getContent();
+
+        $rows = [];
+        foreach (explode("\n", trim($csv)) as $line) {
+            $columns = str_getcsv(trim($line), ';');
+            if (isset($columns[0]) && ctype_digit((string) $columns[0])) {
+                $rows[(int) $columns[0]] = $columns;
+            }
+        }
+
+        return $rows;
+    }
+
+    private function setStatus(int $idProduct, int $active): void
+    {
+        Db::getInstance()->update('product', ['active' => $active], 'id_product = ' . $idProduct);
+        Db::getInstance()->update('product_shop', ['active' => $active], 'id_product = ' . $idProduct . ' AND id_shop = 1');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The Products grid shows a Status column (`ToggleColumn('active')`) and the importer reads the field back as `Active (0/1)`, but the CSV export does not include it. A catalogue exported to be edited and imported again - the use case in the issue - comes back with every product's status lost.<br><br>This is the same column the issue was opened about, in a different state. Up to 8.2.x, `ProductCsvExporter` read it from `badge_danger`, a display field, and printed a status that did not match the product, which is the "randomly modified" in the report. In 9.0 the export moved into `ProductController::exportAction()` and the column did not come with it: `git show <tag>:src/Core/Product/ProductCsvExporter.php \| grep -c badge_danger` returns 1 at 1.7.6.0, 8.0.0 and 8.2.0, and the file is gone at 9.0.0.<br><br>The column is exported from `active`, the stored flag, rather than from anything derived for display.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `ProductExportTest` enables one product, disables another, requests `admin_products_export` and asserts each row carries its own flag. It fails on 9.2.x, where the column is absent.<br><br>Manually: Catalog > Products, note two products with different statuses, Export. Before: no Status column. After: a Status column holding 1 and 0.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #14922, Fixes #16839
| Related PRs       |
| Sponsor company   |

### The decision, and what I rejected

Thanks to @laurain-adipso, whose 2025 comment on the issue pinned the `badge_danger` line in 8.2.x and noted it had moved on develop without knowing where. It moved into the controller, and the column was dropped on the way.

**Exported as `1` / `0` rather than a translated Enabled/Disabled.** The stated use case is exporting to bulk-edit and import back, and the importer's own field is labelled `Active (0/1)`. A localised word would have to be translated back by hand for every row.

**Header labelled Status, matching the grid.** The other headers in this method already follow the grid's labels, and the importer maps columns by position rather than by name, so the label costs the round-trip nothing.

**Rejected: exporting `position` as well.** It is the other grid column missing from the export, and it is not what this issue is about; a position is also meaningless without the category it is a position in.

**Rejected: restoring `ProductCsvExporter`.** The export living in the controller beside the grid it exports is why the two can be kept in step; bringing back a separate exporter to hold one column would re-create the split that lost it.
