### PR TITLE
Stop offering disabled states in the back office forms

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/CountryStateByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/CountryStateByIdChoiceProvider.php
@@ -13,6 +13,7 @@ use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShopException;
 use State;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Validate;
 
 /**
  * Provides choices of country states with state name as key and id as value
@@ -37,11 +38,22 @@ final class CountryStateByIdChoiceProvider implements ConfigurableFormChoiceProv
                 return [];
             }
 
-            $choices = FormChoiceFormatter::formatFormChoices(
-                State::getStatesByIdCountry($countryId, $resolvedOptions['only_active'], 'name', 'asc'),
-                'id_state',
-                'name'
-            );
+            $states = State::getStatesByIdCountry($countryId, $resolvedOptions['only_active'], 'name', 'asc');
+
+            /*
+             * A record already pointing at a state that has since been disabled must keep it in the list.
+             * Without it the select renders with nothing chosen, and saving the form for an unrelated
+             * reason moves the record to whichever state the browser submits instead.
+             */
+            $keptStateId = $resolvedOptions['kept_state_id'];
+            if ($keptStateId > 0 && !in_array($keptStateId, array_column($states, 'id_state'))) {
+                $keptState = new State($keptStateId);
+                if (Validate::isLoadedObject($keptState) && (int) $keptState->id_country === $countryId) {
+                    $states[] = ['id_state' => $keptState->id, 'name' => $keptState->name];
+                }
+            }
+
+            $choices = FormChoiceFormatter::formatFormChoices($states, 'id_state', 'name');
         } catch (PrestaShopException) {
             throw new CoreException(sprintf('An error occurred when getting states for country id "%s"', $countryId));
         }
@@ -56,10 +68,14 @@ final class CountryStateByIdChoiceProvider implements ConfigurableFormChoiceProv
      */
     private function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['only_active' => false]);
+        // Disabled states are hidden by default: every consumer of this provider is a form asking which
+        // state a record belongs to, and the front office has always filtered them out
+        // (CustomerAddressFormatter). Pass only_active => false to get the raw list back.
+        $resolver->setDefaults(['only_active' => true, 'kept_state_id' => 0]);
         $resolver->setRequired('id_country');
         $resolver->setAllowedTypes('id_country', 'int');
         $resolver->setAllowedTypes('only_active', 'bool');
+        $resolver->setAllowedTypes('kept_state_id', 'int');
         $this->allowIdCountryGreaterThanZero($resolver);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/StateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/StateController.php
