### PR TITLE
Record each split order's own payment instead of the largest one's

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -716,8 +716,7 @@ class OrderInvoiceCore extends ObjectModel
             'order_invoice_payment',
             'oip2',
             'oip2.id_order_payment = oip1.id_order_payment
-                AND oip2.id_order_invoice <> oip1.id_order_invoice
-                AND oip2.id_order = oip1.id_order'
+                AND oip2.id_order_invoice <> oip1.id_order_invoice'
         );
         $query->where('oip1.id_order_invoice = ' . (int) $this->id);
 
@@ -753,8 +752,7 @@ class OrderInvoiceCore extends ObjectModel
             'order_invoice_payment',
             'oip2',
             'oip2.id_order_payment = oip1.id_order_payment
-                AND oip2.id_order_invoice <> oip1.id_order_invoice
-                AND oip2.id_order = oip1.id_order'
+                AND oip2.id_order_invoice <> oip1.id_order_invoice'
         );
         $query->leftJoin(
             'order_invoice',

--- a/tests/Integration/Classes/Order/SplitOrderPaymentTest.php
+++ b/tests/Integration/Classes/Order/SplitOrderPaymentTest.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Cache;
+use Configuration;
+use Context;
+use Currency;
+use Db;
+use Language;
+use Order;
+use OrderInvoice;
+use OrderPayment;
+use PHPUnit\Framework\TestCase;
+use Shop;
+use Tools;
+
+/**
+ * A cart split across several carriers becomes several orders sharing one reference. Marking one of them
+ * paid links its payment to the next one's invoice, because Order::setInvoice() looks payments up by
+ * reference - so the amount already received was subtracted from an invoice it had not paid for.
+ */
+class SplitOrderPaymentTest extends TestCase
+{
+    private string $reference = '';
+
+    /** @var int[] */
+    private array $orderIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $context = Context::getContext();
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->shop = new Shop(1);
+
+        $this->reference = 'SPL' . substr((string) microtime(true), -6);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->orderIds as $idOrder) {
+            Db::getInstance()->delete('order_invoice_payment', 'id_order = ' . $idOrder);
+            Db::getInstance()->delete('order_invoice', 'id_order = ' . $idOrder);
+            Db::getInstance()->delete('orders', 'id_order = ' . $idOrder);
+        }
+        Db::getInstance()->delete('order_payment', "order_reference = '" . pSQL(Tools::substr($this->reference, 0, 9)) . "'");
+        $this->orderIds = [];
+        Cache::clean('order_invoice_paid_*');
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider sequenceProvider
+     */
+    public function testEachOrderOfASplitCartRecordsItsOwnAmount(float $first, float $second): void
+    {
+        $orderA = $this->createOrder($first);
+        $orderB = $this->createOrder($second);
+
+        $paidForA = $this->markPaid($orderA);
+        $paidForB = $this->markPaid($orderB);
+
+        $this->assertSame([$first], $paidForA);
+        $this->assertSame([$second], $paidForB, 'the second order records its own total, not what is left of the first');
+        $this->assertSame($first + $second, $this->totalRecorded());
+    }
+
+    /**
+     * @return array<string, float[]>
+     */
+    public function sequenceProvider(): array
+    {
+        return [
+            // The report's asymmetry: paying the larger order first left the smaller one with nothing to
+            // record, because its whole total had already been subtracted.
+            'larger order paid first' => [100.00, 40.00],
+            'smaller order paid first' => [40.00, 100.00],
+        ];
+    }
+
+    /**
+     * The case the sibling total exists for: one payment covering several invoices of one order still
+     * leaves nothing outstanding on either of them.
+     */
+    public function testOnePaymentCoveringSeveralInvoicesOfOneOrderLeavesNothingOutstanding(): void
+    {
+        $order = $this->createOrder(140.00);
+        $invoices = [$this->createInvoice((int) $order->id, 100.00), $this->createInvoice((int) $order->id, 40.00)];
+
+        $payment = $this->createPayment($order, 140.00);
+        foreach ($invoices as $idInvoice) {
+            Db::getInstance()->insert('order_invoice_payment', [
+                'id_order_invoice' => $idInvoice,
+                'id_order_payment' => (int) $payment->id,
+                'id_order' => (int) $order->id,
+            ]);
+        }
+        Cache::clean('order_invoice_paid_*');
+
+        foreach ($invoices as $idInvoice) {
+            $this->assertSame(0.0, (new OrderInvoice($idInvoice))->getRestPaid());
+        }
+    }
+
+    /**
+     * Replays the paid branch of OrderHistory::changeIdOrderState(): the invoice is created with the
+     * existing payments of the reference, then a payment is recorded for whatever is still outstanding.
+     *
+     * @return float[] the amounts recorded
+     */
+    private function markPaid(Order $order): array
+    {
+        $order->setInvoice(true);
+        Cache::clean('order_invoice_paid_*');
+
+        $recorded = [];
+        foreach ($order->getInvoicesCollection() as $invoice) {
+            /** @var OrderInvoice $invoice */
+            $restPaid = $invoice->getRestPaid();
+            if ($restPaid > 0) {
+                $payment = $this->createPayment($order, $restPaid);
+                Db::getInstance()->insert('order_invoice_payment', [
+                    'id_order_invoice' => (int) $invoice->id,
+                    'id_order_payment' => (int) $payment->id,
+                    'id_order' => (int) $order->id,
+                ]);
+                Cache::clean('order_invoice_paid_*');
+                $recorded[] = $restPaid;
+            }
+        }
+
+        return $recorded;
+    }
+
+    private function createOrder(float $total): Order
+    {
+        $source = Db::getInstance()->getRow('SELECT * FROM ' . _DB_PREFIX_ . 'orders ORDER BY id_order ASC');
+        $order = new Order();
+        foreach ($source as $field => $value) {
+            if ('id_order' !== $field && property_exists($order, $field)) {
+                $order->$field = $value;
+            }
+        }
+        $order->id = null;
+        $order->reference = $this->reference;
+        $order->total_paid = $total;
+        $order->total_paid_tax_incl = $total;
+        $order->total_paid_tax_excl = $total;
+        $order->total_paid_real = 0;
+        $order->total_products = $total;
+        $order->total_products_wt = $total;
+        $order->valid = true;
+        $order->add();
+        $this->orderIds[] = (int) $order->id;
+
+        return $order;
+    }
+
+    private function createInvoice(int $idOrder, float $total): int
+    {
+        Db::getInstance()->insert('order_invoice', [
+            'id_order' => $idOrder,
+            'number' => 0,
+            'delivery_number' => 0,
+            'total_discount_tax_excl' => 0,
+            'total_discount_tax_incl' => 0,
+            'total_paid_tax_excl' => $total,
+            'total_paid_tax_incl' => $total,
+            'total_products' => $total,
+            'total_products_wt' => $total,
+            'total_shipping_tax_excl' => 0,
+            'total_shipping_tax_incl' => 0,
+            'shipping_tax_computation_method' => 0,
+            'total_wrapping_tax_excl' => 0,
+            'total_wrapping_tax_incl' => 0,
+            'date_add' => date('Y-m-d H:i:s'),
+        ]);
+
+        return (int) Db::getInstance()->Insert_ID();
+    }
+
+    private function createPayment(Order $order, float $amount): OrderPayment
+    {
+        $payment = new OrderPayment();
+        $payment->order_reference = Tools::substr($order->reference, 0, 9);
+        $payment->id_currency = (int) $order->id_currency;
+        $payment->amount = $amount;
+        $payment->conversion_rate = 1;
+        $payment->save();
+
+        return $payment;
+    }
+
+    private function totalRecorded(): float
+    {
+        return (float) Db::getInstance()->getValue(
+            'SELECT COALESCE(SUM(amount), 0) FROM ' . _DB_PREFIX_ . 'order_payment
+             WHERE order_reference = "' . pSQL(Tools::substr($this->reference, 0, 9)) . '"'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A cart split across several carriers becomes several orders sharing one reference. Marking one of them paid links its payment to the next one's invoice - `Order::setInvoice($use_existing_payment)` looks payments up **by reference** - and `OrderInvoice::getRestPaid()` then subtracts an amount that paid for a different order.<br><br>`getRestPaid()` is `total_paid_tax_incl + getSiblingTotal() - getTotalPaid()`. `getTotalPaid()` counts every payment linked to this invoice, across orders. `getSibling()` and `getSiblingTotal()` only looked at invoices of the **same** order, because their join carried `AND oip2.id_order = oip1.id_order`. The two halves of one formula disagreed about scope, so the second order's total was already accounted for before it was recorded.<br><br>Measured with two orders of 100.00 and 40.00 sharing a reference:<br><br><pre>before   larger paid first    rows: A=100.00  B=none     total recorded 100.00<br>         smaller paid first   rows: A=40.00   B=60.00    total recorded 100.00<br>after    larger paid first    rows: A=100.00  B=40.00    total recorded 140.00<br>         smaller paid first   rows: A=40.00   B=100.00   total recorded 140.00</pre><br>The report's asymmetry is the visible half. The money figure was wrong in **both** sequences: the shop recorded the larger order's total and nothing more, whichever order was marked paid first.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `SplitOrderPaymentTest` builds two orders sharing a reference and replays the paid branch of `OrderHistory::changeIdOrderState()` in both sequences, asserting each order records its own total and that the two add up. Both cases fail on 9.2.x.<br><br>The third case is the control for what the sibling total exists for: one payment covering two invoices of a single order still leaves nothing outstanding on either. It passes on both sides.<br><br>Behat `order` suite: 260 scenarios, 7343 steps, all passing.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #15159
| Related PRs       |
| Sponsor company   |

Reported by @PeeyushAgrawalWebkul, reproduced by @khouloudbelguith on 1.7.6.0 and 1.7.5.2 and by @aniszr on 8.0.4.

### The decision, and what I rejected

The fix makes the two halves of `getRestPaid()` agree: the sibling join no longer restricts itself to one order, so it covers the same invoices that `getTotalPaid()` already counts payments for. Two lines, and `getSiblingTotal()` has exactly one caller - `getRestPaid()` itself - so nothing else changes shape. Dropping a restrictive `AND` can only add matches, and for invoices of one order the restriction was always satisfied, so the case the method exists for cannot regress; the third test pins it anyway.

**Rejected: counting only payments whose `order_invoice_payment.id_order` is this order.** It is the narrower change and it produces the same numbers here. It also makes `getTotalPaid()` blind to links that `setInvoice()` writes across orders on purpose, and the back office already reads a split order as one ledger - `Order::getOrderPaymentCollection()` filters by reference and `GetOrderForViewingHandler` walks `getBrother()`. Making one half of the formula pretend those links are not there contradicts what the rest of the code does with them.

**Rejected: stopping `setInvoice()` from linking a payment that belongs to a different order.** That is the other end of the same asymmetry, and it changes what the link table means. The invoice PDF and the payment block both read it, so the blast radius is much wider than the arithmetic bug being fixed.
