### PR TITLE
Replace PHP serialize with JSON for extra property constraints (CWE-502)

### DIFF
--- a/src/Core/ExtraProperty/Definition/ExtraPropertyDefinition.php
+++ b/src/Core/ExtraProperty/Definition/ExtraPropertyDefinition.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\ExtraProperty\Definition;
 
+use JsonException;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\InvalidExtraPropertyConstraintException;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\InvalidExtraPropertyDefinitionException;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyConstraintMapper;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyValidator;
@@ -319,13 +321,28 @@ final class ExtraPropertyDefinition
         if ('{' === $raw[0]) {
             try {
                 return ExtraPropertyConstraintMapper::constraintsFromJson($raw);
-            } catch (\JsonException) {
+            } catch (JsonException|InvalidExtraPropertyConstraintException $e) {
+                // Corrupt or unsupported JSON constraint blob — degrade to "no constraints"
+                // instead of crashing the page. The error is logged so the shop owner can
+                // investigate and re-save the affected definition.
+                if (class_exists(InvalidExtraPropertyConstraintException::class)) {
+                    @trigger_error(
+                        sprintf('ExtraPropertyDefinition: failed to decode JSON constraints: %s', $e->getMessage()),
+                        E_USER_WARNING
+                    );
+                }
+
                 return null;
             }
         }
 
         // Legacy path: PHP-serialized blob from a row that has not been re-saved yet.
-        $decoded = @unserialize($raw, ['allowed_classes' => true]);
+        // allowed_classes => false prevents __wakeup() and any object instantiation —
+        // all objects become __PHP_Incomplete_Class, which filterConstraints() drops
+        // (they are not Constraint instances). Legacy rows effectively lose their
+        // constraints until re-saved through the BO form or a module re-register,
+        // but the PHP Object Injection surface (CWE-502) is fully closed.
+        $decoded = @unserialize($raw, ['allowed_classes' => false]);
 
         return is_array($decoded) ? self::filterConstraints($decoded) : null;
     }

--- a/src/Core/ExtraProperty/Definition/ExtraPropertyDefinition.php
+++ b/src/Core/ExtraProperty/Definition/ExtraPropertyDefinition.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\ExtraProperty\Definition;
 
 use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\InvalidExtraPropertyDefinitionException;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyConstraintMapper;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyValidator;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Value\ExtraPropertyValueCaster;
 use PrestaShop\PrestaShop\Core\Util\Inflector;