@@ -89,8 +89,10 @@ class StateController extends PrestaShopAdminController
     ): Response {
         try {
             $countryId = (int) $request->query->get('id_country');
+            $queryStateId = (int) $request->query->get('id_state');
             $states = $statesProvider->getChoices([
                 'id_country' => $countryId,
+                'kept_state_id' => $queryStateId,
             ]);
 
             if (!empty($states)) {
@@ -100,7 +102,6 @@ class StateController extends PrestaShopAdminController
                     $htmlResponse = '<option value="0">' . htmlentities($emptyValue, ENT_QUOTES, 'utf-8') . '</option>' . "\n";
                 }
 
-                $queryStateId = (int) $request->query->get('id_state');
                 foreach ($states as $stateName => $stateId) {
                     $htmlResponse .= '<option value="' . $stateId . '"' . ($queryStateId == $stateId ? ' selected="selected"' : '') . '>' . $stateName . '</option>' . "\n";
                 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -85,7 +85,10 @@ class CustomerAddressType extends TranslatorAwareType
             'Invalid characters:',
             'Admin.Notifications.Info'
         ) . ' ' . TypedRegexValidator::GENERIC_NAME_CHARS;
-        $stateChoices = $this->stateChoiceProvider->getChoices(['id_country' => $countryId]);
+        $stateChoices = $this->stateChoiceProvider->getChoices([
+            'id_country' => $countryId,
+            'kept_state_id' => (int) ($data['id_state'] ?? 0),
+        ]);
         $showStates = !empty($stateChoices);
         $requiredFields = $options['requiredFields'];
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
@@ -77,7 +77,10 @@ class ManufacturerAddressType extends TranslatorAwareType
         $nameHint = $this->trans('Invalid characters:', 'Admin.Global') . ' 0-9!<>,;?=+()@#"�{}_$%:';
         $data = $builder->getData();
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;
-        $stateChoices = $this->statesChoiceProvider->getChoices(['id_country' => $countryId]);
+        $stateChoices = $this->statesChoiceProvider->getChoices([
+            'id_country' => $countryId,
+            'kept_state_id' => (int) ($data['id_state'] ?? 0),
+        ]);
         $otherHint = $this->trans('Invalid characters:', 'Admin.Global') . ' <>{}';
 
         $builder

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -219,7 +219,10 @@ class SupplierType extends TranslatorAwareType
             ->add('id_state', ChoiceType::class, [
                 'label' => $this->trans('State', 'Admin.Global'),
                 'required' => true,
-                'choices' => $this->statesChoiceProvider->getChoices(['id_country' => $countryId]),
+                'choices' => $this->statesChoiceProvider->getChoices([
+                    'id_country' => $countryId,
+                    'kept_state_id' => (int) ($data['id_state'] ?? 0),
+                ]),
                 'constraints' => [
                     new AddressStateRequired([
                         'id_country' => $countryId,

--- a/tests/Integration/Adapter/Form/ChoiceProvider/CountryStateByIdChoiceProviderTest.php
+++ b/tests/Integration/Adapter/Form/ChoiceProvider/CountryStateByIdChoiceProviderTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\CountryStateByIdChoiceProvider;
+use State;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class CountryStateByIdChoiceProviderTest extends KernelTestCase
+{
+    /**
+     * United States, the country the demo data gives states to.
+     */
+    private const COUNTRY_ID = 21;
+
+    /**
+     * @var CountryStateByIdChoiceProvider
+     */
+    private $choiceProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DatabaseDump::restoreTables(['state']);
+        self::bootKernel();
+
+        $this->choiceProvider = self::getContainer()->get('prestashop.adapter.form.choice_provider.country_state_by_id');
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(['state']);
+
+        parent::tearDown();
+    }
+
+    public function testADisabledStateIsNotOffered(): void
+    {
+        $stateId = $this->disableFirstState();
+
+        $this->assertNotContains($stateId, $this->choiceProvider->getChoices(['id_country' => self::COUNTRY_ID]));
+    }
+
+    public function testADisabledStateIsKeptWhenItIsTheOneAlreadySelected(): void
+    {
+        $stateId = $this->disableFirstState();
+
+        $choices = $this->choiceProvider->getChoices([
+            'id_country' => self::COUNTRY_ID,
+            'kept_state_id' => $stateId,
+        ]);
+
+        $this->assertContains($stateId, $choices);
+    }
+
+    public function testTheRawListIsStillAvailable(): void
+    {
+        $stateId = $this->disableFirstState();
+
+        $choices = $this->choiceProvider->getChoices([
+            'id_country' => self::COUNTRY_ID,
+            'only_active' => false,
+        ]);
+
+        $this->assertContains($stateId, $choices);
+    }
+
+    private function disableFirstState(): int
+    {
+        $states = State::getStatesByIdCountry(self::COUNTRY_ID, true, 'name', 'asc');
+        $this->assertNotEmpty($states, 'Expected the demo data to give states to country ' . self::COUNTRY_ID);
+
+        $state = new State((int) $states[0]['id_state']);
+        $state->active = false;
+        $this->assertTrue($state->update());
+
+        return (int) $state->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CountryStateByIdChoiceProvider` defaults `only_active` to `false`, and not one of its five callers passes the option, so every back office form that asks which state a record belongs to lists disabled ones: the customer address form, the manufacturer address form, the supplier form, and both `StateController` endpoints that repopulate those selects when the country changes. The front office has always filtered them out — `CustomerAddressFormatter:106` calls `State::getStatesByIdCountry($id, true, ...)` — which is why the report sees the state correctly hidden there and not in the back office. The provider's default becomes the filtered list, and a record already pointing at a state that has since been disabled keeps it through a new `kept_state_id` option.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | BO > International > Locations > States: disable a state of a country that has states. BO > Customers > Addresses > edit an address in that country: the disabled state is no longer in the list, while an address already assigned to it still shows it. Same on BO > Catalog > Brands > Addresses and BO > Catalog > Suppliers, and after switching the country on any of those forms, which reloads the list over AJAX.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28772
| Related PRs       |
| Sponsor company   |

The `only_active` option is kept, so a caller that really wants the raw list can still ask for it.

### Measured

Country 21 (United States, 56 states in the demo data) with state id 1 disabled:

```
getChoices(['id_country' => 21])                      56 choices, disabled state present: YES
getChoices(['id_country' => 21, 'only_active' => 1])  55 choices, disabled state present: no
```

### Why `kept_state_id` exists

Filtering alone is not enough. `ChoiceToValueTransformer::transform()` returns `''` for a value outside the
choice list, so an address whose state has since been disabled would render with nothing selected — and the
field is `required` with no placeholder, so submitting the form for an unrelated reason (a phone number, a
company name) would move the record to whichever state the browser posts. `kept_state_id` puts the
currently referenced state back into the list, and only that one. The four call sites that edit an existing
record pass it; `getStatesAction`, which fires when the country has just changed, does not, because there is
no previous state to preserve.

### Test and mutation check

`tests/Integration/Adapter/Form/ChoiceProvider/CountryStateByIdChoiceProviderTest` disables a state and
asserts it is absent, present when named through `kept_state_id`, and present again with
`only_active => false`.

Mutation check, provider reverted to `9.2.x`: `testADisabledStateIsNotOffered` fails with
`Failed asserting that an array does not contain 1` — a real assertion failure on the reported behaviour.
The `kept_state_id` test errors with `UndefinedOptionsException` instead, which proves nothing by itself;
the first failure is the one that carries the check.

### Also on that thread

#28772 raises a second point, that the zip code is required in the back office address form. That one is
#29625 and is prepared separately on `fix/postcode-not-forced-in-bo-address-form-29625`.
