### PR TITLE
Add the business entity edit page in the Back Office

### DIFF
--- a/src/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandler.php
+++ b/src/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandler.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\CommandHandler\EditBusinessEntityHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShopBundle\Entity\B2B\BusinessEntity;
+use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommandHandler]
+final class EditBusinessEntityHandler implements EditBusinessEntityHandlerInterface
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly BusinessEntityRepository $businessEntityRepository,
+        #[Autowire(service: 'prestashop.adapter.legacy.logger')]
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws BusinessEntityNotFoundException
+     */
+    public function handle(EditBusinessEntityCommand $command): void
+    {
+        $businessEntityId = $command->getBusinessEntityId()->getValue();
+
+        $businessEntity = $this->businessEntityRepository->getBusinessEntityById($businessEntityId);
+
+        if (null === $businessEntity) {
+            throw new BusinessEntityNotFoundException(sprintf('Business entity with id %d was not found.', $businessEntityId));
+        }
+
+        $modifiedFields = $this->getModifiedFields($businessEntity, $command);
+
+        $businessEntity->setName($command->getName());
+        $businessEntity->setLegalName($command->getLegalName());
+        $businessEntity->setExternalRef($command->getExternalRef());
+        $businessEntity->setDeliveryAuthorized($command->isDeliveryAuthorized());
+        $businessEntity->setStatus($command->getStatus());
+        $businessEntity->setIdCustomerGroup($command->getCustomerGroupId());
+
+        $this->em->flush();
+
+        $message = 'Business entity updated successfully';
+        if ([] !== $modifiedFields) {
+            $message .= ' ' . json_encode($modifiedFields, JSON_THROW_ON_ERROR);
+        }
+
+        $this->logger->info(
+            $message,
+            [
+                'object_type' => 'BusinessEntity',
+                'object_id' => $businessEntityId,
+            ]
+        );
+    }
+
+    /**
+     * @return array<string, array{old: mixed, new: mixed}>
+     */
+    private function getModifiedFields(BusinessEntity $businessEntity, EditBusinessEntityCommand $command): array
+    {
+        $modifiedFields = [];
+
+        if ($businessEntity->getName() !== $command->getName()) {
+            $modifiedFields['name'] = ['old' => $businessEntity->getName(), 'new' => $command->getName()];
+        }
+
+        if ($businessEntity->getLegalName() !== $command->getLegalName()) {
+            $modifiedFields['legal_name'] = ['old' => $businessEntity->getLegalName(), 'new' => $command->getLegalName()];
+        }
+
+        if ($businessEntity->getExternalRef() !== $command->getExternalRef()) {
+            $modifiedFields['external_ref'] = ['old' => $businessEntity->getExternalRef(), 'new' => $command->getExternalRef()];
+        }
+
+        if ($businessEntity->isDeliveryAuthorized() !== $command->isDeliveryAuthorized()) {
+            $modifiedFields['delivery_authorized'] = ['old' => $businessEntity->isDeliveryAuthorized(), 'new' => $command->isDeliveryAuthorized()];
+        }
+
+        if ($businessEntity->getStatus() !== $command->getStatus()) {
+            $modifiedFields['status'] = ['old' => $businessEntity->getStatus()->value, 'new' => $command->getStatus()->value];
+        }
+
+        if ($businessEntity->getIdCustomerGroup() !== $command->getCustomerGroupId()) {
+            $modifiedFields['customer_group_id'] = ['old' => $businessEntity->getIdCustomerGroup(), 'new' => $command->getCustomerGroupId()];
+        }
+
+        return $modifiedFields;
+    }
+}

--- a/src/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandler.php
+++ b/src/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandler.php
@@ -8,11 +8,14 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler;
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\ORMException;
+use JsonException;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\CommandHandler\EditBusinessEntityHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\CannotUpdateBusinessEntityException;
 use PrestaShopBundle\Entity\B2B\BusinessEntity;
 use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
 use Psr\Log\LoggerInterface;
