### PR TITLE
Give back the stock a pack took when its order is cancelled

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -198,15 +198,13 @@ class OrderHistoryCore extends ObjectModel
                     // if becoming logable => adds sale
                     if ($new_os->logable && !$old_os->logable) {
                         ProductSale::addProductSale($product['product_id'], $product['product_quantity']);
-                        if (!Pack::isPack($product['product_id'])
-                            && in_array($old_os->id, $error_or_canceled_statuses)) {
+                        if (in_array($old_os->id, $error_or_canceled_statuses)) {
                             StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
                         }
                     } elseif (!$new_os->logable && $old_os->logable) {
                         // if becoming unlogable => removes sale
                         ProductSale::removeProductSale($product['product_id'], $product['product_quantity']);
-                        if (!Pack::isPack($product['product_id'])
-                            && in_array($new_os->id, $error_or_canceled_statuses)) {
+                        if (in_array($new_os->id, $error_or_canceled_statuses)) {
                             StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
                         }
                     } elseif (!$new_os->logable && !$old_os->logable

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_pack_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_pack_stock.feature
@@ -1,0 +1,38 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-pack-stock
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@order-pack-stock
+Feature: Stock of a pack ordered and then cancelled
+  In order to keep the catalog consistent
+  As a BO user
+  I need the stock a pack took to come back when the order is cancelled
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+    And there is a product in the catalog named "packedMug" with a price of 10.00 and 300 items in stock
+    And there is a product in the catalog named "mugPack" with a price of 18.00 and 10 items in stock
+    And product "mugPack" is a pack containing 2 items of product "packedMug"
+    And the pack "mugPack" decrements both packs and products
+
+  Scenario: Cancelling an order gives back the stock the pack took, for the pack and for what it contains
+    Given I am logged in as "test@prestashop.com" employee
+    And I create an empty cart "pack_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "pack_cart"
+    And I add 1 product "mugPack" to the cart "pack_cart"
+    And I add order "pack_order" with the following details:
+      | cart                | pack_cart        |
+      | message             | test             |
+      | payment module name | dummy_payment    |
+      | status              | Payment accepted |
+    Then the available stock for product "mugPack" should be 9
+    And the available stock for product "packedMug" should be 298
+    When I update order "pack_order" status to "Canceled"
+    Then order "pack_order" has status "Canceled"
+    And the available stock for product "mugPack" should be 10
+    And the available stock for product "packedMug" should be 300


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `OrderDetail::updateProductQuantityInStock()` decrements a pack with the same `StockAvailable::updateQuantity()` it uses for any other product, and that routes through `Core\Stock\StockManager::updatePackQuantity()`, which moves the pack and, in decrement-both mode, what it contains. `OrderHistory::changeIdOrderState()` then refused to call it back for a pack, in the two branches that handle a logable to unlogable transition, so cancelling a paid order left the stock taken. The two other branches of the same condition, covering transitions between unlogable states, already called it with no such guard, so the class treated a pack differently depending on which status the order came from. Removes both guards so the restore mirrors the decrement.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a pack of 2 units of a product, quantities set to `Decrement both`, and give it stock. Place an order for one pack and set it to `Payment accepted`: the pack loses 1 and the contained product loses 2. Cancel the order. Before the change neither comes back; after it, both do. Covered by `order_pack_stock.feature`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28713
| Related PRs       |
| Sponsor company   |

### The asymmetry, in one place

`classes/order/OrderHistory.php`, all four branches of the same `if`:

```
new logable, old not     if (!Pack::isPack(...) && old is error/cancel)   -> skipped packs
new not logable, old was if (!Pack::isPack(...) && new is error/cancel)   -> skipped packs      <- the report
both unlogable, -> cancel   (no guard)                                     -> handled packs
both unlogable, <- cancel   (no guard)                                     -> handled packs
```

### Measured, before writing anything

Product 19 turned into a pack of 2 units of product 8 with `pack_stock_type = PACK_BOTH`, then the exact call
`OrderHistory` makes for a non-pack:

```
before                                    pack = 300   contained = 300
StockAvailable::updateQuantity(pack, 0, +1)
after                                     pack = 301   contained = 302
```

So the handler the guards were blocking already does the right thing for a pack, in both directions.

### Test

`tests/Integration/Behaviour/Features/Scenario/Order/order_pack_stock.feature` builds a pack of 2, orders
one, sets `Payment accepted`, asserts `9` and `298`, cancels, and asserts `10` and `300`.

Mutation check: guards restored → `Expects 10, got 9 instead` at the pack assertion; removed again → green.
The **whole order suite** was run on the fix: **261 scenarios, 7366 steps, all passing**, so nothing else in
the order flow depended on packs being skipped there.

### The guards are as old as the file

They are not a leftover from before the pack-aware handler existed — both are present, identically, in
1.7.6.9, 1.7.8.7, 8.0.0, 8.1.0 and 9.x, and `Core\Stock\StockManager::updatePackQuantity()` is already
`PACK_BOTH`-aware in 1.7.6.9. Why they were written is not recoverable from the tags. For context only,
`OrderHistory` carried a third `Pack::isPack` block until 8.1.0 — the Advanced Stock Management restock path
(`PS_ADVANCED_STOCK_MANAGEMENT`: 5 occurrences in 8.1.0, 0 in 9.0.0) — but it lived in the shipped-state
section, not the logable one, so it is not offered as the reason.

The change rests on what it does: the decrement never had the guard, two of the four branches never had it,
the handler is correct in both directions, and the whole order suite passes without it.

### Not addressed

`Adapter\StockManager::updateReservedProductQuantity()` recomputes `reserved_quantity` from `order_detail`
joined on `product_id`, and pack members never appear in `order_detail`, so the reserved column still
ignores them. That is the part @ociohogar's #34863 rewrites; it is a different file and is deliberately not
touched here.
