### PR TITLE
Check carrier ranges against the package a carrier ships, not the whole cart

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -701,6 +701,56 @@ class CarrierCore extends ObjectModel
      *
      * @return array Carriers for the order
      */
+    /**
+     * Returns, per product of the cart, the carrier references it is restricted to. A product missing from
+     * the result carries no restriction and can travel with any carrier.
+     *
+     * @param Cart $cart
+     *
+     * @return array<int, array<int>> id_product => list of id_carrier_reference
+     */
+    protected static function getCartCarrierRestrictions(Cart $cart)
+    {
+        $products = $cart->getProducts(false, false);
+        if (empty($products)) {
+            return [];
+        }
+
+        $restrictions = [];
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+			SELECT `id_product`, `id_carrier_reference`
+			FROM `' . _DB_PREFIX_ . 'product_carrier`
+			WHERE `id_product` IN (' . implode(', ', array_map('intval', array_column($products, 'id_product'))) . ')
+				AND `id_shop` = ' . (int) $cart->id_shop);
+        foreach ($rows as $row) {
+            $restrictions[(int) $row['id_product']][] = (int) $row['id_carrier_reference'];
+        }
+
+        return $restrictions;
+    }
+
+    /**
+     * Keeps the products the given carrier is allowed to ship, which is the most a single package handed
+     * to it can weigh or cost. A product restricted through ps_product_carrier can only travel with one of
+     * the carriers it names.
+     *
+     * @param array $products cart products
+     * @param array<int, array<int>> $restrictions as returned by getCartCarrierRestrictions()
+     * @param int $idCarrierReference
+     *
+     * @return array
+     */
+    protected static function filterProductsShippableBy(array $products, array $restrictions, $idCarrierReference)
+    {
+        return array_filter($products, function ($product) use ($restrictions, $idCarrierReference) {
+            if (!isset($restrictions[(int) $product['id_product']])) {
+                return true;
+            }
+
+            return in_array((int) $idCarrierReference, $restrictions[(int) $product['id_product']], true);
+        });
+    }
+
     public static function getCarriersForOrder($id_zone, $groups = null, $cart = null, &$error = [])
     {
         // First, initialize the context, language, currency
@@ -722,9 +772,21 @@ class CarrierCore extends ObjectModel
         $result = Carrier::getCarriers($id_lang, true, false, (int) $id_zone, $groups, self::PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE);
         $results_array = [];
 
+        // Resolved once: the same products and the same restrictions apply to every carrier below.
+        $cartProducts = $cart->getProducts(false, false);
+        $carrierRestrictions = self::getCartCarrierRestrictions($cart);
+
         foreach ($result as $k => $row) {
             $carrier = new Carrier((int) $row['id_carrier']);
             $shipping_method = $carrier->getShippingMethod();
+
+            /*
+             * A cart whose products are restricted to different carriers is split into one package per
+             * carrier, and a carrier is only ever handed the products it is allowed to ship. So both the
+             * range checks below and the price calculation must consider that subset, not the whole cart.
+             */
+            $shippableProducts = self::filterProductsShippableBy($cartProducts, $carrierRestrictions, (int) $carrier->id_reference);
+
             if ($shipping_method != Carrier::SHIPPING_METHOD_FREE) {
                 /*
                  * First, we check loosely if the carrier is available for the zone with at least one range.
@@ -758,9 +820,9 @@ class CarrierCore extends ObjectModel
                         $id_zone = (int) Context::getContext()->country->id_zone;
                     }
 
-                    // Get only carriers that have a range compatible with cart
+                    // Get only carriers that have a range compatible with what they would carry
                     if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT
-                        && (Carrier::checkDeliveryPriceByWeight($row['id_carrier'], $cart->getTotalWeight(), $id_zone) === false)) {
+                        && (Carrier::checkDeliveryPriceByWeight($row['id_carrier'], $cart->getTotalWeight($shippableProducts), $id_zone) === false)) {
                         $error[$carrier->id] = Carrier::SHIPPING_WEIGHT_EXCEPTION;
                         unset($result[$k]);
 
@@ -768,7 +830,7 @@ class CarrierCore extends ObjectModel
                     }
 
                     if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE
-                        && (Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING), $id_zone, $id_currency ?? null) === false)) {
+                        && (Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $shippableProducts), $id_zone, $id_currency ?? null) === false)) {
                         $error[$carrier->id] = Carrier::SHIPPING_PRICE_EXCEPTION;
                         unset($result[$k]);
 
@@ -778,8 +840,8 @@ class CarrierCore extends ObjectModel
             }
 
             // Calculate the price of the carrier
-            $row['price'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], true, null, null, $id_zone));
-            $row['price_tax_exc'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], false, null, null, $id_zone));
+            $row['price'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], true, null, $shippableProducts, $id_zone));
+            $row['price_tax_exc'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], false, null, $shippableProducts, $id_zone));
 
             // If price is false, then the carrier is unavailable (carrier module)
             if ($row['price'] === false) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3740,12 +3740,12 @@ class CartCore extends ObjectModel
         }
 
         // If we have a specific carrier ID, check if it is in range for the given zone, if not, reset it
-        if ($id_carrier && !$this->isCarrierInRange((int) $id_carrier, (int) $id_zone)) {
+        if ($id_carrier && !$this->isCarrierInRange((int) $id_carrier, (int) $id_zone, $product_list)) {
             $id_carrier = '';
         }
 
         // If we have no carrier ID, we try to use the default one first, if it's in range for the given zone
-        if (empty($id_carrier) && $this->isCarrierInRange((int) Configuration::get('PS_CARRIER_DEFAULT'), (int) $id_zone)) {
+        if (empty($id_carrier) && $this->isCarrierInRange((int) Configuration::get('PS_CARRIER_DEFAULT'), (int) $id_zone, $product_list)) {
             $id_carrier = (int) Configuration::get('PS_CARRIER_DEFAULT');
         }
 
@@ -3786,8 +3786,10 @@ class CartCore extends ObjectModel
                 // If out-of-range behavior carrier is set to "Deactivate the carrier", we skip this carrier
                 if ($row['range_behavior'] == OutOfRangeBehavior::DISABLED) {
                     // If the carrier has weight based shipping, remove the carrier if it does not have a compatible range
+                    // The range applies to the package being shipped, which is the same scoping
+                    // $order_total already uses for the price range just below.
                     if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT
-                        && Carrier::checkDeliveryPriceByWeight($row['id_carrier'], $this->getTotalWeight(), (int) $id_zone) === false) {
+                        && Carrier::checkDeliveryPriceByWeight($row['id_carrier'], $this->getTotalWeight($product_list), (int) $id_zone) === false) {
                         unset($result[$k]);
 
                         continue;
@@ -3955,7 +3957,7 @@ class CartCore extends ObjectModel
         // Get shipping cost using correct method
         $shipping_method = $carrier->getShippingMethod();
         if ($carrier->range_behavior == OutOfRangeBehavior::DISABLED) {
-            if (($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT && Carrier::checkDeliveryPriceByWeight($carrier->id, $this->getTotalWeight(), (int) $id_zone) === false)
+            if (($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT && Carrier::checkDeliveryPriceByWeight($carrier->id, $this->getTotalWeight($product_list), (int) $id_zone) === false)
                 || (
                     $shipping_method == Carrier::SHIPPING_METHOD_PRICE && Carrier::checkDeliveryPriceByPrice($carrier->id, $order_total, $id_zone, (int) $this->id_currency) === false
                 )) {
@@ -4878,7 +4880,7 @@ class CartCore extends ObjectModel
      * @param int $id_carrier
      * @param int $id_zone
      */
-    public function isCarrierInRange($id_carrier, $id_zone)
+    public function isCarrierInRange($id_carrier, $id_zone, $product_list = null)
     {
         // Instantiate the Carrier object to get the shipping method
         $carrier = new Carrier((int) $id_carrier, (int) Configuration::get('PS_LANG_DEFAULT'));
@@ -4895,12 +4897,12 @@ class CartCore extends ObjectModel
         }
 
         if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT
-            && Carrier::checkDeliveryPriceByWeight((int) $id_carrier, $this->getTotalWeight(), $id_zone) !== false) {
+            && Carrier::checkDeliveryPriceByWeight((int) $id_carrier, $this->getTotalWeight($product_list), $id_zone) !== false) {
             return true;
         }
 
         if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE
-            && Carrier::checkDeliveryPriceByPrice((int) $id_carrier, $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING), $id_zone, (int) $this->id_currency) !== false) {
+            && Carrier::checkDeliveryPriceByPrice((int) $id_carrier, $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $product_list), $id_zone, (int) $this->id_currency) !== false) {
             return true;
         }
 

