### PR TITLE
Apportion the order discount to the quantities actually refunded

### DIFF
--- a/src/Adapter/Order/Refund/OrderRefundCalculator.php
+++ b/src/Adapter/Order/Refund/OrderRefundCalculator.php
@@ -68,7 +68,7 @@ class OrderRefundCalculator
         $voucherChosen = false;
         $voucherAmount = $numberZero;
         if ($voucherRefundType === VoucherRefundType::PRODUCT_PRICES_EXCLUDING_VOUCHER_REFUND) {
-            $voucherAmount = new DecimalNumber((string) $order->total_discounts);
+            $voucherAmount = $this->getRefundedShareOfOrderDiscount($order, $productRefunds);
             $refundedAmount = $refundedAmount->minus($voucherAmount);
         } elseif ($voucherRefundType === VoucherRefundType::SPECIFIC_AMOUNT_REFUND) {
             $voucherChosen = true;
@@ -200,6 +200,48 @@ class OrderRefundCalculator
         }
 
         return $productRefunds;
+    }
+
+    /**
+     * The order discount applies to the whole cart, so a refund may only take back the share of it
+     * that the refunded quantities carried. Deducting all of it from a partial refund short-changes
+     * the customer: on a 210 order discounted by 42, refunding the 150 product returned 150 - 42 = 108
+     * where that product's own share is 150 - 30 = 120.
+     *
+     * Refunding every product gives a ratio of one, so a full refund still deducts the whole discount.
+     *
+     * Known limitation: a cart rule that also grants free shipping stores the shipping part inside the
+     * same value, so that part is shared across the products here rather than charged to shipping.
+     *
+     * @param Order $order
+     * @param array $productRefunds
+     *
+     * @return DecimalNumber
+     */
+    private function getRefundedShareOfOrderDiscount(Order $order, array $productRefunds): DecimalNumber
+    {
+        $orderDiscount = new DecimalNumber((string) $order->total_discounts);
+        $orderProductsTotal = new DecimalNumber((string) $order->total_products_wt);
+
+        // Nothing to apportion the discount against, keep deducting it whole.
+        if (!$orderProductsTotal->isGreaterThanZero()) {
+            return $orderDiscount;
+        }
+
+        // The amount actually being refunded, not the products' list price: the merchant may refund
+        // less than a line is worth, and that smaller amount carries a correspondingly smaller share.
+        $refundedProductsTotal = new DecimalNumber('0');
+        foreach ($productRefunds as $productRefund) {
+            $refundedProductsTotal = $refundedProductsTotal->plus(
+                new DecimalNumber((string) $productRefund['total_refunded_tax_incl'])
+            );
+        }
+
+        if ($refundedProductsTotal->isGreaterOrEqualThan($orderProductsTotal)) {
+            return $orderDiscount;
+        }
+
+        return $orderDiscount->times($refundedProductsTotal)->dividedBy($orderProductsTotal);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
@@ -258,13 +258,13 @@ Feature: Refund Order from Back Office (BO)
       | shipping_refund             |                          | 5.5    |
     Then "bo_order_refund" has 1 credit slips
     # Weird behavior, we are in tax EXCLUDED display, so total_products_tax_excl contains the initial refund
-    # amount, and total_products_tax_incl the real one (minus voucher) If we had been in tax INCLUDED display
-    # it would have been the opposite
+    # amount, and total_products_tax_incl the real one (minus the refunded share of the voucher) If we had
+    # been in tax INCLUDED display it would have been the opposite
     Then "bo_order_refund" last credit slip is:
       | amount                  | 8.0  |
       | shipping_cost_amount    | 5.83 |
       | total_products_tax_excl | 8.0  |
-      | total_products_tax_incl | 3.18 |
+      | total_products_tax_incl | 7.292263 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
       | product_quantity_refunded   | 0 |
@@ -617,7 +617,7 @@ Feature: Refund Order from Back Office (BO)
 
   @order-refund
   @order-partial-refund
-  Scenario: Partial refund of products paid partially with a big voucher, too high refund
+  Scenario: Partial refund of products paid partially with a big voucher
     Given I use a voucher "PROMO20" for a discount of 20.0 on the cart "dummy_cart"
     And I add order "bo_order_refund" with the following details:
       | cart                | dummy_cart                 |
@@ -634,8 +634,13 @@ Feature: Refund Order from Back Office (BO)
       | product_name                | quantity                 | amount |
       | Mug Today is a good day     | 1                        | 8      |
       | shipping_refund             |                          | 5.5    |
-    Then I should get error that refund amount is invalid
-    Then "bo_order_refund" has 0 credit slips
+    Then "bo_order_refund" has 1 credit slips
+    # Only this product's share of the 20 discount is deducted. Deducting the whole discount used to make
+    # the refund negative, so refunding a single product from a heavily discounted order was impossible.
+    Then "bo_order_refund" last credit slip is:
+      | amount                  | 8.0 |
+      | total_products_tax_excl | 8.0 |
+      | total_products_tax_incl | 3.729049 |
 
   @order-refund
   @order-partial-refund

--- a/tests/Integration/Behaviour/Features/Scenario/Order/return_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/return_product.feature
@@ -276,15 +276,15 @@ Feature: Refund Order from Back Office (BO)
       | shipping_refund             | 1        |
     Then "bo_order_refund" has 1 credit slips
     # Weird behavior, we are in tax EXCLUDED display, so total_products_tax_excl contains the initial refund
-    # amount, and total_products_tax_incl the real one (minus voucher) If we had been in tax INCLUDED display
-    # it would have been the opposite
+    # amount, and total_products_tax_incl the real one (minus the refunded share of the voucher) If we had
+    # been in tax INCLUDED display it would have been the opposite
     Then "bo_order_refund" last credit slip is:
       | amount                  | 11.9 |
       | shipping_cost_amount    | 7.42 |
       | total_shipping_tax_incl | 7.42 |
       | total_shipping_tax_excl | 7.0  |
       | total_products_tax_excl | 11.9 |
-      | total_products_tax_incl | 7.31 |
+      | total_products_tax_incl | 10.843801 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
       | product_quantity_refunded   | 0 |
@@ -525,7 +525,7 @@ Feature: Refund Order from Back Office (BO)
 
   @order-refund
   @order-return-product
-  Scenario: Return product of products paid partially with a big voucher, too high refund
+  Scenario: Return product of products paid partially with a big voucher
     Given I use a voucher "PROMO20" for a discount of 20.0 on the cart "dummy_cart"
     And I add order "bo_order_refund" with the following details:
       | cart                | dummy_cart             |
@@ -543,8 +543,13 @@ Feature: Refund Order from Back Office (BO)
       | product_name                | quantity |
       | Mug Today is a good day     | 1        |
       | shipping_refund             | 1        |
-    Then I should get error that refund amount is invalid
-    Then "bo_order_refund" has 0 credit slips
+    Then "bo_order_refund" has 1 credit slips
+    # Only this product's share of the 20 discount is deducted. Deducting the whole discount used to make
+    # the refund negative, so refunding a single product from a heavily discounted order was impossible.
+    Then "bo_order_refund" last credit slip is:
+      | amount                  | 11.9 |
+      | total_products_tax_excl | 11.9 |
+      | total_products_tax_incl | 5.545201 |
 
   @order-refund
   @order-return-product

--- a/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
@@ -278,15 +278,15 @@ Feature: Refund Order from Back Office (BO)
       | shipping_refund             | 1        |
     Then "bo_order_refund" has 1 credit slips
     # Weird behavior, we are in tax EXCLUDED display, so total_products_tax_excl contains the initial refund
-    # amount, and total_products_tax_incl the real one (minus voucher) If we had been in tax INCLUDED display
-    # it would have been the opposite
+    # amount, and total_products_tax_incl the real one (minus the refunded share of the voucher) If we had
+    # been in tax INCLUDED display it would have been the opposite
     Then "bo_order_refund" last credit slip is:
       | amount                  | 11.9 |
       | shipping_cost_amount    | 7.42 |
       | total_shipping_tax_incl | 7.42 |
       | total_shipping_tax_excl | 7.0  |
       | total_products_tax_excl | 11.9 |
-      | total_products_tax_incl | 7.31 |
+      | total_products_tax_incl | 10.843801 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
       | product_quantity_refunded   | 0 |
@@ -519,7 +519,7 @@ Feature: Refund Order from Back Office (BO)
 
   @order-refund
   @order-standard-refund
-  Scenario: Standard refund of products paid partially with a big voucher, too high refund
+  Scenario: Standard refund of products paid partially with a big voucher
     Given I use a voucher "PROMO20" for a discount of 20.0 on the cart "dummy_cart"
     And I add order "bo_order_refund" with the following details:
       | cart                | dummy_cart       |
@@ -537,8 +537,13 @@ Feature: Refund Order from Back Office (BO)
       | product_name                | quantity |
       | Mug Today is a good day     | 1        |
       | shipping_refund             | 1        |
-    Then I should get error that refund amount is invalid
-    Then "bo_order_refund" has 0 credit slips
+    Then "bo_order_refund" has 1 credit slips
+    # Only this product's share of the 20 discount is deducted. Deducting the whole discount used to make
+    # the refund negative, so refunding a single product from a heavily discounted order was impossible.
+    Then "bo_order_refund" last credit slip is:
+      | amount                  | 11.9 |
+      | total_products_tax_excl | 11.9 |
+      | total_products_tax_incl | 5.545201 |
 
   @order-refund
   @order-standard-refund


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A refund that excludes the voucher deducted the whole order discount however little was refunded, so a partial refund took back a discount the customer still carries on the products they kept. The refunded share is deducted instead.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run
| Fixed issue or discussion?     | Fixes #18319
| Related PRs       | None
| Sponsor company   |

### Why

`OrderRefundCalculator::computeOrderRefund()` deducted the entire order discount whenever the merchant
chose "product prices excluding voucher":

```php
$voucherAmount = new DecimalNumber((string) $order->total_discounts);
$refundedAmount = $refundedAmount->minus($voucherAmount);
```

The discount belongs to the whole cart, so on a partial refund this takes back a discount the customer
still carries on the products they kept. Using the numbers from #18319: two products at 150 and 60,
subtotal 210, a 20% discount of 42, total 168. Refunding the 150 product returns `150 - 42 = 108`, where
that product's own share is 30 and the correct refund is 120. The customer is short 12.

It also blocks refunds outright. With a discount larger than the line being refunded the subtraction goes
negative and the command fails with "refund amount is invalid", so a single product could not be refunded
from a heavily discounted order at all.

### What it does

Deducts the share of the discount that the refunded quantities carried, measured as the refunded amount
over the order's product total. Refunding everything gives a ratio of one, so a full refund still deducts
the whole discount and is unchanged.

The numerator is `total_refunded_tax_incl`, the amount actually being refunded, not the products' list
price: a merchant may refund less than a line is worth, and that smaller amount carries a correspondingly
smaller share.

### How to test

1. Cart with two products, 150 and 60. Apply a 20% cart rule (discount 42, total 168).
2. Place and pay the order.
3. Order page, partial refund of the 150 product, "product prices excluding voucher".
4. Before: the credit slip amount is 108. After: 120.
5. Full refund of both products still deducts the whole 42 and returns 168.

### Behaviour changes in the test suite

Six scenarios move, all of them voucher-plus-partial-refund; the other 254 in the `order` suite are
untouched.

Three assert the refunded amount and now carry the apportioned value:

- `partial_refund.feature` "paid partially with voucher" — `total_products_tax_incl` 3.18 to 7.292263
- `standard_refund.feature` "paid partially with voucher" — 7.31 to 10.843801
- `return_product.feature` "paid partially with voucher" — 7.31 to 10.843801

Three asserted `refund amount is invalid` for a voucher of 20 on a 37.84 order. That error was an artefact
of subtracting the whole discount from a single line; the line's own share is about 7, so the refund is
valid and the error no longer fires. They now assert the resulting credit slip. The error keeps its
coverage in the scenarios that reach it without a voucher (`partial_refund.feature` invalid-amount cases).

The existing comment in those scenarios already called the old value "Weird behavior". It is reworded to
say the deduction is the refunded share; the tax-basis oddity it describes is untouched by this PR.

### Scope

`OrderSlip::create()` carries the same whole-discount subtraction at `classes/order/OrderSlip.php:365`.
It has no callers in core (`git grep 'OrderSlip::create'` returns a CHANGELOG line and two comments), so
it is left untouched and no test can cover it.

The rendered credit slip follows the corrected figures without any change here.
`HTMLTemplateOrderSlip::__construct()` replaces the order's product list with
`OrderSlip::getOrdersSlipProducts()`, which keeps only the lines that have an `order_slip_detail` row and
merges that row over each one, so the document shows the refunded quantities at the refunded unit prices.

### Notes

A cart rule that also grants free shipping puts the shipping part into the same figure: `total_discounts`
comes from `getOrderTotal(..., Cart::ONLY_DISCOUNTS)`, which selects rules with `FILTER_ACTION_ALL` and
sums them in `Calculator::getDiscountTotal()`, and that method adds the shipping discount
(`initialShippingFees` minus `finalShippingFees`) alongside each rule's own value. So the shipping part is
apportioned across products here rather than charged to shipping. That is unchanged in kind from the
current code, which charged all of it to any partial refund.

This does not change the "product prices" refund option, which refunds the list prices by design. A
merchant who picks that one still sees undiscounted amounts; only the "excluding voucher" option is
affected, which is the option #18319 describes.

Coverage checked: outside the `order` behat suite nothing exercises the refund path. The two credit-slip
UI campaigns (`03_creditSlips/01`, `/02`) create partial refunds with no cart rule, so `total_discounts` is
zero, the apportioned share is zero and their behaviour is identical.