@@ -22,8 +25,8 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class EditBusinessEntityHandler implements EditBusinessEntityHandlerInterface
 {
     public function __construct(
-        private readonly EntityManagerInterface $em,
         private readonly BusinessEntityRepository $businessEntityRepository,
+        private readonly ShopContext $shopContext,
         #[Autowire(service: 'prestashop.adapter.legacy.logger')]
         private readonly LoggerInterface $logger,
     ) {
@@ -31,40 +34,78 @@ final class EditBusinessEntityHandler implements EditBusinessEntityHandlerInterf
 
     /**
      * @throws BusinessEntityNotFoundException
+     * @throws CannotUpdateBusinessEntityException
+     * @throws JsonException
      */
     public function handle(EditBusinessEntityCommand $command): void
     {
         $businessEntityId = $command->getBusinessEntityId()->getValue();
 
-        $businessEntity = $this->businessEntityRepository->getBusinessEntityById($businessEntityId);
+        $shopIds = $this->shopContext->isAllShopContext() ? null : $this->shopContext->getAssociatedShopIds();
+        $businessEntity = $this->businessEntityRepository->findById($businessEntityId, $shopIds);
 
         if (null === $businessEntity) {
             throw new BusinessEntityNotFoundException(sprintf('Business entity with id %d was not found.', $businessEntityId));
         }
 
         $modifiedFields = $this->getModifiedFields($businessEntity, $command);
+        $logMessage = $this->formatLogMessage($modifiedFields);
 
-        $businessEntity->setName($command->getName());
-        $businessEntity->setLegalName($command->getLegalName());
-        $businessEntity->setExternalRef($command->getExternalRef());
-        $businessEntity->setDeliveryAuthorized($command->isDeliveryAuthorized());
-        $businessEntity->setStatus($command->getStatus());
-        $businessEntity->setIdCustomerGroup($command->getCustomerGroupId());
+        if (null !== $command->getName()) {
+            $businessEntity->setName($command->getName());
+        }
 
-        $this->em->flush();
+        if (null !== $command->getLegalName()) {
+            $businessEntity->setLegalName($command->getLegalName());
+        }
 
-        $message = 'Business entity updated successfully';
-        if ([] !== $modifiedFields) {
-            $message .= ' ' . json_encode($modifiedFields, JSON_THROW_ON_ERROR);
+        if ($command->hasExternalRef()) {
+            $businessEntity->setExternalRef($command->getExternalRef());
+        }
+
+        if (null !== $command->getDeliveryAuthorized()) {
+            $businessEntity->setDeliveryAuthorized($command->getDeliveryAuthorized());
+        }
+
+        if (null !== $command->getStatus()) {
+            $businessEntity->setStatus($command->getStatus());
+        }
+
+        if (null !== $command->getCustomerGroupId()) {
+            $businessEntity->setIdCustomerGroup($command->getCustomerGroupId());
+        }
+
+        try {
+            $this->businessEntityRepository->save($businessEntity);
+        } catch (ORMException $e) {
+            throw new CannotUpdateBusinessEntityException('Could not update business entity', 0, $e);
         }
 
         $this->logger->info(
-            $message,
+            $logMessage,
             [
                 'object_type' => 'BusinessEntity',
                 'object_id' => $businessEntityId,
+                // Without this the legacy logger drops an entry identical to a previous one
+                // (PrestaShopLogger::addLog() only inserts if $allowDuplicate || !isPresent()),
+                // which would silently lose repeated edits from the audit trail.
+                'allow_duplicate' => true,
             ]
         );
+    }
+
+    /**
+     * @param array<string, array{old: mixed, new: mixed}> $modifiedFields
+     *
+     * @throws JsonException
+     */
+    private function formatLogMessage(array $modifiedFields): string
+    {
+        if ([] === $modifiedFields) {
+            return 'Business entity updated successfully';
+        }
+
+        return 'Business entity updated successfully ' . json_encode($modifiedFields, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
     }
 
     /**
@@ -74,27 +115,27 @@ final class EditBusinessEntityHandler implements EditBusinessEntityHandlerInterf
     {
         $modifiedFields = [];
 
-        if ($businessEntity->getName() !== $command->getName()) {
+        if (null !== $command->getName() && $businessEntity->getName() !== $command->getName()) {
             $modifiedFields['name'] = ['old' => $businessEntity->getName(), 'new' => $command->getName()];
         }
 
-        if ($businessEntity->getLegalName() !== $command->getLegalName()) {
+        if (null !== $command->getLegalName() && $businessEntity->getLegalName() !== $command->getLegalName()) {
             $modifiedFields['legal_name'] = ['old' => $businessEntity->getLegalName(), 'new' => $command->getLegalName()];
         }
 
-        if ($businessEntity->getExternalRef() !== $command->getExternalRef()) {
+        if ($command->hasExternalRef() && $businessEntity->getExternalRef() !== $command->getExternalRef()) {
             $modifiedFields['external_ref'] = ['old' => $businessEntity->getExternalRef(), 'new' => $command->getExternalRef()];
         }
 
-        if ($businessEntity->isDeliveryAuthorized() !== $command->isDeliveryAuthorized()) {
-            $modifiedFields['delivery_authorized'] = ['old' => $businessEntity->isDeliveryAuthorized(), 'new' => $command->isDeliveryAuthorized()];
+        if (null !== $command->getDeliveryAuthorized() && $businessEntity->isDeliveryAuthorized() !== $command->getDeliveryAuthorized()) {
+            $modifiedFields['delivery_authorized'] = ['old' => $businessEntity->isDeliveryAuthorized(), 'new' => $command->getDeliveryAuthorized()];
         }
 
-        if ($businessEntity->getStatus() !== $command->getStatus()) {
+        if (null !== $command->getStatus() && $businessEntity->getStatus() !== $command->getStatus()) {
             $modifiedFields['status'] = ['old' => $businessEntity->getStatus()->value, 'new' => $command->getStatus()->value];
         }
 
-        if ($businessEntity->getIdCustomerGroup() !== $command->getCustomerGroupId()) {
+        if (null !== $command->getCustomerGroupId() && $businessEntity->getIdCustomerGroup() !== $command->getCustomerGroupId()) {
             $modifiedFields['customer_group_id'] = ['old' => $businessEntity->getIdCustomerGroup(), 'new' => $command->getCustomerGroupId()];
         }
 

--- a/src/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandler.php
+++ b/src/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandler.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler;
 
-use Doctrine\ORM\Exception\ORMException;
-use JsonException;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
@@ -20,6 +18,7 @@ use PrestaShopBundle\Entity\B2B\BusinessEntity;
 use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Throwable;
 
 #[AsCommandHandler]
 final class EditBusinessEntityHandler implements EditBusinessEntityHandlerInterface
@@ -35,7 +34,6 @@ final class EditBusinessEntityHandler implements EditBusinessEntityHandlerInterf
     /**
      * @throws BusinessEntityNotFoundException
      * @throws CannotUpdateBusinessEntityException
-     * @throws JsonException
      */
     public function handle(EditBusinessEntityCommand $command): void
     {
@@ -49,7 +47,6 @@ final class EditBusinessEntityHandler implements EditBusinessEntityHandlerInterf
         }
 
         $modifiedFields = $this->getModifiedFields($businessEntity, $command);
-        $logMessage = $this->formatLogMessage($modifiedFields);
 
         if (null !== $command->getName()) {
             $businessEntity->setName($command->getName());
@@ -77,12 +74,12 @@ final class EditBusinessEntityHandler implements EditBusinessEntityHandlerInterf
 
         try {
             $this->businessEntityRepository->save($businessEntity);
-        } catch (ORMException $e) {
+        } catch (Throwable $e) {
             throw new CannotUpdateBusinessEntityException('Could not update business entity', 0, $e);
         }
 
         $this->logger->info(
-            $logMessage,
+            $this->formatLogMessage($modifiedFields),
             [
                 'object_type' => 'BusinessEntity',
                 'object_id' => $businessEntityId,
@@ -96,16 +93,18 @@ final class EditBusinessEntityHandler implements EditBusinessEntityHandlerInterf
 
     /**
      * @param array<string, array{old: mixed, new: mixed}> $modifiedFields
-     *
-     * @throws JsonException
      */
     private function formatLogMessage(array $modifiedFields): string
     {
+        $baseMessage = 'Business entity updated successfully';
+
         if ([] === $modifiedFields) {
-            return 'Business entity updated successfully';
+            return $baseMessage;
         }
 
-        return 'Business entity updated successfully ' . json_encode($modifiedFields, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        $encodedFields = json_encode($modifiedFields, JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_UNICODE);
+
+        return false === $encodedFields ? $baseMessage : $baseMessage . ' ' . $encodedFields;
     }
 
     /**

--- a/src/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandler.php
+++ b/src/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandler.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForEditing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryHandler\GetBusinessEntityForEditingHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\EditableBusinessEntity;
+use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
+
+#[AsQueryHandler]
+final class GetBusinessEntityForEditingHandler implements GetBusinessEntityForEditingHandlerInterface
+{
+    public function __construct(
+        private readonly BusinessEntityRepository $businessEntityRepository,
+        private readonly ShopContext $shopContext,
+    ) {
+    }
+
+    public function handle(GetBusinessEntityForEditing $query): EditableBusinessEntity
+    {
+        $businessEntityId = $query->getBusinessEntityId()->getValue();
+
+        $shopIds = $this->shopContext->isAllShopContext() ? null : $this->shopContext->getAssociatedShopIds();
+        $businessEntity = $this->businessEntityRepository->getBusinessEntityById($businessEntityId, $shopIds);
+
+        if (null === $businessEntity) {
+            throw new BusinessEntityNotFoundException(sprintf('Business entity with id %d was not found.', $businessEntityId));
+        }
+
+        return new EditableBusinessEntity(
+            $businessEntity->getId(),
+            $businessEntity->getName(),
+            $businessEntity->getLegalName(),
+            $businessEntity->getExternalRef(),
+            $businessEntity->isDeliveryAuthorized(),
+            $businessEntity->getStatus(),
+            $businessEntity->getIdCustomerGroup(),
+            $businessEntity->getIdShop(),
+        );
+    }
+}

--- a/src/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandler.php
+++ b/src/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandler.php
@@ -25,12 +25,15 @@ final class GetBusinessEntityForEditingHandler implements GetBusinessEntityForEd
     ) {
     }
 
+    /**
+     * @throws BusinessEntityNotFoundException
+     */
     public function handle(GetBusinessEntityForEditing $query): EditableBusinessEntity
     {
         $businessEntityId = $query->getBusinessEntityId()->getValue();
 
         $shopIds = $this->shopContext->isAllShopContext() ? null : $this->shopContext->getAssociatedShopIds();
-        $businessEntity = $this->businessEntityRepository->getBusinessEntityById($businessEntityId, $shopIds);
+        $businessEntity = $this->businessEntityRepository->findById($businessEntityId, $shopIds);
 
         if (null === $businessEntity) {
             throw new BusinessEntityNotFoundException(sprintf('Business entity with id %d was not found.', $businessEntityId));

--- a/src/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommand.php
+++ b/src/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommand.php
@@ -15,21 +15,36 @@ use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 /**
  * Class EditBusinessEntityCommand is used to edit the general information of an existing business entity.
  *
+ * Partial-update command: only fields explicitly set via setters are persisted.
+ * A null getter value means "not changed in this request", not "set to null in DB".
+ * External reference is the one nullable field that can also be cleared, so it carries its own
+ * hasExternalRef() marker to tell "clear it" apart from "leave it alone".
+ *
+ * Structural fields (shop, business identifiers) are intentionally absent: they are not editable
+ * through this command.
+ *
  * @see EditBusinessEntityHandlerInterface
  */
 class EditBusinessEntityCommand
 {
     private readonly BusinessEntityId $businessEntityId;
 
-    public function __construct(
-        int $businessEntityId,
-        private readonly string $name,
-        private readonly string $legalName,
-        private readonly ?string $externalRef,
-        private readonly bool $deliveryAuthorized,
-        private readonly BusinessEntityStatus $status,
-        private readonly int $customerGroupId,
-    ) {
+    private ?string $name = null;
+
+    private ?string $legalName = null;
+
+    private ?string $externalRef = null;
+
+    private bool $externalRefSet = false;
+
+    private ?bool $deliveryAuthorized = null;
+
+    private ?BusinessEntityStatus $status = null;
+
+    private ?int $customerGroupId = null;
+
+    public function __construct(int $businessEntityId)
+    {
         $this->businessEntityId = new BusinessEntityId($businessEntityId);
     }
 
@@ -38,14 +53,28 @@ class EditBusinessEntityCommand
         return $this->businessEntityId;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getLegalName(): string
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getLegalName(): ?string
     {
         return $this->legalName;
+    }
+
+    public function setLegalName(string $legalName): self
+    {
+        $this->legalName = $legalName;
+
+        return $this;
     }
 
     public function getExternalRef(): ?string
@@ -53,18 +82,52 @@ class EditBusinessEntityCommand
         return $this->externalRef;
     }
 
-    public function isDeliveryAuthorized(): bool
+    public function hasExternalRef(): bool
+    {
+        return $this->externalRefSet;
+    }
+
+    public function setExternalRef(?string $externalRef): self
+    {
+        $this->externalRef = $externalRef;
+        $this->externalRefSet = true;
+
+        return $this;
+    }
+
+    public function getDeliveryAuthorized(): ?bool
     {
         return $this->deliveryAuthorized;
     }
 
-    public function getStatus(): BusinessEntityStatus
+    public function setDeliveryAuthorized(bool $deliveryAuthorized): self
+    {
+        $this->deliveryAuthorized = $deliveryAuthorized;
+
+        return $this;
+    }
+
+    public function getStatus(): ?BusinessEntityStatus
     {
         return $this->status;
     }
 
-    public function getCustomerGroupId(): int
+    public function setStatus(BusinessEntityStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getCustomerGroupId(): ?int
     {
         return $this->customerGroupId;
+    }
+
+    public function setCustomerGroupId(int $customerGroupId): self
+    {
+        $this->customerGroupId = $customerGroupId;
+
+        return $this;
     }
 }

--- a/src/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommand.php
+++ b/src/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommand.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\CommandHandler\EditBusinessEntityHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityId;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+
+/**
+ * Class EditBusinessEntityCommand is used to edit the general information of an existing business entity.
+ *
+ * @see EditBusinessEntityHandlerInterface
+ */
+class EditBusinessEntityCommand
+{
+    private readonly BusinessEntityId $businessEntityId;
+
+    public function __construct(
+        int $businessEntityId,
+        private readonly string $name,
+        private readonly string $legalName,
+        private readonly ?string $externalRef,
+        private readonly bool $deliveryAuthorized,
+        private readonly BusinessEntityStatus $status,
+        private readonly int $customerGroupId,
+    ) {
+        $this->businessEntityId = new BusinessEntityId($businessEntityId);
+    }
+
+    public function getBusinessEntityId(): BusinessEntityId
+    {
+        return $this->businessEntityId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getLegalName(): string
+    {
+        return $this->legalName;
+    }
+
+    public function getExternalRef(): ?string
+    {
+        return $this->externalRef;
+    }
+
+    public function isDeliveryAuthorized(): bool
+    {
+        return $this->deliveryAuthorized;
+    }
+
+    public function getStatus(): BusinessEntityStatus
+    {
+        return $this->status;
+    }
+
+    public function getCustomerGroupId(): int
+    {
+        return $this->customerGroupId;
+    }
+}

--- a/src/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommand.php
+++ b/src/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommand.php
@@ -20,6 +20,11 @@ use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
  * External reference is the one nullable field that can also be cleared, so it carries its own
  * hasExternalRef() marker to tell "clear it" apart from "leave it alone".
  *
+ * The back-office form always submits every field, so it never exercises the partial path: the
+ * partial semantics are a deliberate choice for callers other than the form — modules and future
+ * API resources — which need to change one field without resending, or silently clearing, the
+ * others. Callers must therefore not assume a getter returning null means the stored value is null.
+ *
  * Structural fields (shop, business identifiers) are intentionally absent: they are not editable
  * through this command.
  *

--- a/src/Core/Domain/BusinessEntity/CommandHandler/EditBusinessEntityHandlerInterface.php
+++ b/src/Core/Domain/BusinessEntity/CommandHandler/EditBusinessEntityHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
+
+interface EditBusinessEntityHandlerInterface
+{
+    public function handle(EditBusinessEntityCommand $command): void;
+}

--- a/src/Core/Domain/BusinessEntity/Exception/CannotUpdateBusinessEntityException.php
+++ b/src/Core/Domain/BusinessEntity/Exception/CannotUpdateBusinessEntityException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception;
+
+class CannotUpdateBusinessEntityException extends BusinessEntityException
+{
+}

--- a/src/Core/Domain/BusinessEntity/Query/GetBusinessEntityForEditing.php
+++ b/src/Core/Domain/BusinessEntity/Query/GetBusinessEntityForEditing.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityId;
+
+class GetBusinessEntityForEditing
+{
+    private readonly BusinessEntityId $businessEntityId;
+
+    public function __construct(int $businessEntityId)
+    {
+        $this->businessEntityId = new BusinessEntityId($businessEntityId);
+    }
+
+    public function getBusinessEntityId(): BusinessEntityId
+    {
+        return $this->businessEntityId;
+    }
+}

--- a/src/Core/Domain/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandlerInterface.php
+++ b/src/Core/Domain/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandlerInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForEditing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\EditableBusinessEntity;
+
+interface GetBusinessEntityForEditingHandlerInterface
+{
+    public function handle(GetBusinessEntityForEditing $query): EditableBusinessEntity;
+}

--- a/src/Core/Domain/BusinessEntity/QueryResult/EditableBusinessEntity.php
+++ b/src/Core/Domain/BusinessEntity/QueryResult/EditableBusinessEntity.php
@@ -13,7 +13,7 @@ use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 /**
  * Transfers the editable general-information fields of a business entity to the edit form.
  */
-final class EditableBusinessEntity
+class EditableBusinessEntity
 {
     public function __construct(
         private readonly int $businessEntityId,

--- a/src/Core/Domain/BusinessEntity/QueryResult/EditableBusinessEntity.php
+++ b/src/Core/Domain/BusinessEntity/QueryResult/EditableBusinessEntity.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult;
+
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+
+/**
+ * Transfers the editable general-information fields of a business entity to the edit form.
+ */
+final class EditableBusinessEntity
+{
+    public function __construct(
+        private readonly int $businessEntityId,
+        private readonly string $name,
+        private readonly ?string $legalName,
+        private readonly ?string $externalRef,
+        private readonly bool $deliveryAuthorized,
+        private readonly BusinessEntityStatus $status,
+        private readonly int $customerGroupId,
+        private readonly int $shopId,
+    ) {
+    }
+
+    public function getBusinessEntityId(): int
+    {
+        return $this->businessEntityId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getLegalName(): ?string
+    {
+        return $this->legalName;
+    }
+
+    public function getExternalRef(): ?string
+    {
+        return $this->externalRef;
+    }
+
+    public function isDeliveryAuthorized(): bool
+    {
+        return $this->deliveryAuthorized;
+    }
+
+    public function getStatus(): BusinessEntityStatus
+    {
+        return $this->status;
+    }
+
+    public function getCustomerGroupId(): int
+    {
+        return $this->customerGroupId;
+    }
+
+    public function getShopId(): int
+    {
+        return $this->shopId;
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataHandler/BusinessEntityFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/BusinessEntityFormDataHandler.php
@@ -12,6 +12,7 @@ use PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler\AddBusinessEntit
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\AddBusinessEntityCommand;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\AbstractBusinessEntityAddress;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityBillingAddress;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityGeneralInformation;
@@ -115,6 +116,20 @@ final class BusinessEntityFormDataHandler implements FormDataHandlerInterface
      */
     public function update($id, array $data)
     {
-        // TODO: US2.1.3
+        $generalInformationData = $data[BusinessEntityType::GENERAL_INFORMATION];
+
+        $command = new EditBusinessEntityCommand(
+            (int) $id,
+            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_NAME],
+            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME],
+            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF],
+            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED],
+            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_STATUS],
+            (int) $generalInformationData[BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID],
+        );
+
+        $this->commandBus->handle($command);
+
+        return (int) $id;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/BusinessEntityFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/BusinessEntityFormDataHandler.php
@@ -37,10 +37,11 @@ final class BusinessEntityFormDataHandler implements FormDataHandlerInterface
     public function create(array $data): int
     {
         $generalInformationData = $data[BusinessEntityType::GENERAL_INFORMATION];
+        $externalRef = $generalInformationData[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF];
         $generalInformation = new BusinessEntityGeneralInformation(
             $generalInformationData[BusinessEntityGeneralInformationType::FIELD_NAME],
             $generalInformationData[BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME],
-            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF],
+            '' === $externalRef ? null : $externalRef,
             $generalInformationData[BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED],
             $generalInformationData[BusinessEntityGeneralInformationType::FIELD_STATUS],
             (int) $data[BusinessEntityType::SHOP_ID],
@@ -114,22 +115,19 @@ final class BusinessEntityFormDataHandler implements FormDataHandlerInterface
     /**
      * {@inheritDoc}
      */
-    public function update($id, array $data)
+    public function update($id, array $data): void
     {
         $generalInformationData = $data[BusinessEntityType::GENERAL_INFORMATION];
+        $externalRef = $generalInformationData[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF];
 
-        $command = new EditBusinessEntityCommand(
-            (int) $id,
-            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_NAME],
-            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME],
-            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF],
-            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED],
-            $generalInformationData[BusinessEntityGeneralInformationType::FIELD_STATUS],
-            (int) $generalInformationData[BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID],
-        );
+        $command = (new EditBusinessEntityCommand((int) $id))
+            ->setName($generalInformationData[BusinessEntityGeneralInformationType::FIELD_NAME])
+            ->setLegalName($generalInformationData[BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME])
+            ->setExternalRef('' === $externalRef ? null : $externalRef)
+            ->setDeliveryAuthorized((bool) $generalInformationData[BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED])
+            ->setStatus($generalInformationData[BusinessEntityGeneralInformationType::FIELD_STATUS])
+            ->setCustomerGroupId((int) $generalInformationData[BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID]);
 
         $this->commandBus->handle($command);
-
-        return (int) $id;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/BusinessEntityFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/BusinessEntityFormDataProvider.php
@@ -44,7 +44,7 @@ final class BusinessEntityFormDataProvider implements FormDataProviderInterface
      *
      * @return array<string, mixed>
      */
-    public function getData($id)
+    public function getData($id): array
     {
         /** @var EditableBusinessEntity $editableBusinessEntity */
         $editableBusinessEntity = $this->queryBus->handle(new GetBusinessEntityForEditing((int) $id));
@@ -70,7 +70,7 @@ final class BusinessEntityFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getDefaultData()
+    public function getDefaultData(): array
     {
         return [
             BusinessEntityType::GENERAL_INFORMATION => [

--- a/src/Core/Form/IdentifiableObject/DataProvider/BusinessEntityFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/BusinessEntityFormDataProvider.php
@@ -9,7 +9,10 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForEditing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\EditableBusinessEntity;
 use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityAddressType;
 use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityGeneralInformationType;
@@ -31,16 +34,37 @@ final class BusinessEntityFormDataProvider implements FormDataProviderInterface
     public function __construct(
         Configuration $configuration,
         private readonly ShopContext $shopContext,
+        private readonly CommandBusInterface $queryBus,
     ) {
         $this->defaultCountryId = $configuration->getInt('PS_COUNTRY_DEFAULT');
     }
 
     /**
      * {@inheritDoc}
+     *
+     * @return array<string, mixed>
      */
     public function getData($id)
     {
-        return [];
+        /** @var EditableBusinessEntity $editableBusinessEntity */
+        $editableBusinessEntity = $this->queryBus->handle(new GetBusinessEntityForEditing((int) $id));
+
+        return [
+            BusinessEntityType::GENERAL_INFORMATION => [
+                BusinessEntityGeneralInformationType::FIELD_NAME => $editableBusinessEntity->getName(),
+                BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => $editableBusinessEntity->getLegalName() ?? '',
+                BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => $editableBusinessEntity->getExternalRef() ?? '',
+                BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => $editableBusinessEntity->isDeliveryAuthorized(),
+                BusinessEntityGeneralInformationType::FIELD_STATUS => $editableBusinessEntity->getStatus(),
+                BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => $editableBusinessEntity->getCustomerGroupId(),
+            ],
+            BusinessEntityType::BILLING_ADDRESS_TYPE => [],
+            BusinessEntityType::SHIPPING_ADDRESS_TYPE => [],
+            BusinessEntityType::BILLING_ADDRESS_AS_SHIPPING_ADDRESS => true,
+            BusinessEntityType::DEFAULT_BILLING_ADDRESS => self::DEFAULT_BILLING_ADDRESS_INDEX,
+            BusinessEntityType::DEFAULT_SHIPPING_ADDRESS => self::DEFAULT_SHIPPING_ADDRESS_INDEX,
+            BusinessEntityType::SHOP_ID => $editableBusinessEntity->getShopId(),
+        ];
     }
 
     /**

--- a/src/Core/Grid/Definition/Factory/BusinessEntityGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/BusinessEntityGridDefinitionFactory.php
@@ -126,6 +126,16 @@ final class BusinessEntityGridDefinitionFactory extends AbstractGridDefinitionFa
                                         'route_param_field' => 'id_business_entity',
                                         'clickable_row' => true,
                                     ])
+                            )
+                            ->add(
+                                (new LinkRowAction('edit'))
+                                    ->setName($this->trans('Edit', [], 'Admin.Actions'))
+                                    ->setIcon('edit')
+                                    ->setOptions([
+                                        'route' => 'admin_business_entities_edit',
+                                        'route_param_name' => 'businessEntityId',
+                                        'route_param_field' => 'id_business_entity',
+                                    ])
                             ),
                     ])
             );

--- a/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
@@ -177,6 +177,54 @@ class BusinessEntitiesController extends PrestaShopAdminController
         );
     }
 
+    #[AdminSecurity("is_granted('update', 'AdminBusinessEntities')", message: 'You do not have permission to edit this.', redirectRoute: 'admin_business_entities_list')]
+    public function editAction(
+        int $businessEntityId,
+        Request $request,
+        #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.business_entity_form_builder')]
+        FormBuilderInterface $formBuilder,
+        #[Autowire(service: 'prestashop.core.form.identifiable_object.business_entity_form_handler')]
+        FormHandlerInterface $formHandler,
+    ): Response {
+        try {
+            $form = $formBuilder->getFormFor($businessEntityId);
+        } catch (BusinessEntityException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            return $this->redirectToRoute('admin_business_entities_list');
+        }
+
+        $form->handleRequest($request);
+
+        try {
+            $result = $formHandler->handleFor($businessEntityId, $form);
+
+            if ($result->getIdentifiableObjectId()) {
+                $this->addFlash(
+                    'success',
+                    $this->trans('Business entity successfully updated.', [], 'Admin.Notifications.Success')
+                );
+
+                return $this->redirectToRoute('admin_business_entities_view', ['businessEntityId' => $businessEntityId]);
+            }
+        } catch (BusinessEntityException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }
+
+        /** @var BusinessEntityForViewing $businessEntityForViewing */
+        $businessEntityForViewing = $this->dispatchQuery(new GetBusinessEntityForViewing($businessEntityId));
+
+        return $this->render(
+            '@PrestaShop/Admin/Sell/BusinessEntity/edit.html.twig',
+            [
+                'layoutTitle' => $businessEntityForViewing->getName(),
+                'businessEntityForm' => $form->createView(),
+                'businessEntity' => $businessEntityForViewing,
+                'businessEntityId' => $businessEntityId,
+            ]
+        );
+    }
+
     private function getBusinessEntitiesToolbarButtons(): array
     {
         $toolbarButtons = [];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
@@ -13,6 +13,7 @@ use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityBil
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityException;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\CannotUpdateBusinessEntityException;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\UnableToCreateBusinessEntityAddress;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForViewing;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetPendingBusinessEntitiesCount;
@@ -121,6 +122,7 @@ class BusinessEntitiesController extends PrestaShopAdminController
                     ],
                     'Admin.Navigation.Menu'
                 ),
+                'layoutHeaderToolbarBtn' => $this->getBusinessEntityViewToolbarButtons($businessEntityId),
                 'businessEntity' => $businessEntityForViewing,
             ]
         );
@@ -199,20 +201,29 @@ class BusinessEntitiesController extends PrestaShopAdminController
         try {
             $result = $formHandler->handleFor($businessEntityId, $form);
 
-            if ($result->getIdentifiableObjectId()) {
-                $this->addFlash(
-                    'success',
-                    $this->trans('Business entity successfully updated.', [], 'Admin.Notifications.Success')
-                );
+            if (null !== $result->getIdentifiableObjectId()) {
+                $this->addFlash('success', $this->trans('Successful update.', [], 'Admin.Notifications.Success'));
 
                 return $this->redirectToRoute('admin_business_entities_view', ['businessEntityId' => $businessEntityId]);
             }
-        } catch (BusinessEntityException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            // The re-display below queries the entity again; if it is gone there is nothing to
+            // render, so leave the page instead of letting the query throw.
+            if ($e instanceof BusinessEntityNotFoundException) {
+                return $this->redirectToRoute('admin_business_entities_list');
+            }
         }
 
-        /** @var BusinessEntityForViewing $businessEntityForViewing */
-        $businessEntityForViewing = $this->dispatchQuery(new GetBusinessEntityForViewing($businessEntityId));
+        try {
+            /** @var BusinessEntityForViewing $businessEntityForViewing */
+            $businessEntityForViewing = $this->dispatchQuery(new GetBusinessEntityForViewing($businessEntityId));
+        } catch (BusinessEntityException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            return $this->redirectToRoute('admin_business_entities_list');
+        }
 
         return $this->render(
             '@PrestaShop/Admin/Sell/BusinessEntity/edit.html.twig',
@@ -221,6 +232,8 @@ class BusinessEntitiesController extends PrestaShopAdminController
                 'businessEntityForm' => $form->createView(),
                 'businessEntity' => $businessEntityForViewing,
                 'businessEntityId' => $businessEntityId,
+                'enableSidebar' => true,
+                'help_link' => $this->generateSidebarLink('AdminBusinessEntities'),
             ]
         );
     }
@@ -233,6 +246,22 @@ class BusinessEntitiesController extends PrestaShopAdminController
             'href' => $this->generateUrl('admin_business_entities_create'),
             'desc' => $this->trans('Add new business entity', [], 'Admin.Navigation.Menu'),
             'icon' => 'add_circle_outline',
+        ];
+
+        return $toolbarButtons;
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private function getBusinessEntityViewToolbarButtons(int $businessEntityId): array
+    {
+        $toolbarButtons = [];
+
+        $toolbarButtons['edit'] = [
+            'href' => $this->generateUrl('admin_business_entities_edit', ['businessEntityId' => $businessEntityId]),
+            'desc' => $this->trans('Edit business entity', [], 'Admin.Orderscustomers.Feature'),
+            'icon' => 'mode_edit',
         ];
 
         return $toolbarButtons;
@@ -255,6 +284,11 @@ class BusinessEntitiesController extends PrestaShopAdminController
             ],
             UnableToCreateBusinessEntityAddress::class => $this->trans(
                 'An error occurred while creating the business entity.',
+                [],
+                'Admin.Notifications.Error'
+            ),
+            CannotUpdateBusinessEntityException::class => $this->trans(
+                'An error occurred while updating the business entity.',
                 [],
                 'Admin.Notifications.Error'
             ),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/BusinessEntity/BusinessEntitiesController.php
@@ -209,9 +209,7 @@ class BusinessEntitiesController extends PrestaShopAdminController
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
-            // The re-display below queries the entity again; if it is gone there is nothing to
-            // render, so leave the page instead of letting the query throw.
-            if ($e instanceof BusinessEntityNotFoundException) {
+            if ($e instanceof BusinessEntityNotFoundException || $e instanceof CannotUpdateBusinessEntityException) {
                 return $this->redirectToRoute('admin_business_entities_list');
             }
         }

--- a/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationType.php
@@ -68,12 +68,14 @@ class BusinessEntityGeneralInformationType extends TranslatorAwareType
             ->add(self::FIELD_STATUS, EnumType::class, [
                 'label' => $this->trans('Status', 'Admin.Global'),
                 'class' => BusinessEntityStatus::class,
+                'constraints' => [new NotBlank()],
             ])
             ->add(self::FIELD_CUSTOMER_GROUP_ID, ChoiceType::class, [
                 'label' => $this->trans('Customer group', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Customer group attached to this business entity.', 'Admin.Catalog.Feature'),
                 'choices' => $this->groupByIdChoiceProvider->getChoices(),
                 'required' => true,
+                'constraints' => [new NotBlank()],
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationType.php
@@ -8,23 +8,18 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\BusinessEntity;
 
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
-use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider;
-use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
-use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\EnumType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Constraints\Length;
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * The two sections below carry inherit_data, so the data handled here stays a flat array keyed by
+ * the FIELD_* constants; the nesting exists only to let each section be rendered on its own row.
+ */
 class BusinessEntityGeneralInformationType extends TranslatorAwareType
 {
+    public const SECTION_IDENTITY = 'identity';
+    public const SECTION_SETTINGS = 'settings';
+
     public const FIELD_NAME = 'name';
     public const FIELD_LEGAL_NAME = 'legal_name';
     public const FIELD_EXTERNAL_REF = 'external_ref';
@@ -32,76 +27,14 @@ class BusinessEntityGeneralInformationType extends TranslatorAwareType
     public const FIELD_STATUS = 'status';
     public const FIELD_CUSTOMER_GROUP_ID = 'customer_group_id';
 
-    public const MAX_NAME_LENGTH = 255;
-
-    public function __construct(
-        TranslatorInterface $translator,
-        array $locales,
-        private readonly GroupByIdChoiceProvider $groupByIdChoiceProvider,
-    ) {
-        parent::__construct($translator, $locales);
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add(self::FIELD_NAME, TextType::class, [
-                'label' => $this->trans('Name', 'Admin.Global'),
-                'help' => $this->trans('The display name of the business entity.', 'Admin.Catalog.Feature'),
-                'constraints' => $this->getNameConstraints(),
-                'required' => true,
+            ->add(self::SECTION_IDENTITY, BusinessEntityIdentityType::class, [
+                'columns_number' => 2,
             ])
-            ->add(self::FIELD_LEGAL_NAME, TextType::class, [
-                'label' => $this->trans('Legal name', 'Admin.Orderscustomers.Feature'),
-                'help' => $this->trans('The official registered name of the company.', 'Admin.Catalog.Feature'),
-                'constraints' => $this->getNameConstraints(),
-                'required' => true,
-            ])
-            ->add(self::FIELD_EXTERNAL_REF, TextType::class, [
-                'label' => $this->trans('External Reference', 'Admin.Global'),
-                'required' => false,
-            ])
-            ->add(self::FIELD_DELIVERY_AUTHORIZED, SwitchType::class, [
-                'label' => $this->trans('Delivery authorized', 'Admin.Global'),
-                'help' => $this->trans('Allow the B2B customer to order using an address that does not belong to the business entity.', 'Admin.Catalog.Feature'),
-            ])
-            ->add(self::FIELD_STATUS, EnumType::class, [
-                'label' => $this->trans('Status', 'Admin.Global'),
-                'class' => BusinessEntityStatus::class,
-                'constraints' => [new NotBlank()],
-            ])
-            ->add(self::FIELD_CUSTOMER_GROUP_ID, ChoiceType::class, [
-                'label' => $this->trans('Customer group', 'Admin.Shopparameters.Feature'),
-                'help' => $this->trans('Customer group attached to this business entity.', 'Admin.Catalog.Feature'),
-                'choices' => $this->groupByIdChoiceProvider->getChoices(),
-                'required' => true,
-                'constraints' => [new NotBlank()],
+            ->add(self::SECTION_SETTINGS, BusinessEntitySettingsType::class, [
+                'columns_number' => 2,
             ]);
-    }
-
-    /**
-     * @return array<int, Constraint>
-     */
-    private function getNameConstraints(): array
-    {
-        return [
-            new NotBlank([
-                'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
-            ]),
-            new Length([
-                'max' => self::MAX_NAME_LENGTH,
-                'maxMessage' => $this->trans(
-                    'This field cannot be longer than %limit% characters',
-                    'Admin.Notifications.Error',
-                    ['%limit%' => self::MAX_NAME_LENGTH]
-                ),
-            ]),
-            new TypedRegex([
-                'type' => TypedRegex::TYPE_GENERIC_NAME,
-            ]),
-            new CleanHtml([
-                'message' => $this->trans('%s is invalid.', 'Admin.Notifications.Error'),
-            ]),
-        ];
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityIdentityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityIdentityType.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\BusinessEntity;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * Names identifying the company. Declared with inherit_data so the submitted data stays flat
+ * under the general information section; the nesting only exists to lay the fields out.
+ */
+class BusinessEntityIdentityType extends TranslatorAwareType
+{
+    public const MAX_NAME_LENGTH = 255;
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(BusinessEntityGeneralInformationType::FIELD_NAME, TextType::class, [
+                'label' => $this->trans('Name', 'Admin.Global'),
+                'help' => $this->trans('The display name of the business entity.', 'Admin.Catalog.Feature'),
+                'constraints' => $this->getNameConstraints(),
+                'required' => true,
+            ])
+            ->add(BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME, TextType::class, [
+                'label' => $this->trans('Legal name', 'Admin.Orderscustomers.Feature'),
+                'help' => $this->trans('The official registered name of the company.', 'Admin.Catalog.Feature'),
+                'constraints' => $this->getNameConstraints(),
+                'required' => true,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefault('inherit_data', true);
+    }
+
+    /**
+     * @return array<int, Constraint>
+     */
+    private function getNameConstraints(): array
+    {
+        return [
+            new NotBlank([
+                'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
+            ]),
+            new Length([
+                'max' => self::MAX_NAME_LENGTH,
+                'maxMessage' => $this->trans(
+                    'This field cannot be longer than %limit% characters',
+                    'Admin.Notifications.Error',
+                    ['%limit%' => self::MAX_NAME_LENGTH]
+                ),
+            ]),
+            new TypedRegex([
+                'type' => TypedRegex::TYPE_GENERIC_NAME,
+            ]),
+            new CleanHtml([
+                'message' => $this->trans('%s is invalid.', 'Admin.Notifications.Error'),
+            ]),
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityIdentityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityIdentityType.php
@@ -18,10 +18,6 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
-/**
- * Names identifying the company. Declared with inherit_data so the submitted data stays flat
- * under the general information section; the nesting only exists to lay the fields out.
- */
 class BusinessEntityIdentityType extends TranslatorAwareType
 {
     public const MAX_NAME_LENGTH = 255;

--- a/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntitySettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntitySettingsType.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\BusinessEntity;
+
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * How the company is referenced and classified. Declared with inherit_data so the submitted data
+ * stays flat under the general information section; the nesting only exists to lay the fields out.
+ */
+class BusinessEntitySettingsType extends TranslatorAwareType
+{
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        private readonly GroupByIdChoiceProvider $groupByIdChoiceProvider,
+    ) {
+        parent::__construct($translator, $locales);
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF, TextType::class, [
+                'label' => $this->trans('External Reference', 'Admin.Global'),
+                'required' => false,
+                // Keeps the field alone on its line, the way the product page breaks a column run.
+                'column_breaker' => true,
+            ])
+            ->add(BusinessEntityGeneralInformationType::FIELD_STATUS, EnumType::class, [
+                'label' => $this->trans('Status', 'Admin.Global'),
+                'class' => BusinessEntityStatus::class,
+                'constraints' => [new NotBlank()],
+            ])
+            ->add(BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID, ChoiceType::class, [
+                'label' => $this->trans('Customer group', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Customer group attached to this business entity.', 'Admin.Catalog.Feature'),
+                'choices' => $this->groupByIdChoiceProvider->getChoices(),
+                'required' => true,
+                'constraints' => [new NotBlank()],
+                'column_breaker' => true,
+            ])
+            ->add(BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED, SwitchType::class, [
+                'label' => $this->trans('Delivery authorized', 'Admin.Global'),
+                'help' => $this->trans('Allow the B2B customer to order using an address that does not belong to the business entity.', 'Admin.Catalog.Feature'),
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefault('inherit_data', true);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntitySettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntitySettingsType.php
@@ -17,15 +17,14 @@ use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * How the company is referenced and classified. Declared with inherit_data so the submitted data
- * stays flat under the general information section; the nesting only exists to lay the fields out.
- */
 class BusinessEntitySettingsType extends TranslatorAwareType
 {
+    public const MAX_EXTERNAL_REF_LENGTH = 255;
+
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
@@ -40,6 +39,16 @@ class BusinessEntitySettingsType extends TranslatorAwareType
             ->add(BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF, TextType::class, [
                 'label' => $this->trans('External Reference', 'Admin.Global'),
                 'required' => false,
+                'constraints' => [
+                    new Length([
+                        'max' => self::MAX_EXTERNAL_REF_LENGTH,
+                        'maxMessage' => $this->trans(
+                            'This field cannot be longer than %limit% characters',
+                            'Admin.Notifications.Error',
+                            ['%limit%' => self::MAX_EXTERNAL_REF_LENGTH]
+                        ),
+                    ]),
+                ],
                 // Keeps the field alone on its line, the way the product page breaks a column run.
                 'column_breaker' => true,
             ])

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/business_entities.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/business_entity/business_entities.yml
@@ -25,3 +25,12 @@ admin_business_entities_create:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::createAction
     _parent: admin_business_entities_list
+
+admin_business_entities_edit:
+  path: /{businessEntityId}/edit
+  methods: [ GET, POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\BusinessEntity\BusinessEntitiesController::editAction
+    _parent: admin_business_entities_list
+  requirements:
+    businessEntityId: \d+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/business_entity.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/business_entity.yml
@@ -4,11 +4,15 @@ services:
     autowire: true
   PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler\AddBusinessEntityHandler: ~
 
+  PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler\EditBusinessEntityHandler: ~
+
   PrestaShop\PrestaShop\Adapter\BusinessEntity\Address\BusinessEntityAddressFormatter: ~
 
   PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler\GetBusinessEntityForViewingHandler:
     arguments:
       $addressFormatter: '@PrestaShop\PrestaShop\Adapter\BusinessEntity\Address\BusinessEntityAddressFormatter'
+
+  PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler\GetBusinessEntityForEditingHandler: ~
 
   PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler\GetPendingBusinessEntitiesCountHandler: ~
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/_general_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/_general_information.html.twig
@@ -1,0 +1,58 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+{% set identifiers = identifiers is defined ? identifiers : null %}
+
+{% form_theme businessEntityForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig' %}
+
+<div class="card">
+  <h3 class="card-header">
+    {{ 'General information'|trans({}, 'Admin.Global') }}
+  </h3>
+  <div class="card-body">
+    <div class="form-wrapper">
+      {{ form_widget(businessEntityForm.general_information.identity) }}
+
+      {% if identifiers is null %}
+        <hr>
+        <div class="row">
+          <div class="col-md-4">
+            <div class="form-group">
+              <label class="form-control-label">{{ 'VAT number'|trans({}, 'Admin.Orderscustomers.Feature') }}</label>
+              <input type="text" class="form-control" placeholder="FR12345678901" disabled>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="form-group">
+              <label class="form-control-label">{{ 'SIREN / SIRET'|trans({}, 'Admin.Orderscustomers.Feature') }}</label>
+              <input type="text" class="form-control" placeholder="123 456 789 00012" disabled>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="form-group">
+              <label class="form-control-label">{{ 'DUNS number'|trans({}, 'Admin.Orderscustomers.Feature') }}</label>
+              <input type="text" class="form-control" placeholder="12-345-6789" disabled>
+            </div>
+          </div>
+        </div>
+      {% elseif identifiers is not empty %}
+        <hr>
+        <div class="row">
+          {% for identifier in identifiers %}
+            <div class="col-md-4">
+              <div class="form-group">
+                <label class="form-control-label">{{ identifier.label }}</label>
+                <input type="text" class="form-control" value="{{ identifier.value }}" disabled>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      <hr>
+      {{ form_widget(businessEntityForm.general_information.settings) }}
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/form.html.twig
@@ -22,10 +22,7 @@
     </h3>
     <div class="card-body">
       <div class="form-wrapper">
-        <div class="row">
-          <div class="col-md-6">{{ form_row(businessEntityForm.general_information.name) }}</div>
-          <div class="col-md-6">{{ form_row(businessEntityForm.general_information.legal_name) }}</div>
-        </div>
+        {{ form_widget(businessEntityForm.general_information.identity) }}
 
         <hr>
         <div class="row">
@@ -50,14 +47,7 @@
         </div>
 
         <hr>
-        <div class="row">
-          <div class="col-md-6">{{ form_row(businessEntityForm.general_information.external_ref) }}</div>
-        </div>
-        <div class="row">
-          <div class="col-md-6">{{ form_row(businessEntityForm.general_information.status) }}</div>
-          <div class="col-md-6">{{ form_row(businessEntityForm.general_information.customer_group_id) }}</div>
-        </div>
-        {{ form_row(businessEntityForm.general_information.delivery_authorized) }}
+        {{ form_widget(businessEntityForm.general_information.settings) }}
       </div>
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/Blocks/form.html.twig
@@ -16,41 +16,7 @@
 {% block business_entity_form %}
   {{ form_start(businessEntityForm, {attr: {novalidate: 'novalidate'}}) }}
   {{ form_errors(businessEntityForm) }}
-  <div class="card">
-    <h3 class="card-header">
-      {{ 'General information'|trans({}, 'Admin.Global') }}
-    </h3>
-    <div class="card-body">
-      <div class="form-wrapper">
-        {{ form_widget(businessEntityForm.general_information.identity) }}
-
-        <hr>
-        <div class="row">
-          <div class="col-md-4">
-            <div class="form-group">
-              <label class="form-control-label">{{ 'VAT number'|trans({}, 'Admin.Global') }}</label>
-              <input type="text" class="form-control" placeholder="FR12345678901" disabled>
-            </div>
-          </div>
-          <div class="col-md-4">
-            <div class="form-group">
-              <label class="form-control-label">{{ 'SIREN / SIRET'|trans({}, 'Admin.Global') }}</label>
-              <input type="text" class="form-control" placeholder="123 456 789 00012" disabled>
-            </div>
-          </div>
-          <div class="col-md-4">
-            <div class="form-group">
-              <label class="form-control-label">{{ 'DUNS number'|trans({}, 'Admin.Global') }}</label>
-              <input type="text" class="form-control" placeholder="12-345-6789" disabled>
-            </div>
-          </div>
-        </div>
-
-        <hr>
-        {{ form_widget(businessEntityForm.general_information.settings) }}
-      </div>
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/_general_information.html.twig') }}
 
   <div class="card">
     <h3 class="card-header d-flex justify-content-between">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/edit.html.twig
@@ -1,0 +1,96 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% form_theme businessEntityForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig' %}
+
+{% block pageTitle %}
+  {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/header.html.twig') }}
+{% endblock %}
+
+{% block content %}
+  {{ form_start(businessEntityForm) }}
+
+  <div class="row">
+    <div class="col-md-8">
+      <div class="card">
+        <h3 class="card-header">
+          {{ 'General information'|trans({}, 'Admin.Global') }}
+        </h3>
+        <div class="card-body">
+          <div class="form-wrapper">
+            <div class="row">
+              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.name) }}</div>
+              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.legal_name) }}</div>
+            </div>
+
+            {# Business identifiers are read-only here; their management is handled in US2.1.6 / US2.1.7. #}
+            {% set identifiers = businessEntity.getIdentifiers %}
+            {% if identifiers is not empty %}
+              <hr>
+              <div class="row">
+                {% for identifier in identifiers %}
+                  <div class="col-md-4">
+                    <div class="form-group">
+                      <label class="form-control-label">{{ identifier.getLabel }}</label>
+                      <input type="text" class="form-control" value="{{ identifier.getValue }}" disabled>
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
+            {% endif %}
+
+            <hr>
+            <div class="row">
+              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.external_ref) }}</div>
+            </div>
+            <div class="row">
+              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.status) }}</div>
+              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.customer_group_id) }}</div>
+            </div>
+            {{ form_row(businessEntityForm.general_information.delivery_authorized) }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-4">
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/company_summary.html.twig') }}
+    </div>
+  </div>
+
+  {# Addresses are read-only here; linking/editing addresses is handled in US2.1.8. #}
+  <div class="alert alert-info mt-3" role="alert">
+    {{ 'Editing addresses will be available in a future release.'|trans({}, 'Admin.Notifications.Info') }}
+  </div>
+
+  <div class="row">
+    <div class="col-md-6">
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/billing_address.html.twig') }}
+    </div>
+    <div class="col-md-6">
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/shipping_address.html.twig') }}
+    </div>
+  </div>
+
+  <div class="d-flex justify-content-end mt-3">
+    <a href="{{ path('admin_business_entities_view', {businessEntityId: businessEntityId}) }}"
+       class="btn btn-outline-secondary mr-3">{{ 'Cancel'|trans({}, 'Admin.Actions') }}</a>
+    <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+  </div>
+
+  {{ form_widget(businessEntityForm._token) }}
+  {{ form_widget(businessEntityForm.shop_id) }}
+  {{ form_widget(businessEntityForm.default_billing_address) }}
+  {{ form_widget(businessEntityForm.default_shipping_address) }}
+  {{ form_end(businessEntityForm, {render_rest: false}) }}
+
+  <div class="row mt-3">
+    <div class="col">
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/linked_customers.html.twig') }}
+    </div>
+  </div>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/edit.html.twig
@@ -19,10 +19,7 @@
         </h3>
         <div class="card-body">
           <div class="form-wrapper">
-            <div class="row">
-              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.name) }}</div>
-              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.legal_name) }}</div>
-            </div>
+            {{ form_widget(businessEntityForm.general_information.identity) }}
 
             {# Business identifiers are read-only here; their management is handled in US2.1.6 / US2.1.7. #}
             {% set identifiers = businessEntity.identifiers %}
@@ -41,14 +38,7 @@
             {% endif %}
 
             <hr>
-            <div class="row">
-              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.external_ref) }}</div>
-            </div>
-            <div class="row">
-              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.status) }}</div>
-              <div class="col-md-6">{{ form_row(businessEntityForm.general_information.customer_group_id) }}</div>
-            </div>
-            {{ form_row(businessEntityForm.general_information.delivery_authorized) }}
+            {{ form_widget(businessEntityForm.general_information.settings) }}
           </div>
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/edit.html.twig
@@ -7,15 +7,12 @@
 
 {% form_theme businessEntityForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig' %}
 
-{% block pageTitle %}
-  {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/header.html.twig') }}
-{% endblock %}
-
 {% block content %}
-  {{ form_start(businessEntityForm) }}
+  {{ form_start(businessEntityForm, {attr: {novalidate: 'novalidate'}}) }}
+  {{ form_errors(businessEntityForm) }}
 
   <div class="row">
-    <div class="col-md-8">
+    <div class="col-12">
       <div class="card">
         <h3 class="card-header">
           {{ 'General information'|trans({}, 'Admin.Global') }}
@@ -28,15 +25,15 @@
             </div>
 
             {# Business identifiers are read-only here; their management is handled in US2.1.6 / US2.1.7. #}
-            {% set identifiers = businessEntity.getIdentifiers %}
+            {% set identifiers = businessEntity.identifiers %}
             {% if identifiers is not empty %}
               <hr>
               <div class="row">
                 {% for identifier in identifiers %}
                   <div class="col-md-4">
                     <div class="form-group">
-                      <label class="form-control-label">{{ identifier.getLabel }}</label>
-                      <input type="text" class="form-control" value="{{ identifier.getValue }}" disabled>
+                      <label class="form-control-label">{{ identifier.label }}</label>
+                      <input type="text" class="form-control" value="{{ identifier.value }}" disabled>
                     </div>
                   </div>
                 {% endfor %}
@@ -56,19 +53,15 @@
         </div>
       </div>
     </div>
-
-    <div class="col-md-4">
-      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/company_summary.html.twig') }}
-    </div>
   </div>
 
   {# Addresses are read-only here; linking/editing addresses is handled in US2.1.8. #}
   <div class="alert alert-info mt-3" role="alert">
-    {{ 'Editing addresses will be available in a future release.'|trans({}, 'Admin.Notifications.Info') }}
+    <p class="alert-text">{{ 'Addresses are read-only on this page.'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
   </div>
 
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-6 mb-3 mb-md-0">
       {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/View/billing_address.html.twig') }}
     </div>
     <div class="col-md-6">
@@ -79,7 +72,7 @@
   <div class="d-flex justify-content-end mt-3">
     <a href="{{ path('admin_business_entities_view', {businessEntityId: businessEntityId}) }}"
        class="btn btn-outline-secondary mr-3">{{ 'Cancel'|trans({}, 'Admin.Actions') }}</a>
-    <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+    <button type="submit" class="btn btn-primary" id="save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
   </div>
 
   {{ form_widget(businessEntityForm._token) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/BusinessEntity/edit.html.twig
@@ -13,35 +13,10 @@
 
   <div class="row">
     <div class="col-12">
-      <div class="card">
-        <h3 class="card-header">
-          {{ 'General information'|trans({}, 'Admin.Global') }}
-        </h3>
-        <div class="card-body">
-          <div class="form-wrapper">
-            {{ form_widget(businessEntityForm.general_information.identity) }}
-
-            {# Business identifiers are read-only here; their management is handled in US2.1.6 / US2.1.7. #}
-            {% set identifiers = businessEntity.identifiers %}
-            {% if identifiers is not empty %}
-              <hr>
-              <div class="row">
-                {% for identifier in identifiers %}
-                  <div class="col-md-4">
-                    <div class="form-group">
-                      <label class="form-control-label">{{ identifier.label }}</label>
-                      <input type="text" class="form-control" value="{{ identifier.value }}" disabled>
-                    </div>
-                  </div>
-                {% endfor %}
-              </div>
-            {% endif %}
-
-            <hr>
-            {{ form_widget(businessEntityForm.general_information.settings) }}
-          </div>
-        </div>
-      </div>
+      {# Business identifiers are read-only here; their management is handled in US2.1.6 / US2.1.7. #}
+      {{ include('@PrestaShop/Admin/Sell/BusinessEntity/Blocks/_general_information.html.twig', {
+        identifiers: businessEntity.identifiers,
+      }) }}
     </div>
   </div>
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/BusinessEntityFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/BusinessEntityFeatureContext.php
@@ -18,10 +18,12 @@ use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\AddBusinessEntityCo
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityException;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForEditing;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForViewing;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetPendingBusinessEntitiesCount;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\AddressForViewing;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\BusinessEntityForViewing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\EditableBusinessEntity;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityBillingAddress;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityId;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityShippingAddress;
@@ -35,6 +37,7 @@ use PrestaShopBundle\Entity\Enum\AddressTypeEnum;
 use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 use PrestaShopBundle\Entity\Enum\CustomerB2bStatus;
 use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 use Validate;
 
 class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
@@ -458,24 +461,40 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @When I edit the business entity :name with the following details:
      */
-    public function iEditTheBusinessEntity(string $name, TableNode $table)
+    public function iEditTheBusinessEntity(string $name, TableNode $table): void
     {
         $businessEntity = $this->getBusinessEntityByName($name);
         $data = $table->getRowsHash();
 
-        $command = new EditBusinessEntityCommand(
-            $businessEntity->getId(),
-            $data['name'] ?? $businessEntity->getName(),
-            $data['legal_name'] ?? (string) $businessEntity->getLegalName(),
-            $data['external_ref'] ?? $businessEntity->getExternalRef(),
-            isset($data['delivery_authorized']) ? (bool) $data['delivery_authorized'] : $businessEntity->isDeliveryAuthorized(),
-            isset($data['status']) ? BusinessEntityStatus::from($data['status']) : $businessEntity->getStatus(),
-            isset($data['customer_group_id']) ? (int) $data['customer_group_id'] : $businessEntity->getIdCustomerGroup()
-        );
+        $command = new EditBusinessEntityCommand($businessEntity->getId());
+
+        if (isset($data['name'])) {
+            $command->setName($data['name']);
+        }
+
+        if (isset($data['legal_name'])) {
+            $command->setLegalName($data['legal_name']);
+        }
+
+        if (isset($data['external_ref'])) {
+            $command->setExternalRef('' === $data['external_ref'] ? null : $data['external_ref']);
+        }
+
+        if (isset($data['delivery_authorized'])) {
+            $command->setDeliveryAuthorized(PrimitiveUtils::castStringBooleanIntoBoolean($data['delivery_authorized']));
+        }
+
+        if (isset($data['status'])) {
+            $command->setStatus(BusinessEntityStatus::from($data['status']));
+        }
+
+        if (isset($data['customer_group_id'])) {
+            $command->setCustomerGroupId((int) $data['customer_group_id']);
+        }
 
         try {
             $this->getCommandBus()->handle($command);
-        } catch (Exception $e) {
+        } catch (BusinessEntityException $e) {
             $this->setLastException($e);
         }
     }
@@ -483,8 +502,12 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then the business entity :name should have the following details:
      */
-    public function businessEntityShouldHaveDetails(string $name, TableNode $table)
+    public function businessEntityShouldHaveDetails(string $name, TableNode $table): void
     {
+        // Re-read from the database, not from the identity map: without this the assertions would
+        // pass on the in-memory entity even if nothing had been flushed.
+        $this->getContainer()->get('doctrine.orm.entity_manager')->clear();
+
         $businessEntity = $this->getBusinessEntityByName($name);
         $data = $table->getRowsHash();
 
@@ -495,10 +518,11 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
             Assert::assertSame($data['legal_name'], $businessEntity->getLegalName());
         }
         if (isset($data['external_ref'])) {
-            Assert::assertSame($data['external_ref'], $businessEntity->getExternalRef());
+            // Mirrors the input step: an empty cell means "cleared", i.e. NULL, not an empty string.
+            Assert::assertSame('' === $data['external_ref'] ? null : $data['external_ref'], $businessEntity->getExternalRef());
         }
         if (isset($data['delivery_authorized'])) {
-            Assert::assertSame((bool) $data['delivery_authorized'], $businessEntity->isDeliveryAuthorized());
+            Assert::assertSame(PrimitiveUtils::castStringBooleanIntoBoolean($data['delivery_authorized']), $businessEntity->isDeliveryAuthorized());
         }
         if (isset($data['status'])) {
             Assert::assertSame(BusinessEntityStatus::from($data['status']), $businessEntity->getStatus());
@@ -509,25 +533,82 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then editing the business entity with id :businessEntityId should raise a not found error
+     * @When I edit the business entity with id :businessEntityId
      */
-    public function editingBusinessEntityShouldRaiseNotFound(int $businessEntityId)
+    public function iEditTheBusinessEntityWithId(int $businessEntityId): void
     {
         try {
-            $this->getCommandBus()->handle(new EditBusinessEntityCommand(
-                $businessEntityId,
-                'Missing',
-                'Missing Legal',
-                null,
-                false,
-                BusinessEntityStatus::PENDING,
-                3
-            ));
-        } catch (Exception $e) {
+            $this->getCommandBus()->handle(
+                (new EditBusinessEntityCommand($businessEntityId))->setName('Missing')
+            );
+        } catch (BusinessEntityException $e) {
             $this->setLastException($e);
         }
+    }
 
-        $this->assertLastErrorIs(BusinessEntityNotFoundException::class);
+    /**
+     * @Then the business entity :name should be editable with the following details:
+     */
+    public function businessEntityShouldBeEditableWithDetails(string $name, TableNode $table): void
+    {
+        $businessEntityId = $this->getBusinessEntityByName($name)->getId();
+        $data = $table->getRowsHash();
+
+        /** @var EditableBusinessEntity $editableBusinessEntity */
+        $editableBusinessEntity = $this->getQueryBus()->handle(new GetBusinessEntityForEditing($businessEntityId));
+
+        Assert::assertSame($name, $editableBusinessEntity->getName());
+
+        if (isset($data['legal_name'])) {
+            Assert::assertSame($data['legal_name'], $editableBusinessEntity->getLegalName());
+        }
+        if (isset($data['external_ref'])) {
+            Assert::assertSame('' === $data['external_ref'] ? null : $data['external_ref'], $editableBusinessEntity->getExternalRef());
+        }
+        if (isset($data['delivery_authorized'])) {
+            Assert::assertSame(PrimitiveUtils::castStringBooleanIntoBoolean($data['delivery_authorized']), $editableBusinessEntity->isDeliveryAuthorized());
+        }
+        if (isset($data['status'])) {
+            Assert::assertSame(BusinessEntityStatus::from($data['status']), $editableBusinessEntity->getStatus());
+        }
+        if (isset($data['customer_group_id'])) {
+            Assert::assertSame((int) $data['customer_group_id'], $editableBusinessEntity->getCustomerGroupId());
+        }
+    }
+
+    /**
+     * Back-dates updated_at through DQL so the refresh performed by the edit becomes measurable:
+     * the column has second precision, so creating and editing within the same second would make a
+     * comparison against created_at non-deterministic. DQL also bypasses the PreUpdate callback,
+     * which a plain flush would let overwrite the back-dated value.
+     *
+     * @Given the business entity :name was last updated an hour ago
+     */
+    public function businessEntityWasLastUpdatedAnHourAgo(string $name): void
+    {
+        $entityManager = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $entityManager
+            ->createQuery(sprintf('UPDATE %s be SET be.updatedAt = :updatedAt WHERE be.id = :id', BusinessEntity::class))
+            ->setParameter('updatedAt', new DateTime('-1 hour'))
+            ->setParameter('id', $this->getBusinessEntityByName($name)->getId())
+            ->execute();
+
+        $entityManager->clear();
+    }
+
+    /**
+     * @Then the business entity :name should have a refreshed updated_at
+     */
+    public function businessEntityShouldHaveRefreshedUpdatedAt(string $name): void
+    {
+        $this->getContainer()->get('doctrine.orm.entity_manager')->clear();
+
+        Assert::assertGreaterThan(
+            new DateTime('-1 minute'),
+            $this->getBusinessEntityByName($name)->getUpdatedAt(),
+            'The updated_at timestamp was not refreshed by the edit.'
+        );
     }
 
     private function getBusinessEntityByName(string $name): BusinessEntity

--- a/tests/Integration/Behaviour/Features/Context/Domain/BusinessEntityFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/BusinessEntityFeatureContext.php
@@ -15,6 +15,7 @@ use DateTimeImmutable;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\AddBusinessEntityCommand;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityException;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForViewing;
@@ -452,6 +453,81 @@ class BusinessEntityFeatureContext extends AbstractDomainFeatureContext
         $businessEntityId = $this->getBusinessEntityByName($name)->getId();
 
         return $this->getQueryBus()->handle(new GetBusinessEntityForViewing($businessEntityId));
+    }
+
+    /**
+     * @When I edit the business entity :name with the following details:
+     */
+    public function iEditTheBusinessEntity(string $name, TableNode $table)
+    {
+        $businessEntity = $this->getBusinessEntityByName($name);
+        $data = $table->getRowsHash();
+
+        $command = new EditBusinessEntityCommand(
+            $businessEntity->getId(),
+            $data['name'] ?? $businessEntity->getName(),
+            $data['legal_name'] ?? (string) $businessEntity->getLegalName(),
+            $data['external_ref'] ?? $businessEntity->getExternalRef(),
+            isset($data['delivery_authorized']) ? (bool) $data['delivery_authorized'] : $businessEntity->isDeliveryAuthorized(),
+            isset($data['status']) ? BusinessEntityStatus::from($data['status']) : $businessEntity->getStatus(),
+            isset($data['customer_group_id']) ? (int) $data['customer_group_id'] : $businessEntity->getIdCustomerGroup()
+        );
+
+        try {
+            $this->getCommandBus()->handle($command);
+        } catch (Exception $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then the business entity :name should have the following details:
+     */
+    public function businessEntityShouldHaveDetails(string $name, TableNode $table)
+    {
+        $businessEntity = $this->getBusinessEntityByName($name);
+        $data = $table->getRowsHash();
+
+        if (isset($data['name'])) {
+            Assert::assertSame($data['name'], $businessEntity->getName());
+        }
+        if (isset($data['legal_name'])) {
+            Assert::assertSame($data['legal_name'], $businessEntity->getLegalName());
+        }
+        if (isset($data['external_ref'])) {
+            Assert::assertSame($data['external_ref'], $businessEntity->getExternalRef());
+        }
+        if (isset($data['delivery_authorized'])) {
+            Assert::assertSame((bool) $data['delivery_authorized'], $businessEntity->isDeliveryAuthorized());
+        }
+        if (isset($data['status'])) {
+            Assert::assertSame(BusinessEntityStatus::from($data['status']), $businessEntity->getStatus());
+        }
+        if (isset($data['customer_group_id'])) {
+            Assert::assertSame((int) $data['customer_group_id'], $businessEntity->getIdCustomerGroup());
+        }
+    }
+
+    /**
+     * @Then editing the business entity with id :businessEntityId should raise a not found error
+     */
+    public function editingBusinessEntityShouldRaiseNotFound(int $businessEntityId)
+    {
+        try {
+            $this->getCommandBus()->handle(new EditBusinessEntityCommand(
+                $businessEntityId,
+                'Missing',
+                'Missing Legal',
+                null,
+                false,
+                BusinessEntityStatus::PENDING,
+                3
+            ));
+        } catch (Exception $e) {
+            $this->setLastException($e);
+        }
+
+        $this->assertLastErrorIs(BusinessEntityNotFoundException::class);
     }
 
     private function getBusinessEntityByName(string $name): BusinessEntity

--- a/tests/Integration/Behaviour/Features/Scenario/BusinessEntity/business_entity_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/BusinessEntity/business_entity_management.feature
@@ -196,6 +196,7 @@ Feature: Manage business entities
       | alias   | address1  | city  | postcode | country_id | is_default |
       | Billing | 1 Edit St | Paris | 75001    | 8          | 1          |
     When I add the business entity
+    And the business entity "Editable Entity" was last updated an hour ago
     And I edit the business entity "Editable Entity" with the following details:
       | name                | Edited Entity |
       | legal_name          | Edited Legal  |
@@ -210,6 +211,78 @@ Feature: Manage business entities
       | status              | active       |
       | customer_group_id   | 1            |
     And the business entity "Edited Entity" should have 1 address
+    And the business entity "Edited Entity" should have a refreshed updated_at
+    And the business entity "Edited Entity" should be editable with the following details:
+      | legal_name          | Edited Legal |
+      | external_ref        | EXT-010-B    |
+      | delivery_authorized | 1            |
+      | status              | active       |
+      | customer_group_id   | 1            |
+
+  Scenario: Editing only one field leaves every other field untouched
+    Given there is a business entity with the following details:
+      | name                | Partial Entity |
+      | legal_name          | Partial Legal  |
+      | external_ref        | EXT-011        |
+      | delivery_authorized | 1              |
+      | status              | pending        |
+      | billing_as_shipping | 1              |
+    And the business entity has the following billing addresses:
+      | alias   | address1     | city  | postcode | country_id | is_default |
+      | Billing | 1 Partial St | Paris | 75001    | 8          | 1          |
+    When I add the business entity
+    And I edit the business entity "Partial Entity" with the following details:
+      | status | active |
+    Then the business entity "Partial Entity" should have the following details:
+      | legal_name          | Partial Legal |
+      | external_ref        | EXT-011       |
+      | delivery_authorized | 1             |
+      | status              | active        |
+
+  Scenario: Turning delivery authorization off with the word false
+    Given there is a business entity with the following details:
+      | name                | Switchable Entity |
+      | legal_name          | Switchable Legal  |
+      | external_ref        | EXT-013           |
+      | delivery_authorized | 1                 |
+      | status              | active            |
+      | billing_as_shipping | 1                 |
+    And the business entity has the following billing addresses:
+      | alias   | address1        | city  | postcode | country_id | is_default |
+      | Billing | 1 Switchable St | Paris | 75001    | 8          | 1          |
+    When I add the business entity
+    And I edit the business entity "Switchable Entity" with the following details:
+      | delivery_authorized | false |
+    # Written with "false" on the way in and "0" on the way out on purpose: a naive (bool) cast
+    # reads "false" as TRUE, so a symmetric table would expect true and pass without testing
+    # anything. "0" is falsy under either cast, so only a correct input cast makes this pass.
+    Then the business entity "Switchable Entity" should have the following details:
+      | delivery_authorized | 0                |
+      | legal_name          | Switchable Legal |
+      | status              | active           |
+
+  Scenario: Clearing the external reference of a business entity
+    Given there is a business entity with the following details:
+      | name                | Clearable Entity |
+      | legal_name          | Clearable Legal  |
+      | external_ref        | EXT-012          |
+      | delivery_authorized | 1                |
+      | status              | active           |
+      | billing_as_shipping | 1                |
+    And the business entity has the following billing addresses:
+      | alias   | address1       | city  | postcode | country_id | is_default |
+      | Billing | 1 Clearable St | Paris | 75001    | 8          | 1          |
+    When I add the business entity
+    And I edit the business entity "Clearable Entity" with the following details:
+      | external_ref |  |
+    Then the business entity "Clearable Entity" should have the following details:
+      | external_ref        |                 |
+      | legal_name          | Clearable Legal |
+      | delivery_authorized | 1               |
+      | status              | active          |
+    And the business entity "Clearable Entity" should be editable with the following details:
+      | external_ref |  |
 
   Scenario: Editing a business entity that does not exist raises a not found error
-    When editing the business entity with id 999999 should raise a not found error
+    When I edit the business entity with id 999999
+    Then I should get an error that the business entity was not found

--- a/tests/Integration/Behaviour/Features/Scenario/BusinessEntity/business_entity_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/BusinessEntity/business_entity_management.feature
@@ -4,7 +4,7 @@
 Feature: Manage business entities
   In order to manage B2B entities
   As a BO user
-  I need to be able to add, view and list business entities
+  I need to be able to add, view, list and edit business entities
 
   Scenario: Add a new business entity with billing address used as shipping address
     Given there is a business entity with the following details:
@@ -183,3 +183,33 @@ Feature: Manage business entities
     And there is a business entity named "Pending Beta" with status "pending"
     And there is a business entity named "Active Gamma" with status "active"
     Then the pending business entities count should be 2
+
+  Scenario: Edit the general information of a business entity
+    Given there is a business entity with the following details:
+      | name                | Editable Entity |
+      | legal_name          | Editable Legal  |
+      | external_ref        | EXT-010         |
+      | delivery_authorized | 0               |
+      | status              | pending         |
+      | billing_as_shipping | 1               |
+    And the business entity has the following billing addresses:
+      | alias   | address1  | city  | postcode | country_id | is_default |
+      | Billing | 1 Edit St | Paris | 75001    | 8          | 1          |
+    When I add the business entity
+    And I edit the business entity "Editable Entity" with the following details:
+      | name                | Edited Entity |
+      | legal_name          | Edited Legal  |
+      | external_ref        | EXT-010-B     |
+      | delivery_authorized | 1             |
+      | status              | active        |
+      | customer_group_id   | 1             |
+    Then the business entity "Edited Entity" should have the following details:
+      | legal_name          | Edited Legal |
+      | external_ref        | EXT-010-B    |
+      | delivery_authorized | 1            |
+      | status              | active       |
+      | customer_group_id   | 1            |
+    And the business entity "Edited Entity" should have 1 address
+
+  Scenario: Editing a business entity that does not exist raises a not found error
+    When editing the business entity with id 999999 should raise a not found error

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/BusinessEntity/BusinessEntityControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/BusinessEntity/BusinessEntityControllerTest.php
@@ -310,7 +310,16 @@ class BusinessEntityControllerTest extends GridControllerTestCase
 
     private function fieldName(string $field): string
     {
-        return sprintf('business_entity[general_information][%s]', $field);
+        $sections = [
+            'name' => 'identity',
+            'legal_name' => 'identity',
+            'external_ref' => 'settings',
+            'status' => 'settings',
+            'customer_group_id' => 'settings',
+            'delivery_authorized' => 'settings',
+        ];
+
+        return sprintf('business_entity[general_information][%s][%s]', $sections[$field], $field);
     }
 
     private static function createBusinessEntity(

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/BusinessEntity/BusinessEntityControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/BusinessEntity/BusinessEntityControllerTest.php
@@ -9,9 +9,12 @@ namespace Tests\Integration\PrestaShopBundle\Controller\Sell\BusinessEntity;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\AddBusinessEntityCommand;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\CannotUpdateBusinessEntityException;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\ValueObject\BusinessEntityBillingAddress;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Tests\Integration\PrestaShopBundle\Controller\GridControllerTestCase;
 use Tests\Integration\PrestaShopBundle\Controller\TestEntityDTO;
 use Tests\Resources\Resetter\BusinessEntityResetter;
@@ -23,6 +26,10 @@ class BusinessEntityControllerTest extends GridControllerTestCase
     private const DEFAULT_COUNTRY_ID = 8;
 
     private const SAVE_BUTTON_SELECTOR = 'save-button';
+
+    private const UNKNOWN_BUSINESS_ENTITY_ID = 999999;
+
+    private const CREATION_SAMPLE_VALUES = ['FR12345678901', '123 456 789 00012', '12-345-6789'];
 
     private const ACTIVE_COMPANY_NAME = 'Grid active company';
     private const PENDING_COMPANY_NAME = 'Grid pending company';
@@ -129,6 +136,92 @@ class BusinessEntityControllerTest extends GridControllerTestCase
         );
         $this->assertSame('', $formValues[$this->fieldName('external_ref')]);
         $this->assertSame('1', $formValues[$this->fieldName('delivery_authorized')]);
+    }
+
+    /**
+     * @depends testIndex
+     */
+    public function testTheCreationPageShowsTheSampleIdentifiers(): void
+    {
+        $crawler = $this->client->request('GET', $this->router->generate('admin_business_entities_create'));
+        $this->assertResponseIsSuccessful();
+
+        foreach (self::CREATION_SAMPLE_VALUES as $sampleValue) {
+            $this->assertCount(
+                1,
+                $crawler->filter(sprintf('input[placeholder="%s"]', $sampleValue)),
+                sprintf('The creation page must show the sample "%s".', $sampleValue)
+            );
+        }
+    }
+
+    /**
+     * @depends testIndex
+     */
+    public function testTheEditPageOfAnEntityWithoutIdentifiersShowsNoSampleValues(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateEditUrl(self::$activeBusinessEntityId));
+        $this->assertResponseIsSuccessful();
+
+        foreach (self::CREATION_SAMPLE_VALUES as $sampleValue) {
+            $this->assertCount(
+                0,
+                $crawler->filter(sprintf('input[placeholder="%s"]', $sampleValue)),
+                sprintf('The creation sample "%s" must not appear on an edit page.', $sampleValue)
+            );
+        }
+    }
+
+    /**
+     * @depends testIndex
+     */
+    public function testEditingAnUnknownEntityRedirectsToTheListingWithAnError(): void
+    {
+        $this->client->request('GET', $this->generateEditUrl(self::UNKNOWN_BUSINESS_ENTITY_ID));
+
+        $this->assertResponseRedirects($this->router->generate('admin_business_entities_list'));
+
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
+        $messages = $session->getFlashBag()->all();
+        $this->assertArrayHasKey('error', $messages);
+        $this->assertContains(
+            'The object cannot be loaded (or found).',
+            $messages['error'],
+            print_r($messages['error'], true)
+        );
+    }
+
+    /**
+     * @depends testIndex
+     */
+    public function testAFailedWriteLeavesTheEditPageInsteadOfRedisplayingIt(): void
+    {
+        $this->client->disableReboot();
+
+        $formHandler = $this->createMock(FormHandlerInterface::class);
+        $formHandler->method('handleFor')->willThrowException(
+            new CannotUpdateBusinessEntityException('Could not update business entity')
+        );
+
+        self::$kernel->getContainer()->set(
+            'prestashop.core.form.identifiable_object.business_entity_form_handler',
+            $formHandler
+        );
+
+        $this->client->request('POST', $this->generateEditUrl(self::$activeBusinessEntityId));
+
+        $this->assertResponseRedirects($this->router->generate('admin_business_entities_list'));
+
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
+        $messages = $session->getFlashBag()->all();
+        $this->assertArrayHasKey('error', $messages);
+        $this->assertContains(
+            'An error occurred while updating the business entity.',
+            $messages['error'],
+            print_r($messages['error'], true)
+        );
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/BusinessEntity/BusinessEntityControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/BusinessEntity/BusinessEntityControllerTest.php
@@ -22,6 +22,8 @@ class BusinessEntityControllerTest extends GridControllerTestCase
     private const DEFAULT_CUSTOMER_GROUP_ID = 1;
     private const DEFAULT_COUNTRY_ID = 8;
 
+    private const SAVE_BUTTON_SELECTOR = 'save-button';
+
     private const ACTIVE_COMPANY_NAME = 'Grid active company';
     private const PENDING_COMPANY_NAME = 'Grid pending company';
 
@@ -105,6 +107,210 @@ class BusinessEntityControllerTest extends GridControllerTestCase
         ])->isEmpty());
 
         $this->resetGridFilters();
+    }
+
+    /**
+     * @depends testIndex
+     */
+    public function testEditPageIsPrefilled(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateEditUrl(self::$activeBusinessEntityId));
+        $this->assertResponseIsSuccessful();
+
+        $formValues = $this->getFormByButton($crawler, self::SAVE_BUTTON_SELECTOR)->getValues();
+
+        // AC3 lists six in-scope fields; asserting a subset would let a provider regression through.
+        $this->assertSame(self::ACTIVE_COMPANY_NAME, $formValues[$this->fieldName('name')]);
+        $this->assertSame('Grid active legal name', $formValues[$this->fieldName('legal_name')]);
+        $this->assertSame(BusinessEntityStatus::ACTIVE->value, $formValues[$this->fieldName('status')]);
+        $this->assertSame(
+            (string) self::DEFAULT_CUSTOMER_GROUP_ID,
+            $formValues[$this->fieldName('customer_group_id')]
+        );
+        $this->assertSame('', $formValues[$this->fieldName('external_ref')]);
+        $this->assertSame('1', $formValues[$this->fieldName('delivery_authorized')]);
+    }
+
+    /**
+     * @depends testEditPageIsPrefilled
+     */
+    public function testEditRedirectsToViewPageAndPersists(): void
+    {
+        $this->client->disableReboot();
+
+        $editUrl = $this->generateEditUrl(self::$activeBusinessEntityId);
+        $crawler = $this->client->request('GET', $editUrl);
+        $this->assertResponseIsSuccessful();
+
+        $form = $this->getFormByButton($crawler, self::SAVE_BUTTON_SELECTOR);
+        $form[$this->fieldName('name')] = 'Grid renamed company';
+        $form[$this->fieldName('legal_name')] = 'Grid renamed legal name';
+        $form[$this->fieldName('external_ref')] = 'EXT-HTTP-1';
+        $form[$this->fieldName('delivery_authorized')] = '0';
+        $form[$this->fieldName('status')] = BusinessEntityStatus::PENDING->value;
+        $this->client->submit($form);
+
+        $this->assertResponseRedirects($this->router->generate(
+            'admin_business_entities_view',
+            ['businessEntityId' => self::$activeBusinessEntityId]
+        ));
+
+        $crawler = $this->client->followRedirect();
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('Grid renamed company', $crawler->filter('body')->text());
+        // AC5 also asks for a success message. Target the flash node AND its text: the admin layout
+        // renders an empty #ajax_confirmation.alert-success on every page, so matching the class
+        // alone would pass even with no flash at all.
+        $this->assertStringContainsString(
+            'Successful update.',
+            $crawler->filter('.alert-success .alert-text')->text(),
+            'A success message must be shown after a successful edit'
+        );
+
+        // Every edited field must survive the round-trip, not only the one that shows in the H1.
+        $formValues = $this->getFormByButton(
+            $this->client->request('GET', $editUrl),
+            self::SAVE_BUTTON_SELECTOR
+        )->getValues();
+        $this->assertSame('Grid renamed company', $formValues[$this->fieldName('name')]);
+        $this->assertSame('Grid renamed legal name', $formValues[$this->fieldName('legal_name')]);
+        $this->assertSame('EXT-HTTP-1', $formValues[$this->fieldName('external_ref')]);
+        $this->assertSame('0', $formValues[$this->fieldName('delivery_authorized')]);
+        $this->assertSame(BusinessEntityStatus::PENDING->value, $formValues[$this->fieldName('status')]);
+
+        $this->restoreActiveBusinessEntity($editUrl);
+    }
+
+    /**
+     * @depends testEditRedirectsToViewPageAndPersists
+     */
+    public function testEditClearsTheExternalReference(): void
+    {
+        $this->client->disableReboot();
+
+        $editUrl = $this->generateEditUrl(self::$activeBusinessEntityId);
+
+        $form = $this->getFormByButton($this->client->request('GET', $editUrl), self::SAVE_BUTTON_SELECTOR);
+        $form[$this->fieldName('external_ref')] = 'EXT-TO-CLEAR';
+        $this->client->submit($form);
+        $this->client->followRedirect();
+
+        $form = $this->getFormByButton($this->client->request('GET', $editUrl), self::SAVE_BUTTON_SELECTOR);
+        $form[$this->fieldName('external_ref')] = '';
+        $this->client->submit($form);
+        $this->client->followRedirect();
+
+        $formValues = $this->getFormByButton(
+            $this->client->request('GET', $editUrl),
+            self::SAVE_BUTTON_SELECTOR
+        )->getValues();
+        $this->assertSame('', $formValues[$this->fieldName('external_ref')]);
+
+        $this->restoreActiveBusinessEntity($editUrl);
+    }
+
+    /**
+     * The edit tests share one fixture, so each of them puts it back the way it found it.
+     */
+    private function restoreActiveBusinessEntity(string $editUrl): void
+    {
+        $form = $this->getFormByButton($this->client->request('GET', $editUrl), self::SAVE_BUTTON_SELECTOR);
+        $form[$this->fieldName('name')] = self::ACTIVE_COMPANY_NAME;
+        $form[$this->fieldName('legal_name')] = 'Grid active legal name';
+        $form[$this->fieldName('external_ref')] = '';
+        $form[$this->fieldName('delivery_authorized')] = '1';
+        $form[$this->fieldName('status')] = BusinessEntityStatus::ACTIVE->value;
+        $this->client->submit($form);
+        $this->client->followRedirect();
+    }
+
+    /**
+     * @depends testEditPageIsPrefilled
+     */
+    public function testEditRejectsABlankRequiredField(): void
+    {
+        $this->client->disableReboot();
+
+        $editUrl = $this->generateEditUrl(self::$activeBusinessEntityId);
+        $form = $this->getFormByButton(
+            $this->client->request('GET', $editUrl),
+            self::SAVE_BUTTON_SELECTOR
+        );
+        $form[$this->fieldName('name')] = '';
+        $this->client->submit($form);
+
+        $this->assertResponseIsSuccessful();
+
+        $formValues = $this->getFormByButton(
+            $this->client->request('GET', $editUrl),
+            self::SAVE_BUTTON_SELECTOR
+        )->getValues();
+        $this->assertSame(self::ACTIVE_COMPANY_NAME, $formValues[$this->fieldName('name')]);
+    }
+
+    /**
+     * @depends testEditPageIsPrefilled
+     */
+    public function testEditPageOffersACancelLinkBackToTheViewPage(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateEditUrl(self::$activeBusinessEntityId));
+        $this->assertResponseIsSuccessful();
+
+        $viewUrl = $this->router->generate(
+            'admin_business_entities_view',
+            ['businessEntityId' => self::$activeBusinessEntityId]
+        );
+
+        $this->assertNotEmpty(
+            $crawler->filter(sprintf('a[href="%s"]', $viewUrl)),
+            'The edit page must offer a link back to the view page'
+        );
+    }
+
+    /**
+     * @depends testIndex
+     */
+    public function testTheListAndTheViewPageBothLinkToTheEditPage(): void
+    {
+        // Admin urls carry a per-generation CSRF token, so the path is what identifies the target.
+        $editPath = sprintf('/sell/business-entities/%d/edit', self::$activeBusinessEntityId);
+
+        $listCrawler = $this->client->request('GET', $this->generateGridUrl());
+        $this->assertResponseIsSuccessful();
+        $this->assertCount(
+            1,
+            $listCrawler->filter(sprintf('%s a[href*="%s"]', $this->getGridSelector(), $editPath)),
+            'The list row action must link to the edit page'
+        );
+        // AC1 asks for Edit to sit in the three-dots menu. The action column renders the FIRST
+        // regular action outside the dropdown and the rest inside it, so a reorder in the grid
+        // definition factory would silently promote Edit to the visible button: pin the dropdown.
+        $this->assertCount(
+            1,
+            $listCrawler->filter(sprintf('%s .dropdown-menu a[href*="%s"]', $this->getGridSelector(), $editPath)),
+            'AC1: the Edit action must sit inside the kebab menu, not as the visible button'
+        );
+
+        $viewCrawler = $this->client->request('GET', $this->router->generate(
+            'admin_business_entities_view',
+            ['businessEntityId' => self::$activeBusinessEntityId]
+        ));
+        $this->assertResponseIsSuccessful();
+        $this->assertCount(
+            1,
+            $viewCrawler->filter(sprintf('.toolbar-icons a[href*="%s"]', $editPath)),
+            'The view page toolbar must link to the edit page'
+        );
+    }
+
+    private function generateEditUrl(int $businessEntityId): string
+    {
+        return $this->router->generate('admin_business_entities_edit', ['businessEntityId' => $businessEntityId]);
+    }
+
+    private function fieldName(string $field): string
+    {
+        return sprintf('business_entity[general_information][%s]', $field);
     }
 
     private static function createBusinessEntity(

--- a/tests/Unit/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandlerTest.php
+++ b/tests/Unit/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandlerTest.php
@@ -3,15 +3,18 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Adapter\BusinessEntity\CommandHandler;
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\ORMException;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler\EditBusinessEntityHandler;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
 use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\CannotUpdateBusinessEntityException;
 use PrestaShopBundle\Entity\B2B\BusinessEntity;
 use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
@@ -19,18 +22,24 @@ use Psr\Log\LoggerInterface;
 
 class EditBusinessEntityHandlerTest extends TestCase
 {
-    public function testItUpdatesAllFieldsAndFlushes(): void
+    private const SHOP_ID = 1;
+
+    public function testItUpdatesAllFieldsAndSaves(): void
     {
         $businessEntity = $this->buildBusinessEntity();
 
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())->method('flush');
-
         $repository = $this->createMock(BusinessEntityRepository::class);
-        $repository->method('getBusinessEntityById')->with(7)->willReturn($businessEntity);
+        $repository->expects($this->once())->method('findById')->with(7, [self::SHOP_ID])->willReturn($businessEntity);
+        $repository->expects($this->once())->method('save')->with($businessEntity);
 
-        $handler = new EditBusinessEntityHandler($em, $repository, $this->createMock(LoggerInterface::class));
-        $handler->handle(new EditBusinessEntityCommand(7, 'New name', 'New legal', 'NEW-REF', true, BusinessEntityStatus::ACTIVE, 9));
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $this->createMock(LoggerInterface::class));
+        $handler->handle((new EditBusinessEntityCommand(7))
+            ->setName('New name')
+            ->setLegalName('New legal')
+            ->setExternalRef('NEW-REF')
+            ->setDeliveryAuthorized(true)
+            ->setStatus(BusinessEntityStatus::ACTIVE)
+            ->setCustomerGroupId(9));
 
         $this->assertSame('New name', $businessEntity->getName());
         $this->assertSame('New legal', $businessEntity->getLegalName());
@@ -45,7 +54,7 @@ class EditBusinessEntityHandlerTest extends TestCase
         $businessEntity = $this->buildBusinessEntity();
 
         $repository = $this->createMock(BusinessEntityRepository::class);
-        $repository->method('getBusinessEntityById')->willReturn($businessEntity);
+        $repository->method('findById')->willReturn($businessEntity);
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
@@ -58,11 +67,17 @@ class EditBusinessEntityHandlerTest extends TestCase
                         && !str_contains($message, '"legal_name"')
                         && !str_contains($message, '"customer_group_id"');
                 }),
-                ['object_type' => 'BusinessEntity', 'object_id' => 7],
+                ['object_type' => 'BusinessEntity', 'object_id' => 7, 'allow_duplicate' => true],
             );
 
-        $handler = new EditBusinessEntityHandler($this->createMock(EntityManagerInterface::class), $repository, $logger);
-        $handler->handle(new EditBusinessEntityCommand(7, 'New name', 'Old legal', 'OLD-REF', false, BusinessEntityStatus::ACTIVE, 3));
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $logger);
+        $handler->handle((new EditBusinessEntityCommand(7))
+            ->setName('New name')
+            ->setLegalName('Old legal')
+            ->setExternalRef('OLD-REF')
+            ->setDeliveryAuthorized(false)
+            ->setStatus(BusinessEntityStatus::ACTIVE)
+            ->setCustomerGroupId(3));
     }
 
     public function testItLogsBaseMessageWhenNothingChanged(): void
@@ -70,33 +85,220 @@ class EditBusinessEntityHandlerTest extends TestCase
         $businessEntity = $this->buildBusinessEntity();
 
         $repository = $this->createMock(BusinessEntityRepository::class);
-        $repository->method('getBusinessEntityById')->willReturn($businessEntity);
+        $repository->method('findById')->willReturn($businessEntity);
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
             ->method('info')
             ->with(
                 'Business entity updated successfully',
-                ['object_type' => 'BusinessEntity', 'object_id' => 7],
+                ['object_type' => 'BusinessEntity', 'object_id' => 7, 'allow_duplicate' => true],
             );
 
-        $handler = new EditBusinessEntityHandler($this->createMock(EntityManagerInterface::class), $repository, $logger);
-        $handler->handle(new EditBusinessEntityCommand(7, 'Old name', 'Old legal', 'OLD-REF', false, BusinessEntityStatus::PENDING, 3));
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $logger);
+        $handler->handle((new EditBusinessEntityCommand(7))
+            ->setName('Old name')
+            ->setLegalName('Old legal')
+            ->setExternalRef('OLD-REF')
+            ->setDeliveryAuthorized(false)
+            ->setStatus(BusinessEntityStatus::PENDING)
+            ->setCustomerGroupId(3));
+    }
+
+    public function testItLooksUpWithoutShopScopeInAllShopContext(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $shopContext = $this->createMock(ShopContext::class);
+        $shopContext->method('isAllShopContext')->willReturn(true);
+        $shopContext->expects($this->never())->method('getAssociatedShopIds');
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->expects($this->once())->method('findById')->with(7, null)->willReturn($businessEntity);
+
+        $handler = new EditBusinessEntityHandler($repository, $shopContext, $this->createMock(LoggerInterface::class));
+        $handler->handle((new EditBusinessEntityCommand(7))
+            ->setName('New name')
+            ->setLegalName('Old legal')
+            ->setExternalRef('OLD-REF')
+            ->setDeliveryAuthorized(false)
+            ->setStatus(BusinessEntityStatus::PENDING)
+            ->setCustomerGroupId(3));
+
+        $this->assertSame('New name', $businessEntity->getName());
+    }
+
+    public function testItLogsEveryModifiedFieldWithItsOldAndNewValue(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($businessEntity);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('info')
+            ->with(
+                'Business entity updated successfully {'
+                . '"name":{"old":"Old name","new":"New name"},'
+                . '"legal_name":{"old":"Old legal","new":"New legal"},'
+                . '"external_ref":{"old":"OLD-REF","new":"NEW-REF"},'
+                . '"delivery_authorized":{"old":false,"new":true},'
+                . '"status":{"old":"pending","new":"active"},'
+                . '"customer_group_id":{"old":3,"new":9}}',
+                ['object_type' => 'BusinessEntity', 'object_id' => 7, 'allow_duplicate' => true],
+            );
+
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $logger);
+        $handler->handle((new EditBusinessEntityCommand(7))
+            ->setName('New name')
+            ->setLegalName('New legal')
+            ->setExternalRef('NEW-REF')
+            ->setDeliveryAuthorized(true)
+            ->setStatus(BusinessEntityStatus::ACTIVE)
+            ->setCustomerGroupId(9));
     }
 
     public function testItThrowsWhenBusinessEntityNotFound(): void
     {
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->never())->method('flush');
-
         $repository = $this->createMock(BusinessEntityRepository::class);
-        $repository->method('getBusinessEntityById')->willReturn(null);
+        $repository->method('findById')->willReturn(null);
+        $repository->expects($this->never())->method('save');
 
-        $handler = new EditBusinessEntityHandler($em, $repository, $this->createMock(LoggerInterface::class));
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $this->createMock(LoggerInterface::class));
 
         $this->expectException(BusinessEntityNotFoundException::class);
 
-        $handler->handle(new EditBusinessEntityCommand(7, 'Name', 'Legal', null, false, BusinessEntityStatus::PENDING, 3));
+        $handler->handle((new EditBusinessEntityCommand(7))
+            ->setName('Name')
+            ->setLegalName('Legal')
+            ->setExternalRef(null)
+            ->setDeliveryAuthorized(false)
+            ->setStatus(BusinessEntityStatus::PENDING)
+            ->setCustomerGroupId(3));
+    }
+
+    private function getMockShopContext(): ShopContext
+    {
+        $shopContext = $this->createMock(ShopContext::class);
+        $shopContext->method('isAllShopContext')->willReturn(false);
+        $shopContext->method('getAssociatedShopIds')->willReturn([self::SHOP_ID]);
+
+        return $shopContext;
+    }
+
+    public function testItLeavesUnsetFieldsUntouched(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($businessEntity);
+        $repository->expects($this->once())->method('save')->with($businessEntity);
+
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $this->createMock(LoggerInterface::class));
+        $handler->handle((new EditBusinessEntityCommand(7))->setStatus(BusinessEntityStatus::ACTIVE));
+
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $businessEntity->getStatus());
+        $this->assertSame('Old name', $businessEntity->getName());
+        $this->assertSame('Old legal', $businessEntity->getLegalName());
+        $this->assertSame('OLD-REF', $businessEntity->getExternalRef());
+        $this->assertFalse($businessEntity->isDeliveryAuthorized());
+        $this->assertSame(3, $businessEntity->getIdCustomerGroup());
+    }
+
+    public function testItLogsOnlyTheFieldsTheCommandActuallyCarries(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($businessEntity);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info')->with(
+            $this->callback(function (string $message): bool {
+                return str_contains($message, '"status"')
+                    && !str_contains($message, '"name"')
+                    && !str_contains($message, '"customer_group_id"');
+            }),
+            $this->anything()
+        );
+
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $logger);
+        $handler->handle((new EditBusinessEntityCommand(7))->setStatus(BusinessEntityStatus::ACTIVE));
+    }
+
+    public function testItClearsExternalRefWhenExplicitlySetToNull(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($businessEntity);
+
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $this->createMock(LoggerInterface::class));
+        $handler->handle((new EditBusinessEntityCommand(7))->setExternalRef(null));
+
+        $this->assertNull($businessEntity->getExternalRef());
+    }
+
+    public function testItKeepsAccentedValuesReadableInTheAuditTrail(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($businessEntity);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info')->with(
+            $this->stringContains('Sécurité Générale'),
+            $this->anything()
+        );
+
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $logger);
+        $handler->handle((new EditBusinessEntityCommand(7))->setName('Sécurité Générale'));
+    }
+
+    /**
+     * The fixture starts with delivery_authorized = false, so every other test only ever proves
+     * the false -> true direction. A guard that ignored `false` would stay green without this.
+     */
+    public function testItTurnsDeliveryAuthorizedBackOff(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+        $businessEntity->setDeliveryAuthorized(true);
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($businessEntity);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info')->with(
+            $this->stringContains('"delivery_authorized"'),
+            $this->anything()
+        );
+
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $logger);
+        $handler->handle((new EditBusinessEntityCommand(7))->setDeliveryAuthorized(false));
+
+        $this->assertFalse($businessEntity->isDeliveryAuthorized());
+    }
+
+    /**
+     * The sibling AddBusinessEntityHandler translates a persistence failure into a domain
+     * exception, and BusinessEntitiesController::getErrorMessages() only maps domain exceptions:
+     * a raw Doctrine exception would fall through to the generic "unexpected error" message.
+     */
+    public function testItTranslatesAPersistenceFailureIntoADomainException(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($businessEntity);
+        $repository->method('save')->willThrowException(new ORMException('Deadlock found'));
+
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $this->createMock(LoggerInterface::class));
+
+        $this->expectException(CannotUpdateBusinessEntityException::class);
+
+        $handler->handle((new EditBusinessEntityCommand(7))->setName('New name'));
     }
 
     private function buildBusinessEntity(): BusinessEntity

