### PR TITLE
Skip the cart rule base totals when the cart carries no rule

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -507,6 +507,13 @@ class CartCore extends ObjectModel
             $result = Cache::retrieve($cache_key);
         }
 
+        // Everything below exists to enrich each row, so a cart carrying no rule has nothing to do here.
+        // Without this the base totals were rebuilt on every call for the ordinary voucher-less cart,
+        // and this method is called several times while a cart or a checkout page is rendered.
+        if (empty($result)) {
+            return $result;
+        }
+
         // Define virtual context to prevent case where the cart is not the in the global context
         $virtual_context = Context::getContext()->cloneContext();
         /* @phpstan-ignore-next-line */

--- a/tests/Integration/Classes/CartTest.php
+++ b/tests/Integration/Classes/CartTest.php
@@ -401,6 +401,39 @@ class CartTest extends KernelTestCase
     }
 
     /**
+     * The enrichment block below the base totals must still run when a rule is applied.
+     */
+    public function testGetCartRulesEnrichesRulesAppliedToTheCart(): void
+    {
+        $product = self::makeProduct('Guarded Product', 10, self::getIdTaxRulesGroup(20));
+
+        self::makeCartRule(5, 'before tax');
+        $cart = self::makeCart();
+
+        $cart->updateQty(1, $product->id);
+
+        $rules = $cart->getCartRules();
+
+        $this->assertCount(1, $rules);
+        $this->assertArrayHasKey('obj', $rules[0]);
+        $this->assertEquals(5, $rules[0]['value_tax_exc']);
+        $this->assertEquals(6, $rules[0]['value_real']);
+    }
+
+    /**
+     * And a cart carrying no rule has nothing to enrich, which is what lets the totals be skipped.
+     */
+    public function testGetCartRulesReturnsNoRowsForACartWithoutAnyRule(): void
+    {
+        $product = self::makeProduct('Ruleless Product', 10, self::getIdTaxRulesGroup(20));
+        $cart = self::makeCart();
+
+        $cart->updateQty(1, $product->id);
+
+        $this->assertSame([], $cart->getCartRules());
+    }
+
+    /**
      * This test checks that if PS_ATCP_SHIPWRAP is set to true then:
      * - the shipping cost of the carrier is understood as tax included instead of tax excluded
      * - the tax excluded shipping cost is deduced from the tax included shipping cost


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Cart::getCartRules()` clones the context and rebuilds the cart's product totals, tax excluded and tax included, before enriching each rule row. Those two values are read only by `getContextualValue()` inside the loop that follows, so a cart with no rule applied computes them and uses none of them. The method is called several times while a cart or a checkout page is rendered, so an ordinary voucher-less cart pays for it repeatedly. This returns as soon as there is nothing to enrich.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/CartTest.php` and the `cart` Behat suite. Functionally nothing changes: a cart with no rule returned an empty array before and still does, and a cart with a rule still comes back with `obj`, `value_real` and `value_tax_exc` filled in.
| UI Tests          | Not run
| Fixed issue or discussion?     |
| Related PRs       |
| Sponsor company   |

### Measured

One product, no cart rule applied, `PS_CART_RULE_FEATURE_ACTIVE` on, counting entries into
`Cart::getOrderTotal()` over ten `getCartRules()` calls:

| | before | after |
| --- | --- | --- |
| `getOrderTotal()` calls | 20 | 0 |
| `Context::cloneContext()` calls | 10 | 0 |

Two `getOrderTotal()` per call, the tax excluded and tax included pair. There is no change in query
count: the callees are cached, so this is CPU and object churn rather than database work — each
`getOrderTotal()` builds a fresh calculator and its service objects.

The saving only applies once the cart rule feature is active, which is the case for any shop that has
ever created a voucher. Before that, an earlier guard already returns from the method.

### Why it is safe

`$virtual_context` is local to the method, is never returned, and the two totals it carries are read in
exactly one place — the `foreach ($result as &$row)` immediately below, through
`getContextualValue($useTax, $virtual_context, $filter)`. With `$result` empty that loop does not run.
`CartRule::autoAddToCart()` still runs before the query, so a rule added automatically is in `$result` and
takes the normal path.

Two tests are added to `CartTest`, using its existing fixture helpers: one asserts that a rule which IS
applied still comes back with `obj`, `value_tax_exc` and `value_real` filled in, which is what guards the
shortcut, and one asserts the rule-less cart still returns an empty array. Making the early return
unconditional turns the first of them red.

Regression: the whole `cart` Behat suite, 242 scenarios and 3538 steps, passes unchanged.
