### PR TITLE
Map PS_PRICE_ROUND_MODE to the constants it actually stores

### DIFF
--- a/src/Core/Pricing/Rounding/RoundingService.php
+++ b/src/Core/Pricing/Rounding/RoundingService.php
@@ -20,20 +20,26 @@ class RoundingService implements RoundingServiceInterface
     /**
      * Maps PrestaShop PS_PRICE_ROUND_MODE config values to DecimalNumber rounding modes.
      *
-     * 0 = Round up away from zero when half way
-     * 1 = Round down towards zero when half way
-     * 2 = Round towards the next even value
-     * 3 = Round up to the nearest value
-     * 4 = Round down to the nearest value
-     * 5 = Truncate
+     * The keys are the PS_ROUND_* constants from config/defines.inc.php, which is also what the
+     * Shop Parameters form stores:
+     *
+     * PS_ROUND_UP        = 0
+     * PS_ROUND_DOWN      = 1
+     * PS_ROUND_HALF_UP   = 2
+     * PS_ROUND_HALF_DOWN = 3
+     * PS_ROUND_HALF_EVEN = 4
+     * PS_ROUND_HALF_ODD  = 5 - deliberately absent, see below
+     *
+     * PS_ROUND_HALF_ODD has no equivalent in the Decimal library, so it falls through to the
+     * default in the constructor. Tools::ps_round() does implement it, so a shop using that mode
+     * still rounds differently here; that mismatch is tracked in issue #30441.
      */
     protected const ROUNDING_MODE_MAP = [
-        0 => Rounding::ROUND_HALF_UP,
-        1 => Rounding::ROUND_HALF_DOWN,
-        2 => Rounding::ROUND_HALF_EVEN,
-        3 => Rounding::ROUND_CEIL,
-        4 => Rounding::ROUND_FLOOR,
-        5 => Rounding::ROUND_TRUNCATE,
+        PS_ROUND_UP => Rounding::ROUND_CEIL,
+        PS_ROUND_DOWN => Rounding::ROUND_FLOOR,
+        PS_ROUND_HALF_UP => Rounding::ROUND_HALF_UP,
+        PS_ROUND_HALF_DOWN => Rounding::ROUND_HALF_DOWN,
+        PS_ROUND_HALF_EVEN => Rounding::ROUND_HALF_EVEN,
     ];
 
     protected readonly string $roundingMode;