--- a/tests/Unit/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandlerTest.php
+++ b/tests/Unit/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandlerTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\BusinessEntity\CommandHandler;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler\EditBusinessEntityHandler;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShopBundle\Entity\B2B\BusinessEntity;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
+use Psr\Log\LoggerInterface;
+
+class EditBusinessEntityHandlerTest extends TestCase
+{
+    public function testItUpdatesAllFieldsAndFlushes(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('getBusinessEntityById')->with(7)->willReturn($businessEntity);
+
+        $handler = new EditBusinessEntityHandler($em, $repository, $this->createMock(LoggerInterface::class));
+        $handler->handle(new EditBusinessEntityCommand(7, 'New name', 'New legal', 'NEW-REF', true, BusinessEntityStatus::ACTIVE, 9));
+
+        $this->assertSame('New name', $businessEntity->getName());
+        $this->assertSame('New legal', $businessEntity->getLegalName());
+        $this->assertSame('NEW-REF', $businessEntity->getExternalRef());
+        $this->assertTrue($businessEntity->isDeliveryAuthorized());
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $businessEntity->getStatus());
+        $this->assertSame(9, $businessEntity->getIdCustomerGroup());
+    }
+
+    public function testItLogsOnlyModifiedFieldsAsJson(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('getBusinessEntityById')->willReturn($businessEntity);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->callback(static function (string $message): bool {
+                    return str_starts_with($message, 'Business entity updated successfully {')
+                        && str_contains($message, '"name"')
+                        && str_contains($message, '"status"')
+                        && !str_contains($message, '"legal_name"')
+                        && !str_contains($message, '"customer_group_id"');
+                }),
+                ['object_type' => 'BusinessEntity', 'object_id' => 7],
+            );
+
+        $handler = new EditBusinessEntityHandler($this->createMock(EntityManagerInterface::class), $repository, $logger);
+        $handler->handle(new EditBusinessEntityCommand(7, 'New name', 'Old legal', 'OLD-REF', false, BusinessEntityStatus::ACTIVE, 3));
+    }
+
+    public function testItLogsBaseMessageWhenNothingChanged(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('getBusinessEntityById')->willReturn($businessEntity);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('info')
+            ->with(
+                'Business entity updated successfully',
+                ['object_type' => 'BusinessEntity', 'object_id' => 7],
+            );
+
+        $handler = new EditBusinessEntityHandler($this->createMock(EntityManagerInterface::class), $repository, $logger);
+        $handler->handle(new EditBusinessEntityCommand(7, 'Old name', 'Old legal', 'OLD-REF', false, BusinessEntityStatus::PENDING, 3));
+    }
+
+    public function testItThrowsWhenBusinessEntityNotFound(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('getBusinessEntityById')->willReturn(null);
+
+        $handler = new EditBusinessEntityHandler($em, $repository, $this->createMock(LoggerInterface::class));
+
+        $this->expectException(BusinessEntityNotFoundException::class);
+
+        $handler->handle(new EditBusinessEntityCommand(7, 'Name', 'Legal', null, false, BusinessEntityStatus::PENDING, 3));
+    }
+
+    private function buildBusinessEntity(): BusinessEntity
+    {
+        $businessEntity = new BusinessEntity();
+        $businessEntity->setName('Old name');
+        $businessEntity->setLegalName('Old legal');
+        $businessEntity->setExternalRef('OLD-REF');
+        $businessEntity->setDeliveryAuthorized(false);
+        $businessEntity->setStatus(BusinessEntityStatus::PENDING);
+        $businessEntity->setIdCustomerGroup(3);
+
+        return $businessEntity;
+    }
+}

