### PR TITLE
Keep the catalog price rule sentinel instead of casting it to zero

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/CatalogPriceRuleFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CatalogPriceRuleFormDataHandler.php
@@ -18,6 +18,13 @@ use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\ValueObject\CatalogPriceR
 final class CatalogPriceRuleFormDataHandler implements FormDataHandlerInterface
 {
     /**
+     * Stored in specific_price_rule.price to mean "this rule sets no price of its own".
+     * A price of 0 is a real price - it makes the products free - so the two cannot be
+     * conflated, and an absent price has to become this rather than being cast to 0.
+     */
+    private const NO_FIXED_PRICE = -1;
+
+    /**
      * @var CommandBusInterface
      */
     private $commandBus;
@@ -56,8 +63,8 @@ final class CatalogPriceRuleFormDataHandler implements FormDataHandlerInterface
             $data['id_shop'] = $this->contextShopId;
         }
 
-        if ($data['leave_initial_price']) {
-            $data['price'] = -1;
+        if ($this->hasNoFixedPrice($data)) {
+            $data['price'] = self::NO_FIXED_PRICE;
         }
 
         $command = new AddCatalogPriceRuleCommand(
@@ -108,8 +115,8 @@ final class CatalogPriceRuleFormDataHandler implements FormDataHandlerInterface
      */
     private function fillCommandWithData(EditCatalogPriceRuleCommand $command, array $data)
     {
-        if ($data['leave_initial_price']) {
-            $data['price'] = -1;
+        if ($this->hasNoFixedPrice($data)) {
+            $data['price'] = self::NO_FIXED_PRICE;
         }
 
         $command->setName($data['name']);
@@ -129,5 +136,15 @@ final class CatalogPriceRuleFormDataHandler implements FormDataHandlerInterface
         if ($data['date_range']['to']) {
             $command->setDateTimeTo($data['date_range']['to']);
         }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function hasNoFixedPrice(array $data): bool
+    {
+        return !empty($data['leave_initial_price'])
+            || null === $data['price']
+            || '' === $data['price'];
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/CatalogPriceRuleFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CatalogPriceRuleFormDataProvider.php
@@ -43,7 +43,10 @@ final class CatalogPriceRuleFormDataProvider implements FormDataProviderInterfac
         $from = $editableCatalogPriceRule->getFrom();
         $to = $editableCatalogPriceRule->getTo();
 
-        if ($price->isLowerOrEqualThanZero()) {
+        // Only a negative price is the "no price of its own" sentinel. A price of 0 is a real
+        // price - the rule makes the products free - so it must stay visible in the field and
+        // leave the checkbox clear, otherwise the form claims the initial price is kept.
+        if ($price->isLowerThanZero()) {
             $price = null;
             $leaveInitialPrice = true;
         }

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CatalogPriceRuleFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CatalogPriceRuleFormDataProviderTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\DataProvider;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\QueryResult\EditableCatalogPriceRule;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\ValueObject\CatalogPriceRuleId;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Reduction;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CatalogPriceRuleFormDataProvider;
+
+/**
+ * A catalog price rule stores -1 in specific_price_rule.price to say it sets no price of its
+ * own; Product::getPriceStatic() reads that as "keep the product price" with `price < 0`.
+ * A price of 0 is a real price and makes the products free, so the form must tell them apart.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/33609
+ */
+class CatalogPriceRuleFormDataProviderTest extends TestCase
+{
+    public function testItTreatsANegativePriceAsNoPriceOfItsOwn(): void
+    {
+        $data = $this->dataForPrice('-1');
+
+        self::assertTrue($data['leave_initial_price'], 'the checkbox has to be ticked for the sentinel');
+        self::assertNull($data['price'], 'and the price field has to stay empty');
+    }
+
+    public function testItKeepsAPriceOfZeroVisible(): void
+    {
+        $data = $this->dataForPrice('0');
+
+        self::assertFalse(
+            $data['leave_initial_price'],
+            'zero is a real price - the rule makes the products free - so the checkbox must stay clear'
+        );
+        self::assertSame('0', $data['price'], 'and the merchant has to be able to see it in the field');
+    }
+
+    public function testItKeepsAnOrdinaryPrice(): void
+    {
+        $data = $this->dataForPrice('20.5');
+
+        self::assertFalse($data['leave_initial_price']);
+        self::assertSame('20.5', $data['price']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function dataForPrice(string $price): array
+    {
+        $rule = new EditableCatalogPriceRule(
+            new CatalogPriceRuleId(1),
+            'A rule',
+            1,
+            1,
+            0,
+            0,
+            1,
+            new DecimalNumber($price),
+            new Reduction(Reduction::TYPE_AMOUNT, '0'),
+            true,
+            new DateTime('2023-01-01 00:00:00'),
+            new DateTime('2030-01-01 00:00:00')
+        );
+
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        $queryBus->method('handle')->willReturn($rule);
+
+        return (new CatalogPriceRuleFormDataProvider($queryBus))->getData(1);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `specific_price_rule.price` holds `-1` to mean "this rule sets no price of its own". Saving a rule with **Leave initial price** unticked and the price field empty stored `0` instead, because `CatalogPriceRuleFormDataHandler` cast the absent value (`(float) null === 0.0`) rather than checking for it. Reloading the form then concealed it: `CatalogPriceRuleFormDataProvider` ticked the box back on for anything `isLowerOrEqualThanZero()`, so the rule looked unchanged while the database said something else.<br><br>Zero is not the sentinel — it is a real price. `Product::getPriceStatic()` keeps the product's own price only when `$specific_price['price'] < 0` (`classes/Product.php:3683`), so a stored `0` makes every matching product **free** while the back office claims the initial price is kept.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a catalog price rule, leave **Leave initial price** ticked, save, and check `ps_specific_price_rule` — the price is `-1`. Edit it, untick the box, leave the price field empty, save. Before this change the row becomes `0` and the reopened form still shows the box ticked; after, the row stays `-1` and the form agrees with it. Separately, saving a rule with an explicit price of `0` now keeps the box clear and shows `0` in the field, instead of pretending the initial price is kept.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33609
| Related PRs       | #33486 is the same field on the legacy page
| Sponsor company   |

### The two halves, which is what @Hlavtox asked for

> one issue is the field itself, we must specifically check it against the empty value, not cast it.
> Secondly, after reloading the page, the checkbox display must be done by strict comparison to `-1`.

Both are addressed:

```
DataHandler   (float) $data['price'] on an absent value  ->  hasNoFixedPrice() checks null/'' first
DataProvider  $price->isLowerOrEqualThanZero()           ->  $price->isLowerThanZero()
```

`isLowerThanZero()` is deliberately the same test the price computation itself uses
(`Product.php:3683`, `$specific_price['price'] < 0`), so the form and the pricing agree on what the
sentinel is rather than each having its own idea.

### Why zero cannot be folded in with -1

The form already accepts `0` — the field carries `GreaterThanOrEqual(0)` — so it is a value a merchant
can deliberately set, and it means "make these products free". Treating it as the sentinel is what made
the bug invisible: the row said free, the form said unchanged.

### Verification

`tests/Unit/.../CatalogPriceRuleFormDataProviderTest.php`, 3 tests / 6 assertions:

```
price -1     -> leave_initial_price true,  field empty
price 0      -> leave_initial_price false, field shows "0"
price 20.5   -> leave_initial_price false, field shows "20.5"
```

Mutation-checked: reverting only `CatalogPriceRuleFormDataProvider.php` to `upstream/9.2.x` while keeping
the test gives `Failed asserting that true is false` on the zero case, 1 failure of 3. Restoring it
returns 3 green.

`php -l` clean on all three files. php-cs-fixer flagged the handler once (its own import ordering),
applied, then 0 of 3. PHPStan with `phpstan.neon.dist` on both changed sources: `[OK] No errors`.

### Not covered

The write side is not unit-tested — `CatalogPriceRuleFormDataHandler` builds commands and dispatches them
through the bus, so asserting on it needs the command objects rather than a return value. The behaviour is
one guard (`hasNoFixedPrice()`) and it is stated in the commit; a behat scenario under
`tests/Integration/Behaviour/Features/Scenario/CatalogPriceRule` would be the natural place if reviewers
want it pinned.
