### PR TITLE
Harden extra property constraint unserialization with a fixed allowlist

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1232,6 +1232,8 @@ abstract class ModuleCore implements ModuleInterface
      *
      * The definition must have entityName and propertyName set.
      * The module name is automatically filled in from $this->name when $definition->getModuleName() is null.
+     * Validation constraints are limited to the classes exposed by ExtraPropertyConstraintMapper;
+     * custom module constraints, callback/normalizer and property-path options are not supported.
      *
      * About BO label translations: store wording/domain pairs in the definition, and also call
      * $this->trans() in the module code so strings are discoverable by the BO translation UI.
@@ -1245,7 +1247,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @return bool always true — failures throw
      *
-     * @throws PrestaShop\PrestaShop\Core\ExtraProperty\Exception\ExtraPropertyException on any failure: scope conflict, destructive schema change, invalid form options, missing base table, DDL or persistence failure (see the reason-code constants on ExtraPropertyRegistryException)
+     * @throws PrestaShop\PrestaShop\Core\ExtraProperty\Exception\ExtraPropertyException on any failure: scope conflict, destructive schema change, invalid constraints or form options, missing base table, DDL or persistence failure (see the reason-code constants on ExtraPropertyRegistryException)
      */
     public function registerExtraProperty(ExtraPropertyDefinition $definition): bool
     {

--- a/src/Core/Domain/ExtraProperty/Exception/ExtraPropertyRegistrationFailureException.php
+++ b/src/Core/Domain/ExtraProperty/Exception/ExtraPropertyRegistrationFailureException.php
@@ -61,6 +61,11 @@ class ExtraPropertyRegistrationFailureException extends ExtraPropertyException
     public const UNKNOWN_SHOP = 7;
 
     /**
+     * The declared constraint graph contains an unsupported class or executable option.
+     */
+    public const INVALID_CONSTRAINTS = 8;
+
+    /**
      * Builds the domain exception from the core exception thrown by the registry,
      * mapping the core reason code to the matching domain code and keeping the
      * core exception as the previous one.
@@ -75,6 +80,7 @@ class ExtraPropertyRegistrationFailureException extends ExtraPropertyException
             ExtraPropertyRegistryException::SCHEMA_FAILURE => self::SCHEMA_FAILURE,
             ExtraPropertyRegistryException::INVALID_FORM_OPTIONS => self::INVALID_FORM_OPTIONS,
             ExtraPropertyRegistryException::UNKNOWN_SHOP => self::UNKNOWN_SHOP,
+            ExtraPropertyRegistryException::INVALID_CONSTRAINTS => self::INVALID_CONSTRAINTS,
             default => self::UNKNOWN,
         };
 

--- a/src/Core/ExtraProperty/Definition/ExtraPropertyDefinition.php
+++ b/src/Core/ExtraProperty/Definition/ExtraPropertyDefinition.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\ExtraProperty\Definition;
 
 use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\InvalidExtraPropertyDefinitionException;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyConstraintSerializer;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyValidator;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Value\ExtraPropertyValueCaster;
 use PrestaShop\PrestaShop\Core\Util\Inflector;
@@ -99,7 +100,7 @@ final class ExtraPropertyDefinition
      * @param list<string>|null $associatedApis Admin API placement entries: "uriPath[:METHOD[,METHOD...]]", matched against the operation URI template (+ optional HTTP methods). No method modifier matches every method.
      * @param string|null $formType fully-qualified Symfony Form type FQCN override for BO forms
      * @param array<string, mixed>|null $formOptions extra options passed verbatim to the Symfony form type constructor
-     * @param list<Constraint>|null $constraints Symfony validation constraints applied to each value before persistence. Null/empty means no validation. Must be serializable (no Callback with a closure).
+     * @param list<Constraint>|null $constraints Symfony validation constraints applied to each value before persistence. Null/empty means no validation. Only constraints supported by ExtraPropertyConstraintMapper are accepted; callback/normalizer, property-path options and custom module constraint classes are not supported.
      * @param string|null $labelWording Translation wording key shown in BO. Required when associatedForms or associatedGrids is set.
      * @param string|null $labelDomain translation domain for label wording
      * @param string|null $descriptionWording translation wording key shown as BO help text
@@ -317,44 +318,15 @@ final class ExtraPropertyDefinition
     /**
      * Normalizes the registry "constraints" cell into a list of Constraint objects.
      *
-     * Accepts both shapes so fromRow() works for an in-memory row (constraints already given as
-     * Constraint objects) and a DB row (constraints serialized to a string):
-     *  - array  → already-decoded constraints; filtered and returned as-is (no unserialize).
-     *  - string → a serialized blob written by trusted module install code (registerExtraProperty);
-     *             unserialized then filtered.
-     * Anything that is not a Symfony Constraint is discarded. Returns null when nothing usable
-     * remains, mirroring the "no validation" default.
+     * Accepts both already-decoded in-memory lists and serialized DB values. The safe serializer
+     * applies the same fixed class allowlist and complete graph validation to both shapes.
+     * Unsupported roots are discarded; valid sibling constraints remain active.
      *
      * @return list<Constraint>|null
      */
     private static function decodeConstraints(mixed $raw): ?array
     {
-        if (is_array($raw)) {
-            return self::filterConstraints($raw);
-        }
-
-        if (!is_string($raw) || '' === $raw) {
-            return null;
-        }
-
-        $decoded = @unserialize($raw, ['allowed_classes' => true]);
-
-        return is_array($decoded) ? self::filterConstraints($decoded) : null;
-    }
-
-    /**
-     * @param array<mixed> $candidates
-     *
-     * @return list<Constraint>|null
-     */
-    private static function filterConstraints(array $candidates): ?array
-    {
-        $constraints = array_values(array_filter(
-            $candidates,
-            static fn (mixed $constraint): bool => $constraint instanceof Constraint
-        ));
-
-        return [] !== $constraints ? $constraints : null;
+        return ExtraPropertyConstraintSerializer::unserialize($raw);
     }
 
     // -------------------------------------------------------------------------

--- a/src/Core/ExtraProperty/Definition/ExtraPropertyDefinitionRepository.php
+++ b/src/Core/ExtraProperty/Definition/ExtraPropertyDefinitionRepository.php
@@ -14,6 +14,8 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ExtraPropertyDefinitionNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ProtectedModuleExtraPropertyDefinitionException;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Schema\ColumnDefinitionMapper;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyConstraintSerializer;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
@@ -29,6 +31,7 @@ class ExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionReposi
     public function __construct(
         protected readonly Connection $connection,
         protected readonly string $prefix,
+        protected readonly ?LoggerInterface $logger = null,
     ) {
     }
 
@@ -49,7 +52,7 @@ class ExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionReposi
         );
 
         return new ExtraPropertyDefinitionCollection(array_values(array_map(
-            static fn (array $row): ExtraPropertyDefinition => ExtraPropertyDefinition::fromRow($row),
+            $this->hydrateDefinition(...),
             $rows
         )));
     }