--- a/tests/Unit/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandlerTest.php
+++ b/tests/Unit/Adapter/BusinessEntity/CommandHandler/EditBusinessEntityHandlerTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Adapter\BusinessEntity\CommandHandler;
 
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\Exception\ORMException;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\BusinessEntity\CommandHandler\EditBusinessEntityHandler;
@@ -19,6 +20,7 @@ use PrestaShopBundle\Entity\B2B\BusinessEntity;
 use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 class EditBusinessEntityHandlerTest extends TestCase
 {
@@ -285,20 +287,77 @@ class EditBusinessEntityHandlerTest extends TestCase
      * The sibling AddBusinessEntityHandler translates a persistence failure into a domain
      * exception, and BusinessEntitiesController::getErrorMessages() only maps domain exceptions:
      * a raw Doctrine exception would fall through to the generic "unexpected error" message.
+     *
+     * @dataProvider providePersistenceFailures
      */
-    public function testItTranslatesAPersistenceFailureIntoADomainException(): void
+    public function testItTranslatesAnyPersistenceFailureIntoADomainException(Throwable $failure): void
     {
         $businessEntity = $this->buildBusinessEntity();
 
         $repository = $this->createMock(BusinessEntityRepository::class);
         $repository->method('findById')->willReturn($businessEntity);
-        $repository->method('save')->willThrowException(new ORMException('Deadlock found'));
+        $repository->method('save')->willThrowException($failure);
 
         $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $this->createMock(LoggerInterface::class));
+
+        try {
+            $handler->handle((new EditBusinessEntityCommand(7))->setName('New name'));
+            $this->fail(sprintf('A %s should have been thrown.', CannotUpdateBusinessEntityException::class));
+        } catch (CannotUpdateBusinessEntityException $e) {
+            $this->assertSame($failure, $e->getPrevious());
+        }
+    }
+
+    /**
+     * @return iterable<string, array{Throwable}>
+     */
+    public static function providePersistenceFailures(): iterable
+    {
+        yield 'ORM level' => [new ORMException('Deadlock found')];
+        yield 'DBAL driver level' => [new DBALException('An exception occurred while executing a query')];
+    }
+
+    public function testItDoesNotWriteToTheAuditTrailWhenTheWriteFailed(): void
+    {
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($this->buildBusinessEntity());
+        $repository->method('save')->willThrowException(new DBALException('Connection lost'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('info');
+
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $logger);
 
         $this->expectException(CannotUpdateBusinessEntityException::class);
 
         $handler->handle((new EditBusinessEntityCommand(7))->setName('New name'));
+    }
+
+    public function testAnUnencodableStoredValueDegradesTheAuditEntryInsteadOfFailingTheEdit(): void
+    {
+        $businessEntity = $this->buildBusinessEntity();
+        $businessEntity->setName("Ancien nom \xB1\x31");
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('findById')->willReturn($businessEntity);
+        $repository->expects($this->once())->method('save');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->logicalAnd(
+                    $this->stringContains('"name"'),
+                    $this->stringContains('New name'),
+                    $this->stringContains("\u{FFFD}")
+                ),
+                $this->anything()
+            );
+
+        $handler = new EditBusinessEntityHandler($repository, $this->getMockShopContext(), $logger);
+        $handler->handle((new EditBusinessEntityCommand(7))->setName('New name'));
+
+        $this->assertSame('New name', $businessEntity->getName());
     }
 
     private function buildBusinessEntity(): BusinessEntity