--- a/tests/Unit/Core/Pricing/Product/Calculator/RoundingCalculatorTest.php
+++ b/tests/Unit/Core/Pricing/Product/Calculator/RoundingCalculatorTest.php
@@ -47,7 +47,8 @@ class RoundingCalculatorTest extends TestCase
 
     public function testRoundsFinalPriceDown(): void
     {
-        $roundingService = new RoundingService(0);
+        // PS_ROUND_UP would take 29.49 up to 30; half-up is the mode that can round down here.
+        $roundingService = new RoundingService(PS_ROUND_HALF_UP);
         $calculator = new RoundingCalculator($roundingService);
 
         $productPrice = ProductPrice::create(1, 0);

--- a/tests/Unit/Core/Pricing/Rounding/RoundingServiceTest.php
+++ b/tests/Unit/Core/Pricing/Rounding/RoundingServiceTest.php
@@ -14,56 +14,52 @@ use PrestaShop\PrestaShop\Core\Pricing\Rounding\RoundingService;
 
 class RoundingServiceTest extends TestCase
 {
-    public function testRoundHalfUp(): void
+    /**
+     * The keys of the map are the PS_ROUND_* constants from config/defines.inc.php, which is what
+     * the Shop Parameters form stores in PS_PRICE_ROUND_MODE. Each expectation below is the value
+     * Tools::ps_round() produces for the same input and mode.
+     *
+     * @dataProvider getLegacyRoundModes
+     */
+    public function testModeMatchesTheLegacyConstant(int $legacyRoundMode, string $input, string $expected): void
     {
-        $service = new RoundingService(0); // PS_PRICE_ROUND_MODE = 0 → ROUND_HALF_UP
-        $result = $service->round(new DecimalNumber('29.5'));
+        $service = new RoundingService($legacyRoundMode);
 
-        $this->assertTrue($result->equals(new DecimalNumber('30')));
+        $this->assertTrue(
+            $service->round(new DecimalNumber($input))->equals(new DecimalNumber($expected)),
+            sprintf('mode %d applied to %s', $legacyRoundMode, $input)
+        );
     }
 
-    public function testRoundHalfDown(): void
+    public static function getLegacyRoundModes(): iterable
     {
-        $service = new RoundingService(1); // PS_PRICE_ROUND_MODE = 1 → ROUND_HALF_DOWN
-        $result = $service->round(new DecimalNumber('29.5'));
-
-        $this->assertTrue($result->equals(new DecimalNumber('29')));
+        // PS_ROUND_UP = 0, away from zero
+        yield 'PS_ROUND_UP 29.01' => [PS_ROUND_UP, '29.01', '30'];
+        yield 'PS_ROUND_UP 29.5' => [PS_ROUND_UP, '29.5', '30'];
+        // PS_ROUND_DOWN = 1, towards zero
+        yield 'PS_ROUND_DOWN 29.99' => [PS_ROUND_DOWN, '29.99', '29'];
+        yield 'PS_ROUND_DOWN 29.5' => [PS_ROUND_DOWN, '29.5', '29'];
+        // PS_ROUND_HALF_UP = 2
+        yield 'PS_ROUND_HALF_UP 29.5' => [PS_ROUND_HALF_UP, '29.5', '30'];
+        yield 'PS_ROUND_HALF_UP 29.4' => [PS_ROUND_HALF_UP, '29.4', '29'];
+        // PS_ROUND_HALF_DOWN = 3
+        yield 'PS_ROUND_HALF_DOWN 29.5' => [PS_ROUND_HALF_DOWN, '29.5', '29'];
+        yield 'PS_ROUND_HALF_DOWN 29.6' => [PS_ROUND_HALF_DOWN, '29.6', '30'];
+        // PS_ROUND_HALF_EVEN = 4
+        yield 'PS_ROUND_HALF_EVEN 29.5' => [PS_ROUND_HALF_EVEN, '29.5', '30'];
+        yield 'PS_ROUND_HALF_EVEN 30.5' => [PS_ROUND_HALF_EVEN, '30.5', '30'];
     }
 
-    public function testRoundHalfEven(): void
+    /**
+     * PS_ROUND_HALF_ODD has no equivalent in the Decimal library, so it falls through to the
+     * constructor default instead of throwing. See issue #30441 for the open question of what it
+     * should do; this only pins that it does not blow up.
+     */
+    public function testHalfOddFallsBackInsteadOfFailing(): void
     {
-        $service = new RoundingService(2); // PS_PRICE_ROUND_MODE = 2 → ROUND_HALF_EVEN
-        // 29.5 → rounds to 30 (nearest even)
-        $result = $service->round(new DecimalNumber('29.5'));
-        $this->assertTrue($result->equals(new DecimalNumber('30')));
+        $service = new RoundingService(PS_ROUND_HALF_ODD);
 
-        // 30.5 → rounds to 30 (nearest even)
-        $result2 = $service->round(new DecimalNumber('30.5'));
-        $this->assertTrue($result2->equals(new DecimalNumber('30')));
-    }
-
-    public function testRoundCeil(): void
-    {
-        $service = new RoundingService(3); // PS_PRICE_ROUND_MODE = 3 → ROUND_CEIL
-        $result = $service->round(new DecimalNumber('29.01'));
-
-        $this->assertTrue($result->equals(new DecimalNumber('30')));
-    }
-
-    public function testRoundFloor(): void
-    {
-        $service = new RoundingService(4); // PS_PRICE_ROUND_MODE = 4 → ROUND_FLOOR
-        $result = $service->round(new DecimalNumber('29.99'));
-
-        $this->assertTrue($result->equals(new DecimalNumber('29')));
-    }
-
-    public function testRoundTruncate(): void
-    {
-        $service = new RoundingService(5); // PS_PRICE_ROUND_MODE = 5 → ROUND_TRUNCATE
-        $result = $service->round(new DecimalNumber('29.99'));
-
-        $this->assertTrue($result->equals(new DecimalNumber('29')));
+        $this->assertTrue($service->round(new DecimalNumber('29.5'))->equals(new DecimalNumber('30')));
     }
 
     public function testRoundWithCustomPrecision(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `RoundingService`'s mode map was keyed by a numbering of its own that does not match `config/defines.inc.php`, which is what the Shop Parameters form writes to `PS_PRICE_ROUND_MODE`. Every mode therefore rounded as a different one — `PS_ROUND_UP` behaved as half-up, `PS_ROUND_HALF_DOWN` as ceil, and so on. Keys the map by the `PS_ROUND_*` constants so it agrees with `Tools::ps_round()`. `PS_ROUND_HALF_ODD` is deliberately left unmapped (see below).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `php vendor/bin/phpunit --configuration tests/Unit/phpunit.xml tests/Unit/Core/Pricing`. Each expectation is the value `Tools::ps_round()` returns for the same input and mode, so the two rounding stacks are pinned together.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | See #30441
| Related PRs       |
| Sponsor company   |

### Measured against the legacy behaviour

`Tools::ps_round()` is what a shop rounds with today, so it is the reference. Over 2.5 / 3.5 / 2.4 / -2.5:

```
before   13 of 24 results disagreed with legacy rounding
after     1 of 24 - PS_ROUND_HALF_ODD on 3.5, which is the open question below
```

Concretely, before the change: `PS_ROUND_UP` on 2.4 gave 2 instead of 3; `PS_ROUND_HALF_UP` on 2.5 gave 2
instead of 3; `PS_ROUND_HALF_DOWN` on 2.5 gave 3 instead of 2; `PS_ROUND_HALF_EVEN` on 3.5 gave 3 instead
of 4.

### Not affecting shops today

The consumers (`RoundingCalculator`, shipping `TaxCalculator`) sit behind `FEATURE_FLAG_NEW_PRICING`
(`new_pricing`), which is **off** in a default install — `Product::isNewPricingEnabled()` gates every call
site. So this is a latent defect that would surface the moment the flag is turned on, not a live one.
That is also why it is worth fixing before anyone enables it.

### The tests encoded the same mistake

`RoundingServiceTest` asserted mode 0 as half-up, mode 3 as ceil and mode 5 as truncate — the wrong
numbering, written from the same assumption as the code, so it locked the bug in. Rewritten against the
`PS_ROUND_*` constants with expectations taken from `Tools::ps_round()`. `RoundingCalculatorTest`'s
`testRoundsFinalPriceDown` also used mode 0 while expecting a downward round; it now uses
`PS_ROUND_HALF_UP`, which is the mode that actually expresses that intent.

**Mutation check:** with `RoundingService` reverted to `upstream/9.2.x` and the new tests kept, **5 of 109
fail**. Suite is green with the fix (109 tests, 215 assertions).

### What this does NOT fix — issue #30441 as reported

The reported 500 comes from a **different** class: `RoundModeConverter::MODE_MAP` (used by
`AbstractOrderHandler`, i.e. the BO order view) has no entry for `PS_ROUND_HALF_ODD`, so
`getNumberRoundMode(5)` throws `CoreException: Cannot map round mode 5`. Measured directly. The Decimal
library has no half-odd mode at all (`truncate/ceil/floor/up/down/even`), while `Tools::ps_round()` does
implement it — so mapping 5 to something else would make the BO order view disagree with the totals the
shop computed. Choosing between implementing half-odd, dropping the option from the UI, or accepting an
approximation is the `Needs Specs` part and is left to maintainers (DECISIONS B19).

Worth noting there is a third, entirely unused mapper — `src/Adapter/RoundingMapper.php` — which maps
half-odd to half-even with the comment "never used". It has no callers.
