### PR TITLE
Fix duplicate entry error in CartRule::copyConditions()

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -301,7 +301,7 @@ class CartRuleCore extends ObjectModel
 		(SELECT ' . (int) $id_cart_rule_destination . ', id_country FROM `' . _DB_PREFIX_ . 'cart_rule_country` WHERE `id_cart_rule` = ' . (int) $id_cart_rule_source . ')');
         Db::getInstance()->execute('
 		INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_combination` (`id_cart_rule_1`, `id_cart_rule_2`)
-		(SELECT ' . (int) $id_cart_rule_destination . ', IF(id_cart_rule_1 != ' . (int) $id_cart_rule_source . ', id_cart_rule_1, id_cart_rule_2) FROM `' . _DB_PREFIX_ . 'cart_rule_combination`
+		(SELECT DISTINCT ' . (int) $id_cart_rule_destination . ', IF(id_cart_rule_1 != ' . (int) $id_cart_rule_source . ', id_cart_rule_1, id_cart_rule_2) FROM `' . _DB_PREFIX_ . 'cart_rule_combination`
 		WHERE `id_cart_rule_1` = ' . (int) $id_cart_rule_source . ' OR `id_cart_rule_2` = ' . (int) $id_cart_rule_source . ')');
 
         // Todo : should be changed soon, be must be copied too


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `CartRule::copyConditions()` copies the `cart_rule_combination` rows of a source cart rule with an `INSERT INTO ... (SELECT <new_id>, IF(...) ...)`. When the combination table contains the same pair in both orientations — `(A, B)` **and** `(B, A)`, which the restriction logic of `AdminCartRulesController` produces over time on real shops — the SELECT returns the same destination row twice and the INSERT fails with `SQLSTATE[23000]: 1062 Duplicate entry '<new>-<B>' for key 'PRIMARY'`. This happens during checkout when a partially used voucher is cloned into a "remainder" voucher (`PaymentModule::validateOrder()` → `createOrderCartRules()`), and since `validateOrder()` is not transactional the order ends up **without any order state** (no invoice, no emails, payment already captured, original voucher still active). Adding `DISTINCT` deduplicates the copied pairs.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create two customer vouchers A and B; enable *partial use* on A with a fixed amount discount higher than a typical order total. 2. Insert the bidirectional rows that the BO restriction logic produces over time: `INSERT INTO ps_cart_rule_combination (id_cart_rule_1, id_cart_rule_2) VALUES (A, B), (B, A);` 3. As the customer owning A, order a product cheaper than the voucher amount, apply voucher A, pay the remainder (e.g. shipping). 4. Without this patch: `Duplicate entry` exception during order validation → order created without any state, invoice or emails. With this patch: order validated normally, remainder voucher created, each combination pair copied once.
| UI Tests          | n/a — single SQL statement fix, covered by the manual test above
| Fixed issue or discussion? | Fixes #42484
| Related PRs       | Supersedes #36321 (same one-line fix, closed for lack of follow-up)
| Sponsor company   | 