--- a/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandlerTest.php
+++ b/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandlerTest.php
@@ -3,6 +3,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Adapter\BusinessEntity\QueryHandler;
@@ -36,7 +37,7 @@ class GetBusinessEntityForEditingHandlerTest extends TestCase
 
         $repository = $this->createMock(BusinessEntityRepository::class);
         $repository->expects($this->once())
-            ->method('getBusinessEntityById')
+            ->method('findById')
             ->with(10, [2])
             ->willReturn($entity);
 
@@ -64,7 +65,7 @@ class GetBusinessEntityForEditingHandlerTest extends TestCase
 
         $repository = $this->createMock(BusinessEntityRepository::class);
         $repository->expects($this->once())
-            ->method('getBusinessEntityById')
+            ->method('findById')
             ->with(10, null)
             ->willReturn($entity);
 
@@ -79,7 +80,7 @@ class GetBusinessEntityForEditingHandlerTest extends TestCase
         $shopContext->method('getAssociatedShopIds')->willReturn([1]);
 
         $repository = $this->createMock(BusinessEntityRepository::class);
-        $repository->method('getBusinessEntityById')->willReturn(null);
+        $repository->method('findById')->willReturn(null);
 
         $handler = new GetBusinessEntityForEditingHandler($repository, $shopContext);
 

