### PR TITLE
Check if theme is not parent with its child currently used while trying to delete

### DIFF
--- a/src/Adapter/Shop/Repository/ShopRepository.php
+++ b/src/Adapter/Shop/Repository/ShopRepository.php
@@ -12,12 +12,13 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
+use PrestaShop\PrestaShop\Core\Shop\ShopThemesNamesProviderInterface;
 use Shop;
 
 /**
  * Provides methods to access data storage for shop
  */
-class ShopRepository extends AbstractObjectModelRepository
+class ShopRepository extends AbstractObjectModelRepository implements ShopThemesNamesProviderInterface
 {
     /**
      * @var Connection
@@ -153,5 +154,20 @@ class ShopRepository extends AbstractObjectModelRepository
         ;
 
         return array_map('intval', $shopIds);
+    }
+
+    /**
+     * Returns all theme names that used by a shop
+     *
+     * @return array<string>
+     */
+    public function getShopThemesNames(): array
+    {
+        return $this->connection->createQueryBuilder()
+            ->select('s.theme_name')
+            ->from($this->dbPrefix . 'shop', 's')
+            ->groupBy('s.theme_name')
+            ->executeQuery()
+            ->fetchFirstColumn();
     }
 }

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -108,8 +108,16 @@ class ThemeManager implements AddonManagerInterface
             return false;
         }
 
+        global $kernel; // sf kernel
+        $themeProvider = $kernel->getContainer()->get('prestashop.core.addon.theme.theme_provider');
+        $currentlyUsedTheme = $themeProvider->getCurrentlyUsedTheme();
+
         /** @var Theme $theme */
         $theme = $this->themeRepository->getInstanceByName($name);
+        if ($theme->getName() === $currentlyUsedTheme->get('parent')) {
+            return false;
+        }
+
         $theme->onUninstall();
 
         $this->filesystem->remove($theme->getDirectory());

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -108,16 +108,8 @@ class ThemeManager implements AddonManagerInterface
             return false;
         }
 
-        global $kernel; // sf kernel
-        $themeProvider = $kernel->getContainer()->get('prestashop.core.addon.theme.theme_provider');
-        $currentlyUsedTheme = $themeProvider->getCurrentlyUsedTheme();
-
         /** @var Theme $theme */
         $theme = $this->themeRepository->getInstanceByName($name);
-        if ($theme->getName() === $currentlyUsedTheme->get('parent')) {
-            return false;
-        }
-
         $theme->onUninstall();
 
         $this->filesystem->remove($theme->getDirectory());

--- a/src/Core/Addon/Theme/ThemeProvider.php
+++ b/src/Core/Addon/Theme/ThemeProvider.php
@@ -6,6 +6,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
+use PrestaShop\PrestaShop\Core\Shop\ShopThemesNamesProviderInterface;
+
 /**
  * Class ThemeProvider
  */
@@ -22,13 +24,19 @@ final class ThemeProvider implements ThemeProviderInterface
     private $theme;
 
     /**
+     * @var ShopThemesNamesProviderInterface
+     */
+    private $shopThemesRepository;
+
+    /**
      * @param ThemeRepository $themeRepository
      * @param Theme $theme
      */
-    public function __construct(ThemeRepository $themeRepository, Theme $theme)
+    public function __construct(ThemeRepository $themeRepository, Theme $theme, ShopThemesNamesProviderInterface $shopThemesRepository)
     {
         $this->themeRepository = $themeRepository;
         $this->theme = $theme;
+        $this->shopThemesRepository = $shopThemesRepository;
     }
 
     /**
@@ -47,5 +55,20 @@ final class ThemeProvider implements ThemeProviderInterface
         return $this->themeRepository->getListExcluding([
             $this->getCurrentlyUsedTheme()->getName(),
         ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNotDeletableThemes(): array
+    {
+        // Get all parent themes because they are not deletable
+        $parentThemes = $this->themeRepository->getParentThemes();
+        // Add the themes used by shop(s)
+        $shopThemes = $this->shopThemesRepository->getShopThemesNames();
+
+        $notDeletableThemes = array_merge($parentThemes, $shopThemes);
+
+        return array_unique($notDeletableThemes);
     }
 }

--- a/src/Core/Addon/Theme/ThemeProviderInterface.php
+++ b/src/Core/Addon/Theme/ThemeProviderInterface.php
@@ -24,4 +24,11 @@ interface ThemeProviderInterface
      * @return Theme[]
      */
     public function getNotUsedThemes();