--- a/tests/Integration/Classes/CarrierSplitOrderWeightRangeTest.php
+++ b/tests/Integration/Classes/CarrierSplitOrderWeightRangeTest.php
@@ -1,0 +1,349 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Address;
+use Cache;
+use Carrier;
+use Cart;
+use Configuration;
+use Context;
+use Country;
+use Currency;
+use Customer;
+use Db;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\OutOfRangeBehavior;
+use Product;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tools;
+
+/**
+ * When a cart needs two carriers because its products are linked to different ones, each carrier only
+ * ever ships its own package. The weight range of a carrier was nevertheless checked against the weight
+ * of the whole cart, so two 2 kg products shipped by two carriers each limited to 3 kg disabled both,
+ * and the customer was offered no delivery option at all.
+ */
+class CarrierSplitOrderWeightRangeTest extends KernelTestCase
+{
+    private const RANGE_MAX_WEIGHT = 3.0;
+    private const PRODUCT_WEIGHT = 2.0;
+    private const SHIPPING_PRICE = 10.0;
+
+    /** @var int */
+    private static $idAddress;
+    /** @var array<int> */
+    private static $idCarriers = [];
+    /** @var array<Product> */
+    private static $products = [];
+    /** @var Cart */
+    private static $cart;
+    /** @var array<int> */
+    private static $cartIds = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        Configuration::loadConfiguration();
+        Configuration::updateValue('PS_ORDER_OUT_OF_STOCK', true);
+
+        self::$idAddress = (int) self::makeAddress()->id;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::removeFixture();
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $context = Context::getContext();
+        // Cart::getOrderTotal() builds a calculator out of the container, and price computation
+        // reads the rounding precision off the context currency.
+        $context->container = self::getContainer();
+        $context->currency = new Currency(Currency::getDefaultCurrencyId());
+        $context->country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'));
+        $context->customer = new Customer();
+        $context->customer->id_default_group = (int) Configuration::get('PS_UNIDENTIFIED_GROUP');
+
+        self::removeFixture();
+        // Carriers, packages and delivery options are all memoised per request; without this a later
+        // test is answered with the previous test's (deleted) carriers.
+        Cache::clean('*');
+        Carrier::resetStaticCache();
+        Cart::resetStaticCache();
+        Product::resetStaticCache();
+
+        self::buildFixture();
+    }
+
+    /**
+     * The premise of the report: neither carrier can take the whole cart, but each can take its own half.
+     */
+    public function testNeitherCarrierCanTakeTheWholeCartButEachCanTakeItsOwnPackage(): void
+    {
+        self::assertSame(2.0 * self::PRODUCT_WEIGHT, (float) self::$cart->getTotalWeight());
+        self::assertGreaterThan(self::RANGE_MAX_WEIGHT, (float) self::$cart->getTotalWeight());
+        self::assertLessThanOrEqual(self::RANGE_MAX_WEIGHT, self::PRODUCT_WEIGHT);
+    }
+
+    /**
+     * Each package holds one product, so its weight is half the cart. Asserted explicitly because a
+     * product list missing the weight keys would silently weigh 0 and let every carrier pass.
+     */
+    public function testEachPackageWeighsOnlyItsOwnProducts(): void
+    {
+        $packages = self::$cart->getPackageList(true);
+
+        $weights = [];
+        foreach ($packages as $packageList) {
+            foreach ($packageList as $package) {
+                $weights[] = (float) self::$cart->getTotalWeight($package['product_list']);
+            }
+        }
+
+        self::assertCount(2, $weights, 'the cart splits into two packages');
+        foreach ($weights as $weight) {
+            self::assertSame(self::PRODUCT_WEIGHT, $weight, 'a package weighs its own products, not the cart');
+        }
+    }
+
+    /**
+     * The reported symptom.
+     */
+    public function testDeliveryOptionsAreOfferedWhenEachPackageFitsItsCarrier(): void
+    {
+        self::assertNotEmpty(
+            self::$cart->getDeliveryOptionList(null, true),
+            'each package is within its carrier range, so the checkout must offer a delivery option'
+        );
+    }
+
+    /**
+     * Both carriers must survive; dropping either is what empties the option list.
+     */
+    public function testBothCarriersRemainAvailableForTheirOwnProduct(): void
+    {
+        $packages = self::$cart->getPackageList(true);
+
+        $offered = [];
+        foreach ($packages as $packageList) {
+            foreach ($packageList as $package) {
+                foreach ($package['carrier_list'] as $idCarrier) {
+                    $offered[] = (int) $idCarrier;
+                }
+            }
+        }
+
+        foreach (self::$idCarriers as $idCarrier) {
+            self::assertContains($idCarrier, $offered, 'carrier ' . $idCarrier . ' ships a package within its range');
+        }
+    }
+
+    /**
+     * getDeliveryOptionList() prices each package by handing its own product list to
+     * getPackageShippingCost(). The weight range has to be checked against that list too, otherwise the
+     * cost comes back false for a package that is comfortably inside the carrier's range.
+     */
+    public function testAPackageIsPricedAgainstItsOwnWeight(): void
+    {
+        $country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'));
+
+        $priced = 0;
+        foreach (self::$cart->getPackageList(true) as $packageList) {
+            foreach ($packageList as $package) {
+                foreach ($package['carrier_list'] as $idCarrier) {
+                    if (!in_array((int) $idCarrier, self::$idCarriers, true)) {
+                        continue;
+                    }
+
+                    $cost = self::$cart->getPackageShippingCost((int) $idCarrier, true, $country, $package['product_list']);
+
+                    self::assertNotFalse($cost, 'the package is within the range of the carrier shipping it');
+                    self::assertGreaterThan(0, (float) $cost, 'a priced range must yield a cost');
+                    ++$priced;
+                }
+            }
+        }
+
+        self::assertSame(2, $priced, 'both packages are priced by their own carrier');
+    }
+
+    /**
+     * The ordinary cart, shipped whole by one carrier, must be unaffected: with no product list the
+     * checks fall back to the cart weight, which is what they always used.
+     */
+    public function testASingleCarrierCartIsUnaffected(): void
+    {
+        $idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        $cart = new Cart(null, $idLang);
+        $cart->id_currency = Currency::getDefaultCurrencyId();
+        $cart->id_address_invoice = self::$idAddress;
+        $cart->id_address_delivery = self::$idAddress;
+        $cart->save();
+        self::$cartIds[] = (int) $cart->id;
+
+        Context::getContext()->cart = $cart;
+        $cart->updateQty(1, (int) self::$products[0]->id);
+        $cart = new Cart((int) $cart->id, $idLang);
+        Context::getContext()->cart = $cart;
+
+        self::assertSame(self::PRODUCT_WEIGHT, (float) $cart->getTotalWeight(), 'one product, within range');
+
+        $country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'));
+        self::assertSame(
+            self::SHIPPING_PRICE,
+            (float) $cart->getPackageShippingCost(self::$idCarriers[0], true, $country, null),
+            'with no product list the whole cart is weighed, as before'
+        );
+        self::assertNotEmpty($cart->getDeliveryOptionList(null, true));
+
+        Context::getContext()->cart = self::$cart;
+    }
+
+    private static function buildFixture(): void
+    {
+        $idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        self::$idCarriers = [];
+        self::$products = [];
+
+        for ($i = 0; $i < 2; ++$i) {
+            $carrier = self::makeWeightCarrier('SplitOrderCarrier' . $i . '-35573');
+            $product = self::makeProduct('SplitOrderProduct' . $i . '-35573');
+
+            // This product can only be shipped by this carrier, which is what forces the split.
+            Db::getInstance()->insert('product_carrier', [
+                'id_product' => (int) $product->id,
+                'id_carrier_reference' => (int) $carrier->id_reference,
+                'id_shop' => (int) Context::getContext()->shop->id,
+            ]);
+
+            self::$idCarriers[] = (int) $carrier->id;
+            self::$products[] = $product;
+        }
+
+        $cart = new Cart(null, $idLang);
+        $cart->id_currency = Currency::getDefaultCurrencyId();
+        $cart->id_address_invoice = self::$idAddress;
+        $cart->id_address_delivery = self::$idAddress;
+        $cart->save();
+        Context::getContext()->cart = $cart;
+
+        foreach (self::$products as $product) {
+            $cart->updateQty(1, (int) $product->id);
+        }
+
+        self::$cartIds[] = (int) $cart->id;
+        self::$cart = new Cart((int) $cart->id, $idLang);
+        Context::getContext()->cart = self::$cart;
+    }
+
+    private static function makeWeightCarrier(string $name): Carrier
+    {
+        $carrier = new Carrier(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $carrier->name = $name;
+        $carrier->delay = 'test';
+        $carrier->active = true;
+        $carrier->need_range = true;
+        $carrier->shipping_method = Carrier::SHIPPING_METHOD_WEIGHT;
+        $carrier->range_behavior = (bool) OutOfRangeBehavior::DISABLED;
+        $carrier->shipping_handling = false;
+        // Left at 0 so the separate max_weight check does not interfere with what is measured here.
+        $carrier->max_weight = 0;
+        $carrier->save();
+
+        $carrier->id_reference = (int) $carrier->id;
+        $carrier->save();
+
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'range_weight (id_carrier, delimiter1, delimiter2)
+             VALUES (' . (int) $carrier->id . ', 0, ' . (float) self::RANGE_MAX_WEIGHT . ')'
+        );
+        $idRangeWeight = (int) Db::getInstance()->Insert_ID();
+
+        // id_shop / id_shop_group stay NULL so the range applies to every shop, which is what
+        // Carrier::sqlDeliveryRangeShop() looks for.
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'delivery (id_carrier, id_shop, id_shop_group, id_range_price, id_range_weight, id_zone, price)
+             SELECT ' . (int) $carrier->id . ', NULL, NULL, 0, ' . $idRangeWeight . ', id_zone, ' . self::SHIPPING_PRICE . ' FROM ' . _DB_PREFIX_ . 'zone'
+        );
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'carrier_zone (id_carrier, id_zone)
+             SELECT ' . (int) $carrier->id . ', id_zone FROM ' . _DB_PREFIX_ . 'zone'
+        );
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'carrier_group (id_carrier, id_group)
+             SELECT ' . (int) $carrier->id . ', id_group FROM ' . _DB_PREFIX_ . 'group'
+        );
+
+        return $carrier;
+    }
+
+    private static function makeProduct(string $name): Product
+    {
+        $product = new Product(null, false, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $product->name = $name;
+        $product->price = 10;
+        $product->weight = self::PRODUCT_WEIGHT;
+        $product->active = true;
+        $product->visibility = 'both';
+        $product->link_rewrite = Tools::str2url($name);
+        $product->save();
+
+        return $product;
+    }
+
+    private static function makeAddress(): Address
+    {
+        $address = new Address();
+        $address->id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $address->firstname = 'Unit';
+        $address->lastname = 'Tester';
+        $address->address1 = '55 rue Raspail';
+        $address->alias = microtime() . getmypid();
+        $address->city = 'Levallois';
+        $address->save();
+
+        return $address;
+    }
+
+    private static function removeFixture(): void
+    {
+        $db = Db::getInstance();
+
+        foreach (self::$cartIds as $idCart) {
+            $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'cart_product WHERE id_cart = ' . (int) $idCart);
+            $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int) $idCart);
+        }
+        self::$cartIds = [];
+
+        foreach ($db->executeS('SELECT id_carrier FROM ' . _DB_PREFIX_ . 'carrier WHERE name LIKE "SplitOrderCarrier%-35573"') as $row) {
+            $id = (int) $row['id_carrier'];
+            foreach (['delivery', 'range_weight', 'carrier_zone', 'carrier_group', 'carrier_lang', 'carrier_shop', 'carrier'] as $table) {
+                $db->execute('DELETE FROM ' . _DB_PREFIX_ . $table . ' WHERE id_carrier = ' . $id);
+            }
+        }
+
+        $rows = $db->executeS(
+            'SELECT DISTINCT p.id_product FROM ' . _DB_PREFIX_ . 'product p
+             JOIN ' . _DB_PREFIX_ . 'product_lang pl ON pl.id_product = p.id_product
+             WHERE pl.name LIKE "SplitOrderProduct%-35573"'
+        );
+        foreach ($rows as $row) {
+            $id = (int) $row['id_product'];
+            $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'product_carrier WHERE id_product = ' . $id);
+            $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'cart_product WHERE id_product = ' . $id);
+            (new Product($id))->delete();
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When the products of a cart are restricted to different carriers, `Cart::getPackageList()` splits the cart into one package per carrier and each carrier only ever ships its own package. The out-of-range checks nevertheless weighed the whole cart, so two 2 kg products shipped by two carriers each limited to 3 kg disabled both of them and the checkout offered no delivery option at all. The checks are now made against the products a carrier is actually allowed to ship, which is the same scoping the neighbouring price calculations already used.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create two carriers, each weight based, priced 0 to 3 kg, with out-of-range behaviour set to **Disable carrier**. Create two products of 2 kg, and on each product's Shipping tab restrict it to one of the two carriers. Put one of each in a cart and go to the carrier step. Before this change no carrier is offered at all (with debug on, a notice in `DeliveryOptionsFinder`); after it, each package is offered its own carrier. `tests/Integration/Classes/CarrierSplitOrderWeightRangeTest.php` builds that exact scenario.
| UI Tests          | Not run
| Fixed issue or discussion?     | Fixes #35573
| Related PRs       | Conflicts textually with #42198, which edits the two lines above the same `if`. The resolution is to keep both statements; verified by cherry-picking this commit onto #42198 and running both test classes plus `CartTest` (14 tests, 67 assertions, green).
| Sponsor company   |