--- a/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandlerTest.php
+++ b/tests/Unit/Adapter/BusinessEntity/QueryHandler/GetBusinessEntityForEditingHandlerTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\BusinessEntity\QueryHandler;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\BusinessEntity\QueryHandler\GetBusinessEntityForEditingHandler;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForEditing;
+use PrestaShopBundle\Entity\B2B\BusinessEntity;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use PrestaShopBundle\Entity\Repository\BusinessEntityRepository;
+
+class GetBusinessEntityForEditingHandlerTest extends TestCase
+{
+    public function testItMapsTheEntityToTheEditableDtoScopedToTheCurrentShops(): void
+    {
+        $entity = $this->createMock(BusinessEntity::class);
+        $entity->method('getId')->willReturn(10);
+        $entity->method('getName')->willReturn('Tan Emporium');
+        $entity->method('getLegalName')->willReturn('Tan Emporium SAS');
+        $entity->method('getExternalRef')->willReturn('EXT-1');
+        $entity->method('isDeliveryAuthorized')->willReturn(true);
+        $entity->method('getStatus')->willReturn(BusinessEntityStatus::ACTIVE);
+        $entity->method('getIdCustomerGroup')->willReturn(5);
+        $entity->method('getIdShop')->willReturn(2);
+
+        $shopContext = $this->createMock(ShopContext::class);
+        $shopContext->method('isAllShopContext')->willReturn(false);
+        $shopContext->method('getAssociatedShopIds')->willReturn([2]);
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->expects($this->once())
+            ->method('getBusinessEntityById')
+            ->with(10, [2])
+            ->willReturn($entity);
+
+        $handler = new GetBusinessEntityForEditingHandler($repository, $shopContext);
+        $editable = $handler->handle(new GetBusinessEntityForEditing(10));
+
+        $this->assertSame(10, $editable->getBusinessEntityId());
+        $this->assertSame('Tan Emporium', $editable->getName());
+        $this->assertSame('Tan Emporium SAS', $editable->getLegalName());
+        $this->assertSame('EXT-1', $editable->getExternalRef());
+        $this->assertTrue($editable->isDeliveryAuthorized());
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $editable->getStatus());
+        $this->assertSame(5, $editable->getCustomerGroupId());
+        $this->assertSame(2, $editable->getShopId());
+    }
+
+    public function testItDoesNotScopeByShopInAllShopContext(): void
+    {
+        $entity = $this->createMock(BusinessEntity::class);
+        $entity->method('getStatus')->willReturn(BusinessEntityStatus::PENDING);
+
+        $shopContext = $this->createMock(ShopContext::class);
+        $shopContext->method('isAllShopContext')->willReturn(true);
+        $shopContext->expects($this->never())->method('getAssociatedShopIds');
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->expects($this->once())
+            ->method('getBusinessEntityById')
+            ->with(10, null)
+            ->willReturn($entity);
+
+        $handler = new GetBusinessEntityForEditingHandler($repository, $shopContext);
+        $handler->handle(new GetBusinessEntityForEditing(10));
+    }
+
+    public function testItThrowsWhenBusinessEntityNotFound(): void
+    {
+        $shopContext = $this->createMock(ShopContext::class);
+        $shopContext->method('isAllShopContext')->willReturn(false);
+        $shopContext->method('getAssociatedShopIds')->willReturn([1]);
+
+        $repository = $this->createMock(BusinessEntityRepository::class);
+        $repository->method('getBusinessEntityById')->willReturn(null);
+
+        $handler = new GetBusinessEntityForEditingHandler($repository, $shopContext);
+
+        $this->expectException(BusinessEntityNotFoundException::class);
+
+        $handler->handle(new GetBusinessEntityForEditing(404));
+    }
+}

