### PR TITLE
Only clear the Smarty cache when a catalog price rule actually changes

### DIFF
--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -372,10 +372,33 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
         }
     }
 
+    /**
+     * Actions that only read data, so they cannot invalidate anything the front office has cached.
+     */
+    private const NON_MUTATING_ACTIONS = [
+        'new',
+        'view',
+        'details',
+        'export',
+        'reset_filters',
+    ];
+
     public function postProcess()
     {
-        Tools::clearSmartyCache();
+        $return = parent::postProcess();
 
-        return parent::postProcess();
+        // A catalog price rule changes front office prices, which templates cache, so the Smarty cache
+        // has to be dropped whenever one is created, edited, toggled or deleted. It does not have to be
+        // dropped to merely look at the list: doing that on every request meant opening this page wiped
+        // the whole cache, which on a shop with a large one is slow enough to time the page out.
+        //
+        // Deliberately a deny list rather than an allow list. Missing a mutating action here would leave
+        // customers looking at stale prices, while missing a read-only one only costs a needless cache
+        // clear, which is what this controller did on every request until now.
+        if (!empty($this->action) && !in_array($this->action, self::NON_MUTATING_ACTIONS, true)) {
+            Tools::clearSmartyCache();
+        }
+
+        return $return;
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `AdminSpecificPriceRuleController::postProcess()` called `Tools::clearSmartyCache()` unconditionally, and `postProcess()` runs on every request to the page - so merely opening Catalog Price Rules wiped the whole front-office cache. Moves the clear after `parent::postProcess()` and runs it only when an action was dispatched, keeping the invalidation for create/edit/toggle/delete and dropping it for listing, filtering, exporting and opening the form.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With a shop that has a populated `var/cache/*/smarty/cache`, open BO > Catalog > Discounts > Catalog Price Rules and confirm the cache directory is left alone. Then create, edit, toggle or delete a rule and confirm the cache is cleared. Bulk delete and bulk enable/disable should clear it too.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29298
| Related PRs       | Same intent as #29592 (closed unmerged)
| Sponsor company   |

### Why not simply delete the call, as #29592 did

@gennaris' PR removed the seven lines outright and was closed unmerged in 2023-09. On the issue,
@FabienPapet had said the cache "needs" to be cleared when rules are added, updated or removed, and
@okom3pom proposed moving it onto the mutating actions - which is what this does. Removing it entirely
loses that invalidation, and stale front-office prices are a worse failure than a slow admin page.

### The deny list is deliberate

`$this->action` is set by `AdminController::initProcess()` before `postProcess()` runs, and covers
`save`, `delete`, `status`, `position`, the read-only `new` / `view` / `details` / `export` /
`reset_filters`, and bulk actions as `'bulk' . $action`. Listing read-only actions and clearing for
everything else means:

- bulk actions are covered without enumerating each one;
- a mutating action added later still clears the cache by default.

An allow list would fail the other way, and that failure shows customers stale prices. The worst case
here is a needless clear - exactly what the controller did on every request before.

### Ordering

The clear now runs **after** `parent::postProcess()` rather than before it, so it drops the cache once the
rule has actually changed rather than beforehand. `setRedirectAfter()` only records the redirect, so the
code still runs.

php-cs-fixer clean, PHPStan clean. Not covered by a test: the behaviour is "did we call a cache clear",
which would need the controller driven through a BO request with an employee session.
