### PR TITLE
Stop saving the cart when the customer has no address to assign

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -420,16 +420,7 @@ class FrontControllerCore extends Controller
                 && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0 || !isset($cart->id_address_invoice) || $cart->id_address_invoice == 0)
                 && $this->context->cookie->id_customer
             ) {
-                $to_update = false;
-                if ($this->automaticallyAllocateDeliveryAddress && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0)) {
-                    $to_update = true;
-                    $cart->id_address_delivery = (int) Address::getFirstCustomerAddressId($cart->id_customer);
-                }
-                if ($this->automaticallyAllocateInvoiceAddress && (!isset($cart->id_address_invoice) || $cart->id_address_invoice == 0)) {
-                    $to_update = true;
-                    $cart->id_address_invoice = (int) Address::getFirstCustomerAddressId($cart->id_customer);
-                }
-                if ($to_update) {
+                if ($this->assignFirstCustomerAddresses($cart)) {
                     $cart->update();
                 }
             }
@@ -504,6 +495,41 @@ class FrontControllerCore extends Controller
             ]
         );
         Hook::exec('action' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
+    }
+
+    /**
+     * Assigns the customer's first address to the cart addresses that are still empty.
+     *
+     * A customer who has no address at all resolves to zero, which is the value those fields already
+     * hold, so nothing changes. Reporting an update in that case made the caller write the cart on
+     * every single page request of such a customer, each write resetting the product caches and
+     * firing actionCartSave.
+     *
+     * @param Cart $cart
+     *
+     * @return bool whether an address was assigned and the cart therefore needs saving
+     */
+    protected function assignFirstCustomerAddresses(Cart $cart)
+    {
+        $assigned = false;
+
+        if ($this->automaticallyAllocateDeliveryAddress && empty($cart->id_address_delivery)) {
+            $idAddress = (int) Address::getFirstCustomerAddressId($cart->id_customer);
+            if ($idAddress) {
+                $cart->id_address_delivery = $idAddress;
+                $assigned = true;
+            }
+        }
+
+        if ($this->automaticallyAllocateInvoiceAddress && empty($cart->id_address_invoice)) {
+            $idAddress = (int) Address::getFirstCustomerAddressId($cart->id_customer);
+            if ($idAddress) {
+                $cart->id_address_invoice = $idAddress;
+                $assigned = true;
+            }
+        }
+
+        return $assigned;
     }
 
     /**

--- a/tests/Integration/Classes/Controller/CartAddressAutoAssignmentTest.php
+++ b/tests/Integration/Classes/Controller/CartAddressAutoAssignmentTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use Address;
+use Cache;
+use Cart;
+use Configuration;
+use Customer;
+use Db;
+use FrontController;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * A logged in customer with no address at all resolves to address zero, which is what the cart already
+ * holds, so nothing changes. The controller nevertheless reported an update and saved the cart on every
+ * page request of that customer, resetting the product caches and firing actionCartSave each time.
+ */
+class CartAddressAutoAssignmentTest extends TestCase
+{
+    private const EMAIL_SUFFIX = '@cart-address-34177.test';
+
+    /** @var Customer */
+    private $customerWithoutAddress;
+    /** @var Customer */
+    private $customerWithAddress;
+    /** @var int */
+    private $idAddress;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::removeFixture();
+
+        $this->customerWithoutAddress = self::makeCustomer('no-address');
+        $this->customerWithAddress = self::makeCustomer('with-address');
+        $this->idAddress = (int) self::makeAddress($this->customerWithAddress)->id;
+
+        Cache::clean('Address::getFirstCustomerAddressId_*');
+    }
+
+    protected function tearDown(): void
+    {
+        self::removeFixture();
+        Cache::clean('Address::getFirstCustomerAddressId_*');
+
+        parent::tearDown();
+    }
+
+    /**
+     * The precondition the bug rests on: there is nothing to assign.
+     */
+    public function testACustomerWithoutAnAddressResolvesToZero(): void
+    {
+        self::assertSame(0, (int) Address::getFirstCustomerAddressId((int) $this->customerWithoutAddress->id));
+    }
+
+    /**
+     * The reported bug: no address to assign must not be reported as an update.
+     */
+    public function testNoUpdateIsReportedWhenTheCustomerHasNoAddress(): void
+    {
+        $cart = $this->makeCart($this->customerWithoutAddress);
+
+        self::assertFalse(
+            $this->assignAddresses($cart),
+            'nothing was assigned, so the cart must not be saved'
+        );
+        self::assertSame(0, (int) $cart->id_address_delivery);
+        self::assertSame(0, (int) $cart->id_address_invoice);
+    }
+
+    /**
+     * And the behaviour that must be kept.
+     */
+    public function testTheFirstAddressIsAssignedWhenTheCustomerHasOne(): void
+    {
+        $cart = $this->makeCart($this->customerWithAddress);
+
+        self::assertTrue($this->assignAddresses($cart), 'an address was assigned, so the cart needs saving');
+        self::assertSame($this->idAddress, (int) $cart->id_address_delivery);
+        self::assertSame($this->idAddress, (int) $cart->id_address_invoice);
+    }
+
+    /**
+     * A cart that already carries both addresses has nothing to do either.
+     */
+    public function testNoUpdateIsReportedWhenBothAddressesAreAlreadySet(): void
+    {
+        $cart = $this->makeCart($this->customerWithAddress);
+        $cart->id_address_delivery = $this->idAddress;
+        $cart->id_address_invoice = $this->idAddress;
+
+        self::assertFalse($this->assignAddresses($cart));
+    }
+
+    /**
+     * The two allocation flags are independent, and a controller that switches one off must not have
+     * the cart saved on its behalf by the other being empty.
+     */
+    public function testOnlyTheEnabledAllocationIsPerformed(): void
+    {
+        $cart = $this->makeCart($this->customerWithAddress);
+
+        self::assertTrue($this->assignAddresses($cart, true, false));
+        self::assertSame($this->idAddress, (int) $cart->id_address_delivery);
+        self::assertSame(0, (int) $cart->id_address_invoice, 'invoice allocation was switched off');
+    }
+
+    private function assignAddresses(Cart $cart, bool $delivery = true, bool $invoice = true): bool
+    {
+        // The constructor of a front controller boots a whole page context; this method only reads the
+        // two allocation flags and the cart handed to it.
+        $controller = (new ReflectionClass(FrontController::class))->newInstanceWithoutConstructor();
+
+        foreach (['automaticallyAllocateDeliveryAddress' => $delivery, 'automaticallyAllocateInvoiceAddress' => $invoice] as $name => $value) {
+            $property = new ReflectionProperty(FrontController::class, $name);
+            $property->setAccessible(true);
+            $property->setValue($controller, $value);
+        }
+
+        $method = new ReflectionMethod(FrontController::class, 'assignFirstCustomerAddresses');
+        $method->setAccessible(true);
+
+        return (bool) $method->invoke($controller, $cart);
+    }
+
+    private function makeCart(Customer $customer): Cart
+    {
+        // Not saved: the method under test only reads and writes the object's own fields.
+        $cart = new Cart();
+        $cart->id_customer = (int) $customer->id;
+        $cart->id_address_delivery = 0;
+        $cart->id_address_invoice = 0;
+
+        return $cart;
+    }
+
+    private static function makeCustomer(string $slug): Customer
+    {
+        $customer = new Customer();
+        $customer->firstname = 'Cart';
+        $customer->lastname = 'Address';
+        $customer->email = $slug . self::EMAIL_SUFFIX;
+        // Only a length check (32 or 60); the fixture never authenticates, so this is a placeholder.
+        $customer->passwd = str_repeat('x', 60);
+        $customer->add();
+
+        return $customer;
+    }
+
+    private static function makeAddress(Customer $customer): Address
+    {
+        $address = new Address();
+        $address->id_customer = (int) $customer->id;
+        $address->id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $address->firstname = 'Cart';
+        $address->lastname = 'Address';
+        $address->address1 = '55 rue Raspail';
+        $address->alias = 'fixture-34177';
+        $address->city = 'Levallois';
+        $address->add();
+
+        return $address;
+    }
+
+    private static function removeFixture(): void
+    {
+        $db = Db::getInstance();
+        $rows = $db->executeS(
+            'SELECT id_customer FROM ' . _DB_PREFIX_ . 'customer WHERE email LIKE "%' . self::EMAIL_SUFFIX . '"'
+        );
+        foreach ($rows as $row) {
+            $id = (int) $row['id_customer'];
+            $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'address WHERE id_customer = ' . $id);
+            $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'customer WHERE id_customer = ' . $id);
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `FrontController::init()` assigns the customer's first address to a cart that has none. It set its `$to_update` flag before knowing whether an address had been found, and `Address::getFirstCustomerAddressId()` returns `false` for a customer with no address, so `(int) false` wrote `0` over the `0` already there and the cart was saved anyway. For a logged in customer who has not created an address yet that happens on every single page request. Each save calls `Cart::resetProductRelatedStaticCache()`, issues an `UPDATE` on `ps_cart`, and fires `actionCartSave`, so listening modules are told the cart was saved when nothing about it changed.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Register a customer and do not add any address. Log in, put a product in the cart, then browse any front office pages. Before this change `ps_cart.date_upd` for that cart advances on every page load and `actionCartSave` fires each time; after it, neither happens until something really changes. Adding an address must still assign it to the cart on the next request. `tests/Integration/Classes/Controller/CartAddressAutoAssignmentTest.php` covers the decision directly.
| UI Tests          | Not run
| Fixed issue or discussion?     | Fixes #34177
| Related PRs       |
| Sponsor company   |

### The change

```php
if ($this->automaticallyAllocateDeliveryAddress && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0)) {
    $to_update = true;                                                              // before knowing
    $cart->id_address_delivery = (int) Address::getFirstCustomerAddressId($cart->id_customer);
}
```

becomes an assignment that only reports work when work was done. This is the direction @Hlavtox asked for
on the issue: only update when there is something to update and the resolved address is not zero.

The block moved into `FrontController::assignFirstCustomerAddresses()`. `init()` cannot be exercised in a
test without booting a whole page, and the repository asks a bug fix to come with one; the extraction is
behaviour preserving and keeps the decision testable. It is a new `protected` method, so a subclass is
unaffected unless it already declares that name.

### Covered

| Case | Expected |
| --- | --- |
| customer has no address | no update reported, both cart fields stay `0` |
| customer has an address | assigned to both fields, update reported |
| cart already has both addresses | no update reported |
| one allocation flag switched off | only the enabled field is assigned |

Restoring the old unconditional flag inside the extracted method turns
`testNoUpdateIsReportedWhenTheCustomerHasNoAddress` red, so the test measures the defect rather than the
refactor. `FrontControllerTest` (7 tests) and `CartTest` are unaffected.