@@ -76,7 +79,7 @@ class ExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionReposi
             return null;
         }
 
-        return ExtraPropertyDefinition::fromRow($this->enrichRowsWithShopAssociations($this->enrichRowsWithColumnMetadata([$row]))[0]);
+        return $this->hydrateDefinition($this->enrichRowsWithShopAssociations($this->enrichRowsWithColumnMetadata([$row]))[0]);
     }
 
     /**
@@ -97,7 +100,7 @@ class ExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionReposi
             return null;
         }
 
-        return ExtraPropertyDefinition::fromRow($this->enrichRowsWithShopAssociations($this->enrichRowsWithColumnMetadata([$row]))[0]);
+        return $this->hydrateDefinition($this->enrichRowsWithShopAssociations($this->enrichRowsWithColumnMetadata([$row]))[0]);
     }
 
     /**
@@ -145,7 +148,7 @@ class ExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionReposi
             'form_type' => $definition->getFormType(),
             'form_options' => null !== $definition->getFormOptions() ? json_encode($definition->getFormOptions()) : null,
             'sql_index' => $definition->getSqlIndex()->value,
-            'constraints' => !empty($definition->getConstraints()) ? serialize($definition->getConstraints()) : null,
+            'constraints' => ExtraPropertyConstraintSerializer::serialize($definition->getConstraints()),
             'associated_forms' => !empty($definition->getAssociatedForms()) ? json_encode(array_values($definition->getAssociatedForms())) : null,
             'associated_grids' => !empty($definition->getAssociatedGrids()) ? json_encode(array_values($definition->getAssociatedGrids())) : null,
             'associated_apis' => !empty($definition->getAssociatedApis()) ? json_encode(array_values($definition->getAssociatedApis())) : null,
@@ -301,6 +304,44 @@ class ExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionReposi
         } else {
             $qb->andWhere($column . ' IS NULL');
         }
+    }
+
+    /**
+     * Decodes constraints before hydration so rejected data can be logged with its registry context.
+     *
+     * @param array<string, mixed> $row
+     */
+    protected function hydrateDefinition(array $row): ExtraPropertyDefinition
+    {
+        $row['constraints'] = ExtraPropertyConstraintSerializer::unserialize(
+            $row['constraints'] ?? null,
+            function (int|string|null $index, string $reason) use ($row): void {
+                $definitionId = isset($row['id_extra_property_definition'])
+                    ? (int) $row['id_extra_property_definition']
+                    : null;
+                $constraintLabel = null === $index ? 'serialized blob' : sprintf('index %s', (string) $index);
+                $message = sprintf(
+                    'Rejected extra property constraint %s for definition #%s (%s/%s/%s): %s',
+                    $constraintLabel,
+                    null !== $definitionId ? (string) $definitionId : 'unknown',
+                    (string) ($row['entity_name'] ?? 'unknown'),
+                    (string) ($row['module_name'] ?? ExtraPropertyDefinition::CORE_MODULE_KEY),
+                    (string) ($row['property_name'] ?? 'unknown'),
+                    $reason
+                );
+
+                try {
+                    $this->logger?->error($message, [
+                        'object_type' => 'extra_property_definition',
+                        'object_id' => $definitionId,
+                    ]);
+                } catch (Throwable) {
+                    // A logging failure must not make a corrupt definition crash a read request.
+                }
+            }
+        );
+
+        return ExtraPropertyDefinition::fromRow($row);
     }
 
     /**

--- a/src/Core/ExtraProperty/Definition/ExtraPropertyRegistry.php
+++ b/src/Core/ExtraProperty/Definition/ExtraPropertyRegistry.php
@@ -12,8 +12,10 @@ namespace PrestaShop\PrestaShop\Core\ExtraProperty\Definition;
 use PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\ExtraPropertyException;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\ExtraPropertyRegistryException;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\InvalidExtraPropertyConstraintException;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Form\FormOptionsValidator;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Schema\ExtraPropertySchemaManagerInterface;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyConstraintSerializer;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -77,8 +79,8 @@ class ExtraPropertyRegistry implements ExtraPropertyRegistryInterface
      *
      * @throws ExtraPropertyRegistryException the failure reason is carried by the exception code:
      *                                        SCOPE_CONFLICT, DESTRUCTIVE_SCHEMA_CHANGE, INVALID_FORM_OPTIONS,
-     *                                        UNKNOWN_SHOP, BASE_TABLE_NOT_FOUND, SCHEMA_FAILURE or
-     *                                        PERSISTENCE_FAILURE
+     *                                        UNKNOWN_SHOP, INVALID_CONSTRAINTS, BASE_TABLE_NOT_FOUND,
+     *                                        SCHEMA_FAILURE or PERSISTENCE_FAILURE
      */
     public function register(ExtraPropertyDefinition $definition): int
     {
@@ -90,7 +92,28 @@ class ExtraPropertyRegistry implements ExtraPropertyRegistryInterface
         $scope = $definition->getScope();
         $normalizedScope = $scope->value;
 
-        // 1. (entity, module, property) is unique across scopes — a single lookup covers both
+        // 1. Validate constraints before any schema DDL. Besides avoiding unsafe serialized
+        // object graphs, this prevents an unsupported module constraint from leaving an orphan
+        // column when the definition row cannot subsequently be persisted.
+        try {
+            ExtraPropertyConstraintSerializer::assertSupported($definition->getConstraints());
+        } catch (InvalidExtraPropertyConstraintException $exception) {
+            $message = sprintf(
+                'Invalid constraints for extra property %s.%s: %s',
+                $entityName,
+                $propertyName,
+                $exception->getMessage()
+            );
+            $this->logger->error($message, ['exception' => $exception]);
+
+            throw new ExtraPropertyRegistryException(
+                $message,
+                ExtraPropertyRegistryException::INVALID_CONSTRAINTS,
+                $exception
+            );
+        }
+
+        // 2. (entity, module, property) is unique across scopes — a single lookup covers both
         // the scope-uniqueness rule and the immutability check on an existing definition.
         $existingDefinition = $this->readRepository->findDefinitionByModuleAndField(
             $entityName,
@@ -111,7 +134,7 @@ class ExtraPropertyRegistry implements ExtraPropertyRegistryInterface
             throw new ExtraPropertyRegistryException($message, ExtraPropertyRegistryException::SCOPE_CONFLICT);
         }
 
-        // 2. Refuse destructive schema changes on an existing definition.
+        // 3. Refuse destructive schema changes on an existing definition.
         if (null !== $existingDefinition && $this->hasStorageChanges($definition, $existingDefinition)) {
             $message = sprintf(
                 'Refusing destructive schema change (type/scope change, size decrease, nullable tightening, enum value removal) for existing extra property %s.%s.',
@@ -123,7 +146,7 @@ class ExtraPropertyRegistry implements ExtraPropertyRegistryInterface
             throw new ExtraPropertyRegistryException($message, ExtraPropertyRegistryException::DESTRUCTIVE_SCHEMA_CHANGE);
         }
 
-        // 3. Refuse a definition whose form field could not be built at render time — being the
+        // 4. Refuse a definition whose form field could not be built at render time — being the
         // single write choke point, this covers every path: BO form, CQRS commands and
         // Module::registerExtraProperty(). The errors must reach the human who typed the options.
         $formOptionErrors = $this->formOptionsValidator->validate(
@@ -140,7 +163,7 @@ class ExtraPropertyRegistry implements ExtraPropertyRegistryInterface
             throw new ExtraPropertyRegistryException($message, ExtraPropertyRegistryException::INVALID_FORM_OPTIONS, errors: $formOptionErrors);
         }
 
-        // 4. Refuse unknown shop ids in the association, BEFORE any DDL or row write: the
+        // 5. Refuse unknown shop ids in the association, BEFORE any DDL or row write: the
         //    association rows carry no foreign key, so an unknown id (e.g. a module calling
         //    registerExtraProperty() with a wrong shop id) would be stored silently and make
         //    the definition invisible on every real shop. Being the single write choke point,
@@ -169,7 +192,7 @@ class ExtraPropertyRegistry implements ExtraPropertyRegistryInterface
             }
         }
 
