### PR TITLE
Fix employee grid filtering for employees without valid shop associations

### DIFF
--- a/src/Core/Grid/Query/EmployeeQueryBuilder.php
+++ b/src/Core/Grid/Query/EmployeeQueryBuilder.php
@@ -8,7 +8,6 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -32,11 +31,6 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
     private $contextShopIds;
 
     /**
-     * @var ShopContext
-     */
-    private $shopContext;
-
-    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
@@ -48,15 +42,13 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
         $contextIdLang,
-        array $contextShopIds,
-        ShopContext $shopContext
+        array $contextShopIds
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
         $this->contextIdLang = $contextIdLang;
         $this->contextShopIds = $contextShopIds;
-        $this->shopContext = $shopContext;
     }
 
     /**
@@ -91,6 +83,34 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function getEmployeeQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
+        // Check whether the employee is associated with one of the existing,
+        // non-deleted shops from the current shop context.
+        $contextShopAssociationSubquery = $this->connection->createQueryBuilder()
+            ->select('1')
+            ->from($this->dbPrefix . 'employee_shop', 'es_context')
+            ->innerJoin(
+                'es_context',
+                $this->dbPrefix . 'shop',
+                's_context',
+                's_context.id_shop = es_context.id_shop AND s_context.deleted = 0'
+            )
+            ->where('e.id_employee = es_context.id_employee')
+            ->andWhere('es_context.id_shop IN (:context_shop_ids)');
+
+        // Only associations to existing, non-deleted shops are considered valid.
+        // This is important because employee_shop may contain orphaned associations
+        // pointing to missing or deleted shops.
+        $validShopAssociationSubquery = $this->connection->createQueryBuilder()
+            ->select('1')
+            ->from($this->dbPrefix . 'employee_shop', 'es_valid')
+            ->innerJoin(
+                'es_valid',
+                $this->dbPrefix . 'shop',
+                's_valid',
+                's_valid.id_shop = es_valid.id_shop AND s_valid.deleted = 0'
+            )
+            ->where('e.id_employee = es_valid.id_employee');
+
         $qb = $this->connection->createQueryBuilder()
             ->from($this->dbPrefix . 'employee', 'e')
             ->leftJoin(
@@ -98,34 +118,28 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->dbPrefix . 'profile_lang',
                 'pl',
                 'e.id_profile = pl.id_profile AND pl.id_lang = ' . (int) $this->contextIdLang
+            )
+            // Keep employees belonging to the current shop context, as well as
+            // employees that are not associated with any valid shop. The latter
+            // covers missing, orphaned and deleted shop associations without
+            // weakening multistore scoping for employees assigned to another
+            // existing shop.
+            ->andWhere(
+                sprintf(
+                    '(EXISTS (%s) OR NOT EXISTS (%s))',
+                    $contextShopAssociationSubquery->getSQL(),
+                    $validShopAssociationSubquery->getSQL()
+                )
+            )
+            ->setParameter(
+                'context_shop_ids',
+                $this->contextShopIds,
+                Connection::PARAM_INT_ARRAY
             );
-
-        $this->addShopContextRestriction($qb);
 
         $this->applyFilters($qb, $searchCriteria->getFilters());
 
         return $qb;
-    }
-
-    /**
-     * Adds the shop context restriction to the QueryBuilder when required.
-     *
-     * @param QueryBuilder $qb
-     */
-    private function addShopContextRestriction(QueryBuilder $qb): void
-    {
-        if ($this->shopContext->isAllShopContext()) {
-            return;
-        }
-
-        $sub = $this->connection->createQueryBuilder()
-            ->select('1')
-            ->from($this->dbPrefix . 'employee_shop', 'es')
-            ->where('e.id_employee = es.id_employee')
-            ->andWhere('es.id_shop IN (:context_shop_ids)');
-
-        $qb->andWhere('EXISTS (' . $sub->getSQL() . ')')
-            ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY);
     }
 
     /**

--- a/src/Core/Grid/Query/EmployeeQueryBuilder.php
+++ b/src/Core/Grid/Query/EmployeeQueryBuilder.php
@@ -8,6 +8,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -31,6 +32,11 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
     private $contextShopIds;
 
     /**
+     * @var ShopContext
+     */
+    private $shopContext;
+
+    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
@@ -42,13 +48,15 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
         $contextIdLang,
-        array $contextShopIds
+        array $contextShopIds,
+        ShopContext $shopContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
         $this->contextIdLang = $contextIdLang;
         $this->contextShopIds = $contextShopIds;
