### PR TITLE
Do not derive a brightness from a value that is not hexadecimal

### DIFF
--- a/src/Core/Util/ColorBrightnessCalculator.php
+++ b/src/Core/Util/ColorBrightnessCalculator.php
@@ -33,6 +33,8 @@ final class ColorBrightnessCalculator
      */
     private function calculate($hexColor)
     {
+        $hexColor = (string) $hexColor;
+
         if (strtolower($hexColor) === 'transparent') {
             return self::BRIGHT_COLOR_MIN;
         }
@@ -41,6 +43,15 @@ final class ColorBrightnessCalculator
 
         if (strlen($hexColor) === 3) {
             $hexColor = $hexColor[0] . $hexColor[0] . $hexColor[1] . $hexColor[1] . $hexColor[2] . $hexColor[2];
+        }
+
+        // Anything that is not a six digit hexadecimal value - a CSS colour name, an rgb() call, an
+        // empty string - has no brightness to derive. Without this guard hexdec() raises a
+        // deprecation for every invalid character and then computes from whichever letters happen
+        // to be hex digits, which is why 'red' reads as bright while 'orange' and 'LimeGreen' do
+        // not. Treat an unusable value the same way as 'transparent'.
+        if (!preg_match('/^[0-9a-fA-F]{6}$/', $hexColor)) {
+            return self::BRIGHT_COLOR_MIN;
         }
 
         $r = hexdec(substr($hexColor, 0, 2));

--- a/tests/Unit/Core/Util/ColorBrightnessCalculatorTest.php
+++ b/tests/Unit/Core/Util/ColorBrightnessCalculatorTest.php
@@ -41,5 +41,54 @@ class ColorBrightnessCalculatorTest extends TestCase
         yield ['#00F', false];
         yield ['#0F1', true];
         yield ['transparent', true];
+
+        // A value that is not a six digit hexadecimal colour has no brightness to derive. Before
+        // these were guarded, hexdec() raised a deprecation per invalid character and produced a
+        // result from whichever letters happened to be hex digits, so 'red' came out bright while
+        // 'orange' and 'LimeGreen' did not. See #30997.
+        yield ['red', true];
+        yield ['orange', true];
+        yield ['DarkOrange', true];
+        yield ['LimeGreen', true];
+        yield ['rgb(255, 0, 0)', true];
+        yield ['', true];
+        yield ['#GGGGGG', true];
+        yield ['#12345', true];
+        yield ['#1234567', true];
+    }
+
+    /**
+     * A non hexadecimal value must not raise a PHP diagnostic, which is what merchants actually
+     * reported seeing on the order status pages.
+     *
+     * @dataProvider getNonHexColors
+     */
+    public function testNonHexColorRaisesNoDiagnostic($color)
+    {
+        $raised = [];
+        set_error_handler(function ($level, $message) use (&$raised) {
+            $raised[] = $message;
+
+            return true;
+        });
+
+        try {
+            $this->colorBrightnessCalculator->isBright($color);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $raised);
+    }
+
+    public static function getNonHexColors()
+    {
+        yield ['red'];
+        yield ['orange'];
+        yield ['DarkOrange'];
+        yield ['LimeGreen'];
+        yield ['rgb(255, 0, 0)'];
+        yield [''];
+        yield ['#GGGGGG'];
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ColorBrightnessCalculator` passed every value straight to `hexdec()`. A CSS colour name, an `rgb()` call or an empty string therefore raised a PHP deprecation per invalid character and still produced a number, derived from whichever letters happened to be hex digits. Rejects anything that is not a six digit hexadecimal value and falls back to the result `transparent` already returns. Also casts the input so a null column value does not raise its own deprecation in `strtolower()`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set an order status colour to a name instead of a hex value (`UPDATE ps_order_state SET color = 'LimeGreen'`) and open BO > Shop Parameters > Order Settings > Statuses, or BO > Orders. Before the change the page logs `hexdec(): Invalid characters passed for attempted conversion` three times per affected row; after it the page is clean and the label uses the same contrast as `transparent`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #30997
| Related PRs       |
| Sponsor company   |

### Why it was worse than "wrong"

The old result was arbitrary, not merely inaccurate — it depended on which letters of the name happen to
be hex digits, so two names a merchant would expect to behave alike were contrasted differently:

```
red          r=0   g=238 b=221  ->  164.9   bright      (dark text)
orange       r=0   g=10  b=14   ->    7.5   not bright  (white text)
DarkOrange   r=218 g=0   b=0    ->   65.2   not bright
LimeGreen    r=0   g=14  b=0    ->    8.2   not bright
#A04532      r=160 g=69  b=50   ->   94.0   not bright  (correct)
```

`red` reads as 3 characters, so it is expanded to `rreedd` first — that is where its 238/221 come from.
This is why @kmorgen saw white text on some names and @Maofree saw the wrong colour on others.

### Verification

- Extended `tests/Unit/Core/Util/ColorBrightnessCalculatorTest.php`: 10 -> 26 tests, all green, and a
  second test asserts that a non-hex value raises **no** PHP diagnostic at all (that is what merchants
  actually reported, per @pame91cl on 8.1.7).
- **Mutation check**: with the fix reverted to `upstream/9.2.x` and the new tests kept, **14 failures** and
  the 14 `Invalid characters passed for attempted conversion` notices come back. The tests are load-bearing.
- PHPUnit deprecation count is unchanged from baseline (479 both ways) — the new data provider is `static`,
  which is why it adds none.
- php-cs-fixer clean, PHPStan clean on the changed class.

### Deliberately NOT done

Colour names are still unsupported. @Hlavtox's position on the issue was to validate and allow hex only,
and supporting names would visibly change existing shops (a name that currently renders white text would
start rendering dark text). Which formats the colour fields accept — hex only, names, `rgb()`, `hsl()` — is
the `Needs Specs` part of this issue and is left to maintainers. This change only stops the calculator
producing diagnostics and arbitrary output from input it cannot read.