-        // 5. Ensure the *_extra table and column exist and match the definition: the schema
+        // 6. Ensure the *_extra table and column exist and match the definition: the schema
         //    manager also syncs remaining non-destructive changes on the live column.
         //    DDL runs BEFORE the row write (see the method docblock): a DDL failure here
         //    persists nothing on a creation and leaves the previous row intact on an update.
@@ -189,7 +212,7 @@ class ExtraPropertyRegistry implements ExtraPropertyRegistryInterface
             throw new ExtraPropertyRegistryException($message, ExtraPropertyRegistryException::SCHEMA_FAILURE, $exception);
         }
 
-        // 6. Insert or update the registry row.
+        // 7. Insert or update the registry row.
         $savedId = $this->writeRepository->save($definition);
 
         if (false === $savedId) {

--- a/src/Core/ExtraProperty/Definition/ExtraPropertyRegistryInterface.php
+++ b/src/Core/ExtraProperty/Definition/ExtraPropertyRegistryInterface.php
@@ -45,7 +45,7 @@ interface ExtraPropertyRegistryInterface
      * @return int The registry row id (insert or update)
      *
      * @throws ExtraPropertyRegistryException the failure reason is carried by the exception code:
-     *                                        SCOPE_CONFLICT, DESTRUCTIVE_SCHEMA_CHANGE, INVALID_FORM_OPTIONS,
+     *                                        SCOPE_CONFLICT, DESTRUCTIVE_SCHEMA_CHANGE, INVALID_FORM_OPTIONS, INVALID_CONSTRAINTS,
      *                                        BASE_TABLE_NOT_FOUND, SCHEMA_FAILURE or PERSISTENCE_FAILURE
      */
     public function register(ExtraPropertyDefinition $definition): int;

--- a/src/Core/ExtraProperty/Exception/ExtraPropertyRegistryException.php
+++ b/src/Core/ExtraProperty/Exception/ExtraPropertyRegistryException.php
@@ -65,6 +65,11 @@ class ExtraPropertyRegistryException extends ExtraPropertyException
     public const UNKNOWN_SHOP = 7;
 
     /**
+     * The declared constraint graph contains an unsupported class or executable option.
+     */
+    public const INVALID_CONSTRAINTS = 8;
+
+    /**
      * @param list<string> $errors individual human-readable errors when the failure
      *                             aggregates several (only INVALID_FORM_OPTIONS provides
      *                             them so far — one entry per invalid form option)

--- a/src/Core/ExtraProperty/Exception/InvalidExtraPropertyConstraintException.php
+++ b/src/Core/ExtraProperty/Exception/InvalidExtraPropertyConstraintException.php
@@ -10,9 +10,8 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\ExtraProperty\Exception;
 
 /**
- * Thrown when a BO "Validation" textarea entry is recognized by name but malformed or carries an
- * invalid argument (e.g. a required value is missing, or a value is supplied to a constraint that
- * takes none).
+ * Thrown when an extra property constraint is malformed, carries an invalid argument, or cannot be
+ * serialized safely (unsupported class, object graph or executable option).
  *
  * Distinct from UnknownExtraPropertyConstraintException, which covers an unrecognized name.
  */

--- a/src/Core/ExtraProperty/Validation/ExtraPropertyConstraintSerializer.php
+++ b/src/Core/ExtraProperty/Validation/ExtraPropertyConstraintSerializer.php
@@ -1,0 +1,329 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\ExtraProperty\Validation;
+
+use __PHP_Incomplete_Class;
+use DateTime;
+use DateTimeImmutable;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\InvalidExtraPropertyConstraintException;
+use SplObjectStorage;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
+use Throwable;
+
+/**
+ * Safely serializes and unserializes extra property constraints.
+ *
+ * The stored format intentionally remains PHP serialization for backward compatibility. Security
+ * relies on a core-owned class allowlist, followed by validation of the complete decoded graph.
+ * This second step is required because allowed_classes alone neither detects incomplete nested
+ * objects nor prevents executable or object-traversal options from being injected into an
+ * allowed class.
+ */
+final class ExtraPropertyConstraintSerializer
+{
+    private const MAX_DEPTH = 64;
+
+    private const CALLABLE_OPTIONS = [
+        'callback',
+        'normalizer',
+    ];
+
+    /**
+     * @var array<class-string, true>|null
+     */
+    private static ?array $allowedClassMap = null;
+
+    /**
+     * @return list<class-string>
+     */
+    public static function getAllowedClasses(): array
+    {
+        return array_keys(self::getAllowedClassMap());
+    }
+
+    /**
+     * @return array<class-string, true>
+     */
+    private static function getAllowedClassMap(): array
+    {
+        return self::$allowedClassMap ??= array_fill_keys(array_values(array_unique([
+            ...array_values(ExtraPropertyConstraintMapper::getAllowedConstraints()),
+            Assert\Required::class,
+            Assert\Optional::class,
+            DateTime::class,
+            DateTimeImmutable::class,
+        ])), true);
+    }
+
+    /**
+     * @param list<Constraint>|null $constraints
+     *
+     * @throws InvalidExtraPropertyConstraintException
+     */
+    public static function assertSupported(?array $constraints): void
+    {
+        if (null === $constraints || [] === $constraints) {
+            return;
+        }
+        if (!array_is_list($constraints)) {
+            throw new InvalidExtraPropertyConstraintException(
+                'Extra property constraints must be provided as a list.'
+            );
+        }
+
+        foreach ($constraints as $index => $constraint) {
+            if (!$constraint instanceof Constraint) {
+                throw new InvalidExtraPropertyConstraintException(sprintf(
+                    'Extra property constraint at index %d must extend %s, got %s.',
+                    $index,
+                    Constraint::class,
+                    get_debug_type($constraint)
+                ));
+            }
+
+            self::assertSupportedNode(
+                $constraint,
+                new SplObjectStorage(),
+                sprintf('constraints[%d]', $index),
+                0
+            );
+        }
+    }
+
+    /**
+     * @param list<Constraint>|null $constraints
+     *
+     * @throws InvalidExtraPropertyConstraintException
+     */
+    public static function serialize(?array $constraints): ?string
+    {
+        if (null === $constraints || [] === $constraints) {
+            return null;
+        }
+
+        self::assertSupported($constraints);
+
+        try {
+            return serialize($constraints);
+        } catch (Throwable $exception) {
+            throw new InvalidExtraPropertyConstraintException(
+                sprintf('Extra property constraints could not be serialized: %s', $exception->getMessage()),
+                0,
+                $exception
+            );
+        }
+    }
+
+    /**
+     * @param mixed $raw Serialized constraints or an already-decoded in-memory list
+     * @param callable(int|string|null, string): void|null $onRejected
+     *
+     * @return list<Constraint>|null
+     */
+    public static function unserialize(mixed $raw, ?callable $onRejected = null): ?array
+    {
+        if (is_array($raw)) {
+            $decoded = $raw;
+        } elseif (is_string($raw) && '' !== $raw) {
+            $decoded = self::decodeString($raw, $onRejected);
+            if (null === $decoded) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+
+        if (!array_is_list($decoded)) {
+            self::reject($onRejected, null, 'Decoded extra property constraints must be a list.');
+
+            return null;
+        }
+
+        $constraints = [];
+        foreach ($decoded as $index => $constraint) {
+            if (!$constraint instanceof Constraint) {
+                self::reject(
+                    $onRejected,
+                    $index,
+                    sprintf('Decoded value is not a Symfony constraint, got %s.', get_debug_type($constraint))
+                );
+
+                continue;
+            }
+
+            try {
+                self::assertSupportedNode(
+                    $constraint,
+                    new SplObjectStorage(),
+                    sprintf('constraints[%d]', $index),
+                    0
+                );
+                $constraints[] = $constraint;
+            } catch (InvalidExtraPropertyConstraintException $exception) {
+                // Reject the complete root constraint, never a nested fragment of a composite.
+                self::reject($onRejected, $index, $exception->getMessage());
+            }
+        }
+
+        return [] !== $constraints ? $constraints : null;
+    }
+
+    /**
+     * @param callable(int|string|null, string): void|null $onRejected
+     *
+     * @return array<mixed>|null
+     */
+    private static function decodeString(string $raw, ?callable $onRejected): ?array
+    {
+        set_error_handler(
+            static function (int $severity, string $message): never {
+                throw new InvalidExtraPropertyConstraintException(
+                    sprintf('Invalid serialized extra property constraints: %s', $message)
+                );
+            }
+        );
+
+        try {
+            $decoded = unserialize($raw, [
+                'allowed_classes' => self::getAllowedClasses(),
+                'max_depth' => self::MAX_DEPTH,
+            ]);
+        } catch (Throwable $exception) {
+            self::reject($onRejected, null, $exception->getMessage());
+
+            return null;
+        } finally {
+            restore_error_handler();
+        }
+
+        if (!is_array($decoded)) {
+            self::reject(
+                $onRejected,
+                null,
+                sprintf('Serialized extra property constraints must decode to an array, got %s.', get_debug_type($decoded))
+            );
+
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param SplObjectStorage<object, null> $visited
+     *
+     * @throws InvalidExtraPropertyConstraintException
+     */
+    private static function assertSupportedNode(
+        mixed $value,
+        SplObjectStorage $visited,
+        string $path,
+        int $depth
+    ): void {
+        if ($depth > self::MAX_DEPTH) {
+            throw new InvalidExtraPropertyConstraintException(sprintf(
+                'Extra property constraint graph exceeds the maximum depth of %d at %s.',
+                self::MAX_DEPTH,
+                $path
+            ));
+        }
+
+        if (is_resource($value)) {
+            throw new InvalidExtraPropertyConstraintException(sprintf(
+                'Resources are not supported in extra property constraints at %s.',
+                $path
+            ));
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $nestedValue) {
+                self::assertSupportedNode(
+                    $nestedValue,
+                    $visited,
+                    sprintf('%s[%s]', $path, (string) $key),
+                    $depth + 1
+                );
+            }
+
+            return;
+        }
+
+        if (!is_object($value)) {
+            return;
+        }
+
+        if ($value instanceof __PHP_Incomplete_Class) {
+            $incompleteData = (array) $value;
+            $className = $incompleteData['__PHP_Incomplete_Class_Name'] ?? 'unknown';
+
+            throw new InvalidExtraPropertyConstraintException(sprintf(
+                'Class "%s" is not allowed in extra property constraints at %s.',
+                $className,
+                $path
+            ));
+        }
+
+        if (!isset(self::getAllowedClassMap()[$value::class])) {
+            throw new InvalidExtraPropertyConstraintException(sprintf(
+                'Class "%s" is not allowed in extra property constraints at %s.',
+                $value::class,
+                $path
+            ));
+        }
+
+        if ($visited->contains($value)) {
+            return;
+        }
+        $visited->attach($value);
+
+        foreach ((array) $value as $rawPropertyName => $propertyValue) {
+            $propertyName = self::normalizePropertyName((string) $rawPropertyName);
+            if (null !== $propertyValue && in_array($propertyName, self::CALLABLE_OPTIONS, true)) {
+                throw new InvalidExtraPropertyConstraintException(sprintf(
+                    'Option "%s" is not supported for extra property constraints because it may execute a callable. ' .
+                    'Normalize the value in module code before validation.',
+                    $propertyName
+                ));
+            }
+            if (null !== $propertyValue && str_ends_with(strtolower($propertyName), 'propertypath')) {
+                throw new InvalidExtraPropertyConstraintException(sprintf(
+                    'Option "%s" is not supported for extra property constraints because it may traverse the validated object. ' .
+                    'Extra property constraints validate an individual value.',
+                    $propertyName
+                ));
+            }
+
+            self::assertSupportedNode(
+                $propertyValue,
+                $visited,
+                $path . '.' . $propertyName,
+                $depth + 1
+            );
+        }
+    }
+
+    private static function normalizePropertyName(string $propertyName): string
+    {
+        $separatorPosition = strrpos($propertyName, "\0");
+
+        return false === $separatorPosition ? $propertyName : substr($propertyName, $separatorPosition + 1);
+    }
+
+    /**
+     * @param callable(int|string|null, string): void|null $onRejected
+     */
+    private static function reject(?callable $onRejected, int|string|null $index, string $reason): void
+    {
+        if (null !== $onRejected) {
+            $onRejected($index, $reason);
+        }
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ExtraPropertyDefinitionController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ExtraPropertyDefinitionController.php
@@ -485,6 +485,11 @@ class ExtraPropertyDefinitionController extends PrestaShopAdminController
                     [],
                     'Admin.Advparameters.Notification'
                 ),
+                ExtraPropertyRegistrationFailureException::INVALID_CONSTRAINTS => $this->trans(
+                    'The validation constraints contain an unsupported class or executable option. Use only the constraints and options supported by the extra property feature.',
+                    [],
+                    'Admin.Advparameters.Notification'
+                ),
             ],
             InvalidExtraPropertyDefinitionException::class => $this->trans(
                 'The submitted extra property definition is invalid. Check the form values and try again.',

--- a/src/PrestaShopBundle/Resources/config/services/extra_property/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/extra_property/common.yml
@@ -18,6 +18,11 @@ services:
     arguments:
       $connection: '@doctrine.dbal.default_connection'
       $prefix: '%database_prefix%'
+      # LegacyLogger is available in Symfony kernels and the hand-built legacy FO container.
+      $logger: '@prestashop.extra_property.constraint_decode_logger'
+
+  prestashop.extra_property.constraint_decode_logger:
+    class: PrestaShop\PrestaShop\Adapter\LegacyLogger
 
   # Note: the definition WRITER interface (ExtraPropertyDefinitionWriterInterface) is intentionally NOT aliased
   # here. Writing definitions (register/unregister) is a back-office-only concern, so the alias lives in

--- a/tests/Integration/Adapter/ContainerBuilderTest.php
+++ b/tests/Integration/Adapter/ContainerBuilderTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Module\Banner\Repository\FrontRepository;
 use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface;
 use PrestaShopBundle\Exception\ServiceContainerException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
@@ -30,6 +31,14 @@ class ContainerBuilderTest extends TestCase
         $entityManager = $container->get('doctrine.orm.entity_manager');
         $this->assertNotNull($entityManager);
         $this->assertInstanceOf(EntityManagerInterface::class, $entityManager);
+    }
+
+    public function testFrontContainerContainsExtraPropertyRepository(): void
+    {
+        $container = ContainerBuilder::getContainer('front', true);
+        $repository = $container->get(ExtraPropertyDefinitionRepositoryInterface::class);
+
+        $this->assertInstanceOf(ExtraPropertyDefinitionRepositoryInterface::class, $repository);
     }
 
     public function testContainerLoadsModuleAutoload()

--- a/tests/Unit/Core/ExtraProperty/ExtraPropertyDefinitionRepositoryTest.php
+++ b/tests/Unit/Core/ExtraProperty/ExtraPropertyDefinitionRepositoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\ExtraProperty;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinition;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ExtraPropertyDefinitionRepositoryTest extends TestCase
+{
+    public function testHydrationLogsRejectedConstraintWithDefinitionContext(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->callback(
+                    static fn (string $message): bool => str_contains($message, 'index 1')
+                        && str_contains($message, 'definition #42')
+                        && str_contains($message, 'product/demoextrafield/video')
+                        && str_contains($message, RepositoryUnsupportedConstraint::class)
+                ),
+                [
+                    'object_type' => 'extra_property_definition',
+                    'object_id' => 42,
+                ]
+            );
+
+        $repository = new TestableExtraPropertyDefinitionRepository(
+            $this->createMock(Connection::class),
+            'ps_',
+            $logger
+        );
+
+        $definition = $repository->hydrate([
+            'id_extra_property_definition' => 42,
+            'entity_name' => 'product',
+            'property_name' => 'video',
+            'type' => 'string',
+            'scope' => 'common',
+            'module_name' => 'demoextrafield',
+            'constraints' => serialize([
+                new Assert\NotBlank(),
+                new Assert\All([new RepositoryUnsupportedConstraint()]),
+            ]),
+        ]);
+
+        $constraints = $definition->getConstraints();
+        $this->assertCount(1, $constraints);
+        $this->assertInstanceOf(Assert\NotBlank::class, $constraints[0]);
+    }
+}
+
+final class RepositoryUnsupportedConstraint extends Constraint
+{
+}
+
+final class TestableExtraPropertyDefinitionRepository extends ExtraPropertyDefinitionRepository
+{
+    /**
+     * @param array<string, mixed> $row
+     */
+    public function hydrate(array $row): ExtraPropertyDefinition
+    {
+        return $this->hydrateDefinition($row);
+    }
+}

--- a/tests/Unit/Core/ExtraProperty/ExtraPropertyRegistryTest.php
+++ b/tests/Unit/Core/ExtraProperty/ExtraPropertyRegistryTest.php
@@ -25,6 +25,7 @@ use Psr\Log\NullLogger;
 use RuntimeException;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Forms;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Validation;
 use Throwable;
 
@@ -45,6 +46,40 @@ class ExtraPropertyRegistryTest extends TestCase
         $registry = $this->buildRegistry(existing: null, expectSave: true);
 
         $this->assertSame(1, $registry->register($incoming));
+    }
+
+    public function testUnsupportedConstraintIsRejectedBeforeAnyLookupOrDdl(): void
+    {
+        $readRepository = $this->createMock(ExtraPropertyDefinitionRepositoryInterface::class);
+        $readRepository->expects($this->never())->method('findDefinitionByModuleAndField');
+
+        $writeRepository = $this->createMock(ExtraPropertyDefinitionWriterInterface::class);
+        $writeRepository->expects($this->never())->method('save');
+
+        $schemaManager = $this->createMock(ExtraPropertySchemaManagerInterface::class);
+        $schemaManager->expects($this->never())->method('ensureExtraTableAndColumn');
+
+        $shopRepository = $this->createMock(ShopRepository::class);
+        $shopRepository->expects($this->never())->method('getAllShopIds');
+
+        $registry = new ExtraPropertyRegistry(
+            $readRepository,
+            $writeRepository,
+            $schemaManager,
+            new NullLogger(),
+            new FormOptionsValidator(
+                Forms::createFormFactoryBuilder()
+                    ->addExtension(new ValidatorExtension(Validation::createValidator()))
+                    ->getFormFactory(),
+                new ExtraPropertyFormTypeMap()
+            ),
+            $shopRepository,
+        );
+
+        $this->expectException(ExtraPropertyRegistryException::class);
+        $this->expectExceptionCode(ExtraPropertyRegistryException::INVALID_CONSTRAINTS);
+
+        $registry->register($this->definition(constraints: [new RegistryUnsupportedConstraint()]));
     }
 
     public function testIdenticalReRegistrationIsAccepted(): void
@@ -540,6 +575,7 @@ class ExtraPropertyRegistryTest extends TestCase
         int|float|string|bool|null $defaultValue = null,
         ?string $formType = null,
         ?array $formOptions = null,
+        ?array $constraints = null,
         ?array $associatedShopIds = null,
     ): ExtraPropertyDefinition {
         return new ExtraPropertyDefinition(
@@ -554,7 +590,12 @@ class ExtraPropertyRegistryTest extends TestCase
             size: $size,
             formType: $formType,
             formOptions: $formOptions,
+            constraints: $constraints,
             associatedShopIds: $associatedShopIds,
         );
     }
