### PR TITLE
Stop forcing a zip code in the back office address form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -296,7 +296,11 @@ class CustomerAddressType extends TranslatorAwareType
                 ],
             ])
             ->add('postcode', TextType::class, [
-                'required' => true,
+                // Whether a zip code is mandatory depends on the country, and the AddressZipCode
+                // constraint below already decides that from its need_zip_code flag. Declaring the
+                // field required here forced it in the browser for every country, including those
+                // that do not use zip codes at all.
+                'required' => false,
                 'label' => $this->trans('Zip/Postal code', 'Admin.Global'),
                 'empty_data' => '',
                 'constraints' => [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The back-office address form declared the postcode field `'required' => true`, which renders the HTML `required` attribute, so the browser refused to submit for countries whose "Zip/postal code" option is unchecked. The server side was already correct: the `AddressZipCode` constraint on the same field is given `'required' => false` and decides from the country's `need_zip_code`. Only the presentational flag was wrong.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | BO > International > Locations > Countries, edit a country and untick "Do you need a zip/postal code?". Then BO > Customers > Addresses > add an address for that country and leave the zip code empty. Before, the browser blocks the submit; after, it saves. Re-tick the option on a country that does need one and confirm an empty zip is still rejected, now by the server-side constraint.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29625
| Related PRs       | Same change as #29696, which was closed as stale rather than on merit
| Sponsor company   |

### Why this is safe

`required` in Symfony is presentational - it drives the HTML attribute and the label's asterisk, and does
not add or remove constraints. Verified against this codebase rather than assumed:

```
required=true    html required attr=true    form valid with empty value=false
required=false   html required attr=false   form valid with empty value=false
```

And the constraint that does the real work is country-driven
(`src/Core/ConstraintValidator/AddressZipCodeValidator.php`):

```php
$requirements = $this->requirementsProvider->getCountryZipCodeRequirements(new CountryId($countryId));
if ($requirements->isRequired() || $constraint->required) {
    // NotBlank
```

with the form passing `'required' => false`, so the requirement comes purely from `need_zip_code`. A
country that does need a zip code is still rejected, by the same code path as before.

### Known trade-off

With `required => false` the field no longer carries the HTML `required` attribute for countries that
*do* need a zip code either, so those lose the browser-side hint and the label asterisk; the server still
rejects an empty value. @Hlavtox suggested on the issue that the better end state is to toggle the
attribute from the existing AJAX that reloads the state list on country change. That needs the zip-code
requirements provider injected into `CustomerAddressType` (it is not today) plus JS work, so it is a
larger change; this one restores correctness first and is strictly better than the current state, which is
simply wrong for no-zip countries.

### Not covered by tests

There is no unit test for `CustomerAddressType`, and the change is a presentational flag, so no test was
added. The behavioural assumption it rests on is the Symfony one measured above.
