### PR TITLE
Validate the order's country from the cart address, not from the context

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -399,7 +399,24 @@ abstract class PaymentModuleCore extends Module
             $this->context->country = $context_country;
         }
 
-        if (!$this->context->country->active) {
+        /*
+         * Check the country of the address the order is taxed on, not the one of the current context.
+         * An off-session call, typically the notification a payment gateway sends from its own server,
+         * carries the country of whoever made the request, and geolocation resolves that to a country
+         * the shop may have disabled - which aborts an order the customer paid for.
+         * AbstractOrderCommandHandler::getCartTaxCountry() resolves the same address, and
+         * AddOrderFromBackOfficeHandler already seeds the context from the cart before calling this,
+         * with a comment saying this check should rely on the cart address instead.
+         * With multi shipping the cart carries no single delivery address; each order's own address is
+         * already validated in createOrderFromCart().
+         */
+        $taxAddressType = Configuration::get('PS_TAX_ADDRESS_TYPE');
+        $taxAddressId = property_exists($this->context->cart, $taxAddressType)
+            ? $this->context->cart->{$taxAddressType}
+            : $this->context->cart->id_address_delivery;
+        $taxAddress = new Address((int) $taxAddressId);
+
+        if (Validate::isLoadedObject($taxAddress) && !(new Country((int) $taxAddress->id_country))->active) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Country is not active', 3, null, 'Cart', (int) $id_cart, true);
 
             throw new PrestaShopException('The order address country is not active.');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PaymentModule::validateOrder()` aborts when `$this->context->country` is disabled. On an off-session call — typically the notification a payment gateway sends from its own server — the context country is the country of whoever made the request, which geolocation resolves from the requesting IP. If that country is disabled in the shop, an order the customer has already paid for is thrown away, even though the customer's own address is in an enabled country. The check now reads the address the cart is taxed on, resolved the same way `AbstractOrderCommandHandler::getCartTaxCountry()` resolves it. The save and restore of `$context_country` around the order loop is untouched.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable geolocation, disable a country, and place an order from an address in an enabled country using a payment module that confirms through a server-to-server notification. Issue that notification from an IP in the disabled country. Before the change `validateOrder()` throws `The order address country is not active.` and the order is lost; after it, the order is validated because the cart's tax address is in an enabled country. Placing an order whose own tax address is in a disabled country is still refused.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28648
| Related PRs       | Supersedes #33392 and #41687, both closed
| Sponsor company   |

### Why this shape rather than removing the check

Both earlier attempts are on the thread. #33392 removed the check outright; @kpodemski asked whether keeping
the context country stable was the point of the original code and @Matt75 warned that the context is used
further down for the invoice PDF, e-mails and more. #41687 kept the check and only flagged the orphaned
orders with the payment-error status, and its author closed it two days later.

Reading the address instead answers both. The context save and restore stays exactly as it is, so nothing
downstream changes; only the value the guard tests moves from "who sent this request" to "where is this
order going". @MatShir asked for that in 2023-07-05 — *"I like the idea of basing the condition on the
address"* — and @idnovate proposed it as his second option in the issue body.

### Core already says so

`AddOrderFromBackOfficeHandler` carries this, immediately before it calls `validateOrder()`:

```php
// Context country, language and currency is used in PaymentModule::validateOrder (it should rely on cart address country instead)
$this->setCartContext($this->contextStateManager, $cart);
```

That seeding is why the back office never hits the bug, and the parenthesis is the same conclusion.

### The check is not lost

`createOrderFromCart()` already validates each order's delivery address when `PS_TAX_ADDRESS_TYPE` is
`id_address_delivery`, throwing `The delivery address country is not active.` With multi shipping the cart
carries no single delivery address, so `Validate::isLoadedObject()` skips the guard and that per-order check
is the one that applies. The `id_address_invoice` configuration, which `createOrderFromCart()` does not
cover, is now checked here against the right address instead of against the context.

### The invoice-address configuration really is covered

The guard steps aside when the tax address is not loadable, so it matters whether a cart can reach payment
without an invoice address. It cannot: `CheckoutAddressesStep` marks itself complete only when both ids are
set (`getIdAddressInvoice() && getIdAddressDelivery()`), and on the demo data
`SELECT COUNT(*) FROM ps_cart WHERE id_address_delivery > 0 AND id_address_invoice = 0` returns 0, as does
the same count over the 60,004 orders. The transient `null` that `CheckoutAddressesStep` writes when the
customer opts out of "use the same address" is exactly what that completeness check blocks.

### No automated test, and the reason is specific

The only caller that reproduces the bug is one where the context was never initialised from the cart. Every
path the test suites drive does initialise it: `AddOrderFromBackOfficeHandler` calls `setCartContext()`,
which sets the country to `getCartTaxCountry($cart)` — the very address the fixed guard reads — so the old
and the new guard see the same value and no scenario can tell them apart. Reproducing it needs a front
office notification request with geolocation resolving to a disabled country, which is what the reporter
described as a "conceptual" test and what QA reproduced with a VPN.

The full `order` behat suite passes on the branch: 260 scenarios, 7344 steps.