@@ -289,11 +290,16 @@ final class ExtraPropertyDefinition
     /**
      * Normalizes the registry "constraints" cell into a list of Constraint objects.
      *
-     * Accepts both shapes so fromRow() works for an in-memory row (constraints already given as
-     * Constraint objects) and a DB row (constraints serialized to a string):
+     * Accepts three shapes so fromRow() works for in-memory rows, new DB rows (JSON), and
+     * legacy DB rows (PHP serialize):
      *  - array  → already-decoded constraints; filtered and returned as-is (no unserialize).
-     *  - string → a serialized blob written by trusted module install code (registerExtraProperty);
-     *             unserialized then filtered.
+     *  - string starting with '{' → JSON blob produced by constraintsToJson(); decoded via
+     *    ExtraPropertyConstraintMapper::constraintsFromJson() (no unserialize, no object
+     *    instantiation — only whitelisted constraint names + scalar options).
+     *  - string (legacy) → a PHP-serialized blob written by an older version; unserialized
+     *    with allowed_classes => true for backward compatibility, then filtered. This path
+     *    is only hit for rows that have not been re-saved since the JSON migration; re-saving
+     *    any definition through the BO form or a module re-register converts it to JSON.
      * Anything that is not a Symfony Constraint is discarded. Returns null when nothing usable
      * remains, mirroring the "no validation" default.
      *
@@ -309,6 +315,16 @@ final class ExtraPropertyDefinition
             return null;
         }
 
+        // JSON path (new writes since the CWE-502 hardening).
+        if ('{' === $raw[0]) {
+            try {
+                return ExtraPropertyConstraintMapper::constraintsFromJson($raw);
+            } catch (\JsonException) {
+                return null;
+            }
+        }
+
+        // Legacy path: PHP-serialized blob from a row that has not been re-saved yet.
         $decoded = @unserialize($raw, ['allowed_classes' => true]);
 
         return is_array($decoded) ? self::filterConstraints($decoded) : null;

--- a/src/Core/ExtraProperty/Definition/ExtraPropertyDefinitionRepository.php
+++ b/src/Core/ExtraProperty/Definition/ExtraPropertyDefinitionRepository.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ExtraPropertyDefinitionNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ProtectedModuleExtraPropertyDefinitionException;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Schema\ColumnDefinitionMapper;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyConstraintMapper;
 use Throwable;
 
 /**
@@ -143,7 +144,7 @@ class ExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionReposi
             'form_type' => $definition->getFormType(),
             'form_options' => null !== $definition->getFormOptions() ? json_encode($definition->getFormOptions()) : null,
             'sql_index' => $definition->getSqlIndex()->value,
-            'constraints' => !empty($definition->getConstraints()) ? serialize($definition->getConstraints()) : null,
+            'constraints' => ExtraPropertyConstraintMapper::constraintsToJson($definition->getConstraints()),
             'associated_forms' => !empty($definition->getAssociatedForms()) ? json_encode(array_values($definition->getAssociatedForms())) : null,
             'associated_grids' => !empty($definition->getAssociatedGrids()) ? json_encode(array_values($definition->getAssociatedGrids())) : null,
             'associated_apis' => !empty($definition->getAssociatedApis()) ? json_encode(array_values($definition->getAssociatedApis())) : null,

--- a/src/Core/ExtraProperty/Validation/ExtraPropertyConstraintMapper.php
+++ b/src/Core/ExtraProperty/Validation/ExtraPropertyConstraintMapper.php
@@ -48,6 +48,12 @@ use Throwable;
  */
 class ExtraPropertyConstraintMapper
 {
+    /**
+     * JSON schema version for the structured constraint blob stored in
+     * ps_extra_property_definition.constraints. Bumped when the shape changes.
+     */
+    public const JSON_VERSION = 1;
+
     private const ALLOWED_CONSTRAINTS = [
         // Presence
         'NotBlank' => Assert\NotBlank::class,
@@ -181,6 +187,248 @@ class ExtraPropertyConstraintMapper
         }
 
         return [] !== $lines ? implode("\n", $lines) : null;
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON serialization (replaces PHP serialize/unserialize for DB storage)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Encodes a list of Constraint instances into a JSON string for safe DB storage.
+     *
+     * Replaces PHP serialize() in ExtraPropertyDefinitionRepository::save(). The JSON shape
+     * is versioned and uses only whitelisted constraint names + scalar/array-of-scalar options,
+     * eliminating the PHP Object Injection attack surface (CWE-502) that unserialize() with
+     * allowed_classes => true created on the read path.
+     *
+     * Constraints whose name is not in the whitelist (module-attached custom constraints) are
+     * still encoded by name + short FQCN so the read-only view page can display them, but
+     * fromJson() will skip them on read-back (they cannot be re-instantiated without the module
+     * being loaded). This matches the existing toNames()/fromNames() asymmetry.
+     *
+     * @param list<Constraint>|null $constraints
+     */
+    public static function constraintsToJson(?array $constraints): ?string
+    {
+        if (null === $constraints || [] === $constraints) {
+            return null;
+        }
+
+        $encoded = [];
+        foreach ($constraints as $constraint) {
+            if ($constraint instanceof Constraint) {
+                $encoded[] = self::constraintToArray($constraint);
+            }
+        }
+
+        return [] !== $encoded
+            ? json_encode(['version' => self::JSON_VERSION, 'constraints' => $encoded], JSON_THROW_ON_ERROR)
+            : null;
+    }
+
+    /**
+     * Decodes a JSON string (produced by constraintsToJson()) back into Constraint instances.
+     *
+     * Replaces PHP unserialize() in ExtraPropertyDefinition::decodeConstraints(). Only
+     * whitelisted constraint names are accepted; options must be scalars or arrays of scalars
+     * (no objects, no nested arrays beyond one level) — this is the strict rule that closes
+     * the Object Injection surface. Unknown names and non-scalar options are silently dropped
+     * (the constraint is skipped), mirroring filterConstraints()'s "drop non-Constraint" behavior.
+     *
+     * @return list<Constraint>|null
+     */
+    public static function constraintsFromJson(?string $json): ?array
+    {
+        if (null === $json || '' === trim($json)) {
+            return null;
+        }
+
+        try {
+            $data = json_decode($json, true, 32, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        if (!is_array($data) || !isset($data['constraints']) || !is_array($data['constraints'])) {
+            return null;
+        }
+
+        $constraints = [];
+        foreach ($data['constraints'] as $entry) {
+            $constraint = self::arrayToConstraint($entry);
+            if (null !== $constraint) {
+                $constraints[] = $constraint;
+            }
+        }
+
+        return [] !== $constraints ? $constraints : null;
+    }
+
+    /**
+     * Encodes a single Constraint into the JSON array shape.
+     *
+     * Composites (All, AtLeastOneOf, Sequentially) encode their nested constraints under a
+     * "constraints" key; Collection encodes its keyed children under a "fields" key. Non-
+     * composite constraints encode their configured options under an "options" key.
+     *
+     * @return array<string, mixed>
+     */
+    private static function constraintToArray(Constraint $constraint): array
+    {
+        $shortName = (new ReflectionClass($constraint))->getShortName();
+
+        if ($constraint instanceof Composite) {
+            $entry = ['name' => $shortName];
+            $nested = $constraint->getNestedConstraints();
+            if (Assert\Collection::class === $constraint::class) {
+                $fields = [];
+                foreach ($nested as $key => $child) {
+                    if (!is_string($key) || !$child instanceof Constraint) {
+                        continue;
+                    }
+                    // Collection wraps each field's constraint in Required/Optional.
+                    // Unwrap to store the inner constraint; re-wrap on decode.
+                    $inner = self::unwrapCollectionField($child);
+                    if (null !== $inner) {
+                        $fields[$key] = self::constraintToArray($inner);
+                        if ($child instanceof Assert\Optional) {
+                            $fields[$key]['optional'] = true;
+                        }
+                    }
+                }
+                $entry['fields'] = $fields;
+            } else {
+                $children = [];
+                foreach ($nested as $child) {
+                    if ($child instanceof Constraint) {
+                        $children[] = self::constraintToArray($child);
+                    }
+                }
+                $entry['constraints'] = $children;
+            }
+
+            return $entry;
+        }
+
+        $configured = self::configuredOptions($constraint);
+        $entry = ['name' => $shortName];
+        $options = [];
+        foreach ($configured as $option => $value) {
+            if (self::isJsonSafeScalar($value)) {
+                $options[$option] = $value;
+            } elseif (is_array($value) && self::isScalarList($value)) {
+                $options[$option] = $value;
+            }
+            // Non-scalar options (objects like DateTimeImmutable, closures) are dropped —
+            // they cannot be represented in JSON and are not needed for the whitelisted set.
+        }
+        $entry['options'] = $options;
+
+        return $entry;
+    }
+
+    /**
+     * Decodes a single JSON array entry back into a Constraint instance, or null if the entry
+     * is not a whitelisted constraint or carries non-scalar options.
+     *
+     * @param mixed $entry
+     */
+    private static function arrayToConstraint(mixed $entry): ?Constraint
+    {
+        if (!is_array($entry) || !isset($entry['name']) || !is_string($entry['name'])) {
+            return null;
+        }
+
+        $name = $entry['name'];
+
+        // Only whitelisted names can be re-instantiated.
+        if (!isset(self::ALLOWED_CONSTRAINTS[$name])) {
+            return null;
+        }
+
+        $fqcn = self::ALLOWED_CONSTRAINTS[$name];
+
+        try {
+            // Composite shape: "constraints" (list) or "fields" (Collection).
+            if (is_subclass_of($fqcn, Composite::class)) {
+                $children = [];
+                if (Assert\Collection::class === $fqcn && isset($entry['fields']) && is_array($entry['fields'])) {
+                    foreach ($entry['fields'] as $key => $child) {
+                        if (!is_string($key)) {
+                            continue;
+                        }
+                        $childConstraint = self::arrayToConstraint($child);
+                        if (null !== $childConstraint) {
+                            // Re-wrap in Optional or Required (default).
+                            $isOptional = is_array($child) && isset($child['optional']) && true === $child['optional'];
+                            $children[$key] = $isOptional
+                                ? new Assert\Optional($childConstraint)
+                                : new Assert\Required($childConstraint);
+                        }
+                    }
+
+                    return [] !== $children ? self::instantiate($fqcn, $name, ['fields' => $children]) : null;
+                }
+
+                if (isset($entry['constraints']) && is_array($entry['constraints'])) {
+                    foreach ($entry['constraints'] as $child) {
+                        $childConstraint = self::arrayToConstraint($child);
+                        if (null !== $childConstraint) {
+                            $children[] = $childConstraint;
+                        }
+                    }
+                    $defaultOption = self::defaultOptionOf($fqcn) ?? 'constraints';
+
+                    return [] !== $children ? self::instantiate($fqcn, $name, [$defaultOption => $children]) : null;
+                }
+
+                return null;
+            }
+
+            // Non-composite shape: "options" (scalar/array-of-scalar map).
+            $options = [];
+            if (isset($entry['options']) && is_array($entry['options'])) {
+                foreach ($entry['options'] as $option => $value) {
+                    if (!is_string($option)) {
+                        continue;
+                    }
+                    if (self::isJsonSafeScalar($value) || (is_array($value) && self::isScalarList($value))) {
+                        $options[$option] = $value;
+                    }
+                }
+            }
+
+            return [] !== $options ? self::instantiate($fqcn, $name, $options) : self::instantiate($fqcn, $name, null);
+        } catch (InvalidExtraPropertyConstraintException) {
+            // Malformed JSON entry (invalid options for the constraint type) — silently skip,
+            // mirroring filterConstraints()'s "drop non-Constraint" behavior.
+            return null;
+        }
+    }
+
+    /**
+     * A value that is safe to round-trip through JSON: string, int, float, bool, null.
+     */
+    private static function isJsonSafeScalar(mixed $value): bool
+    {
+        return null === $value || is_string($value) || is_int($value) || is_float($value) || is_bool($value);
+    }
+
+    /**
+     * Collection stores each field's constraint wrapped in Required/Optional. This unwraps
+     * the inner constraint for JSON encoding (the wrapper is re-added on decode).
+     */
+    private static function unwrapCollectionField(Constraint $wrapper): ?Constraint
+    {
+        if ($wrapper instanceof Assert\Required || $wrapper instanceof Assert\Optional) {
+            $inner = $wrapper->getNestedConstraints();
+            $first = array_values($inner)[0] ?? null;
+
+            return $first instanceof Constraint ? $first : null;
+        }
+
+        // Already a bare constraint (shouldn't happen with Collection, but handle gracefully).
+        return $wrapper;
     }
 
     /**

--- a/src/Core/ExtraProperty/Validation/ExtraPropertyConstraintMapper.php
+++ b/src/Core/ExtraProperty/Validation/ExtraPropertyConstraintMapper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\ExtraProperty\Validation;
 
+use JsonException;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
@@ -201,12 +202,15 @@ class ExtraPropertyConstraintMapper
      * eliminating the PHP Object Injection attack surface (CWE-502) that unserialize() with
      * allowed_classes => true created on the read path.
      *
-     * Constraints whose name is not in the whitelist (module-attached custom constraints) are
-     * still encoded by name + short FQCN so the read-only view page can display them, but
-     * fromJson() will skip them on read-back (they cannot be re-instantiated without the module
-     * being loaded). This matches the existing toNames()/fromNames() asymmetry.
+     * Only constraints whose FQCN is in the whitelist can be encoded — a module's custom
+     * constraint named "Length" is NOT mistaken for the Symfony one (the lookup compares
+     * the full class name). Non-whitelisted constraints throw
+     * InvalidExtraPropertyConstraintException so the caller knows the save cannot proceed
+     * without dropping or replacing the offending constraint.
      *
      * @param list<Constraint>|null $constraints
+     *
+     * @throws InvalidExtraPropertyConstraintException when a constraint's FQCN is not in the whitelist
      */
     public static function constraintsToJson(?array $constraints): ?string
     {
@@ -232,10 +236,13 @@ class ExtraPropertyConstraintMapper
      * Replaces PHP unserialize() in ExtraPropertyDefinition::decodeConstraints(). Only
      * whitelisted constraint names are accepted; options must be scalars or arrays of scalars
      * (no objects, no nested arrays beyond one level) — this is the strict rule that closes
-     * the Object Injection surface. Unknown names and non-scalar options are silently dropped
-     * (the constraint is skipped), mirroring filterConstraints()'s "drop non-Constraint" behavior.
+     * the Object Injection surface. The JSON schema version must match JSON_VERSION exactly.
+     * Invalid entries (unknown name, non-scalar option, missing composite key) throw
+     * InvalidExtraPropertyConstraintException so the caller can degrade gracefully.
      *
      * @return list<Constraint>|null
+     *
+     * @throws InvalidExtraPropertyConstraintException when the JSON schema version is unsupported or an entry is malformed
      */
     public static function constraintsFromJson(?string $json): ?array
     {
@@ -245,20 +252,41 @@ class ExtraPropertyConstraintMapper
 
         try {
             $data = json_decode($json, true, 32, JSON_THROW_ON_ERROR);
-        } catch (\JsonException) {
+        } catch (JsonException) {
             return null;
         }
 
-        if (!is_array($data) || !isset($data['constraints']) || !is_array($data['constraints'])) {
+        if (!is_array($data) || !isset($data['version']) || !is_int($data['version'])) {
+            return null;
+        }
+
+        // Reject unknown JSON schema versions explicitly — the shape may have changed
+        // in ways this decoder cannot handle safely.
+        if ($data['version'] !== self::JSON_VERSION) {
+            throw new InvalidExtraPropertyConstraintException(sprintf(
+                'Unsupported JSON constraint schema version %d. This decoder supports version %d only.',
+                $data['version'],
+                self::JSON_VERSION
+            ));
+        }
+
+        if (!isset($data['constraints']) || !is_array($data['constraints'])) {
             return null;
         }
 
         $constraints = [];
-        foreach ($data['constraints'] as $entry) {
-            $constraint = self::arrayToConstraint($entry);
-            if (null !== $constraint) {
-                $constraints[] = $constraint;
+        try {
+            foreach ($data['constraints'] as $entry) {
+                $constraint = self::arrayToConstraint($entry);
+                if (null !== $constraint) {
+                    $constraints[] = $constraint;
+                }
             }
+        } catch (InvalidExtraPropertyConstraintException $e) {
+            // Invalid entries are rejected explicitly by arrayToConstraint(). The read
+            // path (fromRow) catches this so a corrupt DB row degrades to "no constraints"
+            // instead of crashing the page, but the error is surfaced to the caller.
+            throw $e;
         }
 
         return [] !== $constraints ? $constraints : null;
@@ -275,10 +303,23 @@ class ExtraPropertyConstraintMapper
      */
     private static function constraintToArray(Constraint $constraint): array
     {
-        $shortName = (new ReflectionClass($constraint))->getShortName();
+        // Validate the constraint's FQCN against the whitelist by reverse lookup.
+        // This prevents a module's custom constraint named "Length" from being
+        // encoded as the Symfony Length and decoded back as the wrong class.
+        // Non-whitelisted constraints cannot be round-tripped through JSON and
+        // must fail explicitly rather than being silently dropped or mis-encoded.
+        $name = self::nameOf($constraint);
+        if (null === $name) {
+            throw new InvalidExtraPropertyConstraintException(sprintf(
+                'Constraint "%s" is not in the whitelist and cannot be JSON-encoded. ' .
+                'Only core Symfony constraints and PrestaShop custom constraints registered in %s are allowed.',
+                $constraint::class,
+                self::class
+            ));
+        }
 
         if ($constraint instanceof Composite) {
-            $entry = ['name' => $shortName];
+            $entry = ['name' => $name];
             $nested = $constraint->getNestedConstraints();
             if (Assert\Collection::class === $constraint::class) {
                 $fields = [];
@@ -311,7 +352,7 @@ class ExtraPropertyConstraintMapper
         }
 
         $configured = self::configuredOptions($constraint);
-        $entry = ['name' => $shortName];
+        $entry = ['name' => $name];
         $options = [];
         foreach ($configured as $option => $value) {
             if (self::isJsonSafeScalar($value)) {
@@ -328,82 +369,100 @@ class ExtraPropertyConstraintMapper
     }
 
     /**
-     * Decodes a single JSON array entry back into a Constraint instance, or null if the entry
-     * is not a whitelisted constraint or carries non-scalar options.
+     * Decodes a single JSON array entry back into a Constraint instance.
+     *
+     * Throws InvalidExtraPropertyConstraintException for any invalid entry (unknown name,
+     * non-scalar option, missing composite key, etc.) so the caller can decide whether to
+     * abort or degrade. Returns null only for a valid composite entry with no children.
      *
      * @param mixed $entry
+     *
+     * @throws InvalidExtraPropertyConstraintException when the entry is malformed or carries an unknown name
      */
     private static function arrayToConstraint(mixed $entry): ?Constraint
     {
         if (!is_array($entry) || !isset($entry['name']) || !is_string($entry['name'])) {
-            return null;
+            throw new InvalidExtraPropertyConstraintException(
+                'Invalid JSON constraint entry: missing or non-string "name" key.'
+            );
         }
 
         $name = $entry['name'];
 
-        // Only whitelisted names can be re-instantiated.
+        // Only whitelisted names can be re-instantiated — reject explicitly.
         if (!isset(self::ALLOWED_CONSTRAINTS[$name])) {
-            return null;
+            throw new InvalidExtraPropertyConstraintException(sprintf(
+                'Unknown constraint "%s" in JSON data. Allowed constraints: %s.',
+                $name,
+                implode(', ', self::getAllowedNames())
+            ));
         }
 
         $fqcn = self::ALLOWED_CONSTRAINTS[$name];
 
-        try {
-            // Composite shape: "constraints" (list) or "fields" (Collection).
-            if (is_subclass_of($fqcn, Composite::class)) {
-                $children = [];
-                if (Assert\Collection::class === $fqcn && isset($entry['fields']) && is_array($entry['fields'])) {
-                    foreach ($entry['fields'] as $key => $child) {
-                        if (!is_string($key)) {
-                            continue;
-                        }
-                        $childConstraint = self::arrayToConstraint($child);
-                        if (null !== $childConstraint) {
-                            // Re-wrap in Optional or Required (default).
-                            $isOptional = is_array($child) && isset($child['optional']) && true === $child['optional'];
-                            $children[$key] = $isOptional
-                                ? new Assert\Optional($childConstraint)
-                                : new Assert\Required($childConstraint);
-                        }
+        // Composite shape: "constraints" (list) or "fields" (Collection).
+        if (is_subclass_of($fqcn, Composite::class)) {
+            $children = [];
+            if (Assert\Collection::class === $fqcn && isset($entry['fields']) && is_array($entry['fields'])) {
+                foreach ($entry['fields'] as $key => $child) {
+                    if (!is_string($key)) {
+                        throw new InvalidExtraPropertyConstraintException(sprintf(
+                            'Invalid Collection field key in constraint "%s": keys must be strings, got %s.',
+                            $name,
+                            get_debug_type($key)
+                        ));
                     }
-
-                    return [] !== $children ? self::instantiate($fqcn, $name, ['fields' => $children]) : null;
+                    $childConstraint = self::arrayToConstraint($child);
+                    // Re-wrap in Optional or Required (default).
+                    $isOptional = is_array($child) && isset($child['optional']) && true === $child['optional'];
+                    $children[$key] = $isOptional
+                        ? new Assert\Optional($childConstraint)
+                        : new Assert\Required($childConstraint);
                 }
 
-                if (isset($entry['constraints']) && is_array($entry['constraints'])) {
-                    foreach ($entry['constraints'] as $child) {
-                        $childConstraint = self::arrayToConstraint($child);
-                        if (null !== $childConstraint) {
-                            $children[] = $childConstraint;
-                        }
-                    }
-                    $defaultOption = self::defaultOptionOf($fqcn) ?? 'constraints';
-
-                    return [] !== $children ? self::instantiate($fqcn, $name, [$defaultOption => $children]) : null;
-                }
-
-                return null;
+                return [] !== $children ? self::instantiate($fqcn, $name, ['fields' => $children]) : null;
             }
 
-            // Non-composite shape: "options" (scalar/array-of-scalar map).
-            $options = [];
-            if (isset($entry['options']) && is_array($entry['options'])) {
-                foreach ($entry['options'] as $option => $value) {
-                    if (!is_string($option)) {
-                        continue;
-                    }
-                    if (self::isJsonSafeScalar($value) || (is_array($value) && self::isScalarList($value))) {
-                        $options[$option] = $value;
-                    }
+            if (isset($entry['constraints']) && is_array($entry['constraints'])) {
+                foreach ($entry['constraints'] as $child) {
+                    $children[] = self::arrayToConstraint($child);
                 }
+                $defaultOption = self::defaultOptionOf($fqcn) ?? 'constraints';
+
+                return [] !== $children ? self::instantiate($fqcn, $name, [$defaultOption => $children]) : null;
             }
 
-            return [] !== $options ? self::instantiate($fqcn, $name, $options) : self::instantiate($fqcn, $name, null);
-        } catch (InvalidExtraPropertyConstraintException) {
-            // Malformed JSON entry (invalid options for the constraint type) — silently skip,
-            // mirroring filterConstraints()'s "drop non-Constraint" behavior.
-            return null;
+            throw new InvalidExtraPropertyConstraintException(sprintf(
+                'Composite constraint "%s" is missing its "constraints" or "fields" key in JSON data.',
+                $name
+            ));
         }
+
+        // Non-composite shape: "options" (scalar/array-of-scalar map).
+        $options = [];
+        if (isset($entry['options']) && is_array($entry['options'])) {
+            foreach ($entry['options'] as $option => $value) {
+                if (!is_string($option)) {
+                    throw new InvalidExtraPropertyConstraintException(sprintf(
+                        'Invalid option key in constraint "%s": keys must be strings, got %s.',
+                        $name,
+                        get_debug_type($option)
+                    ));
+                }
+                if (self::isJsonSafeScalar($value) || (is_array($value) && self::isScalarList($value))) {
+                    $options[$option] = $value;
+                } else {
+                    throw new InvalidExtraPropertyConstraintException(sprintf(
+                        'Invalid option "%s" in constraint "%s": value must be a scalar or array of scalars, got %s.',
+                        $option,
+                        $name,
+                        get_debug_type($value)
+                    ));
+                }
+            }
+        }
+
+        return [] !== $options ? self::instantiate($fqcn, $name, $options) : self::instantiate($fqcn, $name, null);
     }
 
     /**
@@ -412,6 +471,25 @@ class ExtraPropertyConstraintMapper
     private static function isJsonSafeScalar(mixed $value): bool
     {
         return null === $value || is_string($value) || is_int($value) || is_float($value) || is_bool($value);
+    }
+
+    /**
+     * Reverse lookup: returns the whitelist short name for a constraint's exact FQCN,
+     * or null when the FQCN is not in the whitelist. This is the safe counterpart to
+     * resolveName() — it compares the full class name, not the short name, so a
+     * module's custom constraint named "Length" is NOT mistaken for the Symfony one.
+     */
+    private static function nameOf(Constraint $constraint): ?string
+    {
+        $fqcn = $constraint::class;
+
+        foreach (self::ALLOWED_CONSTRAINTS as $shortName => $allowedFqcn) {
+            if ($fqcn === $allowedFqcn) {
+                return $shortName;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Unit/Core/ExtraProperty/ExtraPropertyDefinitionFromRowTest.php
+++ b/tests/Unit/Core/ExtraProperty/ExtraPropertyDefinitionFromRowTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinition;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyType;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Schema\ColumnDefinitionMapper;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyConstraintMapper;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -64,8 +65,23 @@ class ExtraPropertyDefinitionFromRowTest extends TestCase
         $this->assertNull($invalid->getEnumValues());
     }
 
-    public function testConstraintsRoundTripFromSerializedRow(): void
+    public function testConstraintsRoundTripFromJsonRow(): void
     {
+        $json = ExtraPropertyConstraintMapper::constraintsToJson([new Assert\Url(), new Assert\Length(['max' => 50])]);
+        $row = self::BASE_ROW + ['constraints' => $json];
+
+        $constraints = ExtraPropertyDefinition::fromRow($row)->getConstraints();
+
+        $this->assertIsArray($constraints);
+        $this->assertCount(2, $constraints);
+        $this->assertInstanceOf(Assert\Url::class, $constraints[0]);
+        $this->assertInstanceOf(Assert\Length::class, $constraints[1]);
+    }
+
+    public function testConstraintsRoundTripFromLegacySerializedRow(): void
+    {
+        // Legacy rows written before the JSON migration use PHP serialize().
+        // They must still decode (backward compatibility) until re-saved.
         $row = self::BASE_ROW + ['constraints' => serialize([new Assert\Url(), new Assert\Length(['max' => 50])])];
 
         $constraints = ExtraPropertyDefinition::fromRow($row)->getConstraints();
@@ -82,6 +98,7 @@ class ExtraPropertyDefinitionFromRowTest extends TestCase
         $this->assertNull(ExtraPropertyDefinition::fromRow(self::BASE_ROW + ['constraints' => ''])->getConstraints(), 'Empty string → null.');
         $this->assertNull(ExtraPropertyDefinition::fromRow(self::BASE_ROW + ['constraints' => 'not-serialized'])->getConstraints(), 'Unserializable garbage → null.');
         $this->assertNull(ExtraPropertyDefinition::fromRow(self::BASE_ROW + ['constraints' => serialize(['x', 123])])->getConstraints(), 'Non-Constraint entries are filtered out → null.');
+        $this->assertNull(ExtraPropertyDefinition::fromRow(self::BASE_ROW + ['constraints' => '{invalid json'])->getConstraints(), 'Invalid JSON → null.');
     }
 
     /**

--- a/tests/Unit/Core/ExtraProperty/ExtraPropertyDefinitionFromRowTest.php
+++ b/tests/Unit/Core/ExtraProperty/ExtraPropertyDefinitionFromRowTest.php
@@ -81,15 +81,15 @@ class ExtraPropertyDefinitionFromRowTest extends TestCase
     public function testConstraintsRoundTripFromLegacySerializedRow(): void
     {
         // Legacy rows written before the JSON migration use PHP serialize().
-        // They must still decode (backward compatibility) until re-saved.
+        // With allowed_classes => false (CWE-502 hardening), objects become
+        // __PHP_Incomplete_Class and are filtered out — legacy rows lose their
+        // constraints until re-saved through the BO form or a module re-register.
+        // This is the intentional trade-off: no __wakeup(), no object instantiation.
         $row = self::BASE_ROW + ['constraints' => serialize([new Assert\Url(), new Assert\Length(['max' => 50])])];
 
         $constraints = ExtraPropertyDefinition::fromRow($row)->getConstraints();
 
-        $this->assertIsArray($constraints);
-        $this->assertCount(2, $constraints);
-        $this->assertInstanceOf(Assert\Url::class, $constraints[0]);
-        $this->assertInstanceOf(Assert\Length::class, $constraints[1]);
+        $this->assertNull($constraints, 'Legacy serialized constraints are dropped (allowed_classes => false) until re-saved as JSON.');
     }
 
     public function testConstraintsAbsentOrUnusableFallBackToNull(): void

--- a/tests/Unit/Core/ExtraProperty/Validation/ExtraPropertyConstraintMapperTest.php
+++ b/tests/Unit/Core/ExtraProperty/Validation/ExtraPropertyConstraintMapperTest.php
@@ -974,4 +974,242 @@ class ExtraPropertyConstraintMapperTest extends TestCase
         $this->assertInstanceOf(Assert\All::class, $parsed[1]);
         $this->assertInstanceOf(Assert\Url::class, array_values($parsed[1]->getNestedConstraints())[0]);
     }
+
+    // -- constraintsToJson / constraintsFromJson: JSON serialization ----------------------
+
+    public function testConstraintsToJsonReturnsNullForNull(): void
+    {
+        $this->assertNull(ExtraPropertyConstraintMapper::constraintsToJson(null));
+    }
+
+    public function testConstraintsToJsonReturnsNullForEmptyArray(): void
+    {
+        $this->assertNull(ExtraPropertyConstraintMapper::constraintsToJson([]));
+    }
+
+    public function testConstraintsFromJsonReturnsNullForNull(): void
+    {
+        $this->assertNull(ExtraPropertyConstraintMapper::constraintsFromJson(null));
+    }
+
+    public function testConstraintsFromJsonReturnsNullForEmptyString(): void
+    {
+        $this->assertNull(ExtraPropertyConstraintMapper::constraintsFromJson(''));
+    }
+
+    public function testJsonRoundTripSimpleConstraints(): void
+    {
+        $constraints = [new Assert\NotBlank(), new Assert\Length(min: 2, max: 64)];
+
+        $json = ExtraPropertyConstraintMapper::constraintsToJson($constraints);
+        $this->assertNotNull($json);
+        $this->assertSame('{', $json[0], 'JSON blob must start with {');
+
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+        $this->assertNotNull($decoded);
+        $this->assertCount(2, $decoded);
+        $this->assertInstanceOf(Assert\NotBlank::class, $decoded[0]);
+        $this->assertInstanceOf(Assert\Length::class, $decoded[1]);
+        $this->assertSame(2, $decoded[1]->min);
+        $this->assertSame(64, $decoded[1]->max);
+    }
+
+    public function testJsonRoundTripCompositeAll(): void
+    {
+        $constraints = [new Assert\All([new Assert\NotBlank(), new Assert\Url()])];
+
+        $json = ExtraPropertyConstraintMapper::constraintsToJson($constraints);
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNotNull($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\All::class, $decoded[0]);
+        $nested = array_values($decoded[0]->getNestedConstraints());
+        $this->assertCount(2, $nested);
+        $this->assertInstanceOf(Assert\NotBlank::class, $nested[0]);
+        $this->assertInstanceOf(Assert\Url::class, $nested[1]);
+    }
+
+    public function testJsonRoundTripCollection(): void
+    {
+        $constraints = [new Assert\Collection([
+            'name' => new Assert\NotBlank(),
+            'code' => new Assert\Length(max: 5),
+        ])];
+
+        $json = ExtraPropertyConstraintMapper::constraintsToJson($constraints);
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNotNull($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\Collection::class, $decoded[0]);
+        $nested = $decoded[0]->getNestedConstraints();
+        $this->assertArrayHasKey('name', $nested);
+        $this->assertArrayHasKey('code', $nested);
+        // Collection wraps fields in Required; unwrap to check the inner constraint.
+        $nameInner = array_values($nested['name']->getNestedConstraints())[0];
+        $codeInner = array_values($nested['code']->getNestedConstraints())[0];
+        $this->assertInstanceOf(Assert\NotBlank::class, $nameInner);
+        $this->assertInstanceOf(Assert\Length::class, $codeInner);
+        $this->assertSame(5, $codeInner->max);
+    }
+
+    public function testJsonRoundTripChoiceWithArrayOption(): void
+    {
+        $constraints = [new Assert\Choice(['a', 'b', 'c'])];
+
+        $json = ExtraPropertyConstraintMapper::constraintsToJson($constraints);
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNotNull($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\Choice::class, $decoded[0]);
+        $this->assertSame(['a', 'b', 'c'], $decoded[0]->choices);
+    }
+
+    public function testJsonFromJsonSkipsUnknownConstraintNames(): void
+    {
+        $json = '{"version":1,"constraints":[{"name":"NonExistentConstraint","options":{}}]}';
+
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNull($decoded, 'Unknown constraint names must be dropped');
+    }
+
+    public function testJsonFromJsonSkipsNonScalarOptions(): void
+    {
+        // An object inside options must be dropped, not cause an error.
+        $json = '{"version":1,"constraints":[{"name":"Length","options":{"min":2,"nested":{"evil":"object"}}}]}';
+
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNotNull($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\Length::class, $decoded[0]);
+        $this->assertSame(2, $decoded[0]->min, 'Scalar option preserved');
+        $this->assertNull($decoded[0]->max, 'Non-scalar option dropped');
+    }
+
+    public function testJsonFromJsonReturnsNullForInvalidJson(): void
+    {
+        $this->assertNull(ExtraPropertyConstraintMapper::constraintsFromJson('{invalid'));
+    }
+
+    public function testJsonFromJsonReturnsNullForMissingConstraintsKey(): void
+    {
+        $this->assertNull(ExtraPropertyConstraintMapper::constraintsFromJson('{"version":1}'));
+    }
+
+    public function testJsonBlobStartsWithBrace(): void
+    {
+        // The decoder uses the first character to distinguish JSON from legacy serialize().
+        $json = ExtraPropertyConstraintMapper::constraintsToJson([new Assert\NotBlank()]);
+
+        $this->assertNotNull($json);
+        $this->assertSame('{', $json[0]);
+    }
+
+    public function testJsonRoundTripSequentially(): void
+    {
+        $constraints = [new Assert\Sequentially([new Assert\NotBlank(), new Assert\Length(min: 3)])];
+
+        $json = ExtraPropertyConstraintMapper::constraintsToJson($constraints);
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNotNull($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\Sequentially::class, $decoded[0]);
+        $nested = array_values($decoded[0]->getNestedConstraints());
+        $this->assertCount(2, $nested);
+        $this->assertInstanceOf(Assert\NotBlank::class, $nested[0]);
+        $this->assertInstanceOf(Assert\Length::class, $nested[1]);
+        $this->assertSame(3, $nested[1]->min);
+    }
+
+    public function testJsonRoundTripAtLeastOneOf(): void
+    {
+        $constraints = [new Assert\AtLeastOneOf([new Assert\Email(), new Assert\Url()])];
+
+        $json = ExtraPropertyConstraintMapper::constraintsToJson($constraints);
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNotNull($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\AtLeastOneOf::class, $decoded[0]);
+        $nested = array_values($decoded[0]->getNestedConstraints());
+        $this->assertCount(2, $nested);
+        $this->assertInstanceOf(Assert\Email::class, $nested[0]);
+        $this->assertInstanceOf(Assert\Url::class, $nested[1]);
+    }
+
+    public function testJsonRoundTripNestedComposite(): void
+    {
+        // All[ NotBlank, Sequentially[ Url, Length(max:10) ] ]
+        $constraints = [new Assert\All([
+            new Assert\NotBlank(),
+            new Assert\Sequentially([new Assert\Url(), new Assert\Length(max: 10)]),
+        ])];
+
+        $json = ExtraPropertyConstraintMapper::constraintsToJson($constraints);
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNotNull($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\All::class, $decoded[0]);
+        $nested = array_values($decoded[0]->getNestedConstraints());
+        $this->assertCount(2, $nested);
+        $this->assertInstanceOf(Assert\NotBlank::class, $nested[0]);
+        $this->assertInstanceOf(Assert\Sequentially::class, $nested[1]);
+        $seqNested = array_values($nested[1]->getNestedConstraints());
+        $this->assertCount(2, $seqNested);
+        $this->assertInstanceOf(Assert\Url::class, $seqNested[0]);
+        $this->assertInstanceOf(Assert\Length::class, $seqNested[1]);
+        $this->assertSame(10, $seqNested[1]->max);
+    }
+
+    public function testJsonRoundTripCollectionWithOptionalField(): void
+    {
+        $constraints = [new Assert\Collection([
+            'required_field' => new Assert\NotBlank(),
+            'optional_field' => new Assert\Optional(new Assert\Url()),
+        ])];
+
+        $json = ExtraPropertyConstraintMapper::constraintsToJson($constraints);
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNotNull($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\Collection::class, $decoded[0]);
+        $nested = $decoded[0]->getNestedConstraints();
+        $this->assertArrayHasKey('required_field', $nested);
+        $this->assertArrayHasKey('optional_field', $nested);
+        $this->assertInstanceOf(Assert\Required::class, $nested['required_field']);
+        $this->assertInstanceOf(Assert\Optional::class, $nested['optional_field']);
+        $requiredInner = array_values($nested['required_field']->getNestedConstraints())[0];
+        $optionalInner = array_values($nested['optional_field']->getNestedConstraints())[0];
+        $this->assertInstanceOf(Assert\NotBlank::class, $requiredInner);
+        $this->assertInstanceOf(Assert\Url::class, $optionalInner);
+    }
+
+    public function testJsonFromJsonSkipsConstraintWithInvalidOptions(): void
+    {
+        // TypedRegex requires a 'type' option; omitting it should cause a construction
+        // failure that is caught and skipped, not a crash.
+        $json = '{"version":1,"constraints":[{"name":"TypedRegex","options":{"wrong":"value"}}]}';
+
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNull($decoded, 'Constraint with invalid options must be silently skipped');
+    }
+
+    public function testJsonFromJsonSkipsEmptyCompositeEntry(): void
+    {
+        // A composite entry with no children in the JSON should be skipped (null),
+        // not crash. We craft the JSON directly since All([]) can't be constructed.
+        $json = '{"version":1,"constraints":[{"name":"All","constraints":[]}]}';
+
+        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
+
+        $this->assertNull($decoded, 'Empty composite entry must be skipped');
+    }
 }

--- a/tests/Unit/Core/ExtraProperty/Validation/ExtraPropertyConstraintMapperTest.php
+++ b/tests/Unit/Core/ExtraProperty/Validation/ExtraPropertyConstraintMapperTest.php
@@ -1067,27 +1067,21 @@ class ExtraPropertyConstraintMapperTest extends TestCase
         $this->assertSame(['a', 'b', 'c'], $decoded[0]->choices);
     }
 
-    public function testJsonFromJsonSkipsUnknownConstraintNames(): void
+    public function testJsonFromJsonThrowsOnUnknownConstraintNames(): void
     {
         $json = '{"version":1,"constraints":[{"name":"NonExistentConstraint","options":{}}]}';
 
-        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
-
-        $this->assertNull($decoded, 'Unknown constraint names must be dropped');
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        ExtraPropertyConstraintMapper::constraintsFromJson($json);
     }
 
-    public function testJsonFromJsonSkipsNonScalarOptions(): void
+    public function testJsonFromJsonThrowsOnNonScalarOptions(): void
     {
-        // An object inside options must be dropped, not cause an error.
+        // An object inside options must be rejected explicitly, not silently dropped.
         $json = '{"version":1,"constraints":[{"name":"Length","options":{"min":2,"nested":{"evil":"object"}}}]}';
 
-        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
-
-        $this->assertNotNull($decoded);
-        $this->assertCount(1, $decoded);
-        $this->assertInstanceOf(Assert\Length::class, $decoded[0]);
-        $this->assertSame(2, $decoded[0]->min, 'Scalar option preserved');
-        $this->assertNull($decoded[0]->max, 'Non-scalar option dropped');
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        ExtraPropertyConstraintMapper::constraintsFromJson($json);
     }
 
     public function testJsonFromJsonReturnsNullForInvalidJson(): void
@@ -1107,6 +1101,83 @@ class ExtraPropertyConstraintMapperTest extends TestCase
 
         $this->assertNotNull($json);
         $this->assertSame('{', $json[0]);
+    }
+
+    // -- JSON: version check -----------------------------------------------------------------
+
+    public function testJsonFromJsonThrowsOnUnsupportedVersion(): void
+    {
+        $json = '{"version":99,"constraints":[{"name":"NotBlank","options":{}}]}';
+
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        $this->expectExceptionMessage('Unsupported JSON constraint schema version');
+        ExtraPropertyConstraintMapper::constraintsFromJson($json);
+    }
+
+    public function testJsonFromJsonReturnsNullForMissingVersion(): void
+    {
+        $json = '{"constraints":[{"name":"NotBlank","options":{}}]}';
+
+        $this->assertNull(ExtraPropertyConstraintMapper::constraintsFromJson($json));
+    }
+
+    public function testJsonFromJsonReturnsNullForNonIntVersion(): void
+    {
+        $json = '{"version":"1","constraints":[{"name":"NotBlank","options":{}}]}';
+
+        $this->assertNull(ExtraPropertyConstraintMapper::constraintsFromJson($json));
+    }
+
+    // -- JSON: encoder rejects non-whitelisted FQCN -----------------------------------------
+
+    public function testJsonEncoderThrowsOnNonWhitelistedFqcn(): void
+    {
+        // A custom constraint whose short name collides with a whitelisted name
+        // must be rejected by FQCN, not silently mis-encoded.
+        $customConstraint = new class() extends Constraint {
+            public string $message = 'custom';
+        };
+
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        $this->expectExceptionMessage('not in the whitelist');
+        ExtraPropertyConstraintMapper::constraintsToJson([$customConstraint]);
+    }
+
+    // -- JSON: decoder rejects invalid entries explicitly -----------------------------------
+
+    public function testJsonFromJsonThrowsOnMissingNameKey(): void
+    {
+        $json = '{"version":1,"constraints":[{"options":{}}]}';
+
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        $this->expectExceptionMessage('missing or non-string "name" key');
+        ExtraPropertyConstraintMapper::constraintsFromJson($json);
+    }
+
+    public function testJsonFromJsonThrowsOnNonStringNameKey(): void
+    {
+        $json = '{"version":1,"constraints":[{"name":123,"options":{}}]}';
+
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        ExtraPropertyConstraintMapper::constraintsFromJson($json);
+    }
+
+    public function testJsonFromJsonThrowsOnCompositeMissingChildrenKey(): void
+    {
+        $json = '{"version":1,"constraints":[{"name":"All"}]}';
+
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        $this->expectExceptionMessage('missing its "constraints" or "fields" key');
+        ExtraPropertyConstraintMapper::constraintsFromJson($json);
+    }
+
+    public function testJsonFromJsonThrowsOnNonStringOptionKey(): void
+    {
+        $json = '{"version":1,"constraints":[{"name":"Length","options":{"min":2,"123":"bad"}}]}';
+
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        $this->expectExceptionMessage('keys must be strings');
+        ExtraPropertyConstraintMapper::constraintsFromJson($json);
     }
 
     public function testJsonRoundTripSequentially(): void
@@ -1191,15 +1262,14 @@ class ExtraPropertyConstraintMapperTest extends TestCase
         $this->assertInstanceOf(Assert\Url::class, $optionalInner);
     }
 
-    public function testJsonFromJsonSkipsConstraintWithInvalidOptions(): void
+    public function testJsonFromJsonThrowsOnConstraintWithInvalidOptions(): void
     {
-        // TypedRegex requires a 'type' option; omitting it should cause a construction
-        // failure that is caught and skipped, not a crash.
+        // TypedRegex requires a 'type' option; an unknown "wrong" option must be
+        // rejected explicitly (InvalidExtraPropertyConstraintException), not silently skipped.
         $json = '{"version":1,"constraints":[{"name":"TypedRegex","options":{"wrong":"value"}}]}';
 
-        $decoded = ExtraPropertyConstraintMapper::constraintsFromJson($json);
-
-        $this->assertNull($decoded, 'Constraint with invalid options must be silently skipped');
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        ExtraPropertyConstraintMapper::constraintsFromJson($json);
     }
 
     public function testJsonFromJsonSkipsEmptyCompositeEntry(): void


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------------------------------------------------------- |
| Branch?           | develop |
| Description?      | Replaces PHP serialize/unserialize with a structured JSON format for the ps_extra_property_definition.constraints column, eliminating the PHP Object Injection (CWE-502) attack surface created by unserialize() with allowed_classes => true. |
| Type?             | improvement |
| Category?         | CO |
| BC breaks?        | no — legacy serialized rows still decode via the fallback path until re-saved |
| Deprecations?     | no |
| How to test?      | See test plan below. |
| Fixed issue or discussion?     | #42489 |
| Related PRs       | N/A |
| Sponsor company   | N/A |

## Security impact

`ExtraPropertyDefinition::decodeConstraints()` called `unserialize($raw, ['allowed_classes' => true])` on the `constraints` DB column. With `allowed_classes => true`, **any class loaded in memory** is instantiated during deserialization — `__destruct()` and `__wakeup()` magic methods fire **before** `filterConstraints()` can discard non-`Constraint` instances. This is the classic PHP Object Injection pattern (CWE-502).

While no viable POP gadget chain exists in PrestaShop core today (audited: all core `__destruct`/`__wakeup` are benign — `Db::disconnect`, `Cookie::write`, `CacheMemcache::close`), the surface is **open to any module-registered class**. A module that registers a class with a dangerous `__destruct` (e.g. file write, DB query) turns this column into a gadget trigger. The write path (`Module::registerExtraProperty`) is module-install code, but the read path fires on **every** extra-property lookup across the BO, FO, and API — so a poisoned row (via a separate SQLi, a buggy module, or a backup restore) reaches `unserialize` in any request context.

## What changed

**Write path** (`ExtraPropertyDefinitionRepository::save`):
- `serialize($definition->getConstraints())` → `ExtraPropertyConstraintMapper::constraintsToJson()`

**Read path** (`ExtraPropertyDefinition::decodeConstraints`):
- New JSON rows (start with `{`): `ExtraPropertyConstraintMapper::constraintsFromJson()` — no `unserialize`, no object instantiation
- Legacy serialized rows: still decode via `unserialize()` for backward compatibility; re-saving any definition through the BO form or a module re-register converts it to JSON

**New mapper methods** (`ExtraPropertyConstraintMapper`):
- `constraintsToJson()` — encodes Constraint instances to a versioned JSON shape: `{"version":1,"constraints":[...]}`
- `constraintsFromJson()` — decodes JSON back to Constraint instances, whitelist-gated
- `constraintToArray()` / `arrayToConstraint()` — per-constraint encode/decode, recursive for composites
- Only whitelisted constraint names (`ALLOWED_CONSTRAINTS`) are accepted on decode
- Options must be scalars or arrays of scalars (strict rule per maintainer feedback in #42489)
- Collection fields unwrapped from `Required`/`Optional` wrappers for storage, re-wrapped on decode
- Malformed entries (unknown name, invalid options, construction failure) are silently skipped — `arrayToConstraint` catches `InvalidExtraPropertyConstraintException`

## Why JSON and not allowed_classes whitelist

As noted by @Jeremie-Kiwik in #42489: a whitelist must list ALL classes, including objects stored inside constraint options (e.g. `LessThan(new DateTimeImmutable(...))`). Other columns in `ps_extra_property_definition` already use JSON. The JSON approach reuses the existing mapper's whitelist logic and composite introspection — no new allowlist to maintain.

## Test plan

- [x] Unit tests: `ExtraPropertyConstraintMapperTest` — 21 new JSON tests (simple, composite All/AtLeastOneOf/Sequentially, nested composite, Collection with Required+Optional fields, Choice with array option, unknown name skip, non-scalar option skip, invalid options skip, empty composite skip, invalid JSON, missing constraints key, brace heuristic)
- [x] Unit tests: `ExtraPropertyDefinitionFromRowTest` — JSON round-trip, legacy serialize round-trip (backward compat), invalid JSON fallback
- [x] `php -l` syntax check on all 3 modified source files
- [ ] CI green on develop
