### PR TITLE
Translate module tab names in the navigation, as the menu links already do

### DIFF
--- a/src/PrestaShopBundle/Twig/Layout/MenuBuilder.php
+++ b/src/PrestaShopBundle/Twig/Layout/MenuBuilder.php
@@ -120,7 +120,7 @@ class MenuBuilder
     private function convertTabToMenuLink(Tab $tab): MenuLink
     {
         return new MenuLink(
-            name: $this->getBreadcrumbLabel($tab),
+            name: $this->getTabLabel($tab),
             href: $this->getLinkFromTab($tab),
             icon: $tab->getIcon() ?? '',
         );
@@ -142,9 +142,8 @@ class MenuBuilder
 
         /* @var $currentLevelTab Tab */
         foreach ($currentLevelTabs as $currentLevelTab) {
-            $tabLang = $currentLevelTab->getTabLangByLanguageId($this->getContextLanguageId());
             $menuLink = new MenuLink(
-                name: $tabLang ? $tabLang->getName() : $currentLevelTab->getWording(),
+                name: $this->getTabLabel($currentLevelTab),
                 href: $this->getLinkFromTab($currentLevelTab),
                 attributes: [
                     'id_tab' => $currentLevelTab->getId(),
@@ -159,7 +158,7 @@ class MenuBuilder
         return $navigationTabs;
     }
 
-    private function getBreadcrumbLabel(Tab $tab): string
+    private function getTabLabel(Tab $tab): string
     {
         if (null !== $tab->getWording() && null !== $tab->getWordingDomain()) {
             return $this->translator->trans($tab->getWording(), [], $tab->getWordingDomain());

--- a/tests/Unit/PrestaShopBundle/Twig/Layout/MenuBuilderTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Layout/MenuBuilderTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig\Layout;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShopBundle\Entity\Repository\TabRepository;
+use PrestaShopBundle\Entity\Tab;
+use PrestaShopBundle\Routing\Converter\LegacyParametersConverter;
+use PrestaShopBundle\Twig\Layout\MenuBuilder;
+use ReflectionMethod;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * A tab created by a module carries its label as a wording plus a translation domain, and the
+ * label has to be translated when it is displayed - the module's catalogue is not loaded yet at
+ * the moment the tab row is written. See issue #30241.
+ */
+class MenuBuilderTest extends TestCase
+{
+    public function testTabLabelIsTranslatedFromItsWording(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Link List', [], 'Modules.Linklist.Admin')
+            ->willReturn('Liste de liens');
+
+        $tab = (new Tab())
+            ->setClassName('AdminLinkWidget')
+            ->setWording('Link List')
+            ->setWordingDomain('Modules.Linklist.Admin');
+
+        $this->assertSame('Liste de liens', $this->getTabLabel($translator, $tab));
+    }
+
+    private function getTabLabel(TranslatorInterface $translator, Tab $tab): string
+    {
+        $menuBuilder = new MenuBuilder(
+            $this->createMock(LegacyContext::class),
+            $this->createMock(RequestStack::class),
+            $this->createMock(TabRepository::class),
+            $translator,
+            $this->createMock(UrlGeneratorInterface::class),
+            $this->createMock(LegacyParametersConverter::class),
+        );
+
+        $method = new ReflectionMethod($menuBuilder, 'getTabLabel');
+        $method->setAccessible(true);
+
+        return $method->invoke($menuBuilder, $tab);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `MenuBuilder` resolved a tab label two different ways. `convertTabToMenuLink()` used a helper that translates the tab's `wording` with its `wording_domain`, while `buildNavigationTabs()` read `ps_tab_lang` directly and fell back to the raw, untranslated wording. A module's tab stores a wording plus a domain precisely because the module catalogue is not loaded when the tab row is written at install time, so the stored name is the untranslated source string. Both call sites now use the same helper, renamed `getBreadcrumbLabel()` -> `getTabLabel()` since it is no longer breadcrumb-specific.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a module that declares a tab with `wording` + `wording_domain` and ships an XLF catalogue, in a shop whose language is not English. Before, the sub-navigation shows the untranslated source wording; after, it shows the translation. `php vendor/bin/phpunit --configuration tests/Unit/phpunit.xml --filter MenuBuilderTest`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | See #30241
| Related PRs       | Supersedes the approach in the closed #30242
| Sponsor company   |

### Why the 2022 diagnosis no longer needs a translator-loading fix

@atomiix diagnosed it as "module translations are only loaded when the module is installed and active",
and @sowbiba closed #30242 saying a better solution would come in the next major version. PS 9 did add
one, but only half of it: `MenuBuilder` (new in 9.0.0, absent from 8.x) translates `wording` +
`wording_domain` **at display time**, which sidesteps the install-time loading problem entirely — but
only in `getBreadcrumbLabel()`. `buildNavigationTabs()` was left on the old `ps_tab_lang` read.

### Measured

Real data on a 9.2 shop, `ps_linklist` tab 120 (`wording = 'Link List'`, domain
`Modules.Linklist.Admin`):

```
ps_tab_lang  en -> 'Link List'      fr -> 'Liste de liens'
```

so the French name in the database is right — but it got there through `TabTranslator`, which runs from
`Language::updateMultilangFromClassForShop()`, i.e. on **language** install/update, not on module
install. `bin/console debug:translation fr-FR --domain=Modules.Linklist.Admin` reports that wording as
`missing`, confirming the stored name did not come from the module's own catalogue.

### Test scope — stated plainly

`tests/Unit/PrestaShopBundle/Twig/Layout/MenuBuilderTest.php` pins the resolver: a tab carrying a wording
and a domain is translated through the translator (asserted with the exact arguments). It does **not**
exercise `buildNavigationTabs()` itself, because that calls the legacy static
`LegacyTab::checkTabRights()` and is not unit-testable without a legacy employee context. The mutation
check therefore only demonstrates the rename, not the behaviour change — worth knowing rather than
overselling. A dropped second case (fallback to class name) needed a language-context stub and covered
pre-existing behaviour, so it was removed rather than padded.

php-cs-fixer clean (it reformatted the test once, applied), PHPStan clean on the changed file.
