### PR TITLE
Bound the currency symbol length and the number of decimals

### DIFF
--- a/src/Core/Domain/Currency/ValueObject/Precision.php
+++ b/src/Core/Domain/Currency/ValueObject/Precision.php
@@ -13,6 +13,12 @@ class Precision
     public const DEFAULT_PRECISION = 2;
 
     /**
+     * Every price column in the database is decimal(20,6), so digits beyond the sixth are always zero.
+     * For reference, the highest fraction digits CLDR declares for any currency is 4.
+     */
+    public const MAX_PRECISION = 6;
+
+    /**
      * @var int
      */
     private $precision;
@@ -25,6 +31,7 @@ class Precision
     public function __construct(int $precision)
     {
         $this->assertIsPositiveInteger($precision);
+        $this->assertIsNotAboveMaximum($precision);
         $this->precision = $precision;
     }
 
@@ -45,6 +52,18 @@ class Precision
     {
         if ((int) $precision < 0) {
             throw new CurrencyConstraintException(sprintf('Given precision "%s" is not valid. It must be a positive integer', var_export($precision, true)), CurrencyConstraintException::INVALID_PRECISION);
+        }
+    }
+
+    /**
+     * @param int $precision
+     *
+     * @throws CurrencyConstraintException
+     */
+    private function assertIsNotAboveMaximum(int $precision)
+    {
+        if ($precision > self::MAX_PRECISION) {
+            throw new CurrencyConstraintException(sprintf('Given precision "%s" is not valid. It must not be greater than %d', var_export($precision, true), self::MAX_PRECISION), CurrencyConstraintException::INVALID_PRECISION);
         }
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -8,6 +8,7 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Currencies;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\Precision;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
@@ -32,6 +33,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class CurrencyType extends TranslatorAwareType
 {
+    /**
+     * The longest currency symbol CLDR ships for any locale is 5 characters, so this leaves ample room
+     * for a custom one while keeping the value short enough for the grids and price blocks that print it.
+     */
+    public const MAX_SYMBOL_LENGTH = 20;
+
     /**
      * @var array
      */
@@ -130,12 +137,13 @@ class CurrencyType extends TranslatorAwareType
                 'required' => false,
                 'options' => [
                     'constraints' => [
+                        // The longest currency symbol CLDR ships for any of its locales is 5 characters.
                         new Length([
-                            'max' => 255,
+                            'max' => self::MAX_SYMBOL_LENGTH,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 255]
+                                ['%limit%' => self::MAX_SYMBOL_LENGTH]
                             ),
                         ]),
                     ],
@@ -222,18 +230,14 @@ class CurrencyType extends TranslatorAwareType
                             ]
                         ),
                     ]),
-                    /*
-                     * I added this constraint because if range is too big it causes an "out of range" error in Vue.
-                     * I chose maximum precision based on this
-                     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Precision_range
-                     */
+                    // Every price column is decimal(20,6), so digits past the sixth are always zero.
                     new LessThanOrEqual([
-                        'value' => 20,
+                        'value' => Precision::MAX_PRECISION,
                         'message' => $this->trans(
                             'This value should be less than or equal to %value%.',
                             'Admin.Notifications.Error',
                             [
-                                '%value%' => 20,
+                                '%value%' => Precision::MAX_PRECISION,
                             ]
                         ),
                     ]),

--- a/tests/Unit/Core/Domain/Currency/ValueObject/CurrencyPrecisionTest.php
+++ b/tests/Unit/Core/Domain/Currency/ValueObject/CurrencyPrecisionTest.php
@@ -32,6 +32,18 @@ class CurrencyPrecisionTest extends TestCase
             [
                 -42,
             ],
+            [
+                7,
+            ],
+            [
+                '981',
+            ],
+            [
+                49,
+            ],
+            [
+                8,
+            ],
         ];
     }
 
