### PR TITLE
Scope the front office attribute filter to the current shop's stock

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -776,8 +776,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                     }
                     $id_attributes = Db::getInstance()->executeS('SELECT pac2.`id_attribute` FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac2' .
                         ((!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && false === (bool) Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) ?
+                        // The stock rows of every shop live in the same table, so without the restriction an
+                        // attribute stays selectable because some other shop, possibly in a group this one
+                        // shares nothing with, still has stock for that combination.
                         ' INNER JOIN `' . _DB_PREFIX_ . 'stock_available` pa ON pa.id_product_attribute = pac2.id_product_attribute
-                        WHERE pa.quantity > 0 AND ' :
+                        WHERE pa.quantity > 0' . StockAvailable::addSqlShopRestriction(null, null, 'pa') . ' AND ' :
                         ' WHERE ') .
                         'pac2.`id_product_attribute` IN (' . implode(',', array_map('intval', $id_product_attributes)) . ')
                         AND pac2.id_attribute NOT IN (' . implode(',', array_map('intval', $current_selected_attributes)) . ')');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | With `PS_DISP_UNAVAILABLE_ATTR` off, `ProductController` narrows the second and later attribute groups to the values that still have a combination in stock given what is already selected. That query joins `stock_available` with **no shop restriction at all** — `INNER JOIN stock_available pa ON pa.id_product_attribute = pac2.id_product_attribute WHERE pa.quantity > 0` — so an attribute stays selectable as long as *any* shop has stock for that combination, including a shop of a group the current one shares nothing with. The value is then offered and does nothing when clicked, because the combination really is unavailable in this shop. Adds `StockAvailable::addSqlShopRestriction()`, which every other stock read on this page already uses, directly or through `Product::sqlStock()`.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Two shop groups that do not share stock. A product with two attribute groups, for example Colour and Size. In shop A, leave one Size out of stock for a Colour while another Size of that Colour has stock; give that same out-of-stock combination stock in a shop of the other group. Open the product in shop A with `Shop Parameters > Product Settings > Display unavailable product attributes` set to No. Before the change the Size is offered and clicking it does nothing; after it, the Size is gone.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28697
| Related PRs       |
| Sponsor company   |
| Branch?           | 9.2.x

### Measured

Demo product 1 (Size x Colour). Combination `Size:M | Colour:White` set to quantity `0` for shop 1 and given
`50` on a `stock_available` row belonging to shop 2, a shop outside shop 1's group. Running the controller's
own query verbatim, with `White` as the already-selected attribute:

```
sizes still offered, query as it is    L, M, S, XL      <- M comes from shop 2
sizes still offered, shop-restricted   L, S, XL
```

The restriction the fix injects for that context is `AND pa.id_shop = 1 AND pa.id_shop_group = 0`, and for a
group that shares stock it is the `id_shop_group = <group> AND id_shop = 0` form, so both multistore stock
modes are handled by the existing helper.

### Why the rest of the page is right and only this is wrong

`attributes_quantity`, which drives the second wash a few lines below and the colour list, comes from
`Product::getAttributesGroups()`, which joins through `Product::sqlStock()` and therefore through
`addSqlShopRestriction()`. `Product::getAttributeCombinations()` reads its quantities from
`StockAvailable::getQuantityAvailableByProduct()`, also restricted. This one inline query is the only stock
read on the product page without a shop clause.

### No automated test

The query lives inline in a legacy front controller, which no harness here drives — the behat multishop
scenarios cover the CQRS and domain layers, not `ProductController`. The measurement above is the evidence,
and the change is the same helper call used everywhere else in the file's neighbourhood. A front office smoke
test with the setting off returns 200 with the attribute markup intact.
