### PR TITLE
Anchor the legacy admin base URL on the admin directory

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -838,6 +838,37 @@ class AdminControllerCore extends Controller
     }
 
     /**
+     * Builds the base URL every legacy link and post-action redirect of the page is derived from.
+     *
+     * It is anchored on the admin directory rather than being the bare `index.php`, because a relative
+     * file name resolves against whatever path the page was served from. A legacy controller reached
+     * through the front-controller form `.../admin-dir/index.php/?controller=...` resolved every one of
+     * those links to `.../admin-dir/index.php/index.php?...`, which matches no route.
+     *
+     * Tools::sanitizeAdminUrl() already expects this shape: it strips the shop's physical URI and only
+     * appends the admin directory when it is absent, so redirects built on top of it stay correct.
+     *
+     * @param string $controller
+     * @param string $back
+     *
+     * @return string
+     */
+    protected static function buildCurrentIndex($controller, $back = '')
+    {
+        $base = 'index.php';
+        if (defined('_PS_ADMIN_DIR_')) {
+            $base = __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/index.php';
+        }
+
+        $currentIndex = $base . ($controller !== '' ? '?controller=' . $controller : '');
+        if ($back !== '') {
+            $currentIndex .= '&back=' . urlencode($back);
+        }
+
+        return $currentIndex;
+    }
+
+    /**
      * Set the filters used for the list display.
      */
     protected function getCookieFilterPrefix()
@@ -2785,11 +2816,10 @@ class AdminControllerCore extends Controller
         }
 
         // Set current index
