### PR TITLE
Round the cart's price before reduction like the price beside it

### DIFF
--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -558,8 +558,20 @@ class CartLazyArray extends AbstractLazyArray
             }
         }
 
-        $rawProduct['price'] = Tools::ps_round($rawProduct['price'], Context::getContext()->getComputingPrecision());
-        $rawProduct['price_wt'] = Tools::ps_round($rawProduct['price_wt'], Context::getContext()->getComputingPrecision());
+        $computingPrecision = Context::getContext()->getComputingPrecision();
+        $rawProduct['price'] = Tools::ps_round($rawProduct['price'], $computingPrecision);
+        $rawProduct['price_wt'] = Tools::ps_round($rawProduct['price_wt'], $computingPrecision);
+
+        /*
+         * The price before reduction has to be rounded here too. It ends up in regular_price, next to the
+         * price rounded above, and PriceFormatter rounds with the locale's rule rather than the shop's, so
+         * an unrounded value shown beside a rounded one can differ by a cent - visibly, on the same line.
+         */
+        foreach (['price_without_reduction', 'price_without_reduction_without_tax'] as $priceBeforeReduction) {
+            if (isset($rawProduct[$priceBeforeReduction])) {
+                $rawProduct[$priceBeforeReduction] = Tools::ps_round($rawProduct[$priceBeforeReduction], $computingPrecision);
+            }
+        }
 
         if ($this->cartPresenter->includeTaxes()) {
             $rawProduct['price_amount'] = $rawProduct['price'] = $rawProduct['price_wt'];

--- a/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
@@ -10,6 +10,7 @@ use Cart;
 use Context;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter;
 use RuntimeException;
 
 class CartFeatureContext extends AbstractPrestaShopFeatureContext
@@ -117,6 +118,39 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
     public function totalCartWithoutTaxShouldBe($precisely, $expectedTotal)
     {
         $this->expectsTotal($expectedTotal, false, !empty($precisely));
+    }
+
+    /**
+     * The cart shows the selling price and the price before reduction side by side. They are formatted from
+     * two different values, and only one of them used to be rounded with the shop's rounding mode, so a
+     * price with more decimals than the currency could show a cent of difference between the two.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/28621
+     *
+     * @Then /^the displayed price and price before reduction of product "(.+)" in my cart should be identical$/
+     */
+    public function displayedPriceAndPriceBeforeReductionShouldMatch($productName)
+    {
+        $presented = (new CartPresenter())->present($this->getCurrentCart());
+
+        foreach ($presented['products'] as $product) {
+            if ($product['name'] !== $productName) {
+                continue;
+            }
+
+            if ($product['price'] !== $product['regular_price']) {
+                throw new RuntimeException(sprintf(
+                    'Product "%s" is displayed at %s but with a price before reduction of %s',
+                    $productName,
+                    $product['price'],
+                    $product['regular_price']
+                ));
+            }
+
+            return;
+        }
+
+        throw new RuntimeException(sprintf('Product "%s" is not in the cart', $productName));
     }
 
     protected function expectsTotal($expectedTotal, $withTax = true, $precisely = false)

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/displayed_price_before_reduction.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/displayed_price_before_reduction.feature
@@ -1,0 +1,21 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-displayed-price-before-reduction
+@restore-all-tables-before-feature
+@cart-displayed-price-before-reduction
+Feature: Displayed price and price before reduction of a cart line
+  As a customer
+  I must see the same amount for the price of a product and for its price before reduction,
+  whichever rounding mode the shop uses
+
+  Scenario: A price with more decimals than the currency, rounded down
+    Given I have an empty default cart
+    And specific shop configuration for "rounding mode" is set to round down
+    And there is a product in the catalog named "product1" with a price of 600.008 and 1000 items in stock
+    When I add 1 items of product "product1" in my cart
+    Then the displayed price and price before reduction of product "product1" in my cart should be identical
+
+  Scenario: The same price rounded up
+    Given I have an empty default cart
+    And specific shop configuration for "rounding mode" is set to round up
+    And there is a product in the catalog named "product1" with a price of 600.001 and 1000 items in stock
+    When I add 1 items of product "product1" in my cart
+    Then the displayed price and price before reduction of product "product1" in my cart should be identical


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CartLazyArray` rounds the selling price of a cart line with `Tools::ps_round()`, i.e. with the shop's rounding mode, and leaves `price_without_reduction` untouched. Both are then handed to `PriceFormatter`, which rounds with the locale's own rule. A price carrying more decimals than the currency therefore comes out rounded down as `price` and rounded half up as `regular_price` — a cent apart, on the same cart line, which is what the report shows. The two values before reduction are now rounded exactly where the two selling prices already are.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shop Parameters > General: `Round mode` = `Round down`, `Round type` = `Round on each item`. A product at 163.49 in the default currency and a second currency at a conversion rate of 3.67. Add the product to the cart in that currency: before the change the line shows 600.00 as the price and 600.01 as the price before reduction; after it, both are 600.00. Covered by `Cart/Rounding/displayed_price_before_reduction.feature`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28621
| Related PRs       |
| Sponsor company   |

### Measured, with the reporter's own numbers

Product at 163.49, currency at 3.67, `Round down` + `Round on each item`. `163.49 * 3.67 = 600.0083`.

```
                                     before            after
cart row price / price_wt            600.0083          600.0083     (raw, unchanged)
cart row total / total_wt            600.0             600.0
presented price                      AED600.00         AED600.00
presented regular_price              AED600.01         AED600.00    <- the report
summary total_products(_wt)          600               600
```

`CartLazyArray` was rounding only two of the four per-unit values it passes on:

```php
$rawProduct['price']    = Tools::ps_round($rawProduct['price'],    $precision);
$rawProduct['price_wt'] = Tools::ps_round($rawProduct['price_wt'], $precision);
```

`ProductLazyArray` then formats `price_without_reduction_without_tax` and `price_without_reduction` into
`regular_price_tax_excluded` / `regular_price_tax_included` with the same `PriceFormatter` used for the
rounded pair, so the difference is purely which values were rounded first.

### Test

`tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/displayed_price_before_reduction.feature`, next
to the existing rounding scenarios, adds a price with more decimals than the currency under `round down` and
under `round up`, and a new `CartFeatureContext` step asserts the two displayed amounts are identical. The
step compares the two formatted values rather than a literal, so it does not depend on the tax rate or the
currency of the fixture.

Mutation check: presenter reverted to `9.2.x` →
`Product "product1" is displayed at $600.00 but with a price before reduction of $600.01` under round down,
and the mirror `$600.01` versus `$600.00` under round up; restored → green.

Regression: the full `cart` suite (244 scenarios, 3548 steps) and the full `order` suite (260 scenarios,
7344 steps) both pass on the branch.

### Scope

Only the cart line's own values. `RosaBenouamer`'s 2023 comment asks that both places be checked — the cart
page and the checkout summary — and both read `regular_price` from this same presenter, so both follow.