--- a/tests/Unit/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommandTest.php
+++ b/tests/Unit/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommandTest.php
@@ -3,6 +3,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Core\Domain\BusinessEntity\Command;
@@ -14,41 +15,56 @@ use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 
 class EditBusinessEntityCommandTest extends TestCase
 {
-    public function testItExposesAllConstructorParamsViaGetters(): void
+    public function testItExposesEverySetValueViaGetters(): void
     {
-        $command = new EditBusinessEntityCommand(
-            7,
-            'My Business Entity',
-            'Legal Name SAS',
-            'EXT-007',
-            true,
-            BusinessEntityStatus::ACTIVE,
-            5,
-        );
+        $command = (new EditBusinessEntityCommand(7))
+            ->setName('My Business Entity')
+            ->setLegalName('Legal Name SAS')
+            ->setExternalRef('EXT-007')
+            ->setDeliveryAuthorized(true)
+            ->setStatus(BusinessEntityStatus::ACTIVE)
+            ->setCustomerGroupId(5);
 
         $this->assertSame(7, $command->getBusinessEntityId()->getValue());
         $this->assertSame('My Business Entity', $command->getName());
         $this->assertSame('Legal Name SAS', $command->getLegalName());
         $this->assertSame('EXT-007', $command->getExternalRef());
-        $this->assertTrue($command->isDeliveryAuthorized());
+        $this->assertTrue($command->getDeliveryAuthorized());
         $this->assertSame(BusinessEntityStatus::ACTIVE, $command->getStatus());
         $this->assertSame(5, $command->getCustomerGroupId());
     }
 
-    public function testItAcceptsNullExternalRef(): void
+    public function testAFreshCommandChangesNothing(): void
     {
-        $command = new EditBusinessEntityCommand(
-            1,
-            'Name',
-            'Legal',
-            null,
-            false,
-            BusinessEntityStatus::PENDING,
-            3,
-        );
+        $command = new EditBusinessEntityCommand(7);
 
+        $this->assertNull($command->getName());
+        $this->assertNull($command->getLegalName());
         $this->assertNull($command->getExternalRef());
-        $this->assertFalse($command->isDeliveryAuthorized());
+        $this->assertNull($command->getDeliveryAuthorized());
+        $this->assertNull($command->getStatus());
+        $this->assertNull($command->getCustomerGroupId());
+        $this->assertFalse($command->hasExternalRef());
+    }
+
+    public function testSettersAreChainableAndIndependent(): void
+    {
+        $command = (new EditBusinessEntityCommand(7))->setStatus(BusinessEntityStatus::PENDING);
+
+        $this->assertSame(BusinessEntityStatus::PENDING, $command->getStatus());
+        $this->assertNull($command->getName());
+        $this->assertNull($command->getCustomerGroupId());
+    }
+
+    public function testItTellsAClearedExternalRefApartFromAnUntouchedOne(): void
+    {
+        $untouched = new EditBusinessEntityCommand(7);
+        $this->assertNull($untouched->getExternalRef());
+        $this->assertFalse($untouched->hasExternalRef());
+
+        $cleared = (new EditBusinessEntityCommand(7))->setExternalRef(null);
+        $this->assertNull($cleared->getExternalRef());
+        $this->assertTrue($cleared->hasExternalRef());
     }
 
     public function testItRejectsNonPositiveId(): void
@@ -56,6 +72,6 @@ class EditBusinessEntityCommandTest extends TestCase
         $this->expectException(BusinessEntityConstraintException::class);
         $this->expectExceptionCode(BusinessEntityConstraintException::INVALID_ID);
 
-        new EditBusinessEntityCommand(0, 'Name', 'Legal', null, false, BusinessEntityStatus::PENDING, 3);
+        new EditBusinessEntityCommand(0);
     }
 }

--- a/tests/Unit/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommandTest.php
+++ b/tests/Unit/Core/Domain/BusinessEntity/Command/EditBusinessEntityCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\BusinessEntity\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Exception\BusinessEntityConstraintException;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+
+class EditBusinessEntityCommandTest extends TestCase
+{
+    public function testItExposesAllConstructorParamsViaGetters(): void
+    {
+        $command = new EditBusinessEntityCommand(
+            7,
+            'My Business Entity',
+            'Legal Name SAS',
+            'EXT-007',
+            true,
+            BusinessEntityStatus::ACTIVE,
+            5,
+        );
+
+        $this->assertSame(7, $command->getBusinessEntityId()->getValue());
+        $this->assertSame('My Business Entity', $command->getName());
+        $this->assertSame('Legal Name SAS', $command->getLegalName());
+        $this->assertSame('EXT-007', $command->getExternalRef());
+        $this->assertTrue($command->isDeliveryAuthorized());
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $command->getStatus());
+        $this->assertSame(5, $command->getCustomerGroupId());
+    }
+
+    public function testItAcceptsNullExternalRef(): void
+    {
+        $command = new EditBusinessEntityCommand(
+            1,
+            'Name',
+            'Legal',
+            null,
+            false,
+            BusinessEntityStatus::PENDING,
+            3,
+        );
+
+        $this->assertNull($command->getExternalRef());
+        $this->assertFalse($command->isDeliveryAuthorized());
+    }
+
+    public function testItRejectsNonPositiveId(): void
+    {
+        $this->expectException(BusinessEntityConstraintException::class);
+        $this->expectExceptionCode(BusinessEntityConstraintException::INVALID_ID);
+
+        new EditBusinessEntityCommand(0, 'Name', 'Legal', null, false, BusinessEntityStatus::PENDING, 3);
+    }
+}

--- a/tests/Unit/Core/Domain/BusinessEntity/QueryResult/EditableBusinessEntityTest.php
+++ b/tests/Unit/Core/Domain/BusinessEntity/QueryResult/EditableBusinessEntityTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\BusinessEntity\QueryResult;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\EditableBusinessEntity;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+
+class EditableBusinessEntityTest extends TestCase
+{
+    public function testItExposesAllConstructorParamsViaGetters(): void
+    {
+        $editable = new EditableBusinessEntity(
+            10,
+            'Tan Emporium',
+            'Tan Emporium SAS',
+            'EXT-1',
+            true,
+            BusinessEntityStatus::ACTIVE,
+            5,
+            2,
+        );
+
+        $this->assertSame(10, $editable->getBusinessEntityId());
+        $this->assertSame('Tan Emporium', $editable->getName());
+        $this->assertSame('Tan Emporium SAS', $editable->getLegalName());
+        $this->assertSame('EXT-1', $editable->getExternalRef());
+        $this->assertTrue($editable->isDeliveryAuthorized());
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $editable->getStatus());
+        $this->assertSame(5, $editable->getCustomerGroupId());
+        $this->assertSame(2, $editable->getShopId());
+    }
+
+    public function testItAcceptsNullLegalNameAndExternalRef(): void
+    {
+        $editable = new EditableBusinessEntity(1, 'Name', null, null, false, BusinessEntityStatus::PENDING, 3, 1);
+
+        $this->assertNull($editable->getLegalName());
+        $this->assertNull($editable->getExternalRef());
+    }
+}

--- a/tests/Unit/Core/Domain/BusinessEntity/QueryResult/EditableBusinessEntityTest.php
+++ b/tests/Unit/Core/Domain/BusinessEntity/QueryResult/EditableBusinessEntityTest.php
@@ -3,6 +3,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Core\Domain\BusinessEntity\QueryResult;

