### PR TITLE
Stop a friendly URL ending on a dash when the name ends on a bracket

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -103,6 +103,13 @@ function str2url(str, encoding, ucfirst)
   str = str.replace(/[\u0028\u0029\u0021\u003F\u002E\u0026\u005E\u007E\u002B\u002A\u002F\u003A\u003B\u003C\u003D\u003E]/g, '');
   str = str.replace(/[\s\'\:\/\[\]-]+/g, ' ');
 
+  // A separator at either end collapses to a space, which would otherwise become a leading or trailing
+  // dash. Left alone when the name is nothing but separators, matching the PHP side, because an empty
+  // result would not be a valid link_rewrite while the single dash is.
+  if (str.trim() !== '') {
+    str = str.trim();
+  }
+
   // Add special char not used for url rewrite
   str = str.replace(/[ ]/g, '-');
   str = str.replace(/[\/\\"'|,;%]*/g, '');

--- a/src/Core/Util/String/StringModifier.php
+++ b/src/Core/Util/String/StringModifier.php
@@ -111,6 +111,16 @@ final class StringModifier implements StringModifierInterface
 
         $return_str = preg_replace('/[\s\'\:\/\[\]\-]+/', ' ', $return_str);
 
+        // A separator at either end collapses to a space, which would otherwise become a leading or
+        // trailing dash. Square brackets are the visible case: they survive the filtering above, while
+        // round ones are dropped outright, which is why only they left a dangling dash.
+        $trimmed = trim($return_str);
+        if ($trimmed !== '') {
+            // Kept as it was when the name is nothing but separators, since an empty result would not
+            // pass Validate::isLinkRewrite() while the single dash does.
+            $return_str = $trimmed;
+        }
+
         return str_replace([' ', '/'], '-', $return_str);
     }
 

--- a/tests/Unit/Core/Util/String/StringModifierTest.php
+++ b/tests/Unit/Core/Util/String/StringModifierTest.php
@@ -22,6 +22,30 @@ class StringModifierTest extends TestCase
         $this->stringModifier = new StringModifier();
     }
 
+    /**
+     * Square brackets survive the character filter and then collapse to a space, so one at the end of a
+     * name became a trailing dash in the friendly URL, while round brackets - dropped outright by the
+     * filter - did not. Brackets still separate words, they just no longer dangle.
+     *
+     * @dataProvider getStringsWithBrackets
+     */
+    public function testItDoesNotLeaveASeparatorDanglingInAUrl(string $string, string $expected): void
+    {
+        $this->assertSame($expected, $this->stringModifier->str2url($string, false));
+    }
+
+    public static function getStringsWithBrackets(): Generator
+    {
+        yield 'trailing square brackets' => ['Product name [text]', 'product-name-text'];
+        yield 'leading square brackets' => ['[text] Product name', 'text-product-name'];
+        yield 'brackets inside still separate words' => ['Red car[big]', 'red-car-big'];
+        yield 'round brackets are dropped, as before' => ['Product name (text)', 'product-name-text'];
+        yield 'trailing dash' => ['Product name -', 'product-name'];
+        yield 'trailing colon' => ['Product name:', 'product-name'];
+        yield 'no separators at the edges' => ['Product name text', 'product-name-text'];
+        yield 'inner punctuation is unaffected' => ['Red car / big', 'red-car-big'];
+    }
+
     public function testItTransformsCamelCaseToSplitWords(): void
     {
         $data = [
@@ -157,11 +181,11 @@ class StringModifierTest extends TestCase
     {
         yield ['!@#$%^&*()_+-={}[]|:;"<>,.?/', '-', false];
         yield ['Some !@#$%^&*()_+-={}[]|:;"<>,.?/ text', 'some-text', false];
-        yield ['Some text 123 !@#$%^&*()_+-={}[]|:;"<>,.?/', 'some-text-123-', false];
+        yield ['Some text 123 !@#$%^&*()_+-={}[]|:;"<>,.?/', 'some-text-123', false];
         yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-aeiou', false];
         yield ['!@#$%^&*()_+-={}[]|:;"<>,.?/', '-', false];
         yield ['Some !@#$%^&*()_+-={}[]|:;"<>,.?/ text', 'some-text', false];
-        yield ['Some text 123 !@#$%^&*()_+-={}[]|:;"<>,.?/', 'some-text-123-', false];
+        yield ['Some text 123 !@#$%^&*()_+-={}[]|:;"<>,.?/', 'some-text-123', false];
         yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-aeiou', false];
         yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-áéíóú', true];
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `str2url()` keeps square brackets through its character filter and then collapses them along with the other separators into a space, so a bracket at the end of a product name became a trailing space and, after the final substitution, a trailing dash. Round brackets are dropped outright by the filter, which is why only square ones showed it. The collapsed value is now trimmed, on the PHP side and in the admin JavaScript that previews the same URL.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a product named `Product name [text]` and look at the friendly URL on the SEO tab: it read `product-name-text-` and now reads `product-name-text`. `Red car[big]` still becomes `red-car-big`, and `Product name (text)` is unchanged. `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/Util/String/StringModifierTest.php`.
| UI Tests          | Not run
| Fixed issue or discussion?     | Fixes #39394
| Related PRs       |
| Sponsor company   |

### Following the discussion on the issue

@kpodemski: "`]` should not create the last `-`". @Hlavtox: "It definitely shouldn't create the last dash,
thats certain", while also noting that turning the brackets into a separator is right, since `Red car[big]`
should be `red-car-big` and not `red-carbig`. This keeps the substitution and removes only the dangling
separator, at either end, so `[text] Product name` gives `text-product-name` too.

### The one case deliberately left as it was

A name consisting only of separators produced a single `-`, and still does. Trimming would give an empty
string, and `Validate::isLinkRewrite('')` returns 0 while `isLinkRewrite('-')` returns 1 — so the
"cleaner" result would be the one that cannot be saved. The two existing data sets in
`StringModifierTest` covering that input are unchanged; the two that encoded the trailing dash
(`'some-text-123-'`) are updated, which is the behaviour this fixes.

### Both sides agree

@Hlavtox noted this has to be adjusted on the JavaScript side too. `js/admin.js` has the same collapse and
substitution, and gets the same trim. Running the two implementations over the same inputs:

| input | PHP | JS |
| --- | --- | --- |
| `Product name [text]` | `product-name-text` | `product-name-text` |
| `[text] Product name` | `text-product-name` | `text-product-name` |
| `Red car[big]` | `red-car-big` | `red-car-big` |
| `Product name (text)` | `product-name-text` | `product-name-text` |
| `!@#$%^&*()_+-={}[]\|:;"<>,.?/` | `-` | `-` |
| `Some text 123 !@#$%^&*()_+-={}[]\|:;"<>,.?/` | `some-text-123` | `some-text-123` |

Ten inputs checked, all matching, which matters because the JavaScript renders the preview while the PHP
writes the value that is stored.
