### PR TITLE
Bound the length of the local units

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
@@ -9,6 +9,7 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Localization;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
 
 /**
  * Class LocalUnitsType is responsible for building 'Improve > International > Localization' page
@@ -16,6 +17,13 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class LocalUnitsType extends TranslatorAwareType
 {
+    /**
+     * The longest unit shipped by any of the 96 localization packs is 9 characters, so this leaves room
+     * for an uncommon one while keeping the value short enough for the carrier and product shipping forms
+     * that print it next to a field.
+     */
+    public const MAX_UNIT_LENGTH = 20;
+
     /**
      * {@inheritdoc}
      */
@@ -31,6 +39,16 @@ class LocalUnitsType extends TranslatorAwareType
                     'The default weight unit for your shop (e.g. "kg" for kilograms, "lbs" for pound-mass, etc.).',
                     'Admin.International.Help'
                 ),
+                'constraints' => [
+                    new Length([
+                        'max' => self::MAX_UNIT_LENGTH,
+                        'maxMessage' => $this->trans(
+                            'This field cannot be longer than %limit% characters',
+                            'Admin.Notifications.Error',
+                            ['%limit%' => self::MAX_UNIT_LENGTH]
+                        ),
+                    ]),
+                ],
             ])
             ->add('distance_unit', TextType::class, [
                 'label' => $this->trans(
@@ -41,6 +59,16 @@ class LocalUnitsType extends TranslatorAwareType
                     'The default distance unit for your shop (e.g. "km" for kilometer, "mi" for mile, etc.).',
                     'Admin.International.Help'
                 ),
+                'constraints' => [
+                    new Length([
+                        'max' => self::MAX_UNIT_LENGTH,
+                        'maxMessage' => $this->trans(
+                            'This field cannot be longer than %limit% characters',
+                            'Admin.Notifications.Error',
+                            ['%limit%' => self::MAX_UNIT_LENGTH]
+                        ),
+                    ]),
+                ],
             ])
             ->add('volume_unit', TextType::class, [
                 'label' => $this->trans(
@@ -51,6 +79,16 @@ class LocalUnitsType extends TranslatorAwareType
                     'The default volume unit for your shop (e.g. "L" for liter, "gal" for gallon, etc.).',
                     'Admin.International.Help'
                 ),
+                'constraints' => [
+                    new Length([
+                        'max' => self::MAX_UNIT_LENGTH,
+                        'maxMessage' => $this->trans(
+                            'This field cannot be longer than %limit% characters',
+                            'Admin.Notifications.Error',
+                            ['%limit%' => self::MAX_UNIT_LENGTH]
+                        ),
+                    ]),
+                ],
             ])
             ->add('dimension_unit', TextType::class, [
                 'label' => $this->trans(
@@ -61,6 +99,16 @@ class LocalUnitsType extends TranslatorAwareType
                     'The default dimension unit for your shop (e.g. "cm" for centimeter, "in" for inch, etc.).',
                     'Admin.International.Help'
                 ),
+                'constraints' => [
+                    new Length([
+                        'max' => self::MAX_UNIT_LENGTH,
+                        'maxMessage' => $this->trans(
+                            'This field cannot be longer than %limit% characters',
+                            'Admin.Notifications.Error',
+                            ['%limit%' => self::MAX_UNIT_LENGTH]
+                        ),
+                    ]),
+                ],
             ]);
     }
 }

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsTypeTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsTypeTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Improve\International\Localization;
+
+use PrestaShopBundle\Form\Admin\Improve\International\Localization\LocalUnitsType;
+use Tests\Integration\PrestaShopBundle\Form\FormListenerTestCase;
+
+class LocalUnitsTypeTest extends FormListenerTestCase
+{
+    /**
+     * Deliberately a literal and not LocalUnitsType::MAX_UNIT_LENGTH: the test has to keep loading
+     * against a build without the constant, otherwise reverting the fix produces an "undefined constant"
+     * error instead of a failing assertion.
+     */
+    private const MAX_UNIT_LENGTH = 20;
+
+    /**
+     * @dataProvider getUnitFieldNames
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/28910
+     */
+    public function testAUnitLongerThanTheLimitIsRejected(string $fieldName): void
+    {
+        $form = $this->createForm(LocalUnitsType::class, ['csrf_protection' => false]);
+        $form->submit($this->submittedUnits([$fieldName => str_repeat('a', self::MAX_UNIT_LENGTH + 1)]));
+
+        $this->assertFalse($form->isValid());
+        $this->assertGreaterThan(0, $form->get($fieldName)->getErrors()->count());
+    }
+
+    /**
+     * @dataProvider getUnitFieldNames
+     */
+    public function testAUnitAtTheLimitIsAccepted(string $fieldName): void
+    {
+        $form = $this->createForm(LocalUnitsType::class, ['csrf_protection' => false]);
+        $form->submit($this->submittedUnits([$fieldName => str_repeat('a', self::MAX_UNIT_LENGTH)]));
+
+        $this->assertTrue($form->isValid(), (string) $form->getErrors(true, false));
+    }
+
+    public function getUnitFieldNames(): iterable
+    {
+        yield ['weight_unit'];
+        yield ['distance_unit'];
+        yield ['volume_unit'];
+        yield ['dimension_unit'];
+    }
+
+    /**
+     * @param array<string, string> $overrides
+     *
+     * @return array<string, string>
+     */
+    private function submittedUnits(array $overrides): array
+    {
+        return array_merge([
+            'weight_unit' => 'kg',
+            'distance_unit' => 'km',
+            'volume_unit' => 'L',
+            'dimension_unit' => 'cm',
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The four fields of the `Local units` block on Improve > International > Localization carry no constraint at all — `LocalUnitsType` builds them as bare `TextType` — and `LocalUnitsConfiguration::validateConfiguration()` only checks that the keys are present. So any string can be saved into `PS_WEIGHT_UNIT`, `PS_DISTANCE_UNIT`, `PS_VOLUME_UNIT` and `PS_DIMENSION_UNIT`, and it is then printed next to the fields of the carrier form (`Shipping locations and costs`, `Size, weight, and group access`) and the product shipping tab, which is what the report shows. Adds a `Length` constraint of 20 characters to each field.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Improve > International > Localization > Local units: enter a unit longer than 20 characters and save. Before the change it is accepted and then wrecks the carrier and product shipping forms; after it, the field is rejected with a message. Units of normal length behave as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28910
| Related PRs       |
| Sponsor company   |

### Where 20 comes from

Parsing the `<unit>` elements of the 96 localization packs shipped under `localization/`, the longest unit
value is **9 characters** — `سانتی‌متر` (centimeter, Persian, which carries a zero-width non-joiner); the next
longest is 7. 20 is a bit over twice that, which leaves room for an uncommon unit while staying short enough
for the form suffixes that print it. It is also the same bound used for the currency symbol in the branch
for #28911, so the two related limits agree.

@aecarlosae proposed 10 on the thread in 2022. That would be tight: the longest unit PrestaShop itself
ships is 9.

### Test

`tests/Integration/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsTypeTest`
submits each of the four fields at the limit and one character over it. The limit is written as a **literal**
in the test, not as `LocalUnitsType::MAX_UNIT_LENGTH`: referencing the constant makes the test fail to load
against a build without it, so reverting the fix produces `Error: Undefined constant` and
`No tests executed` instead of a failing assertion — which proves nothing. With literals the mutation check
is real: reverted form type → four `Failed asserting that true is false`; restored → green.

The form is created with `csrf_protection => false`; without it every submit fails on the token before any
constraint runs, and the "accepted" cases were red for the wrong reason.

### Not addressed

`LocalUnitsConfiguration::validateConfiguration()` still only checks that the four keys exist, and the
fields still accept an empty value. Neither is what this report is about.
