### PR TITLE
Stop the hidden module selector from blocking the translations form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -117,6 +117,12 @@ class ModifyTranslationsType extends TranslatorAwareType
                 'row_attr' => [
                     'class' => 'js-module-form-group d-none',
                 ],
+                // The field only applies to the "modules" translation type, and its row is hidden for
+                // every other one. Left required, it renders a required select whose placeholder option
+                // is empty, so the browser refuses to submit the form and reports nothing, because the
+                // control it would point at is hidden. The page relied on JavaScript disabling the
+                // select to avoid that.
+                'required' => false,
                 'placeholder' => '---',
                 'autocomplete' => true,
                 'choices' => $this->moduleChoices,

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsTypeTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsTypeTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Improve\International\Translations;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * The module selector only applies to the "modules" translation type and its row is hidden for every
+ * other one. While it was required, it rendered a required select whose placeholder option is empty, so
+ * the browser refused to submit the form and reported nothing, the control it would have pointed at
+ * being hidden. Choosing "Back office" and pressing Edit therefore did nothing at all.
+ */
+class ModifyTranslationsTypeTest extends KernelTestCase
+{
+    /** @var FormInterface */
+    private $form;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        // Building the module choices reaches the module repository, which needs a shop and a language.
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+        $shopContextBuilder->setShopId(1);
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+        $languageContextBuilder->setDefaultLanguageId(1);
+
+        /** @var FormHandlerInterface $formHandler */
+        $formHandler = self::getContainer()->get('prestashop.admin.translations_settings.modify_translations.form_handler');
+        $this->form = $formHandler->getForm();
+    }
+
+    public function testTheModuleSelectorIsNotRequired(): void
+    {
+        self::assertFalse(
+            $this->form->get('module')->isRequired(),
+            'the module selector does not apply to every translation type, so it must not block submission'
+        );
+    }
+
+    /**
+     * A required select is only harmless while something else has a value; this one starts on an empty
+     * placeholder, which is what made the requirement impossible to satisfy without touching the field.
+     */
+    public function testTheModuleSelectorStillOffersAnEmptyPlaceholder(): void
+    {
+        $config = $this->form->get('module')->getConfig();
+
+        self::assertSame('---', $config->getOption('placeholder'));
+        self::assertNull($this->form->get('module')->getData(), 'nothing is preselected');
+    }
+
+    /**
+     * The row is hidden by default, which is the other half of why the browser could not report it.
+     */
+    public function testTheModuleRowIsHiddenByDefault(): void
+    {
+        $rowAttr = $this->form->get('module')->getConfig()->getOption('row_attr');
+
+        self::assertArrayHasKey('class', $rowAttr);
+        self::assertStringContainsString('d-none', $rowAttr['class']);
+    }
+
+    /**
+     * And the field that is always visible keeps its requirement, so this did not simply relax the form.
+     */
+    public function testTheAlwaysVisibleLanguageSelectorStaysRequired(): void
+    {
+        self::assertTrue($this->form->get('language')->isRequired());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On the Translations page, the module selector only applies to the "modules" translation type and its row carries `d-none` for every other one. It was still a required field, and it is the only conditional selector with a placeholder, so its selected option is empty. Choosing "Back office" and pressing Edit therefore made the browser refuse to submit and report nothing, since the control it would point at is hidden. The page only worked because `FormFieldToggle` disables hidden selects on `window.load`; whenever that has not taken effect the form is stuck, which is what the report describes.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to International > Translations, leave "Type of translation" on "Back office", select a language and press Edit. Before this change nothing happens; after it the page opens. Switching the type to "Modules" and back, which is the workaround in the report, is no longer needed. `tests/Integration/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsTypeTest.php` pins the field configuration.
| UI Tests          | Not run
| Fixed issue or discussion?     | Fixes #38803
| Related PRs       |
| Sponsor company   |

### Why the field, and only this field

Three conditional selectors share the same hidden row treatment, but only `module` can block submission:

| Field | Placeholder | Selected on load | Can block |
| --- | --- | --- | --- |
| `theme` | none | first real choice | no |
| `email_content_type` | none | first real choice | no |
| `module` | `---` | the empty placeholder | **yes** |

A required control is only satisfiable when something is selected, and this is the one that starts empty.

### Why removing the requirement is safe

`required` on a Symfony form type is a rendering option, not a constraint, and nothing on the server side
depended on it. `TranslationsController::modifyTranslationsAction()` never validates this form: it hands
the raw request to `TranslationRouteFinder`, which resolves an empty or unknown module through
`isModuleUsingNewTranslationSystem()` into an `InvalidModuleException`, and the controller already turns
that into a flash message and a redirect. So the worst case after this change is a clear message where the
current behaviour is a silent refusal to submit.

The always visible language selector keeps its requirement, and the test asserts that too so this cannot
quietly become a blanket relaxation of the form.
