### PR TITLE
Order the webservice order_rows explicitly by id_order_detail

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1638,7 +1638,8 @@ class OrderCore extends ObjectModel
             `unit_price_tax_incl`,
             `unit_price_tax_excl`
             FROM `' . _DB_PREFIX_ . 'order_detail`
-            WHERE id_order = ' . (int) $this->id;
+            WHERE id_order = ' . (int) $this->id . '
+            ORDER BY `id_order_detail` ASC';
         $result = Db::getInstance()->executeS($query);
 
         return $result;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Order::getWsOrderRows()` fills the `order_rows` association of the `orders` webservice resource and has no `ORDER BY`. The ascending `id_order_detail` order the API is expected to return — stated as the correct behaviour by the product team on #29133 — happens only because the optimizer picks the `order_detail_order` secondary index, whose entries carry the primary key. `EXPLAIN` on the demo shop confirms it (`key: order_detail_order`, `Extra: Using index`), but `ps_order_detail` also carries `id_order_id_order_detail`, `product_id` and `id_tax_rules_group`, so nothing in the SQL pins the result order. This adds the `ORDER BY` the contract already assumes.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `GET /api/orders/<id>` and read the `order_rows` association: rows come back in ascending `id_order_detail`, as before, now guaranteed by the query rather than by the chosen index.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Related to #29133
| Related PRs       |
| Sponsor company   |

### No test, deliberately

The change does not alter output on any plan the optimizer currently picks — measured before and after on
order 2 of the demo shop, both `id 3, id 4`. A test would therefore be green with and without the fix, which
is worse than no test: it would claim coverage it does not have. There is no portable way to make MySQL
return the rows in a different order on demand.

### Why this is only half of #29133

The reported mismatch is between this list and the back office order page. Those two differ by **sort key**,
not by direction, and the back office key is shared by six other surfaces including the invoice, the
delivery slip and the credit slip. Changing it is a spec decision and is deliberately not part of this
branch. Full analysis in the issue comment.
