### PR TITLE
Fix Aliases help sidebar

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchAliasController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchAliasController.php
@@ -44,6 +44,7 @@ class SearchAliasController extends PrestaShopAdminController
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/Search/index.html.twig', [
             'aliasGrid' => $this->presentGrid($aliasGrid),
+            'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink('AdminSearchConf'),
             'layoutHeaderToolbarBtn' => [
                 'add' => [

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/07_search/01_search/03_helpCard.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/07_search/01_search/03_helpCard.ts
@@ -1,0 +1,70 @@
+import testContext from '@utils/testContext';
+import {expect} from 'chai';
+
+import {
+  boDashboardPage,
+  boLoginPage,
+  boSearchPage,
+  boSearchAliasPage,
+  type BrowserContext,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_shopParameters_search_search_helpCard';
+
+describe('BO - Shop Parameters - Search : Help card on Aliases page', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should go to the Aliases page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToAliasesPage', baseContext);
+
+    const searchPageURL = await boDashboardPage.getAttributeContent(
+      page,
+      `${boDashboardPage.searchLink} a`,
+      'href',
+    );
+    await boSearchPage.goTo(page, searchPageURL);
+    await boSearchPage.goToAliasesPage(page);
+
+    const pageTitle = await boSearchAliasPage.getPageTitle(page);
+    expect(pageTitle).to.equals(boSearchAliasPage.pageTitle);
+  });
+
+  it('should open the help side bar and check the document language', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'openHelpSidebar', baseContext);
+
+    const isHelpSidebarVisible = await boSearchAliasPage.openHelpSideBar(page);
+    expect(isHelpSidebarVisible).to.eq(true);
+
+    const documentURL = await boSearchAliasPage.getHelpDocumentURL(page);
+    expect(documentURL).to.contains('country=en');
+  });
+
+  it('should close the help side bar', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeHelpSidebar', baseContext);
+
+    const isHelpSidebarClosed = await boSearchAliasPage.closeHelpSideBar(page);
+    expect(isHelpSidebarClosed).to.eq(true);
+  });
+});


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The Aliases listing passed a documentation link to the toolbar without enabling sidebar mode, so Help was rendered as a regular link instead of the closable back-office help panel. This enables the sidebar on the listing and adds a functional UI regression covering open, document language, and close behavior.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In the back office, open **Shop Parameters > Search > Aliases**, click **Help**, verify the documentation panel opens on the right, then close it.
| UI Tests          | Local MySQL Docker campaign: `03_helpCard.ts` passes 4/4. The same campaign fails at the open/close assertions without the controller flag. MariaDB campaign was not run locally.
| Fixed issue or discussion?     | Fixes #40932
| Related PRs       | None
| Sponsor company   | None

## Validation

- focused Playwright UI campaign on a fresh Docker-installed 9.2.x shop: 4 passing
- full `tests/UI` ESLint: passing
- targeted PHPStan: no errors
- PHP syntax and php-cs-fixer dry run: passing
- `git diff --check`

## AI assistance

OpenAI Codex assisted with source navigation, implementation, and validation. The final two-file diff and the reported checks were verified before publication.