--- a/tests/Unit/Core/Form/IdentifiableObject/DataHandler/BusinessEntityFormDataHandlerTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataHandler/BusinessEntityFormDataHandlerTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\DataHandler;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Command\EditBusinessEntityCommand;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\BusinessEntityFormDataHandler;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityGeneralInformationType;
+use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityType;
+
+/**
+ * The edit half of AC5: the mapping from submitted form data to the Edit command.
+ */
+class BusinessEntityFormDataHandlerTest extends TestCase
+{
+    public function testItMapsTheSubmittedGeneralInformationOntoTheEditCommand(): void
+    {
+        $command = $this->handleUpdate([
+            BusinessEntityGeneralInformationType::FIELD_NAME => 'Edited Entity',
+            BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Edited Legal',
+            BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => 'EXT-010-B',
+            BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => true,
+            BusinessEntityGeneralInformationType::FIELD_STATUS => BusinessEntityStatus::ACTIVE,
+            BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => '9',
+        ]);
+
+        $this->assertSame(7, $command->getBusinessEntityId()->getValue());
+        $this->assertSame('Edited Entity', $command->getName());
+        $this->assertSame('Edited Legal', $command->getLegalName());
+        $this->assertSame('EXT-010-B', $command->getExternalRef());
+        $this->assertTrue($command->getDeliveryAuthorized());
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $command->getStatus());
+        $this->assertSame(9, $command->getCustomerGroupId());
+    }
+
+    /**
+     * Boundary guard, not a bug fix: on the form path Symfony already normalises the empty optional
+     * field to NULL (pinned by BusinessEntityGeneralInformationTypeTest), so this only covers
+     * non-form callers such as the API or an import handing over an empty string.
+     */
+    public function testItSendsAnEmptiedExternalRefAsNull(): void
+    {
+        $command = $this->handleUpdate([
+            BusinessEntityGeneralInformationType::FIELD_NAME => 'Edited Entity',
+            BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Edited Legal',
+            BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => '',
+            BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => false,
+            BusinessEntityGeneralInformationType::FIELD_STATUS => BusinessEntityStatus::PENDING,
+            BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => 3,
+        ]);
+
+        $this->assertNull($command->getExternalRef());
+    }
+
+    public function testItForwardsAnAlreadyNullExternalRefUntouched(): void
+    {
+        $command = $this->handleUpdate([
+            BusinessEntityGeneralInformationType::FIELD_NAME => 'Edited Entity',
+            BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Edited Legal',
+            BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => null,
+            BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => false,
+            BusinessEntityGeneralInformationType::FIELD_STATUS => BusinessEntityStatus::PENDING,
+            BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => 3,
+        ]);
+
+        $this->assertNull($command->getExternalRef());
+    }
+
+    /**
+     * @param array<string, mixed> $generalInformationData
+     */
+    private function handleUpdate(array $generalInformationData): EditBusinessEntityCommand
+    {
+        $dispatched = null;
+
+        $commandBus = $this->createMock(CommandBusInterface::class);
+        $commandBus->expects($this->once())
+            ->method('handle')
+            ->willReturnCallback(function ($command) use (&$dispatched) {
+                $dispatched = $command;
+
+                return null;
+            });
+
+        $handler = new BusinessEntityFormDataHandler($commandBus, $this->createMock(ShopContext::class));
+        $handler->update(7, [BusinessEntityType::GENERAL_INFORMATION => $generalInformationData]);
+
+        $this->assertInstanceOf(EditBusinessEntityCommand::class, $dispatched);
+
+        return $dispatched;
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/BusinessEntityFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/BusinessEntityFormDataProviderTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\DataProvider;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\Query\GetBusinessEntityForEditing;
+use PrestaShop\PrestaShop\Core\Domain\BusinessEntity\QueryResult\EditableBusinessEntity;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\BusinessEntityFormDataProvider;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityAddressType;
+use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityGeneralInformationType;
+use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityType;
+
+/**
+ * AC3: every editable field must reach the form pre-filled with the stored value.
+ */
+class BusinessEntityFormDataProviderTest extends TestCase
+{
+    private const BUSINESS_ENTITY_ID = 7;
+    private const SHOP_ID = 1;
+    private const SHOP_COUNTRY_ID = 8;
+
+    public function testItPreFillsEveryEditableFieldFromTheStoredEntity(): void
+    {
+        $data = $this->buildProvider($this->buildEditableBusinessEntity())->getData(self::BUSINESS_ENTITY_ID);
+
+        $generalInformation = $data[BusinessEntityType::GENERAL_INFORMATION];
+
+        $this->assertSame('Stored Entity', $generalInformation[BusinessEntityGeneralInformationType::FIELD_NAME]);
+        $this->assertSame('Stored Legal', $generalInformation[BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME]);
+        $this->assertSame('EXT-010', $generalInformation[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF]);
+        $this->assertTrue($generalInformation[BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED]);
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $generalInformation[BusinessEntityGeneralInformationType::FIELD_STATUS]);
+        $this->assertSame(9, $generalInformation[BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID]);
+        $this->assertSame(self::SHOP_ID, $data[BusinessEntityType::SHOP_ID]);
+    }
+
+    public function testItQueriesTheEntityBeingEdited(): void
+    {
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        $queryBus->expects($this->once())
+            ->method('handle')
+            ->with($this->callback(static function (GetBusinessEntityForEditing $query): bool {
+                return self::BUSINESS_ENTITY_ID === $query->getBusinessEntityId()->getValue();
+            }))
+            ->willReturn($this->buildEditableBusinessEntity());
+
+        $this->buildProvider(null, $queryBus)->getData(self::BUSINESS_ENTITY_ID);
+    }
+
+    /**
+     * Nullable columns are exposed to the form as empty strings. Nothing is lost on the way back:
+     * Symfony normalises the empty optional field to NULL when the form is submitted.
+     */
+    public function testItExposesNullableFieldsAsEmptyStrings(): void
+    {
+        $editableBusinessEntity = new EditableBusinessEntity(
+            self::BUSINESS_ENTITY_ID,
+            'Stored Entity',
+            null,
+            null,
+            false,
+            BusinessEntityStatus::PENDING,
+            3,
+            self::SHOP_ID
+        );
+
+        $generalInformation = $this->buildProvider($editableBusinessEntity)
+            ->getData(self::BUSINESS_ENTITY_ID)[BusinessEntityType::GENERAL_INFORMATION];
+
+        $this->assertSame('', $generalInformation[BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME]);
+        $this->assertSame('', $generalInformation[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF]);
+    }
+
+    public function testDefaultDataStartsAPendingEntityWithTheShopCountry(): void
+    {
+        $data = $this->buildProvider($this->buildEditableBusinessEntity())->getDefaultData();
+
+        $generalInformation = $data[BusinessEntityType::GENERAL_INFORMATION];
+
+        $this->assertSame('', $generalInformation[BusinessEntityGeneralInformationType::FIELD_NAME]);
+        $this->assertFalse($generalInformation[BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED]);
+        $this->assertSame(BusinessEntityStatus::PENDING, $generalInformation[BusinessEntityGeneralInformationType::FIELD_STATUS]);
+
+        // The shop country the test name promises: it seeds the first billing address so the State
+        // choices can be built. Dropping it used to leave this test green.
+        $this->assertSame(
+            self::SHOP_COUNTRY_ID,
+            $data[BusinessEntityType::BILLING_ADDRESS_TYPE][BusinessEntityFormDataProvider::DEFAULT_BILLING_ADDRESS_INDEX][BusinessEntityAddressType::FIELD_COUNTRY_ID]
+        );
+    }
+
+    private function buildEditableBusinessEntity(): EditableBusinessEntity
+    {
+        return new EditableBusinessEntity(
+            self::BUSINESS_ENTITY_ID,
+            'Stored Entity',
+            'Stored Legal',
+            'EXT-010',
+            true,
+            BusinessEntityStatus::ACTIVE,
+            9,
+            self::SHOP_ID
+        );
+    }
+
+    private function buildProvider(?EditableBusinessEntity $editableBusinessEntity, ?CommandBusInterface $queryBus = null): BusinessEntityFormDataProvider
+    {
+        if (null === $queryBus) {
+            $queryBus = $this->createMock(CommandBusInterface::class);
+            $queryBus->method('handle')->willReturn($editableBusinessEntity);
+        }
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('getInt')->with('PS_COUNTRY_DEFAULT')->willReturn(self::SHOP_COUNTRY_ID);
+
+        return new BusinessEntityFormDataProvider($configuration, $this->createMock(ShopContext::class), $queryBus);
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationTypeTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Sell\BusinessEntity;
+
+use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider;
+use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
+use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityGeneralInformationType;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Throwable;
+
+/**
+ * AC4 asks the edit page to enforce "the same validation as creation". That is guaranteed by
+ * construction — both actions autowire the same form builder, hence this single type — so what is
+ * worth pinning here is the contract that guarantee rests on: which fields are mandatory, which one
+ * is optional, and that the mandatory ones actually carry their constraints.
+ */
+class BusinessEntityGeneralInformationTypeTest extends TypeTestCase
+{
+    protected function getExtensions(): array
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        // GroupByIdChoiceProvider is final, so it cannot be doubled: build the real one on top of a
+        // mocked data provider instead.
+        $groupDataProvider = $this->createMock(GroupDataProvider::class);
+        $groupDataProvider->method('getGroups')->willReturn([
+            ['id_group' => 3, 'name' => 'Customer'],
+            ['id_group' => 1, 'name' => 'Visitor'],
+        ]);
+        $groupByIdChoiceProvider = new GroupByIdChoiceProvider($groupDataProvider, 1);
+
+        return [
+            new PreloadedExtension([
+                new BusinessEntityGeneralInformationType($translator, [], $groupByIdChoiceProvider),
+                new SwitchType(),
+            ], []),
+            // Registers the "constraints" option; the custom PrestaShop validators behind
+            // TypedRegex/CleanHtml are not exercised here, only the wiring is asserted.
+            new ValidatorExtension($this->buildValidator()),
+        ];
+    }
+
+    /**
+     * TypedRegex and CleanHtml resolve to PrestaShop validators with their own dependencies, which a
+     * standalone validator cannot build. They are stubbed out: this test asserts the wiring of the
+     * constraints and the mapping of a submission, not the behaviour of those two validators.
+     */
+    private function buildValidator(): ValidatorInterface
+    {
+        return Validation::createValidatorBuilder()
+            ->setConstraintValidatorFactory(new class() extends ConstraintValidatorFactory {
+                public function getInstance(Constraint $constraint): ConstraintValidatorInterface
+                {
+                    try {
+                        return parent::getInstance($constraint);
+                    } catch (Throwable) {
+                        return new class() extends ConstraintValidator {
+                            public function validate($value, Constraint $constraint): void
+                            {
+                            }
+                        };
+                    }
+                }
+            })
+            ->getValidator();
+    }
+
+    public function testNameAndLegalNameAreMandatoryAndConstrained(): void
+    {
+        $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
+
+        foreach ([BusinessEntityGeneralInformationType::FIELD_NAME, BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME] as $field) {
+            $config = $form->get($field)->getConfig();
+
+            $this->assertTrue($config->getOption('required'), sprintf('"%s" must be mandatory.', $field));
+
+            $constraints = $config->getOption('constraints');
+            $this->assertNotEmpty($constraints, sprintf('"%s" must carry validation constraints.', $field));
+
+            // All four, not just the two obvious ones: dropping TypedRegex or CleanHtml would
+            // otherwise leave this test green while the field lost its sanitisation.
+            $this->assertSame(
+                [NotBlank::class, Length::class, TypedRegex::class, CleanHtml::class],
+                array_map('get_class', $constraints),
+                sprintf('"%s" must keep its four constraints, in the order the create path uses.', $field)
+            );
+        }
+    }
+
+    /**
+     * AC4 asks for the mandatory fields to be enforced. "required => true" is only an HTML
+     * attribute, and the edit page renders the form with novalidate — so without a constraint a
+     * crafted POST omitting these keys was accepted, and reached the command as null: a TypeError
+     * (hence a 500) for the status, and a silently persisted id_customer_group = 0 for the group.
+     */
+    public function testStatusAndCustomerGroupAreRejectedWhenMissing(): void
+    {
+        $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
+        $form->submit([
+            BusinessEntityGeneralInformationType::FIELD_NAME => 'Probe',
+            BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Probe Legal',
+            BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => 'REF',
+            BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => '1',
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertFalse($form->isValid(), 'A submission without status nor customer group must be rejected.');
+
+        $fieldsInError = [];
+        foreach ($form->getErrors(true) as $error) {
+            $fieldsInError[] = $error->getOrigin()->getName();
+        }
+
+        $this->assertContains(BusinessEntityGeneralInformationType::FIELD_STATUS, $fieldsInError);
+        $this->assertContains(BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID, $fieldsInError);
+    }
+
+    public function testExternalRefIsOptionalSoItCanBeCleared(): void
+    {
+        $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
+        $config = $form->get(BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF)->getConfig();
+
+        $this->assertFalse($config->getOption('required'));
+        $this->assertEmpty($config->getOption('constraints'));
+    }
+
+    /**
+     * The exact round trip a NULL external_ref takes: the data provider exposes it as '', the field
+     * renders pre-filled with '', and the merchant saves without touching it.
+     */
+    public function testAnUntouchedEmptyExternalRefComesBackAsNullNotAsAnEmptyString(): void
+    {
+        $form = $this->factory->create(BusinessEntityGeneralInformationType::class, [
+            BusinessEntityGeneralInformationType::FIELD_NAME => 'Stored Entity',
+            BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Stored Legal',
+            // What BusinessEntityFormDataProvider::getData() produces for a NULL column.
+            BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => '',
+            BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => false,
+            BusinessEntityGeneralInformationType::FIELD_STATUS => BusinessEntityStatus::PENDING,
+            BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => 3,
+        ]);
+
+        $form->submit([
+            BusinessEntityGeneralInformationType::FIELD_NAME => 'Stored Entity',
+            BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Stored Legal',
+            BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => '',
+            BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => '0',
+            BusinessEntityGeneralInformationType::FIELD_STATUS => BusinessEntityStatus::PENDING->value,
+            BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => 3,
+        ]);
+
+        $this->assertNull(
+            $form->getData()[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF],
+            'Symfony normalises an empty optional text field to NULL, so the column keeps its NULL.'
+        );
+    }
+
+    public function testItMapsASubmissionOntoTheSixEditableFields(): void
+    {
+        $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
+
+        $form->submit([
+            BusinessEntityGeneralInformationType::FIELD_NAME => 'Edited Entity',
+            BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Edited Legal',
+            BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => '',
+            BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => '1',
+            BusinessEntityGeneralInformationType::FIELD_STATUS => BusinessEntityStatus::ACTIVE->value,
+            BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => 3,
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+
+        $data = $form->getData();
+        $this->assertSame('Edited Entity', $data[BusinessEntityGeneralInformationType::FIELD_NAME]);
+        $this->assertSame('Edited Legal', $data[BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME]);
+        // A cleared optional text field comes back as null, which the data handler forwards as NULL.
+        $this->assertNull($data[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF]);
+        $this->assertTrue($data[BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED]);
+        $this->assertSame(BusinessEntityStatus::ACTIVE, $data[BusinessEntityGeneralInformationType::FIELD_STATUS]);
+        $this->assertSame(3, $data[BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID]);
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationTypeTest.php
@@ -14,8 +14,13 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider;
 use PrestaShopBundle\Entity\Enum\BusinessEntityStatus;
 use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityGeneralInformationType;
+use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntityIdentityType;
+use PrestaShopBundle\Form\Admin\Sell\BusinessEntity\BusinessEntitySettingsType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Extension\ColumnsNumberExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Constraint;
@@ -53,9 +58,15 @@ class BusinessEntityGeneralInformationTypeTest extends TypeTestCase
 
         return [
             new PreloadedExtension([
-                new BusinessEntityGeneralInformationType($translator, [], $groupByIdChoiceProvider),
+                new BusinessEntityGeneralInformationType($translator, []),
+                new BusinessEntityIdentityType($translator, []),
+                new BusinessEntitySettingsType($translator, [], $groupByIdChoiceProvider),
                 new SwitchType(),
-            ], []),
+            ], [
+                // The two sections declare columns_number and two fields declare column_breaker;
+                // both options come from this extension, which a standalone TypeTestCase does not load.
+                FormType::class => [new ColumnsNumberExtension()],
+            ]),
             // Registers the "constraints" option; the custom PrestaShop validators behind
             // TypedRegex/CleanHtml are not exercised here, only the wiring is asserted.
             new ValidatorExtension($this->buildValidator()),
@@ -92,7 +103,7 @@ class BusinessEntityGeneralInformationTypeTest extends TypeTestCase
         $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
 
         foreach ([BusinessEntityGeneralInformationType::FIELD_NAME, BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME] as $field) {
-            $config = $form->get($field)->getConfig();
+            $config = $this->field($form, $field)->getConfig();
 
             $this->assertTrue($config->getOption('required'), sprintf('"%s" must be mandatory.', $field));
 
@@ -118,12 +129,12 @@ class BusinessEntityGeneralInformationTypeTest extends TypeTestCase
     public function testStatusAndCustomerGroupAreRejectedWhenMissing(): void
     {
         $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
-        $form->submit([
+        $form->submit($this->submission([
             BusinessEntityGeneralInformationType::FIELD_NAME => 'Probe',
             BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Probe Legal',
             BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => 'REF',
             BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => '1',
-        ]);
+        ]));
 
         $this->assertTrue($form->isSynchronized());
         $this->assertFalse($form->isValid(), 'A submission without status nor customer group must be rejected.');
@@ -140,7 +151,7 @@ class BusinessEntityGeneralInformationTypeTest extends TypeTestCase
     public function testExternalRefIsOptionalSoItCanBeCleared(): void
     {
         $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
-        $config = $form->get(BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF)->getConfig();
+        $config = $this->field($form, BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF)->getConfig();
 
         $this->assertFalse($config->getOption('required'));
         $this->assertEmpty($config->getOption('constraints'));
@@ -162,14 +173,14 @@ class BusinessEntityGeneralInformationTypeTest extends TypeTestCase
             BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => 3,
         ]);
 
-        $form->submit([
+        $form->submit($this->submission([
             BusinessEntityGeneralInformationType::FIELD_NAME => 'Stored Entity',
             BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Stored Legal',
             BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => '',
             BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => '0',
             BusinessEntityGeneralInformationType::FIELD_STATUS => BusinessEntityStatus::PENDING->value,
             BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => 3,
-        ]);
+        ]));
 
         $this->assertNull(
             $form->getData()[BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF],
@@ -181,14 +192,14 @@ class BusinessEntityGeneralInformationTypeTest extends TypeTestCase
     {
         $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
 
-        $form->submit([
+        $form->submit($this->submission([
             BusinessEntityGeneralInformationType::FIELD_NAME => 'Edited Entity',
             BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Edited Legal',
             BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => '',
             BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => '1',
             BusinessEntityGeneralInformationType::FIELD_STATUS => BusinessEntityStatus::ACTIVE->value,
             BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => 3,
-        ]);
+        ]));
 
         $this->assertTrue($form->isSynchronized());
 
@@ -200,5 +211,43 @@ class BusinessEntityGeneralInformationTypeTest extends TypeTestCase
         $this->assertTrue($data[BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED]);
         $this->assertSame(BusinessEntityStatus::ACTIVE, $data[BusinessEntityGeneralInformationType::FIELD_STATUS]);
         $this->assertSame(3, $data[BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID]);
+    }
+
+    /**
+     * The two sections exist to lay the fields out and carry inherit_data, so the submitted payload
+     * is nested while the resulting data stays flat — which is what the assertions above rely on.
+     */
+    private function sectionOf(string $field): string
+    {
+        return in_array($field, [
+            BusinessEntityGeneralInformationType::FIELD_NAME,
+            BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME,
+        ], true)
+            ? BusinessEntityGeneralInformationType::SECTION_IDENTITY
+            : BusinessEntityGeneralInformationType::SECTION_SETTINGS;
+    }
+
+    private function field(FormInterface $form, string $field): FormInterface
+    {
+        return $form->get($this->sectionOf($field))->get($field);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function submission(array $values): array
+    {
+        $submission = [
+            BusinessEntityGeneralInformationType::SECTION_IDENTITY => [],
+            BusinessEntityGeneralInformationType::SECTION_SETTINGS => [],
+        ];
+
+        foreach ($values as $field => $value) {
+            $submission[$this->sectionOf($field)][$field] = $value;
+        }
+
+        return $submission;
     }
 }

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Sell/BusinessEntity/BusinessEntityGeneralInformationTypeTest.php
@@ -148,13 +148,62 @@ class BusinessEntityGeneralInformationTypeTest extends TypeTestCase
         $this->assertContains(BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID, $fieldsInError);
     }
 
-    public function testExternalRefIsOptionalSoItCanBeCleared(): void
+    public function testExternalRefIsOptionalButBoundedToItsColumn(): void
     {
         $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
         $config = $this->field($form, BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF)->getConfig();
 
         $this->assertFalse($config->getOption('required'));
-        $this->assertEmpty($config->getOption('constraints'));
+        $this->assertSame(
+            [Length::class],
+            array_map('get_class', $config->getOption('constraints'))
+        );
+    }
+
+    public function testAnExternalRefLongerThanItsColumnIsRejected(): void
+    {
+        $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
+        $form->submit($this->submission([
+            BusinessEntityGeneralInformationType::FIELD_NAME => 'Probe',
+            BusinessEntityGeneralInformationType::FIELD_LEGAL_NAME => 'Probe Legal',
+            BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF => str_repeat('X', BusinessEntitySettingsType::MAX_EXTERNAL_REF_LENGTH + 1),
+            BusinessEntityGeneralInformationType::FIELD_DELIVERY_AUTHORIZED => '1',
+            BusinessEntityGeneralInformationType::FIELD_STATUS => BusinessEntityStatus::ACTIVE->value,
+            BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID => 3,
+        ]));
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertCount(
+            1,
+            $this->field($form, BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF)->getErrors(),
+            'The error must be attached to the field, so the merchant sees it where they typed.'
+        );
+    }
+
+    public function testTheSectionsCarryTheirLayoutOptions(): void
+    {
+        $form = $this->factory->create(BusinessEntityGeneralInformationType::class);
+
+        foreach ([
+            BusinessEntityGeneralInformationType::SECTION_IDENTITY,
+            BusinessEntityGeneralInformationType::SECTION_SETTINGS,
+        ] as $section) {
+            $this->assertSame(
+                2,
+                $form->get($section)->getConfig()->getOption('columns_number'),
+                sprintf('Section "%s" must lay its fields out in two columns.', $section)
+            );
+        }
+
+        foreach ([
+            BusinessEntityGeneralInformationType::FIELD_EXTERNAL_REF,
+            BusinessEntityGeneralInformationType::FIELD_CUSTOMER_GROUP_ID,
+        ] as $field) {
+            $this->assertTrue(
+                $this->field($form, $field)->getConfig()->getOption('column_breaker'),
+                sprintf('"%s" must break the column run.', $field)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds the **edit** page for Business Entities in the Back Office, behind the existing B2B feature flag. An "Edit" entry point is added to the listing row actions and to the detail page toolbar. The form edits the general information — name, legal name, external reference, status, customer group and delivery authorization — while business identifiers and addresses stay read-only on this page (they belong to later user stories). The write side is a **partial update** command: `EditBusinessEntityCommand` takes the id in its constructor and exposes nullable fields with fluent setters, so a caller may submit one field without resending the other five. All reads and writes are shop-scoped through `ShopContext`, including the write path. No ObjectModel, no raw SQL.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" below.
| UI Tests          | https://github.com/soledis-contributeur/ga.tests.ui.pr/actions/runs/33605768185, https://github.com/soledis-contributeur/ga.tests.ui.pr/actions/runs/33605878125
| Fixed issue or discussion? | Fixes #40628
| Related PRs       | Follows #42285 (US2.1.2 — view & list business entities), merged into `develop`. Itself following #41190 (US2.1.1 — create a business entity).
| Sponsor company   | Soledis

## How to test

**Prerequisites** — enable the B2B feature flag **and** B2B mode, then rebuild the admin theme
(`npm run build` in `admin-dev/themes/new-theme`). Create at least one business entity with a
billing address.

**Entry points**

1. On `Sell > Business Entities > Business entities`, the row actions now offer **Edit** next to
   **View details**. With two actions, the grid switches to the three-dot menu.
2. On the detail page, the toolbar offers **Edit business entity**.

**Editing**

3. Open the edit page. The six in-scope fields are pre-filled with the stored values: name, legal
   name, external reference, status, customer group, delivery authorization.
4. The page title is the **entity name alone**, and the form spans the full width — see the
   deliberate choices below.
5. Change the name and save. You are redirected to the **detail page** of that entity, a success
   message is shown, and every edited field survives the round-trip.
6. Click **Cancel**: you return to the detail page without saving.
7. Edit **one field only** and save: the five others must be untouched in the database. This is the
   point of the partial update command.
8. Clear the **external reference** and save: the field must come back empty, not keep its previous
   value. It is the only nullable field that can legitimately be erased.
9. Submit with the **name** emptied: the form comes back with a validation error, nothing is written.
10. Request `/business-entities/999999/edit` (a non-existent id): you are redirected to the listing
    with an error message, not a 500.
11. In a multistore installation, request the edit URL of an entity attached to **another** shop:
    it is reported as not found. The write path is shop-scoped like the read paths — a tab-level
    permission is not shop-aware.
12. Check `Advanced Parameters > Logs`: the edit is recorded with the employee, the timestamp and
    the list of modified fields. Edit a field containing accented characters and confirm the log
    is readable (no `\uXXXX` escaping).

**Automated tests**

- `php vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter BusinessEntity` — 118 tests, 339 assertions.
- `php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/PrestaShopBundle/Controller/Sell/BusinessEntity/BusinessEntityControllerTest.php`
  — 12 tests, 77 assertions, covering the listing, the filter form, the whole HTTP edit path and the two error branches.
- `php vendor/bin/behat -c tests/Integration/Behaviour/behat.yml --suite=business_entity`
  — 16 scenarios, 99 steps.

## Deferred — not in this PR

These are consciously postponed, not oversights:

- **Business identifiers are read-only** on the edit page — their management is US2.1.6 / US2.1.7.
- **Addresses are read-only** on the edit page, with an explicit banner saying so — editing and
  linking addresses is US2.1.8.
- **Delete** and bulk delete — US2.1.4.
- The six deviations already arbitrated on #42285 remain in force and are not restated here.
- **A driver-level failure on a *read* is left to surface.** `findById()` sits outside the guard
  that wraps the write: an infrastructure outage should not become a flash message and a redirect
  to a listing that cannot query the database either.
- **Column bounds live on the form types, not in a `BusinessEntitySettings` of the domain.**
  Nineteen core classes do the latter; following them here would mean reaching into code merged by
  earlier stories of this epic, which is out of scope for a review fix.

## Deliberate choices worth flagging to reviewers

- **`EditBusinessEntityCommand` exposes a `hasExternalRef()` marker.** The core partial-update
  pattern (`EditQuickAccessCommand` and 7 siblings) uses `null` to mean "field not submitted", and
  its setters take non-nullable types. That vocabulary cannot express "clear this field", and
  `external_ref` is legitimately erasable. The marker is the smallest addition that keeps the rest
  of the pattern intact; it is documented in the class docblock and covered end to end by a Behat
  scenario and an HTTP test. We could not find a core precedent for a nullable **erasable** field —
  if one exists, we will follow it.
- **Two `NotBlank` constraints were added to the shared general information form.**
  `status` and `customer_group_id` carried no constraint at all: `required => true` is only an HTML
  attribute, and the back office renders forms with `novalidate`. A POST omitting those keys was
  accepted with `NULL` values, which produced a `TypeError` (a 500, since the controller catches
  `Exception` and `TypeError` extends `Error`), or silently persisted `id_customer_group = 0`.
  The fix lives in BusinessEntitySettingsType, shared by both pages, so that AC4 — "the same validation as creation" —  stays true by construction, and the creation path is closed by the same change.
- **The edit page title is the entity name alone**, not "Editing business entity %name%", and the
  **summary card is not rendered on the edit page**, so the form spans the full width. Both follow
  the approved mock-up. The `{% block pageTitle %}` override was removed: the layout renders the
  title, as it does in 14 of the 15 `edit.html.twig` of the core.
- **`updated_at` is not refreshed when a submission changes nothing.** Doctrine only fires
  `@PreUpdate` when there is a changeset, and refreshing a timestamp on a write that changed nothing
  would falsify the audit trail.
- **`BusinessEntityControllerTest` extends `GridControllerTestCase`, not `FormGridControllerTestCase`.**
  The latter imposes the hooks of the creation path, whose submit button has no `id="save-button"`.
- **`save()` is `persist()` + `flush()`**, and the flush covers the whole UnitOfWork. That is a
  limitation of the shared repository, not something this PR can close without changing its
  semantics for every other caller.
- **The handler catches `Throwable` around `save()`, not a Doctrine class.**
  `Doctrine\DBAL\Exception` does not extend `ORMException`, so a driver-level failure escaped
  uncaught, with no domain exception for the controller to map to a message. Catching everything
  the save can raise costs the ability to tell how far the write got, which the controller then
  reads conservatively: it leaves the page rather than re-display over a unit of work
  `UnitOfWork::commit()` may have closed.
- **`Blocks/_general_information.html.twig` is shared by the create and the edit page.** The two
  pages differ in everything else — address collections and prototypes on one side, read-only
  address cards and linked customers on the other — but the general information card was identical
  apart from the identifiers strip, which the partial takes as a parameter.
- **`MAX_NAME_LENGTH` moved from `BusinessEntityGeneralInformationType` to
  `BusinessEntityIdentityType`** when the sections were split. It is a public constant of code
  already merged into `develop`, with no consumer anywhere in the repository, and 9.3.0 is
  unreleased — but it is a public surface relocated without deprecation, so it is stated here
  rather than left to be found.

## Test coverage: what is actually pinned

Every guard added here was verified by removing it and watching a test fail — one negative
control per guard, rather than relying on the suite as a whole. The ones worth naming:

| Guard removed | What failed |
|---|---|
| `addFlash('success')` | the AC5 test |
| `id="save-button"` | "Could not find form in the page" |
| `hasExternalRef()` marker | the external-reference clearing scenario |
| the `null !==` guards in the handler | the partial-update scenario |
| the `Throwable` wrapper around `save()`, narrowed back to `ORMException` | the DBAL case of the persistence-failure provider |
| `Length(max: 255)` on `external_ref` | the over-long external reference test |
| `JSON_UNESCAPED_UNICODE` | the accented-log test |
| `JSON_INVALID_UTF8_SUBSTITUTE`, swapped for `IGNORE` and then dropped | the audit-degradation test, on both mutations |
| `is defined` on the shared partial, back to the `default` filter | the edit page, which then showed the creation samples |
| the same ternary falling back to `[]` instead of `null` | the creation page, which then showed none |
| the early return on `CannotUpdateBusinessEntityException` | the failed-write test, which then re-displayed instead of leaving |
| the redirect target and the flash literal | the unknown-entity test, on two separate mutations |

One guard is deliberately **not** pinned, and is named here rather than left to be found: moving
`formatLogMessage()` after `save()`. A mutation putting it back before the save survives the suite,
because once the JSON flags changed the ordering has no observable effect. It is defence in depth,
not a behaviour the suite pins.