### PR TITLE
Expand the global catalog price rule sentinel in getProductIdByDate

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -669,13 +669,46 @@ class SpecificPriceCore extends ObjectModel
 					`from_quantity` = 1 AND
 					`reduction` > 0
 		' . $query_extra);
-        $ids_product = [];
+        // A catalog price rule with no condition is stored as a single row holding id_product = 0,
+        // which the price engine reads as "every product of the shop" (see couldHaveSpecificPrice).
+        // Callers of this method filter on the ids returned here, so the sentinel has to be expanded
+        // or it filters on a product id that cannot exist. Detecting it in the result set rather than
+        // in the table keeps the expansion bound to the shop, currency, country, group and date
+        // range already applied by the query above.
+        $rows = [];
+        $has_global_rule = false;
         foreach ($results as $value) {
+            if ((int) $value['id_product'] === 0) {
+                $has_global_rule = true;
+
+                continue;
+            }
+
+            $rows[(int) $value['id_product'] . '-' . (int) $value['id_product_attribute']] = [
+                (int) $value['id_product'],
+                (int) $value['id_product_attribute'],
+            ];
+        }
+
+        if ($has_global_rule) {
+            $shop_products = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+			SELECT `id_product`
+			FROM `' . _DB_PREFIX_ . 'product_shop`
+			WHERE `id_shop` = ' . (int) $id_shop);
+
+            foreach ($shop_products as $shop_product) {
+                // id_product_attribute stays 0: the rule applies to the product as a whole.
+                $rows[(int) $shop_product['id_product'] . '-0'] = [(int) $shop_product['id_product'], 0];
+            }
+        }
+
+        $ids_product = [];
+        foreach ($rows as list($id_product, $id_product_attribute)) {
             $ids_product[] = $with_combination_id ?
                 [
-                    'id_product' => (int) $value['id_product'],
-                    'id_product_attribute' => (int) $value['id_product_attribute'],
-                ] : (int) $value['id_product'];
+                    'id_product' => $id_product,
+                    'id_product_attribute' => $id_product_attribute,
+                ] : $id_product;
         }
 
         return $ids_product;

