### PR TITLE
Do not offer soft deleted currencies in the order payment form

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -713,7 +713,8 @@ class CurrencyCore extends ObjectModel
     }
 
     /**
-     * Get Currencies by Shop ID.
+     * Get Currencies by Shop ID. Soft deleted currencies are excluded, like in every other listing
+     * of this class, because they cannot be reached from the back office anymore.
      *
      * @param int $idShop Shop ID
      *
@@ -725,7 +726,7 @@ class CurrencyCore extends ObjectModel
 		SELECT *
 		FROM `' . _DB_PREFIX_ . 'currency` c
 		LEFT JOIN `' . _DB_PREFIX_ . 'currency_shop` cs ON (cs.`id_currency` = c.`id_currency`)
-        ' . ($idShop ? ' WHERE cs.`id_shop` = ' . (int) $idShop : '') . '
+		WHERE c.`deleted` = 0' . ($idShop ? ' AND cs.`id_shop` = ' . (int) $idShop : '') . '
 		ORDER BY `iso_code` ASC');
 
         return self::addCldrDatasToCurrency($currencies);

--- a/tests/Integration/Classes/CurrencyTest.php
+++ b/tests/Integration/Classes/CurrencyTest.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Classes;
 
+use Context;
 use Currency;
+use Db;
 use PHPUnit\Framework\TestCase;
 use Tests\Resources\DatabaseDump;
 
@@ -41,5 +43,44 @@ class CurrencyTest extends TestCase
         $idByIsoCode = Currency::getIdByIsoCode('ZZZ', 0, true);
         $this->assertNotEquals(0, $idByIsoCode);
         $this->assertIsInt($idByIsoCode);
+    }
+
+    public function testGetCurrenciesByIdShopExcludesSoftDeletedCurrencies(): void
+    {
+        $shopId = (int) Context::getContext()->shop->id;
+
+        $currency = new Currency();
+        $currency->name = 'ZZZ';
+        $currency->symbol = 'ZZZ';
+        $currency->precision = 2;
+        $currency->iso_code = 'ZZZ';
+        $currency->active = 1;
+        $currency->conversion_rate = 1.10;
+        $this->assertTrue($currency->add());
+        $currencyId = (int) $currency->id;
+
+        $this->assertContains($currencyId, $this->getCurrencyIdsForShop($shopId));
+
+        $currency->delete();
+
+        // The shop association survives the soft delete, so the join alone still matches the row.
+        $this->assertNotEmpty(Db::getInstance()->executeS(
+            'SELECT `id_currency` FROM `' . _DB_PREFIX_ . 'currency_shop` WHERE `id_currency` = ' . $currencyId
+        ));
+        $this->assertNotContains($currencyId, $this->getCurrencyIdsForShop($shopId));
+        $this->assertNotContains($currencyId, $this->getCurrencyIdsForShop(0));
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getCurrencyIdsForShop(int $shopId): array
+    {
+        return array_map(
+            static function (array $currency): int {
+                return (int) $currency['id_currency'];
+            },
+            Currency::getCurrenciesByIdShop($shopId)
+        );
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Currency::getCurrenciesByIdShop()` is the only currency listing in `classes/Currency.php` with no `deleted` filter — `findAll()` and `getInstalledCurrencies()` both carry one. Deleting a currency is a soft delete: `Currency::delete()` calls `ObjectModel::softDelete()`, which flips the flag and leaves the `currency_shop` association in place, so the shop join keeps finding the row. Its one caller is `CurrencySymbolByIdChoiceProvider`, which builds the currency dropdown of the back office order page's "Add payment" block, so every currency ever removed from the shop is still offered there. Picking one is accepted by `AddPaymentHandler` (`Validate::isLoadedObject()` is true for a soft deleted row) and `Order::addOrderPayment()` then converts the amount with that currency's `conversion_rate`, which is frozen at deletion time because `Currency::refreshCurrencies()` walks `getCurrencies(true, false, true)` and that excludes deleted rows.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a second currency, then delete it in International > Currencies. Open BO > Orders > any order and look at the currency dropdown of the "Add payment" block. Before the change the deleted currency is still listed and a payment can be recorded in it; after it, it is gone. `tests/Integration/Classes/CurrencyTest::testGetCurrenciesByIdShopExcludesSoftDeletedCurrencies` covers both the `$idShop` and the `$idShop = 0` call shapes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29208
| Related PRs       |
| Sponsor company   |

### What the issue reported, and what is left of it

The reporter had two currencies whose CLDR symbol is both `$` (COP and USD in a Spanish back office) and
saw a payment of 100,000 land as roughly 300,000,000. On 8.0.0 the provider built its choices as

```php
$choices[$currency['symbol']] = (int) $currency['id_currency'];   // 8.0.0
```

so the two `$` currencies collided on the same array key and only the last one survived; the payment was
attributed to the wrong currency id and then converted at that currency's rate, which for COP is ~3000-4000
and reproduces the reported magnitude. Hlavtox's #37318 (merged 2024-11-28, milestone 9.0.0) routed the
provider through `FormChoiceFormatter`, which appends the id to duplicated labels. Measured on 9.2.x with
two `$` currencies installed:

```
CurrencySymbolByIdChoiceProvider::getChoices(['id_shop' => 1])
array (
  '$ (2)' => 2,
  '$ (3)' => 3,
  '£'     => 4,     <- id 4 is deleted = 1
  '€'     => 1,
)
```

So the reported symptom is fixed, and the `Needs Specs` question (how to tell two same-symbol currencies
apart in this dropdown) was answered by that PR's `(id)` suffix. What is left is the second defect AureRita
recorded on the same thread: *"even if you delete the currency, when you have a payment, that'll pay with
this currency"*. That is `'£' => 4` above, and it is what this PR removes.

### The harm, measured

Order 1 of the demo shop, `id_currency = 1` (EUR), `total_paid = 61.80`. Currency 4 is a soft deleted
currency with a frozen `conversion_rate` of 0.85. Adding a 100,000 payment in it through
`Order::addOrderPayment()`:

```
BEFORE: total_paid_real = 0.000000
AFTER : total_paid_real = 117647.060000

ps_order_payment: id_currency = 4, conversion_rate = 0.850000, amount = 100000.000000
```

`classes/order/Order.php:1881-1885` runs the amount through `Tools::convertPrice()` twice using that rate,
and `classes/Currency.php:1048` (`refreshCurrencies()` -> `getCurrencies(true, false, true)` ->
`findAll()`, which filters `c.deleted = 0`) means the rate stored on the payment can never be corrected
again. So this is an accounting defect, not only dropdown hygiene.

### Why `deleted` only, and not `active`

`findAll()` filters `deleted` unconditionally and takes `active` as a parameter, which is the in-class
precedent. A deleted currency cannot be reached from the back office at all, so offering it is
unambiguously wrong. A disabled currency is a reversible merchant choice, and an existing order placed in a
currency that was later disabled can still legitimately receive a payment, so removing those too would be a
behaviour change with a real downside. `ChangeOrderCurrencyType` on the same page does filter `active`
through `CurrencyByIdChoiceProvider`; aligning the two is a separate decision and is deliberately not made
here.

### Known edge

If an order's own currency has been deleted, the dropdown no longer preselects it. Symfony's
`ChoiceToValueTransformer::transform()` returns `''` for a value outside the choice list rather than
throwing, so the page renders normally with nothing selected. Before this change that order could still
take a payment in the deleted currency, which is the behaviour being removed.

### Scope

`getCurrenciesByIdShop()` has exactly one caller in core, and none in any of the native module
repositories checked. No existing test referenced it before this PR.