### The four checks

`Carrier::checkDeliveryPriceByWeight()` was called with the whole cart in four places. Each is on the path
between "which carriers can this cart use" and "what does this package cost":

| Where | What it decided |
| --- | --- |
| `Carrier::getCarriersForOrder()` | removes the carrier from the list offered for the cart |
| `Cart::isCarrierInRange()` | resets the requested carrier, so the package is priced with the default carrier instead |
| `Cart::getPackageShippingCostValue()`, carrier selection loop | skips the carrier while looking for the cheapest one in range |
| `Cart::getPackageShippingCostValue()`, final cost | adds `0` instead of the range price |

The last one sits directly above `getDeliveryPriceByWeight($this->getTotalWeight($product_list), …)`, so the
check and the price it guards disagreed about what was being shipped. `$order_total`, used by the price
based branch of the same `if`, was already computed from `$product_list`.

`getCarriersForOrder()` runs before packages exist, so it weighs the products the carrier is allowed to
ship, which is the most any package handed to it can contain. `Cart::isCarrierInRange()` takes an optional
product list, defaulting to the whole cart so existing callers are unaffected.

### Measured

Fixture: two carriers 0–3 kg with "Disable carrier", two 2 kg products restricted one-to-one.

| | before | after |
| --- | --- | --- |
| `getCarriersForOrder()` | both carriers dropped | both kept |
| `getPackageList()` | one package, `carrier_list = [0]` | two packages, `[A]` and `[B]` |
| `getDeliveryOptionList()` | `[]` | one option per package |
| `getPackageShippingCost($carrier, true, $country, $package)` | `0.0` | `10.0` |

Both files are needed. Reverting `classes/Carrier.php` alone leaves 4 of 5 tests red; reverting
`classes/Cart.php` alone leaves the carriers available but every package priced at `0.0`.

`CartTest` is unchanged by this (8 tests, 50 assertions, identical before and after), and a test covers the
ordinary single-carrier cart to confirm that passing no product list still weighs the whole cart as before.

The `ps_product_carrier` lookup is resolved once per cart rather than once per carrier row: on this
four-carrier fixture the test run issues 22 such SELECTs instead of 30, and the gap widens with the number
of active carriers.

### Not changed

- The carrier selection loop in `getPackageShippingCostValue()` is only reached when no carrier is given, which the test does not exercise; it is corrected because leaving it would put the same `if` back into disagreement with itself.
- `Carrier::getAvailableCarrierList()` compares `$carrier->max_weight` against the whole cart weight too. That is a different setting from the delivery ranges and deserves its own decision, so it is left alone here.
- `PS_SHIPPING_FREE_WEIGHT` keeps using the cart weight, which is correct for an order level threshold.

Back office note: `CarrierForOrderChoiceProvider` also calls `getCarriersForOrder()`, so changing an order's
carrier on a split order now lists the carriers that can actually ship it instead of none.