--- a/tests/Integration/Classes/SpecificPriceGlobalRuleExpansionTest.php
+++ b/tests/Integration/Classes/SpecificPriceGlobalRuleExpansionTest.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use SpecificPrice;
+use SpecificPriceRule;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+/**
+ * A catalog price rule that carries no condition is materialised as a single specific_price row with
+ * id_product = 0, standing for every product of the shop. getProductIdByDate() handed that sentinel to
+ * its callers, which filter products on it, so a shop-wide rule discounted products everywhere except
+ * on the pages built from this list.
+ */
+class SpecificPriceGlobalRuleExpansionTest extends TestCase
+{
+    use ContextMockerTrait;
+    private const RULE_NAME = 'test-global-rule-expansion';
+
+    /** @var int */
+    private $shopId;
+
+    /** @var string */
+    private $now;
+
+    /** @var string|false */
+    private $featureWasActive;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        $this->shopId = (int) self::getContext()->shop->id;
+        $this->now = date('Y-m-d H:i:00');
+
+        $this->featureWasActive = Configuration::get('PS_SPECIFIC_PRICE_FEATURE_ACTIVE');
+        Configuration::updateGlobalValue('PS_SPECIFIC_PRICE_FEATURE_ACTIVE', 1);
+
+        $this->removeRule();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRule();
+        Configuration::updateGlobalValue('PS_SPECIFIC_PRICE_FEATURE_ACTIVE', $this->featureWasActive);
+
+        parent::tearDown();
+    }
+
+    /**
+     * The sentinel is what the rule really writes — this is the precondition the rest of the test
+     * relies on, so it is asserted rather than assumed.
+     */
+    public function testAShopWideRuleIsStoredAsASingleSentinelRow(): void
+    {
+        $rule = $this->applyGlobalRule();
+
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_product FROM ' . _DB_PREFIX_ . 'specific_price WHERE id_specific_price_rule = ' . (int) $rule->id
+        );
+
+        self::assertCount(1, $rows, 'a rule without conditions writes one row, not one per product');
+        self::assertSame(0, (int) $rows[0]['id_product'], 'that row carries the id_product = 0 sentinel');
+    }
+
+    public function testTheSentinelIsNeverHandedToCallers(): void
+    {
+        self::assertNotContains(0, $this->getIds(), 'no rule, no sentinel');
+
+        $this->applyGlobalRule();
+
+        self::assertNotContains(0, $this->getIds(), 'id_product = 0 matches no product, so it must not be returned');
+    }
+
+    public function testEveryProductOfTheShopIsReturnedUnderAShopWideRule(): void
+    {
+        $this->applyGlobalRule();
+        $ids = $this->getIds();
+
+        $missing = array_diff($this->getShopProductIds(), $ids);
+
+        self::assertSame([], array_values($missing), 'a shop-wide rule discounts every product of the shop');
+    }
+
+    /**
+     * The reported symptom: a product with no specific price of its own was left out.
+     */
+    public function testAProductWithoutItsOwnSpecificPriceIsIncluded(): void
+    {
+        $untouched = (int) Db::getInstance()->getValue(
+            'SELECT ps.id_product FROM ' . _DB_PREFIX_ . 'product_shop ps
+             WHERE ps.id_shop = ' . $this->shopId . '
+               AND ps.id_product NOT IN (SELECT id_product FROM ' . _DB_PREFIX_ . 'specific_price)
+             ORDER BY ps.id_product'
+        );
+        self::assertGreaterThan(0, $untouched, 'fixture needs a product with no specific price of its own');
+
+        self::assertNotContains($untouched, $this->getIds(), 'precondition: not discounted before the rule');
+
+        $this->applyGlobalRule();
+
+        self::assertContains($untouched, $this->getIds(), 'the shop-wide rule discounts it too');
+    }
+
+    /**
+     * The expansion has to stay inside the shop the sentinel row belongs to.
+     */
+    public function testTheExpansionIsScopedToTheShopTheRuleBelongsTo(): void
+    {
+        $otherShop = 1 + (int) Db::getInstance()->getValue('SELECT MAX(id_shop) FROM ' . _DB_PREFIX_ . 'shop');
+        $before = $this->getIds($otherShop);
+
+        $this->applyGlobalRule();
+
+        self::assertSame($before, $this->getIds($otherShop), 'a rule of another shop must not expand here');
+    }
+
+    /**
+     * getRandomSpecial() asks for combinations; the expanded entries stand for the whole product.
+     */
+    public function testExpandedEntriesCarryNoCombination(): void
+    {
+        $this->applyGlobalRule();
+
+        $rows = SpecificPrice::getProductIdByDate(
+            $this->shopId, 0, (int) Configuration::get('PS_COUNTRY_DEFAULT'), 1, $this->now, $this->now, 0, true
+        );
+
+        $shopProducts = $this->getShopProductIds();
+        $seen = [];
+        foreach ($rows as $row) {
+            self::assertArrayHasKey('id_product_attribute', $row);
+            if (in_array((int) $row['id_product'], $shopProducts, true) && (int) $row['id_product_attribute'] === 0) {
+                $seen[] = (int) $row['id_product'];
+            }
+        }
+
+        self::assertSame([], array_values(array_diff($shopProducts, $seen)));
+    }
+
+    /**
+     * @return array<int>
+     */
+    private function getIds(?int $shopId = null): array
+    {
+        SpecificPrice::resetStaticCache();
+
+        return array_map('intval', SpecificPrice::getProductIdByDate(
+            $shopId ?? $this->shopId,
+            0,
+            (int) Configuration::get('PS_COUNTRY_DEFAULT'),
+            1,
+            $this->now,
+            $this->now
+        ));
+    }
+
+    /**
+     * @return array<int>
+     */
+    private function getShopProductIds(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_product FROM ' . _DB_PREFIX_ . 'product_shop WHERE id_shop = ' . $this->shopId
+        );
+
+        return array_map(function ($row) { return (int) $row['id_product']; }, $rows);
+    }
+
+    private function applyGlobalRule(): SpecificPriceRule
+    {
+        $rule = new SpecificPriceRule();
+        $rule->name = self::RULE_NAME;
+        $rule->id_shop = $this->shopId;
+        $rule->id_currency = 0;
+        $rule->id_country = 0;
+        $rule->id_group = 0;
+        $rule->from_quantity = 1;
+        $rule->price = -1;
+        $rule->reduction = 10;
+        $rule->reduction_tax = 1;
+        $rule->reduction_type = 'percentage';
+        $rule->from = '0000-00-00 00:00:00';
+        $rule->to = '0000-00-00 00:00:00';
+        $rule->add();
+        $rule->apply();
+
+        return $rule;
+    }
+
+    private function removeRule(): void
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_specific_price_rule FROM ' . _DB_PREFIX_ . 'specific_price_rule WHERE name = "' . self::RULE_NAME . '"'
+        );
+        foreach ($rows as $row) {
+            (new SpecificPriceRule((int) $row['id_specific_price_rule']))->delete();
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A catalog price rule with no condition is not stored as one row per product. `SpecificPriceRule::getAffectedProducts()` returns `[['id_product' => 0, 'id_product_attribute' => null]]`, so the rule writes a single `specific_price` row carrying `id_product = 0`, standing for every product of the shop. The price engine reads that sentinel — `couldHaveSpecificPrice()` keeps it in a dedicated `$_hasGlobalProductRules` flag — but `SpecificPrice::getProductIdByDate()` returned it verbatim. Its two callers filter products on the ids it returns, so `Product::getPricesDrop()` built `AND p.id_product IN (0, …)` and `Product::getRandomSpecial()` filled its temporary table with `(0, 0)`, both matching no product. The shop-wide discount therefore applied on product pages while the prices-drop page and the random-special block ignored it. This expands the sentinel to the products of the shop. It is detected in the result set rather than in the table, so the expansion stays bound to the shop, currency, country, group and date range the query already applies.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In the BO, create a catalog price rule (Catalog > Discounts > Catalog price rules) with a reduction but **no condition group**, so it targets the whole shop. On the FO, open a product that has no specific price of its own: the discount is shown. Then open the prices-drop page (`?controller=prices-drop`): before this change the product is absent and only products holding their own `specific_price` row are listed; after it, every product of the shop is listed. `tests/Integration/Classes/SpecificPriceGlobalRuleExpansionTest.php` covers the same behaviour at the `getProductIdByDate()` boundary.
| UI Tests          | Not run
| Fixed issue or discussion?     | Fixes #35227
| Related PRs       | Builds on the same function as #41898 (shop-group scoping); the two merge cleanly and compose — the expansion inherits that scoping because the sentinel is read from the scoped result set.
| Sponsor company   |

### Measured

On a 9.2 shop with 20 products, 19 of them active and sellable, and two products carrying their own `specific_price` row:

| | before | after |
| --- | --- | --- |
| `getProductIdByDate()` | `[1, 2, 0]` | every product of the shop |
| `Product::getPricesDrop(…, $count = true)` | 2 | 19 |

The `19` rather than `20` is `getPricesDrop()`'s own `active` / `show_price` / visibility filtering, which is unchanged.

The price engine was verified to honour the sentinel on the same fixture: with the rule applied, `SpecificPrice::getSpecificPrice()` for a product with no row of its own matched the `id_product = 0` row. That asymmetry between the two readers of the same table is the bug.

### On the previous attempts

#35333 and #35910 (@gennaris) proposed the same direction and were never reviewed. This takes a different detection point, because theirs keys the expansion off `self::$_hasGlobalProductRules`, which is populated only inside `couldHaveSpecificPrice()`, i.e. only once `getSpecificPrice()` has run. Measured with their patch applied:

| | `$_hasGlobalProductRules` | `getProductIdByDate()` |
| --- | --- | --- |
| cold (start of a request) | `null` | `[1, 2, 3, 0]` — sentinel still returned |
| warm (after a `getSpecificPrice()` call) | `true` | every product |

`getPricesDrop()` runs before any product is priced, so the cold column is the prices-drop path. That flag is also filled by an unscoped `SELECT 1 FROM specific_price WHERE id_product = 0`, so once warm it ignores shop, currency, country, group and the date window — an expired or other-shop rule would list every product. Reading the sentinel out of the result set avoids both problems.

### Cost

When a shop-wide rule exists the returned list is the shop's product ids, so `getPricesDrop()`'s `IN` list and `getRandomSpecial()`'s temporary-table insert are O(products). That cost is only paid when such a rule exists, and in that case every product genuinely is discounted. The expansion is scoped to the shop but deliberately not to `active`: both callers already filter `product_shop.active = 1` themselves, and narrowing it here would change what the method means.