+
+    /**
+     * Get themes names that cannot be deleted.
+     *
+     * @return array
+     */
+    public function getNotDeletableThemes();
 }

--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -147,4 +147,24 @@ class ThemeRepository implements AddonRepositoryInterface
             return json_decode($content, true);
         }
     }
+
+    /**
+     * Get all parent themes names
+     *
+     * @return array
+     */
+    public function getParentThemes(): array
+    {
+        $parentThemes = [];
+
+        $diskThemes = $this->getThemesOnDisk();
+
+        foreach ($diskThemes as $diskTheme) {
+            if ($diskTheme->get('parent')) {
+                $parentThemes[] = $diskTheme->get('parent');
+            }
+        }
+
+        return $parentThemes;
+    }
 }

--- a/src/Core/Domain/Theme/CommandHandler/DeleteThemeHandler.php
+++ b/src/Core/Domain/Theme/CommandHandler/DeleteThemeHandler.php
@@ -7,6 +7,7 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Theme\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeProviderInterface;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Command\DeleteThemeCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\CannotDeleteThemeException;
@@ -23,11 +24,18 @@ final class DeleteThemeHandler implements DeleteThemeHandlerInterface
     private $themeManager;
 
     /**
-     * @param ThemeManager $themeManager
+     * @var ThemeProviderInterface
      */