-        $current_index = 'index.php' . (($controller = Tools::getValue('controller')) ? '?controller=' . $controller : '');
-        if ($back = Tools::getValue('back')) {
-            $current_index .= '&back=' . urlencode($back);
-        }
-        self::$currentIndex = $current_index;
+        self::$currentIndex = self::buildCurrentIndex(
+            (string) Tools::getValue('controller'),
+            (string) Tools::getValue('back')
+        );
 
         if ((int) Tools::getValue('liteDisplaying')) {
             $this->display_header = false;

--- a/tests/Integration/Classes/Controller/AdminCurrentIndexTest.php
+++ b/tests/Integration/Classes/Controller/AdminCurrentIndexTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use AdminController;
+use Context;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Tools;
+
+/**
+ * Every legacy link and post-action redirect of an admin page is built on AdminController::$currentIndex.
+ * While that was the bare file name `index.php`, it resolved against whatever path the page had been
+ * served from, so a legacy controller reached through `.../admin-dir/index.php/?controller=...` produced
+ * links to `.../admin-dir/index.php/index.php?...`, which matches no route.
+ */
+class AdminCurrentIndexTest extends TestCase
+{
+    public function testTheBaseIsAnchoredOnTheAdminDirectory(): void
+    {
+        $currentIndex = $this->buildCurrentIndex('AdminProducts');
+
+        self::assertStringStartsWith(
+            __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/index.php',
+            $currentIndex,
+            'the base must not be a bare file name resolved against the current path'
+        );
+        self::assertStringEndsWith('?controller=AdminProducts', $currentIndex);
+    }
+
+    /**
+     * The shape of the value must not depend on how the page was reached; that is the whole point.
+     */
+    public function testTheBaseIsTheSameWhicheverPathServedThePage(): void
+    {
+        $served = [
+            '/admin-dir/index.php?controller=AdminProducts',
+            '/admin-dir/index.php/?controller=AdminProducts',
+            '/admin-dir/?controller=AdminProducts',
+        ];
+
+        $built = [];
+        foreach ($served as $requestUri) {
+            $_SERVER['REQUEST_URI'] = $requestUri;
+            $built[] = $this->buildCurrentIndex('AdminProducts');
+        }
+        unset($_SERVER['REQUEST_URI']);
+
+        self::assertCount(1, array_unique($built), 'the base is independent of the request path');
+    }
+
+    public function testTheBackParameterIsCarriedAndEncoded(): void
+    {
+        $currentIndex = $this->buildCurrentIndex('AdminProducts', 'index.php?controller=AdminDashboard');
+
+        self::assertStringContainsString('&back=' . urlencode('index.php?controller=AdminDashboard'), $currentIndex);
+    }
+
+    /**
+     * Redirects are built by concatenating onto this value and handing the result to sanitizeAdminUrl().
+     * The anchored shape must survive that without the admin directory or the shop's physical URI
+     * appearing twice.
+     */
+    public function testARedirectBuiltOnItKeepsEachSegmentOnce(): void
+    {
+        $url = Tools::sanitizeAdminUrl($this->buildCurrentIndex('AdminProducts') . '&token=abc123');
+
+        $adminDir = basename(_PS_ADMIN_DIR_);
+        self::assertSame(1, substr_count($url, '/' . $adminDir . '/'), 'the admin directory appears once');
+
+        $physicalUri = Context::getContext()->shop->physical_uri;
+        if ($physicalUri !== '' && $physicalUri !== '/') {
+            self::assertSame(1, substr_count($url, $physicalUri), 'the shop physical URI appears once');
+        }
+
+        self::assertStringNotContainsString('index.php/index.php', $url, 'this is the reported symptom');
+    }
+
+    private function buildCurrentIndex(string $controller, string $back = ''): string
+    {
+        $method = new ReflectionMethod(AdminController::class, 'buildCurrentIndex');
+        $method->setAccessible(true);
+
+        return (string) $method->invoke(null, $controller, $back);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Every legacy link and post-action redirect of an admin page is built on `AdminController::$currentIndex`, which was the bare file name `index.php`. A relative file name resolves against whatever path the page was served from, so a legacy controller reached through the front-controller form `.../admin-dir/index.php/?controller=...` produced links to `.../admin-dir/index.php/index.php?...`, which matches no route and raises `No route found for "GET .../index.php/index.php"`. The base is now built from the shop's base URI and the admin directory, so it no longer depends on how the page was reached.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a legacy back-office page through the trailing-slash form, `.../admin-dir/index.php/?controller=AdminCartRules&token=...`, and use any list link or submit the form. Before this change the target is `.../index.php/index.php?...` and the page raises `No route found`; after it, the link is anchored on the admin directory and resolves. `tests/Integration/Classes/Controller/AdminCurrentIndexTest.php` covers the base itself.
| UI Tests          | Not run
| Fixed issue or discussion?     | Fixes #37329
| Related PRs       |
| Sponsor company   |

### Why this direction

Two directions were possible: anchor the base, or stop serving legacy controllers under the trailing-slash
form. The second only removes one way of reaching the broken state — a base used to build links should not
depend on the path the current page happened to be served from, so the first is the actual defect.

### Blast radius, checked before choosing

`$currentIndex` has 134 references. A grep for `str_replace|preg_|substr|strpos|explode|rtrim|ltrim` across
them returns nothing: every consumer either concatenates query parameters onto it
(`self::$currentIndex . '&' . $identifier . '=' . $id . '&token=' . $token`) or hands it to a template as a
link base. `ContextStateManager` saves and restores the value verbatim and never inspects it.

Redirects were the one real risk, and the shape is already the expected one: `Tools::sanitizeAdminUrl()`
strips the shop's `physical_uri` "to avoid duplicate admin path" and only appends the admin directory when
it is absent. A test asserts that a redirect built on the new base carries the admin directory and the
physical URI exactly once each.

The construction moved into `AdminController::buildCurrentIndex()` so it can be exercised without booting a
whole admin page; it keeps the `back` parameter handling unchanged, and falls back to the previous bare
`index.php` if `_PS_ADMIN_DIR_` is not defined.

### What is not covered

This changes what every legacy back-office link renders as. I verified the base itself, the redirect
composition, and that nothing manipulates the string, and ran the admin controller and unit suites (34 and
705 tests). I did not click through the back office, so the UI suite is the check worth running on this one.
