### PR TITLE
Ask for the birthdate with a date input

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -79,7 +79,9 @@ class CustomerFormCore extends AbstractForm
     public function fillFromCustomer(Customer $customer)
     {
         $params = get_object_vars($customer);
-        $params['birthday'] = $customer->birthday === '0000-00-00' ? null : Tools::displayDate($customer->birthday);
+        // A date input reads its value as ISO whatever the shop's locale is, so the stored value is passed
+        // through rather than localised - Tools::displayDate() here left the field blank.
+        $params['birthday'] = $customer->birthday === '0000-00-00' ? null : $customer->birthday;
 
         return $this->fillWith($params);
     }
@@ -124,6 +126,9 @@ class CustomerFormCore extends AbstractForm
         }
 
         // check birthdayField against null case is mandatory.
+        // A date input submits ISO whatever the shop's locale is, and that is already the stored form, so
+        // only the localised format the field used to be filled with still needs converting. A value that
+        // is neither is already reported by the field's own format check.
         $birthdayField = $this->getField('birthday');
         if (!empty($birthdayField)
             && !empty($birthdayField->getValue())

--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -186,7 +186,7 @@ class CustomerFormatterCore implements FormFormatterInterface
         if ($this->ask_for_birthdate) {
             $format['birthday'] = (new FormField())
                 ->setName('birthday')
-                ->setType('text')
+                ->setType('date')
                 ->setLabel(
                     $this->translator->trans(
                         'Birthdate',

--- a/tests/Integration/Classes/Form/CustomerBirthdateTest.php
+++ b/tests/Integration/Classes/Form/CustomerBirthdateTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Form;
+
+use Configuration;
+use Context;
+use Customer;
+use CustomerForm;
+use CustomerFormatter;
+use CustomerPersister;
+use DateTime;
+use Language;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The birthdate field was declared as a text input, so it was typed by hand in the shop's localised format
+ * and the date branch both maintained themes already carry was never reached.
+ */
+class CustomerBirthdateTest extends KernelTestCase
+{
+    private CustomerForm $form;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+        global $kernel;
+        $kernel = self::$kernel;
+
+        $context = Context::getContext();
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+
+        $translator = self::getContainer()->get('translator');
+        $formatter = (new CustomerFormatter($translator, $context->language))
+            ->setAskForBirthdate(true)
+            ->setAskForPartnerOptin(false);
+
+        $this->form = new CustomerForm(
+            $context->smarty,
+            $context,
+            $translator,
+            $formatter,
+            new CustomerPersister($context, self::getContainer()->get('hashing'), $translator, false),
+            []
+        );
+    }
+
+    public function testTheFieldIsADateInput(): void
+    {
+        $this->assertSame('date', $this->form->getFormatter()->getFormat()['birthday']->getType());
+    }
+
+    /**
+     * A date input reads its value as ISO, so a localised one leaves the field blank.
+     */
+    public function testTheStoredValueIsOfferedBackUnlocalised(): void
+    {
+        $customer = new Customer();
+        $customer->birthday = '1990-05-17';
+
+        $this->form->fillFromCustomer($customer);
+
+        $this->assertSame('1990-05-17', $this->form->getField('birthday')->getValue());
+    }
+
+    /**
+     * @dataProvider birthdayProvider
+     */
+    public function testWhatTheFormMakesOfASubmittedBirthdate(string $submitted, ?string $stored, bool $errors): void
+    {
+        $this->form->fillWith([
+            'id_customer' => '',
+            'firstname' => 'Birthdate',
+            'lastname' => 'Probe',
+            'email' => 'birthdate.probe.' . uniqid() . '@example.test',
+            'password' => 'Correct horse battery',
+            'birthday' => $submitted,
+        ]);
+        $this->form->validate();
+
+        $field = $this->form->getField('birthday');
+        $this->assertSame($errors, !empty($field->getErrors()));
+        if (null !== $stored) {
+            $this->assertSame($stored, $field->getValue());
+        }
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string|null, 2: bool}>
+     */
+    public function birthdayProvider(): array
+    {
+        return [
+            // What a date input submits, whatever the shop's locale is, and already the stored form.
+            'iso, what a date input submits' => ['1990-05-17', '1990-05-17', false],
+            // What the field used to be filled with. Still accepted, and still converted.
+            'the shop localised format' => [self::localised('1990-05-17'), '1990-05-17', false],
+            // Neither: the form says so instead of leaving it to a message naming a property.
+            'neither format' => ['hello', null, true],
+        ];
+    }
+
+    private static function localised(string $iso): string
+    {
+        $language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+
+        return (new DateTime($iso))->format($language->date_format_lite);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CustomerFormatter::getFormat()` declared the birthdate as `->setType('text')`, so the customer typed a date by hand in the shop's localised format. Both maintained themes already carry a `{elseif $field.type === 'date'}` branch rendering `<input type="date">` - `classic-theme/templates/_partials/form-fields.tpl:101` and `hummingbird/templates/_partials/form-fields.tpl:98` - and it was never reached because core never sent that type.<br><br>A date input reads and submits its value as ISO whatever the shop's locale is, so `fillFromCustomer()` now offers the stored value back as it is. `Tools::displayDate()` there produced the localised string, which a date input cannot read, so the field would have rendered blank for an existing customer.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `CustomerBirthdateTest` asserts the field's type, that an existing birthdate is offered back unlocalised, and what the form makes of each of the three shapes a value can arrive in.<br><br>Manually: My account > Personal information with `PS_CUSTOMER_BIRTHDATE` on. Before: a text box wanting `05/31/1970`. After: the browser's date picker, prefilled with the stored date.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #15253
| Related PRs       | #13036 by @ecomm360
| Sponsor company   |

### The decision, and what I rejected

**Builds on #13036 by @ecomm360**, closed by @PierreRambaud in 2021 for inactivity rather than on merit. Those two lines are this change; the rest here is the test and the comments explaining why the second line is not optional.

**The validation is deliberately untouched.** I first added a branch reporting a value that matches neither format, and then measured that it was redundant - `hello` already produces one error and my branch made it two:

    before   [hello]  errors=["Format should be 05/31/1970."]
    after    [hello]  errors=["Invalid date format.","Format should be 05/31/1970."]

So it was removed. What the existing code does with each shape, measured:

    1990-05-17   ISO, what a date input submits   locale check fails, value passes through unchanged, and ISO is the stored form
    05/17/1990   the localised format             locale check passes, converted to 1990-05-17
    hello        neither                          reported by the field's own format check

The ISO case works through the existing code by construction rather than by accident: `Validate::isBirthDate($value, $localisedFormat)` returns false for it, nothing is converted, and the value is already what `Customer::$definition` validates with `isBirthDate` on `Y-m-d`. Measured: `validateFields()` returns true for `1990-05-17` and rejects the other two.

**Rejected: removing the `(E.g.: 05/31/1970)` hint and the placeholder from the field.** A date input ignores the placeholder and shows its own format, so both read as leftovers. A browser without `type="date"` support falls back to a text box, where the hint is still the right instruction - so removing it would take something away from exactly the users who need it.

**Not touched: the `{elseif $field.type === 'birthday'}` branch** the report also asks about. It is unreachable because no formatter emits that type, but it lives in the theme repositories, so it is theirs to remove.