+}
+
+final class RegistryUnsupportedConstraint extends Constraint
+{
 }

--- a/tests/Unit/Core/ExtraProperty/Validation/ExtraPropertyConstraintSerializerTest.php
+++ b/tests/Unit/Core/ExtraProperty/Validation/ExtraPropertyConstraintSerializerTest.php
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\ExtraProperty\Validation;
+
+use DateTime;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\InvalidExtraPropertyConstraintException;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyConstraintMapper;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyConstraintSerializer;
+use ReflectionClass;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ExtraPropertyConstraintSerializerTest extends TestCase
+{
+    public function testAllowlistContainsOnlyMapperConstraintsAndRequiredAuxiliaryClasses(): void
+    {
+        $expected = array_values(array_unique([
+            ...array_values(ExtraPropertyConstraintMapper::getAllowedConstraints()),
+            Assert\Required::class,
+            Assert\Optional::class,
+            DateTime::class,
+            DateTimeImmutable::class,
+        ]));
+
+        $this->assertSame($expected, ExtraPropertyConstraintSerializer::getAllowedClasses());
+    }
+
+    public function testEveryCallableOptionInAllowedConstraintsIsExplicitlyBlocked(): void
+    {
+        $detectedOptions = [];
+        foreach (ExtraPropertyConstraintMapper::getAllowedConstraints() as $constraintClass) {
+            $reflection = new ReflectionClass($constraintClass);
+            foreach ($reflection->getProperties() as $property) {
+                $declaresCallable = false !== stripos((string) $property->getDocComment(), 'callable')
+                    || str_contains((string) $property->getType(), 'Closure');
+                if (!$declaresCallable) {
+                    continue;
+                }
+
+                $detectedOptions[] = sprintf('%s::$%s', $constraintClass, $property->getName());
+                $this->assertContains(
+                    $property->getName(),
+                    ['callback', 'normalizer'],
+                    sprintf(
+                        'Callable option %s::$%s needs an explicit security decision.',
+                        $constraintClass,
+                        $property->getName()
+                    )
+                );
+            }
+        }
+
+        sort($detectedOptions);
+        $expectedOptions = [
+            Assert\Choice::class . '::$callback',
+            Assert\Email::class . '::$normalizer',
+            Assert\Ip::class . '::$normalizer',
+            Assert\Length::class . '::$normalizer',
+            Assert\NotBlank::class . '::$normalizer',
+            Assert\Regex::class . '::$normalizer',
+            Assert\Url::class . '::$normalizer',
+            Assert\Uuid::class . '::$normalizer',
+        ];
+        sort($expectedOptions);
+
+        $this->assertSame(
+            $expectedOptions,
+            $detectedOptions,
+            'The reviewed callable option list changed; classify every addition before updating this assertion.'
+        );
+    }
+
+    public function testAllowedConstraintsDoNotIntroduceUnserializationMagicMethods(): void
+    {
+        foreach (ExtraPropertyConstraintMapper::getAllowedConstraints() as $constraintClass) {
+            $reflection = new ReflectionClass($constraintClass);
+            foreach (['__wakeup', '__unserialize', '__destruct', '__call'] as $method) {
+                $this->assertFalse(
+                    $reflection->hasMethod($method),
+                    sprintf('Magic method %s::%s() needs an explicit security review.', $constraintClass, $method)
+                );
+            }
+        }
+    }
+
+    public function testNestedConstraintsAndDateTimeValuesRoundTripWithoutLosingOptions(): void
+    {
+        $date = new DateTimeImmutable('2030-01-02 03:04:05+00:00');
+        $constraints = [
+            new Assert\Collection([
+                'fields' => [
+                    'name' => new Assert\Required([
+                        new Assert\NotBlank(),
+                        new Assert\Length(['min' => 2, 'max' => 64]),
+                    ]),
+                    'published_at' => new Assert\Optional([
+                        new Assert\AtLeastOneOf([
+                            new Assert\IsNull(),
+                            new Assert\LessThan($date),
+                        ]),
+                    ]),
+                ],
+                'allowExtraFields' => false,
+            ]),
+        ];
+
+        $decoded = ExtraPropertyConstraintSerializer::unserialize(
+            ExtraPropertyConstraintSerializer::serialize($constraints)
+        );
+
+        $this->assertEquals($constraints, $decoded);
+    }
+
+    public function testEveryMapperConstraintClassRoundTrips(): void
+    {
+        $requiredOptions = [
+            'Length' => 'Length(max: 10)',
+            'Regex' => "Regex('/^a$/')",
+            'Range' => 'Range(min: 0, max: 10)',
+            'EqualTo' => 'EqualTo(1)',
+            'NotEqualTo' => 'NotEqualTo(1)',
+            'IdenticalTo' => 'IdenticalTo(1)',
+            'NotIdenticalTo' => 'NotIdenticalTo(1)',
+            'LessThan' => 'LessThan(1)',
+            'LessThanOrEqual' => 'LessThanOrEqual(1)',
+            'GreaterThan' => 'GreaterThan(1)',
+            'GreaterThanOrEqual' => 'GreaterThanOrEqual(1)',
+            'DivisibleBy' => 'DivisibleBy(2)',
+            'CardScheme' => "CardScheme(['VISA'])",
+            'Count' => 'Count(max: 10)',
+            'Type' => "Type('string')",
+            'All' => 'All[ NotBlank ]',
+            'AtLeastOneOf' => 'AtLeastOneOf[ NotBlank, NotNull ]',
+            'Collection' => 'Collection[ field: NotBlank ]',
+            'Sequentially' => 'Sequentially[ NotBlank, Length(max: 10) ]',
+            'TypedRegex' => "TypedRegex('generic_name')",
+        ];
+        $testedClasses = [];
+
+        foreach (ExtraPropertyConstraintMapper::getAllowedNames() as $name) {
+            $constraints = ExtraPropertyConstraintMapper::fromNames($requiredOptions[$name] ?? $name);
+            $decoded = ExtraPropertyConstraintSerializer::unserialize(
+                ExtraPropertyConstraintSerializer::serialize($constraints)
+            );
+
+            $this->assertEquals($constraints, $decoded, sprintf('%s must round-trip.', $name));
+            $testedClasses[] = $constraints[0]::class;
+        }
+
+        $this->assertSame(
+            array_values(ExtraPropertyConstraintMapper::getAllowedConstraints()),
+            $testedClasses
+        );
+    }
+
+    public function testCustomConstraintIsRejectedBeforeSerialization(): void
+    {
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        $this->expectExceptionMessage(UnsupportedConstraint::class);
+
+        ExtraPropertyConstraintSerializer::serialize([new UnsupportedConstraint()]);
+    }
+
+    public function testExecutableNormalizerAndCallbackOptionsAreRejected(): void
+    {
+        foreach ([
+            new Assert\Length(['min' => 1, 'normalizer' => 'trim']),
+            new Assert\Choice(['callback' => 'str_split']),
+        ] as $constraint) {
+            try {
+                ExtraPropertyConstraintSerializer::serialize([$constraint]);
+                $this->fail(sprintf('%s should have been rejected.', $constraint::class));
+            } catch (InvalidExtraPropertyConstraintException $exception) {
+                $this->assertStringContainsString('may execute a callable', $exception->getMessage());
+            }
+        }
+    }
+
+    public function testCallableOptionsInjectedInSerializedBlobAreRejectedOnRead(): void
+    {
+        foreach ([
+            new Assert\Length(['min' => 1, 'normalizer' => 'system']),
+            new Assert\Choice(['callback' => 'system']),
+        ] as $tamperedConstraint) {
+            $rejections = [];
+
+            // Bypass the safe write path to reproduce a blob written directly to the database.
+            $decoded = ExtraPropertyConstraintSerializer::unserialize(
+                serialize([new Assert\NotBlank(), $tamperedConstraint]),
+                static function (int|string|null $index, string $reason) use (&$rejections): void {
+                    $rejections[] = [$index, $reason];
+                }
+            );
+
+            $this->assertCount(1, $decoded);
+            $this->assertInstanceOf(Assert\NotBlank::class, $decoded[0]);
+            $this->assertCount(1, $rejections);
+            $this->assertSame(1, $rejections[0][0]);
+            $this->assertStringContainsString('may execute a callable', $rejections[0][1]);
+        }
+    }
+
+    public function testPropertyPathInjectedInSerializedBlobIsRejectedOnRead(): void
+    {
+        $rejections = [];
+
+        $decoded = ExtraPropertyConstraintSerializer::unserialize(
+            serialize([
+                new Assert\NotBlank(),
+                new Assert\LessThan(['propertyPath' => 'sensitiveProperty']),
+            ]),
+            static function (int|string|null $index, string $reason) use (&$rejections): void {
+                $rejections[] = [$index, $reason];
+            }
+        );
+
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\NotBlank::class, $decoded[0]);
+        $this->assertSame(1, $rejections[0][0]);
+        $this->assertStringContainsString('may traverse the validated object', $rejections[0][1]);
+    }
+
+    public function testRecursiveArrayGraphIsRejectedAtDepthLimit(): void
+    {
+        $payload = [];
+        $payload['self'] = &$payload;
+
+        $this->expectException(InvalidExtraPropertyConstraintException::class);
+        $this->expectExceptionMessage('exceeds the maximum depth');
+
+        ExtraPropertyConstraintSerializer::serialize([
+            new Assert\NotBlank(['payload' => $payload]),
+        ]);
+    }
+
+    public function testInvalidNestedClassDropsWholeCompositeButKeepsValidSibling(): void
+    {
+        $rejections = [];
+        $serialized = serialize([
+            new Assert\NotBlank(),
+            new Assert\All([new UnsupportedConstraint()]),
+        ]);
+
+        $decoded = ExtraPropertyConstraintSerializer::unserialize(
+            $serialized,
+            static function (int|string|null $index, string $reason) use (&$rejections): void {
+                $rejections[] = [$index, $reason];
+            }
+        );
+
+        $this->assertCount(1, $decoded);
+        $this->assertInstanceOf(Assert\NotBlank::class, $decoded[0]);
+        $this->assertCount(1, $rejections);
+        $this->assertSame(1, $rejections[0][0]);
+        $this->assertStringContainsString(UnsupportedConstraint::class, $rejections[0][1]);
+    }
+
+    public function testDisallowedWakeupIsNeverExecuted(): void
+    {
+        WakeupGadget::$wakeupCalls = 0;
+
+        $decoded = ExtraPropertyConstraintSerializer::unserialize(serialize([new WakeupGadget()]));
+
+        $this->assertNull($decoded);
+        $this->assertSame(0, WakeupGadget::$wakeupCalls);
+    }
+
+    public function testMalformedPayloadIsRejectedWithoutEmittingAWarning(): void
+    {
+        $rejections = [];
+
+        $decoded = ExtraPropertyConstraintSerializer::unserialize(
+            'not-serialized',
+            static function (int|string|null $index, string $reason) use (&$rejections): void {
+                $rejections[] = [$index, $reason];
+            }
+        );
+
+        $this->assertNull($decoded);
+        $this->assertCount(1, $rejections);
+        $this->assertNull($rejections[0][0]);
+        $this->assertStringContainsString('Invalid serialized extra property constraints', $rejections[0][1]);
+    }
+}
+
+final class UnsupportedConstraint extends Constraint
+{
+}
+
+final class WakeupGadget
+{
+    public static int $wakeupCalls = 0;
+
+    public function __wakeup(): void
+    {
+        ++self::$wakeupCalls;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Hardens the deserialization of extra property validation constraints. `ExtraPropertyDefinition::decodeConstraints()` called `unserialize()` with `allowed_classes => true`, so any autoloadable class in the shop (core or module) could be instantiated from the `ps_extra_property_definition.constraints` column before the `instanceof Constraint` filter ran — meaning `__wakeup()`/`__destruct()` had already fired by the time the filter discarded the object. This PR introduces a single codec, `ExtraPropertyConstraintSerializer`, that owns the whole serialization contract: a fixed core class allowlist passed to `unserialize()`, plus a recursive validation of the decoded graph. The stored format stays PHP serialization, so there is **no data migration and no change to rows already written by 9.2 beta installs**. See the detailed notes below the table.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" section below.
| UI Tests          |
| Fixed issue or discussion?     | Fixes #42489
| Related PRs       | #42492 proposes an alternative approach to the same issue (switching the storage format to JSON). This PR is offered as a lower-risk alternative for 9.2 — see "Why not JSON" below.
| Sponsor company   | Kiwik

---

## What changes

A new `ExtraPropertyConstraintSerializer` centralizes serialization, deserialization and validation of extra property constraints:

- **Fixed core allowlist.** `unserialize()` now receives an explicit class list instead of `true`: the constraints already exposed by `ExtraPropertyConstraintMapper`, plus `Required`/`Optional` (which `Collection` generates internally for its children) and `DateTime`/`DateTimeImmutable` (usable as comparison bounds). The list is owned by core and is never derived from the stored blob or from the database.
- **`max_depth` and no `@`.** The error-suppression operator is gone; `unserialize()` warnings are converted through a scoped error handler and reported as a rejection reason.
- **Recursive validation of the decoded graph.** `allowed_classes` alone is not sufficient: it does not detect incomplete nested objects, and it does not prevent executable scalar options from being set on an *allowed* class. The walk therefore also rejects `callback`/`normalizer` and every `*PropertyPath` option, refuses any `__PHP_Incomplete_Class`, and guards against cycles and excessive depth.
- **Validation before DDL.** `ExtraPropertyRegistry::register()` validates constraints as its first step, before the schema manager runs, so an unsupported constraint can no longer leave an orphan column behind. A new `INVALID_CONSTRAINTS` reason code is mapped to a clear back-office error message.
- **Asymmetric failure contract.** Writes fail closed: `register()` throws, nothing is persisted. Reads fail safe: an invalid root constraint is dropped and logged at `error` level with its registry context (definition id, entity, module, property, reason) instead of throwing — a corrupt or tampered row must never break a front-office page render.

## Why the class allowlist is not enough on its own

`allowed_classes` only governs which *classes* may be instantiated. Several allowed constraints expose options that Symfony later invokes or resolves against the validated object (`normalizer`, `Choice::$callback`, and the `*PropertyPath` family). Those are plain strings, so a class allowlist does not cover them, and the `is_callable()` guard Symfony applies in the constructor is bypassed because `unserialize()` does not call constructors. Blocking them explicitly is what makes the allowlist meaningful, which is why the recursive walk is part of the fix rather than an optional extra.

A regression test asserts the exact list of callable-typed options across the allowlisted constraints, so a future Symfony version introducing a new one fails the build instead of silently widening the surface.

## Why not JSON

Switching the column to JSON (as proposed in #42492) was considered and set aside for 9.2:

- it requires migrating rows already stored by beta installs, and a definition whose constraints silently disappear is a validation bypass on values that used to be rejected;
- the JSON round-trip cannot represent every constraint option, so re-saving a definition can drop configuration;
- most importantly, it does not close the executable-option surface described above — those options are plain strings and survive a JSON round-trip just as well.

A structured storage format may still be the right long-term direction; it can be done deliberately in a later version with a proper migration, rather than under release pressure.

## Behavior change to be aware of

The feature is still in beta, so this is not covered by the backward compatibility promise, but it is worth stating explicitly:

- a module registering a **custom constraint class** (any `Constraint` subclass outside `ExtraPropertyConstraintMapper`'s list) is now rejected at `Module::registerExtraProperty()` with a clear message, instead of being accepted and silently dropped on a later read;
- constraints carrying a `normalizer`, `callback` or `*PropertyPath` option are rejected the same way. These options have no meaningful use for an extra property, which validates a single scalar value;
- an already-stored beta row containing either of the above has its offending constraint dropped on read, with an `error` log line naming the definition.

An extension point letting modules declare their own constraint classes was deliberately left out of this PR to keep it small and reviewable before the release; it can be added later without breaking this contract.

## How to test

**1. Nothing changed for supported constraints**

- Go to `Advanced Parameters > Extra Properties`, create or edit a property, and fill the "Validation" field with a mix of supported constraints, for example:
  ```
  NotBlank
  Length(min: 2, max: 64)
  All[ Url ]
  ```
- Save, then reopen the definition: the constraints must be displayed exactly as typed.
- Submit a value that violates one of them in the form where the property is displayed: the validation error must still be raised.

**2. No orphan column on rejection**

- Register a new property from module code with an unsupported constraint (a custom `Constraint` subclass), for example in a test module's `install()`.
- The call must throw an `ExtraPropertyException` and the storage column must **not** have been created in the corresponding `*_extra` table.

**3. A corrupt row degrades instead of crashing**

- Manually alter the `constraints` value of one row in `ps_extra_property_definition` (any string that is not a valid serialized constraint list).
- Browse the back-office grid and a front-office page displaying that entity: both must render normally, the property behaving as if it had no validation, and an `error` line must be present in the logs naming the definition id, entity, module and property.

**4. Automated tests**

```
php vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter ExtraProperty
php vendor/bin/phpstan analyse src/Core/ExtraProperty/
```
