### PR TITLE
Cover the credit slip document's product list

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderRefundFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderRefundFeatureContext.php
@@ -192,6 +192,67 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * The credit slip document builds its product list through OrderSlip::getOrdersSlipProducts(), which
+     * HTMLTemplateOrderSlip::__construct() assigns over $order->products. It must contain only the lines
+     * that were refunded, at the refunded quantity and the refunded amount rather than the list price.
+     *
+     * @Then :orderReference last credit slip lists these refunded products:
+     *
+     * @param string $orderReference
+     * @param TableNode $table
+     */
+    public function checkOrderSlipProducts(string $orderReference, TableNode $table): void
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+
+        $order = new Order($orderId);
+        $orderSlips = $order->getOrderSlipsCollection();
+        /** @var OrderSlip $orderSlip */
+        $orderSlip = $orderSlips->offsetGet($orderSlips->count() - 1);
+
+        $slipProducts = array_values(OrderSlip::getOrdersSlipProducts((int) $orderSlip->id, $order));
+        $expectedRows = $table->getColumnsHash();
+
+        Assert::assertCount(
+            count($expectedRows),
+            $slipProducts,
+            sprintf(
+                'The credit slip should list %d product line(s), got %d: %s',
+                count($expectedRows),
+                count($slipProducts),
+                implode(', ', array_column($slipProducts, 'product_name'))
+            )
+        );
+
+        foreach ($expectedRows as $index => $expectedRow) {
+            $actual = $slipProducts[$index];
+            foreach ($expectedRow as $field => $expectedValue) {
+                if ('product_name' === $field) {
+                    Assert::assertSame(
+                        $expectedValue,
+                        $actual['product_name'],
+                        sprintf('Credit slip line %d is not the expected product', $index)
+                    );
+
+                    continue;
+                }
+
+                Assert::assertEquals(
+                    (float) $expectedValue,
+                    (float) $actual[$field],
+                    sprintf(
+                        'Invalid %s on credit slip line %d, expected %s instead of %s',
+                        $field,
+                        $index,
+                        $expectedValue,
+                        $actual[$field]
+                    )
+                );
+            }
+        }
+    }
+
+    /**
      * @Given return product is enabled
      */
     public function enabledReturnProduct(): void

--- a/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
@@ -86,6 +86,28 @@ Feature: Refund Order from Back Office (BO)
 
   @order-refund
   @order-partial-refund
+  Scenario: The credit slip document lists only the refunded lines, at the refunded amount
+    Given I add order "bo_order_refund" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Processing in progress     |
+    And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+      | product_quantity            | 2 |
+    And product "Mug Today is a good day" in order "bo_order_refund" has following details:
+      | product_quantity            | 1 |
+    When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
+      | product_name                | quantity                 | amount |
+      | Mug Today is a good day     | 1                        | 3.5    |
+    Then "bo_order_refund" has 1 credit slips
+    # The order also holds 2 "Mug The best is yet to come", which was not refunded and must not appear.
+    # The amount is the 3.5 that was refunded, not the 11.9 the line is worth.
+    Then "bo_order_refund" last credit slip lists these refunded products:
+      | product_name            | product_quantity | total_price_tax_excl |
+      | Mug Today is a good day | 1                | 3.5                  |
+
+  @order-refund
+  @order-partial-refund
   Scenario: Partial refund of products with restock
     Given I add order "bo_order_refund" with the following details:
       | cart                | dummy_cart                 |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Adds the first assertion on what a credit slip document actually contains. No production code changes.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run
| Fixed issue or discussion?     |
| Related PRs       | None
| Sponsor company   |

### Why

Nothing in the repository asserts what a credit slip contains. `git grep -l HTMLTemplate -- tests/`
returns nothing, and the two credit-slip UI campaigns only filter, sort and paginate the grid.

The document does not print the order. `HTMLTemplateOrderSlip::__construct()` replaces the order's
product list:

```php
$this->order->products = OrderSlip::getOrdersSlipProducts($this->order_slip->id, $this->order);
```

and `OrderSlip::getOrdersSlipProducts()` keeps only the order details that have an `order_slip_detail`
row with a non-zero quantity, merging that row over each one so the line carries the refunded quantity
and the refunded unit price. That selection is the whole reason a partial refund prints the refunded
lines rather than the entire order, and it was untested.

### What it does

One scenario and one step. The scenario orders two different products, refunds a single line for less
than the line is worth, and asserts the slip holds that line only, at the refunded amount.

The step reads the list through `OrderSlip::getOrdersSlipProducts()`, the same call the document makes,
so it pins the behaviour rather than the rendering.

### How to test

```
vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order \
  --name "The credit slip document lists only the refunded lines"
```

### Why it is worth having

Both halves were confirmed to bite, by breaking them:

- dropping the refunded-line filter in `getOrdersSlipProducts()` fails with
  `The credit slip should list 1 product line(s), got 2: Mug The best is yet to come, Mug Today is a good day`
- reversing the `array_merge()` so the order values win over the slip values fails with
  `Invalid total_price_tax_excl on credit slip line 0, expected 3.5 instead of 11.900000`

The second is the interesting one: 11.9 is what the line is worth and 3.5 is what was refunded, so the
assertion separates the two rather than passing on either.

The full `order` suite is green with it.
