### PR TITLE
Update the supplier currency symbol wherever the money widget put it

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/supplier/product-suppliers-collection.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/supplier/product-suppliers-collection.ts
@@ -105,7 +105,10 @@ export default class ProductSuppliersCollection {
       const symbol = $(e.target).find(':selected')?.attr('symbol');
       $(e.target)
         .parents(this.map.productsSupplierRowSelector)
-        .find('.money-type .input-group-prepend .input-group-text')
+        // The money widget renders the symbol before or after the input depending on the
+        // locale's money pattern, so it can sit in either group. Matching only the prepend
+        // one left the symbol stale for every locale that puts it after the amount.
+        .find('.money-type .input-group-text')
         // @ts-ignore
         .html(symbol);
     });


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On the product Options tab, changing a supplier's currency refreshes the cost price symbol through a handler that only looked inside `.input-group-prepend`. `money_widget` renders that symbol before **or** after the input depending on the locale's money pattern, so for every locale that shows it after the amount the selector matched nothing and the stale symbol stayed on screen. Matches the element by its own class instead, which is what this collection's own map already declares for it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Have at least two currencies. Product edit > Options > add a supplier, then change the currency select on that row. The symbol next to Cost price should follow the selection. Check with a locale whose money pattern puts the symbol after the amount (for example French, `1 234,56 €`) - that is the case that was broken.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29346
| Related PRs       |
| Sponsor company   |

### The chain, traced end to end

Everything except the last hop was already correct, which is why this looked mysterious:

- `CurrencyByIdChoiceProvider::getChoicesAttributes()` puts a `symbol` attribute on each option, keyed by
  the same `sprintf('%s (%s)', name, iso_code)` label `getChoices()` uses - so the keys do match and the
  attribute is rendered.
- `product-suppliers-collection.ts` reads it on change: `$(e.target).find(':selected')?.attr('symbol')`.
- The update then targeted `.money-type .input-group-prepend .input-group-text`.

And `bootstrap_4_layout.html.twig` renders the symbol in one of two places:

```twig
{% set prepend = '{{' == money_pattern[0:2] %}
{% if not prepend %}<div class="input-group-prepend"><span class="input-group-text">…
{{ block('form_widget_simple') }}
{% if prepend %}<div class="input-group-append"><span class="input-group-text">…
```

(the variable name is inverted: `prepend = true` means the *widget* comes first, so the symbol is
appended). For an append locale the handler's selector matches nothing.

### Precedent

`specific-price-map.ts` on the same product page already spells both positions out:

```ts
fixedPriceSymbol: '.js-fixed-price-row .input-group.money-type .input-group-append .input-group-text, '
  + '.js-fixed-price-row .input-group.money-type .input-group-prepend .input-group-text',
```

and `product-suppliers-map.ts` already declares the locale-agnostic form for this very element:

```ts
currencySymbol: (supplierIndex) => `#product_supplier_row_${supplierIndex} .money-type .input-group-text`
```

so the handler was the only place assuming prepend.

### Not verified locally

The container has no node, so eslint and `tsc --noEmit` could not be run here, and the back office needs
an employee login to see the rendered widget - the append/prepend branch is read from the Twig source,
not from a rendered page. CI is authoritative for both. Built assets are not tracked
(`git ls-files admin-dev/themes/new-theme/public` is empty), so the source change is the whole change.