-    public function __construct(ThemeManager $themeManager)
+    private $themeProvider;
+
+    /**
+     * @param ThemeManager $themeManager
+     * @param ThemeProviderInterface $themeProvider
+     */
+    public function __construct(ThemeManager $themeManager, ThemeProviderInterface $themeProvider)
     {
         $this->themeManager = $themeManager;
+        $this->themeProvider = $themeProvider;
     }
 
     /**
@@ -36,6 +44,10 @@ final class DeleteThemeHandler implements DeleteThemeHandlerInterface
     public function handle(DeleteThemeCommand $command)
     {
         $plainThemeName = $command->getThemeName()->getValue();
+
+        if (in_array($plainThemeName, $this->themeProvider->getNotDeletableThemes())) {
+            throw new CannotDeleteThemeException(sprintf('Theme "%s" is used and thus cannot be deleted.', $plainThemeName));
+        }
 
         if (!$this->themeManager->uninstall($plainThemeName)) {
             throw new CannotDeleteThemeException(sprintf('Theme "%s" is used and thus cannot be deleted.', $plainThemeName));

--- a/src/Core/Shop/ShopThemesNamesProviderInterface.php
+++ b/src/Core/Shop/ShopThemesNamesProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Core\Shop;
+
+/**
+ * Interface ShopThemesNamesProviderInterface
+ */
+interface ShopThemesNamesProviderInterface
+{
+    /**
+     * Get theme names used by shops.
+     *
+     * @return list<string>
+     */
+    public function getShopThemesNames(): array;
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -84,6 +84,7 @@ class ThemeController extends PrestaShopAdminController
             'faviconPath' => $logoProvider->getFaviconPath(),
             'currentlyUsedTheme' => $themeProvider->getCurrentlyUsedTheme(),
             'notUsedThemes' => $themeProvider->getNotUsedThemes(),
+            'notDeletableThemes' => $themeProvider->getNotDeletableThemes(),
             'isDevModeOn' => $this->getConfiguration()->get('_PS_MODE_DEV_'),
             'isSingleShopContext' => $this->getShopContext()->getShopConstraint()->isSingleShopContext(),
             'isMultiShopFeatureUsed' => $this->getShopContext()->isMultiShopUsed(),

--- a/src/PrestaShopBundle/Resources/config/services/core/addon.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/addon.yml
@@ -69,6 +69,7 @@ services:
     arguments:
       - '@prestashop.core.addon.theme.repository'
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.theme'
+      - '@PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository'
 
   prestashop.core.addon.theme.theme_provider:
     alias: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeProvider

--- a/src/PrestaShopBundle/Resources/config/services/core/domain/theme.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/domain/theme.yml
@@ -25,6 +25,7 @@ services:
     autoconfigure: true
     arguments:
       - '@prestashop.core.addon.theme.theme_manager'
+      - '@prestashop.core.addon.theme.theme_provider'
 
   prestashop.core.domain.theme.command_handler.adapt_theme_to_rtl_languages_handler:
     class: 'PrestaShop\PrestaShop\Core\Domain\Theme\CommandHandler\AdaptThemeToRTLLanguagesHandler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -111,6 +111,11 @@
                         </i>
                       </button>
                     </form>
+                  {% else %}
+                    <button disabled class="btn action-button">
+                      <i class="material-icons icon-current-theme">done</i>
+                      {{ 'Used parent theme'|trans({}, 'Admin.Design.Feature') }}
+                    </button>
                   {% endif %}
                 {% endblock %}
               {% endembed %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -102,7 +102,7 @@
                       <span>{{ 'Use this theme'|trans({}, 'Admin.Design.Feature') }}</span>
                     </button>
                   </form>
-                  {% if theme.name != currentlyUsedTheme.get('parent') %}
+                  {% if theme.name not in notDeletableThemes %}
                     <form action="{{ path('admin_themes_delete', {themeName: theme.name}) }}" method="post" class="d-inline">
                       <input type="hidden" name="token" value="{{ csrf_token('delete-theme') }}"/>
                       <button type="button" class="btn delete-button js-display-delete-theme-modal">
@@ -112,9 +112,9 @@
                       </button>
                     </form>
                   {% else %}
-                    <button title="{{ 'You can\'t delete the parent of a theme currently used'|trans({}, 'Admin.Design.Feature') }}" disabled class="btn delete-button">
+                    <button title="{{ 'You can\'t delete this theme because it is either currently used or a parent'|trans({}, 'Admin.Design.Feature') }}" disabled class="btn delete-button">
                       <i class="material-icons icon-current-theme">done</i>
-                      {{ 'Used parent theme'|trans({}, 'Admin.Design.Feature') }}
+                      {{ 'Used theme'|trans({}, 'Admin.Design.Feature') }}
                     </button>
                   {% endif %}
                 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -102,14 +102,16 @@
                       <span>{{ 'Use this theme'|trans({}, 'Admin.Design.Feature') }}</span>
                     </button>
                   </form>
-                  <form action="{{ path('admin_themes_delete', {themeName: theme.name}) }}" method="post" class="d-inline">
-                    <input type="hidden" name="token" value="{{ csrf_token('delete-theme') }}"/>
-                    <button type="button" class="btn delete-button js-display-delete-theme-modal">
-                      <i class="material-icons">
-                        delete
-                      </i>
-                    </button>
-                  </form>
+                  {% if theme.name != currentlyUsedTheme.get('parent') %}
+                    <form action="{{ path('admin_themes_delete', {themeName: theme.name}) }}" method="post" class="d-inline">
+                      <input type="hidden" name="token" value="{{ csrf_token('delete-theme') }}"/>
+                      <button type="button" class="btn delete-button js-display-delete-theme-modal">
+                        <i class="material-icons">
+                          delete
+                        </i>
+                      </button>
+                    </form>
+                  {% endif %}
                 {% endblock %}
               {% endembed %}
             {% endfor %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -112,7 +112,7 @@
                       </button>
                     </form>
                   {% else %}
-                    <button title="{{ 'You can\'t delete the parent of a theme currently used'|trans({}, 'Admin.Design.Feature') }}" disabled class="btn action-button">
+                    <button title="{{ 'You can\'t delete the parent of a theme currently used'|trans({}, 'Admin.Design.Feature') }}" disabled class="btn delete-button">
                       <i class="material-icons icon-current-theme">done</i>
                       {{ 'Used parent theme'|trans({}, 'Admin.Design.Feature') }}
                     </button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -112,7 +112,7 @@
                       </button>
                     </form>
                   {% else %}
-                    <button disabled class="btn action-button">
+                    <button title="{{ 'You can\'t delete the parent of a theme currently used'|trans({}, 'Admin.Design.Feature') }}" disabled class="btn action-button">
                       <i class="material-icons icon-current-theme">done</i>
                       {{ 'Used parent theme'|trans({}, 'Admin.Design.Feature') }}
                     </button>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Avoid the admin to delete a parent theme when its child is currently used as the shop theme
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a child theme and try to delete its parent theme
| UI Tests          | /
| Fixed issue or discussion?     | Fixes #42486 
| Related PRs       | /
| Sponsor company   | Agence Off
