### PR TITLE
Wrap long customization text in the back office

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
@@ -60,7 +60,7 @@
                         <strong>{{ 'Text #'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
                       {% endif %}
                     </div>
-                    <div class="col-6">
+                    <div class="col-6 text-break">
                       {% if customizationField.type == 'customizable_file' %}
                         <img src="{{ customizationField.image }}">
                       {% elseif customizationField.allow_html|default(false) %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -167,7 +167,7 @@
         </div>
       {% endif %}
       {% for customization in product.customizations.textCustomizations %}
-        <p>
+        <p class="text-break">
           <strong>{{ customization.name }} :</strong>
           {% if customization.htmlAllowed %}
             {{ customization.value|raw_purified }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A customization value containing no spaces widens the table it sits in, because a table column grows to fit its longest unbreakable content. Both `Admin/Sell/Order/Order/Blocks/View/product.html.twig` and `Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig` print the value with no wrapping rule, so one long token pushes the product table past the page and hides the columns to its right. The field accepts 1024 characters, so it is easy to hit. Adds Bootstrap's `.text-break` (`overflow-wrap: break-word`), which the admin theme already ships.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add a customizable text field to a product, order it from the front office with a 300-character string that contains no spaces, then open BO > Orders > that order. Before the change the product table runs off the page and the right-hand columns are unreachable; after it the value wraps inside its cell. Same check on BO > Customers > Carts > that cart.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #31183
| Related PRs       |
| Sponsor company   |

### Measured, against the shipped `theme.css`

A harness in the doc root loading the real `/admin-dev/themes/new-theme/public/theme.css`, with a
271-character token inside a 700px container:

```
order view    (table scrollWidth)   2245px  ->   700px
cart view     (table scrollWidth)   3353px  ->   709px
short-value reference for the cart view       709px   <- identical, so the long token no longer widens anything
```

The 9px is the table's own padding, not the string: a short value produces the same 709px.

### A fixture mistake worth recording

The first harness put the unfixed and the fixed paragraph in the **same `<td>`**, and reported that
`.text-break` changed nothing (`clientWidth` 2221 in both cases). That reading was an artefact: the
unfixed paragraph had already forced the cell to 2221px, so the fixed one had room to spare and never
needed to wrap. Measured in isolation, the class works. Control and treatment must not share a container.

### Scope

Only the two back-office templates that print a customization **value**. The third place that mentions
customizations, `Order/Blocks/Create/cart.html.twig:200`, is a `<span class="js-customization-value">`
filled by JavaScript in the order-creation flow, is not part of this report, and is left alone.
The front office already wraps these values, which is why QA saw FO OK and BO NOK on every version.