@@ -49,32 +61,24 @@ class CurrencyPrecisionTest extends TestCase
     {
         return [
             [
-                '008',
-                8,
+                '006',
+                6,
             ],
             [
-                '8',
-                8,
+                '6',
+                6,
             ],
             [
-                '981',
-                981,
-            ],
-            [
-                '49',
-                49,
+                '2',
+                2,
             ],
             [
                 '0',
                 0,
             ],
             [
-                8,
-                8,
-            ],
-            [
-                981,
-                981,
+                4,
+                4,
             ],
             [
                 0,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A currency can currently be saved with a 255 character symbol and 20 decimals, which is what produces the broken currency grid, product list, order list, pricing tab and front office price blocks in the report. The symbol constraint matched the `varchar(255)` column rather than anything about currencies, and the 20 decimal cap was chosen from a JavaScript precision limit. Both bounds are replaced with data-derived ones: the symbol is capped at 20 characters and the precision at 6. The precision bound is placed on the `Precision` value object rather than only on the form, so the Admin API and the CQRS commands are covered too.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | BO > International > Currencies > edit a currency. Entering a symbol longer than 20 characters, or more than 6 decimals, is now rejected with a message instead of being saved. Values within the bounds behave as before. The same limits apply through `AddCurrencyCommand` / `EditCurrencyCommand`, so the Admin API rejects them as well.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28911
| Related PRs       |
| Sponsor company   |

### Where the two numbers come from

Neither is a taste call.

**Symbol, 20 characters.** Parsed every `<symbol>` element of the 788 locale files PrestaShop ships under
`localization/CLDR/core/common/main/` — 15,366 symbols. The longest is **5 characters**
(`‎CN¥‎` in `he.xml`, `සිෆ්එ` in `si.xml`, `د.ع.‏` in `lrc.xml`, `F CFP` in `ln.xml`). 20 leaves four times
that for a custom or virtual currency while staying short enough for a grid cell.

**Precision, 6 decimals.** Every price column in the schema is `decimal(20,6)` — checked
`ps_product.price`, `ps_orders.total_paid`, `ps_specific_price.reduction` — so a seventh decimal is always
zero once the value has been through the database. Independently, the highest `digits` any currency
declares in `supplementalData.xml` is **4**, and only two currencies use it:

```
CLDR currency fraction digits: {0: 43, 2: 21, 3: 6, 4: 2}
```

The replaced cap of 20 came with the comment *"if range is too big it causes an out of range error in Vue"*,
i.e. it was a front-end limit, not a monetary one.

### Why the value object and not just the form

`Precision` asserted only `>= 0`; its own unit test asserted that `981` and `49` are valid values. The form
was the sole gate, so `AddCurrencyCommand` and `EditCurrencyCommand` — and therefore the Admin API — accepted
anything. The bound now lives in the value object, and the form's `LessThanOrEqual` reads
`Precision::MAX_PRECISION` so the two cannot drift.

### Test

`CurrencyPrecisionTest` moves `8`, `49` and `981` from the valid provider to the invalid one and adds `7`;
`6` and `4` are the new upper valid cases. The provider deliberately uses literals rather than
`Precision::MAX_PRECISION`, so the test still loads against an unpatched value object — the first version
referenced the constant and the mutation run died with *"Undefined constant"* and *"No tests executed"*,
which proves nothing. Mutation check with literals: reverted value object →
four `Failed asserting that exception ... is thrown`; restored → green.

The symbol length is a form constraint with no domain object behind it and is not covered by a test; the
change there is one constant.

### No existing data is affected

`SELECT COUNT(*) FROM ps_currency WHERE precision > 6` returns 0 on a fresh install, and no install path can
produce such a row: `AddOfficialCurrencyHandler::getPrecision()` falls back to
`$cldrCurrency->getDecimalDigits()`, which CLDR caps at 4, and the 96 localization packs under
`localization/` carry only a `decimals` flag of `0` or `1`, never a precision. A value above 6 can only come
from someone typing it into this form.

### Not addressed

The report also shows the layout breaking. Bounding the input stops new occurrences; it does not reflow a
grid for a shop that already stored a long symbol. No behat scenario or fixture uses a precision above 3,
so nothing in the suite depends on the old range.
