### PR TITLE
Fix module controller resolution on case-sensitive filesystems (Linux/FreeBSD)

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -388,14 +388,19 @@ class DispatcherCore
 
                 // Only proceed if module exists and is active
                 if (Validate::isLoadedObject($module) && $module->active) {
+                    // Load module controllers
                     $controllers = Dispatcher::getControllers(_PS_MODULE_DIR_ . $module_name . '/controllers/front/');
                     $controller_name = $controllers[strtolower($this->controller)] ?? null;
 
                     if ($controller_name !== null) {
+                        // Include base controller file, using the filename as it is on disk
                         $controller_file = $module_name . '/controllers/front/' . $controller_name . '.php';
                         include_once _PS_MODULE_DIR_ . $controller_file;
+
+                        // Default module controller class naming convention
                         $controller_class = $module_name . $controller_name . 'ModuleFrontController';
 
+                        // If an override exists, load it and use the override naming convention instead
                         if (file_exists(_PS_OVERRIDE_DIR_ . 'modules/' . $controller_file)) {
                             include_once _PS_OVERRIDE_DIR_ . 'modules/' . $controller_file;
                             $controller_class = $module_name . $controller_name . 'ModuleFrontControllerOverride';

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -400,8 +400,6 @@ class DispatcherCore
                             include_once _PS_OVERRIDE_DIR_ . 'modules/' . $controller_file;
                             $controller_class = $module_name . $controller_name . 'ModuleFrontControllerOverride';
                         }
-
-                        return $controller_class;
                     }
                 }
 

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -389,16 +389,22 @@ class DispatcherCore
                 // Only proceed if module exists and is active
                 if (Validate::isLoadedObject($module) && $module->active) {
                     $controllers = Dispatcher::getControllers(_PS_MODULE_DIR_ . $module_name . '/controllers/front/');
-                    if ($controller_name = $controllers[strtolower($this->controller)] ?? null) {
+                    $controller_name = $controllers[strtolower($this->controller)] ?? null;
+
+                    if ($controller_name !== null) {
                         $controller_file = $module_name . '/controllers/front/' . $controller_name . '.php';
-                        include_once(_PS_MODULE_DIR_ . $controller_file);
+                        include_once _PS_MODULE_DIR_ . $controller_file;
                         $controller_class = $module_name . $controller_name . 'ModuleFrontController';
+
                         if (file_exists(_PS_OVERRIDE_DIR_ . 'modules/' . $controller_file)) {
-                            include_once(_PS_OVERRIDE_DIR_ . 'modules/' . $controller_file);
+                            include_once _PS_OVERRIDE_DIR_ . 'modules/' . $controller_file;
                             $controller_class = $module_name . $controller_name . 'ModuleFrontControllerOverride';
                         }
+
+                        return $controller_class;
                     }
                 }
+
                 $params_hook_action_dispatcher = [
                     'controller_type' => self::FC_FRONT,
                     'controller_class' => $controller_class,

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -388,21 +388,14 @@ class DispatcherCore
 
                 // Only proceed if module exists and is active
                 if (Validate::isLoadedObject($module) && $module->active) {
-                    // Load module controllers
-                    $controllers = Dispatcher::getControllers(_PS_MODULE_DIR_ . "$module_name/controllers/front/");
-                    if (isset($controllers[strtolower($this->controller)])) {
-                        // Include base controller file
-                        include_once _PS_MODULE_DIR_ . "$module_name/controllers/front/{$this->controller}.php";
-
-                        // If override exists, load it and use override class and it's naming convention
-                        if (file_exists(
-                            _PS_OVERRIDE_DIR_ . "modules/$module_name/controllers/front/{$this->controller}.php"
-                        )) {
-                            include_once _PS_OVERRIDE_DIR_ . "modules/$module_name/controllers/front/{$this->controller}.php";
-                            $controller_class = $module_name . $this->controller . 'ModuleFrontControllerOverride';
-                        } else {
-                            // Otherwise use default module controller class naming convention
-                            $controller_class = $module_name . $this->controller . 'ModuleFrontController';
+                    $controllers = Dispatcher::getControllers(_PS_MODULE_DIR_ . $module_name . '/controllers/front/');
+                    if ($controller_name = $controllers[strtolower($this->controller)] ?? null) {
+                        $controller_file = $module_name . '/controllers/front/' . $controller_name . '.php';
+                        include_once(_PS_MODULE_DIR_ . $controller_file);
+                        $controller_class = $module_name . $controller_name . 'ModuleFrontController';
+                        if (file_exists(_PS_OVERRIDE_DIR_ . 'modules/' . $controller_file)) {
+                            include_once(_PS_OVERRIDE_DIR_ . 'modules/' . $controller_file);
+                            $controller_class = $module_name . $controller_name . 'ModuleFrontControllerOverride';
                         }
                     }
                 }


### PR DESCRIPTION
### Fix module controller resolution on case-sensitive filesystems (Linux/FreeBSD)

#### Problem
On case-sensitive filesystems (FreeBSD UFS/ZFS, Linux ext4), module front controllers fail to load with `Warning: include_once(...): Failed to open stream` and `Fatal error: Class not found` if the case in the URL/route (`$this->controller`) differs from the actual filename on disk (e.g., `Catalog.php` vs `catalog.php`).

In the current implementation, `Dispatcher::getControllers()` checks for the controller's existence using `strtolower()`, but the subsequent `include_once` call uses `$this->controller` directly. This bypasses the actual filename mapping and breaks file inclusion on systems where casing matters.

#### Solution
Retrieve the actual mapped filename (`$controller_name`) returned by `Dispatcher::getControllers()` and use it for both `include_once` and class name construction (`$controller_class`). This guarantees that the correct, case-accurate filename from the filesystem is loaded regardless of the input route casing, ensuring cross-platform compatibility across Windows, macOS, and POSIX-compliant case-sensitive OSes.

<!--
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
-->

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Resolves case-sensitivity resolution for module front controllers on POSIX OSes. (Note: This issue has been present since PrestaShop 1.7.x and persists in 8.x versions)
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue?      | N/A
| How to test?      | See testing steps below

---

### Bug description
`DispatcherCore` fails to include module front controllers on case-sensitive filesystems (FreeBSD / Linux) when there is a casing mismatch between the route parameter (`$this->controller`) and the actual file name on disk.

### Root cause
The current lookup checks `isset($controllers[strtolower($this->controller)])`, but then erroneously attempts to include `_PS_MODULE_DIR_ . "$module_name/controllers/front/{$this->controller}.php"`.

On Windows or macOS (case-insensitive FS), `include_once` silently succeeds regardless of character casing. On Linux/FreeBSD (case-sensitive FS), `include_once` fails with a PHP Warning, leading to a fatal `Class not found` error.

### How to test
1. Deploy PrestaShop on a case-sensitive environment (Linux ext4 or FreeBSD UFS/ZFS).
2. Install a module with a lowercased front controller filename (e.g., `modules/example/controllers/front/catalog.php`).
3. Access the controller via a route/URL with capitalized casing (e.g., `index.php?fc=module&module=example&controller=Catalog`).
4. **Without this fix:** PHP Warning `include_once(.../Catalog.php): Failed to open stream` followed by `Fatal error: Uncaught Error: Class not found`.
5. **With this fix:** The controller resolves correctly via the mapped filename (`catalog.php`) and loads as expected.

---

**P.S. Special greetings to the Core Team ~~lamers~~ developing exclusively on NTFS and macOS case-insensitive filesystems!** 
Greetings from the POSIX / FreeBSD world, where `Catalog.php` and `catalog.php` are actually two completely different files. Please remember to test route resolutions on case-sensitive filesystems before releasing! 🐧🌴