+        $this->shopContext = $shopContext;
     }
 
     /**
@@ -83,18 +91,6 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function getEmployeeQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        $sub = $this->connection->createQueryBuilder()
-            ->select('1')
-            ->from($this->dbPrefix . 'employee_shop', 'es')
-            ->where('e.id_employee = es.id_employee')
-            ->andWhere('es.id_shop IN (:context_shop_ids)');
-
-        // Subquery to identify employees not linked to any shop
-        $missingShopLinkSubquery = $this->connection->createQueryBuilder()
-            ->select('1')
-            ->from($this->dbPrefix . 'employee_shop', 'es')
-            ->where('e.id_employee = es.id_employee');
-
         $qb = $this->connection->createQueryBuilder()
             ->from($this->dbPrefix . 'employee', 'e')
             ->leftJoin(
@@ -102,14 +98,34 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->dbPrefix . 'profile_lang',
                 'pl',
                 'e.id_profile = pl.id_profile AND pl.id_lang = ' . (int) $this->contextIdLang
-            )
-            ->andWhere('EXISTS (' . $sub->getSQL() . ')')
-            ->orWhere('NOT EXISTS (' . $missingShopLinkSubquery->getSQL() . ')')
-            ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY);
+            );
+
+        $this->addShopContextRestriction($qb);
 
         $this->applyFilters($qb, $searchCriteria->getFilters());
 
         return $qb;
+    }
+
+    /**
+     * Adds the shop context restriction to the QueryBuilder when required.
+     *
+     * @param QueryBuilder $qb
+     */
+    private function addShopContextRestriction(QueryBuilder $qb): void
+    {
+        if ($this->shopContext->isAllShopContext()) {
+            return;
+        }
+
+        $sub = $this->connection->createQueryBuilder()
+            ->select('1')
+            ->from($this->dbPrefix . 'employee_shop', 'es')
+            ->where('e.id_employee = es.id_employee')
+            ->andWhere('es.id_shop IN (:context_shop_ids)');
+
+        $qb->andWhere('EXISTS (' . $sub->getSQL() . ')')
+            ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY);
     }
 
     /**

--- a/src/Core/Grid/Query/EmployeeQueryBuilder.php
+++ b/src/Core/Grid/Query/EmployeeQueryBuilder.php
@@ -89,6 +89,12 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
             ->where('e.id_employee = es.id_employee')
             ->andWhere('es.id_shop IN (:context_shop_ids)');
 
+        // Subquery to identify employees not linked to any shop
+        $missingShopLinkSubquery = $this->connection->createQueryBuilder()
+            ->select('1')
+            ->from($this->dbPrefix . 'employee_shop', 'es')
+            ->where('e.id_employee = es.id_employee');
+
         $qb = $this->connection->createQueryBuilder()
             ->from($this->dbPrefix . 'employee', 'e')
             ->leftJoin(
@@ -98,6 +104,7 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
                 'e.id_profile = pl.id_profile AND pl.id_lang = ' . (int) $this->contextIdLang
             )
             ->andWhere('EXISTS (' . $sub->getSQL() . ')')
+            ->orWhere('NOT EXISTS (' . $missingShopLinkSubquery->getSQL() . ')')
             ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY);
 
         $this->applyFilters($qb, $searchCriteria->getFilters());

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -74,6 +74,7 @@ services:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
       - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
       - "@=service('prestashop.adapter.legacy.context').getContext().shop.getContextListShopID()"
+      - '@PrestaShop\PrestaShop\Core\Context\ShopContext'
     public: true
 
   prestashop.core.grid.query_builder.contact:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -74,7 +74,6 @@ services:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
       - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
       - "@=service('prestashop.adapter.legacy.context').getContext().shop.getContextListShopID()"
-      - '@PrestaShop\PrestaShop\Core\Context\ShopContext'
     public: true
 
   prestashop.core.grid.query_builder.contact:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Fixes the Employees grid filtering when an employee has no valid shop association. The previous attempt in #38614 relied on the shop context and did not cover the single-shop case. This new implementation follows the approach proposed by @boo-code in #35094: instead of relying only on the presence of rows in `employee_shop`, shop associations are checked against existing, non-deleted shops. This allows employees with no shop association, orphaned associations pointing to missing shops, or associations to deleted shops to remain visible and manageable in the Back Office, while employees assigned to another existing shop remain correctly filtered out. This PR supersedes #38614, which could not be reopened after its original base branch was removed.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | **Case 1 — Employee without any shop association**<br>1. Create an employee in **Advanced Parameters > Team > Employees**.<br>2. Retrieve the ID of the newly created employee.<br>3. Delete all rows for this employee from the `employee_shop` table.<br>4. Return to **Advanced Parameters > Team > Employees** without logging out.<br>5. Verify that the employee is still displayed.<br><br>**Case 2 — Employee associated with a missing shop**<br>1. Create an employee.<br>2. Replace its `employee_shop.id_shop` association with an ID that does not exist in the `shop` table.<br>3. Reload the Employees grid.<br>4. Verify that the employee is still displayed.<br><br>**Case 3 — Employee associated with a deleted shop**<br>1. Create an employee and associate it with a shop.<br>2. Set `deleted = 1` for that shop in the `shop` table.<br>3. Reload the Employees grid.<br>4. Verify that the employee is still displayed.<br><br>**Case 4 — Multistore: employee without shop associations in All shops context**<br>1. Enable multistore and make sure at least two active shops exist.<br>2. Create an employee.<br>3. Delete all rows for this employee from the `employee_shop` table.<br>4. Select **All shops** as the current shop context.<br>5. Open **Advanced Parameters > Team > Employees**.<br>6. Verify that the employee is displayed.<br><br>**Case 5 — Multistore shop scoping is preserved**<br>1. Enable multistore and make sure at least two active shops exist.<br>2. Associate an employee only with Shop 2.<br>3. Select Shop 1 as the current shop context.<br>4. Verify that the employee associated only with Shop 2 is **not** displayed.<br>5. Verify that employees associated with Shop 1 are still displayed normally.<br>6. Select **All shops** and verify that employees associated with both shops are displayed.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/33595213486
| Fixed issue or discussion?     | Fixes #35094
| Related PRs       | Supersedes #38614. A new PR was created because the previous one could not be reopened after its base branch was removed.
| Sponsor company   | Codencode snc