### PR TITLE
Keep the picked attribute when falling back to an in-stock combination

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1146,28 +1146,46 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                         }
                     );
                     if (count($checkProductAttribute)) {
-                        // now lets find other combinations for the selected attributes.
+                        // now lets find other combinations for the selected attributes. The dropdowns are
+                        // washed from left to right, each group only offering values that still combine,
+                        // in stock, with the groups before it, so an unavailable combination means an
+                        // earlier group was just changed and the groups after it hold stale values. Keep
+                        // the longest leading run of requested attributes that an available combination
+                        // still satisfies, and let the stale ones be picked again.
+                        $availableCombinations = [];
+                        foreach ($availableProductAttributes as $elem) {
+                            $idProductAttribute = (int) $elem['id_product_attribute'];
+                            if (!isset($availableCombinations[$idProductAttribute])) {
+                                $availableCombinations[$idProductAttribute] = [
+                                    'id_product_attribute' => $idProductAttribute,
+                                    'quantity' => $elem['quantity'],
+                                    'id_attributes' => [],
+                                ];
+                            }
+                            $availableCombinations[$idProductAttribute]['id_attributes'][] = $elem['id_attribute'];
+                        }
+
+                        // getAttributeCombinations() orders its rows by attribute group position, the same
+                        // order the dropdowns are washed in, so the requested attributes come out in the
+                        // order the groups constrain each other.
                         $alternativeProductAttribute = [];
-                        foreach ($checkProductAttribute as $key => $attribute) {
-                            $alternativeAttribute = array_filter(
-                                $availableProductAttributes,
-                                function ($elem) use ($attribute) {
-                                    return $elem['id_attribute'] == $attribute['id_attribute'] && !$elem['is_color_group'];
+                        foreach (array_column($checkProductAttribute, 'id_attribute') as $idAttribute) {
+                            $availableCombinations = array_filter(
+                                $availableCombinations,
+                                function ($combination) use ($idAttribute) {
+                                    return in_array($idAttribute, $combination['id_attributes']);
                                 }
                             );
-                            foreach ($alternativeAttribute as $key => $value) {
-                                $alternativeProductAttribute[$key] = $value;
+                            if (empty($availableCombinations)) {
+                                break;
                             }
+                            $alternativeProductAttribute = $availableCombinations;
                         }
 
                         if (count($alternativeProductAttribute)) {
-                            // if alternative combination is found, order the list by quantity to use the one with more stock.
+                            // among the combinations that keep as much of the request as possible, use the one with more stock.
                             usort($alternativeProductAttribute, function ($a, $b) {
-                                if ($a['quantity'] == $b['quantity']) {
-                                    return 0;
-                                }
-
-                                return ($a['quantity'] > $b['quantity']) ? -1 : 1;
+                                return $b['quantity'] <=> $a['quantity'];
                             });
 
                             return (int) array_shift($alternativeProductAttribute)['id_product_attribute'];

--- a/tests/Integration/Classes/Controller/CombinationFallbackTest.php
+++ b/tests/Integration/Classes/Controller/CombinationFallbackTest.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use Configuration;
+use PHPUnit\Framework\TestCase;
+use Product;
+use ProductController;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * With "Display unavailable attributes" off, picking an attribute whose combination is out of stock
+ * makes the controller fall back to a neighbouring combination.
+ *
+ * The dropdowns are washed from left to right: a group only offers values that still combine, in
+ * stock, with the groups before it. An unavailable combination therefore means an earlier group was
+ * just changed and the groups after it hold stale values, so the fallback has to keep the leading
+ * groups and re-pick the trailing ones. Keeping the wrong side makes the dropdown appear to snap
+ * back to its previous value.
+ */
+class CombinationFallbackTest extends TestCase
+{
+    private const COLOUR_GROUP = 2;
+    private const SIZE_GROUP = 1;
+    private const WAREHOUSE_GROUP = 9;
+    private const MATERIAL_GROUP = 3;
+    private const FINISH_GROUP = 4;
+
+    private const WHITE = 801;
+    private const BLACK = 802;
+    private const SIZE_40 = 401;
+    private const SIZE_44 = 441;
+    private const SIZE_45 = 451;
+    private const WAREHOUSE_A = 901;
+    private const WAREHOUSE_B = 902;
+    private const COTTON = 501;
+    private const LINEN = 502;
+    private const MATT = 601;
+    private const GLOSS = 602;
+    private const HANDLE_GROUP = 5;
+    private const WITH_HANDLE = 701;
+    private const WITHOUT_HANDLE = 702;
+    private const PACK_1 = 111;
+    private const PACK_4 = 114;
+    private const PACK_15 = 115;
+
+    /** @var array<string, string> */
+    private array $originalConfiguration = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (['PS_DISP_UNAVAILABLE_ATTR' => '0', 'PS_ORDER_OUT_OF_STOCK' => '0'] as $key => $value) {
+            $this->originalConfiguration[$key] = (string) Configuration::get($key);
+            Configuration::updateValue($key, $value);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalConfiguration as $key => $value) {
+            Configuration::updateValue($key, $value);
+        }
+        $this->originalConfiguration = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getFallbackScenarios
+     *
+     * @param array<int, array{attributes: array<int, int>, quantity: int, default: int}> $combinations
+     * @param array<int, int> $groups
+     */
+    public function testTheFallbackKeepsTheAttributeThatWasPicked(
+        array $combinations,
+        array $groups,
+        int $requestedIdProductAttribute,
+        int $pickedAttribute,
+        int $expectedIdProductAttribute,
+        string $message
+    ): void {
+        $landedOn = $this->fallbackFor($combinations, $groups, $requestedIdProductAttribute);
+
+        self::assertSame($expectedIdProductAttribute, $landedOn, $message);
+        self::assertContains(
+            $pickedAttribute,
+            $combinations[$landedOn]['attributes'],
+            'the combination it fell back to dropped the attribute the visitor picked'
+        );
+    }
+
+    /**
+     * Nothing in the requested colour is in stock, so there is no way to honour the pick. Falling
+     * back to another colour is correct here, and pins that the fix did not turn into "never move".
+     */
+    public function testItStillMovesWhenThePickCannotBeHonoured(): void
+    {
+        $combinations = [
+            3001 => ['attributes' => [self::WHITE, self::SIZE_40], 'quantity' => 1, 'default' => 1],
+            3002 => ['attributes' => [self::BLACK, self::SIZE_40], 'quantity' => 0, 'default' => 0],
+            3003 => ['attributes' => [self::WHITE, self::SIZE_44], 'quantity' => 2, 'default' => 0],
+            3004 => ['attributes' => [self::BLACK, self::SIZE_44], 'quantity' => 0, 'default' => 0],
+        ];
+
+        $landedOn = $this->fallbackFor($combinations, [self::COLOUR_GROUP, self::SIZE_GROUP], 3002);
+
+        self::assertContains($landedOn, [3001, 3003], 'it should still land on an in-stock combination');
+        self::assertSame(self::WHITE, $combinations[$landedOn]['attributes'][0]);
+    }
+
+    /**
+     * Issue #33720. Handle group first, package size second. Exactly the reporter's stock table:
+     * with a handle only the 4-pack is in stock, without a handle only the 1- and 15-packs are.
+     * Standing on "with handle / 4" and picking "without handle" asks for a combination that does
+     * not exist, and the visitor must not be pushed back to "with handle".
+     */
+    public function testPickingTheOtherHandleKeepsItAndMovesThePackSize(): void
+    {
+        $combinations = [
+            4001 => ['attributes' => [self::WITH_HANDLE, self::PACK_1], 'quantity' => 0, 'default' => 0],
+            4002 => ['attributes' => [self::WITH_HANDLE, self::PACK_4], 'quantity' => 4, 'default' => 1],
+            4003 => ['attributes' => [self::WITH_HANDLE, self::PACK_15], 'quantity' => 0, 'default' => 0],
+            4004 => ['attributes' => [self::WITHOUT_HANDLE, self::PACK_1], 'quantity' => 3, 'default' => 0],
+            4005 => ['attributes' => [self::WITHOUT_HANDLE, self::PACK_4], 'quantity' => 0, 'default' => 0],
+            4006 => ['attributes' => [self::WITHOUT_HANDLE, self::PACK_15], 'quantity' => 2, 'default' => 0],
+        ];
+
+        $landedOn = $this->fallbackFor($combinations, [self::HANDLE_GROUP, self::SIZE_GROUP], 4005);
+
+        self::assertContains($landedOn, [4004, 4006], 'it should stay without a handle and move the pack size');
+        self::assertSame(
+            self::WITHOUT_HANDLE,
+            $combinations[$landedOn]['attributes'][0],
+            'the handle the visitor picked has to survive the fallback'
+        );
+    }
+
+    /**
+     * The trailing groups are the stale ones, so they are the ones that move. Reaching this request
+     * through the dropdowns is not possible: the size dropdown is washed to sizes that are in stock
+     * for the selected colour, so White/40 could only come from a hand-written query string.
+     */
+    public function testTheLeadingGroupWinsWhenALaterGroupIsStale(): void
+    {
+        $combinations = self::colourFirstCatalogue();
+
+        $landedOn = $this->fallbackFor($combinations, [self::COLOUR_GROUP, self::SIZE_GROUP], 2001);
+
+        self::assertSame(2003, $landedOn);
+        self::assertSame(self::WHITE, $combinations[$landedOn]['attributes'][0], 'the leading group is kept');
+    }
+
+    /**
+     * Colour first, size second. In stock: Black/40 (2), White/44 (1), Black/45 (1).
+     *
+     * @return array<int, array{attributes: array<int, int>, quantity: int, default: int}>
+     */
+    private static function colourFirstCatalogue(): array
+    {
+        return [
+            2001 => ['attributes' => [self::WHITE, self::SIZE_40], 'quantity' => 0, 'default' => 0],
+            2002 => ['attributes' => [self::BLACK, self::SIZE_40], 'quantity' => 2, 'default' => 0],
+            2003 => ['attributes' => [self::WHITE, self::SIZE_44], 'quantity' => 1, 'default' => 1],
+            2004 => ['attributes' => [self::BLACK, self::SIZE_44], 'quantity' => 0, 'default' => 0],
+            2005 => ['attributes' => [self::WHITE, self::SIZE_45], 'quantity' => 0, 'default' => 0],
+            2006 => ['attributes' => [self::BLACK, self::SIZE_45], 'quantity' => 1, 'default' => 0],
+        ];
+    }
+
+    public static function getFallbackScenarios(): iterable
+    {
+        yield 'picking a colour keeps that colour' => [
+            self::colourFirstCatalogue(),
+            [self::COLOUR_GROUP, self::SIZE_GROUP],
+            2004,
+            self::BLACK,
+            2002,
+            'picking Black on an out-of-stock size fell back to White, discarding the colour',
+        ];
+
+        // Two plain groups, the shape reported in #32125. In stock: 40/B (2), 44/A (1), 45/B (1).
+        $sizeFirst = [
+            1001 => ['attributes' => [self::SIZE_40, self::WAREHOUSE_A], 'quantity' => 0, 'default' => 0],
+            1002 => ['attributes' => [self::SIZE_40, self::WAREHOUSE_B], 'quantity' => 2, 'default' => 0],
+            1003 => ['attributes' => [self::SIZE_44, self::WAREHOUSE_A], 'quantity' => 1, 'default' => 1],
+            1004 => ['attributes' => [self::SIZE_44, self::WAREHOUSE_B], 'quantity' => 0, 'default' => 0],
+            1005 => ['attributes' => [self::SIZE_45, self::WAREHOUSE_A], 'quantity' => 0, 'default' => 0],
+            1006 => ['attributes' => [self::SIZE_45, self::WAREHOUSE_B], 'quantity' => 1, 'default' => 0],
+        ];
+
+        yield 'picking a size keeps that size with two plain groups' => [
+            $sizeFirst,
+            [self::SIZE_GROUP, self::WAREHOUSE_GROUP],
+            1001,
+            self::SIZE_40,
+            1002,
+            'picking size 40 should move the second group, not the size',
+        ];
+
+        // Same, but the combination that keeps only the untouched warehouse holds far more stock.
+        $sizeFirstRestocked = $sizeFirst;
+        $sizeFirstRestocked[1003]['quantity'] = 10;
+
+        yield 'stock elsewhere does not outweigh the picked attribute' => [
+            $sizeFirstRestocked,
+            [self::SIZE_GROUP, self::WAREHOUSE_GROUP],
+            1001,
+            self::SIZE_40,
+            1002,
+            'a restock on another size pulled the visitor off the size they picked',
+        ];
+
+        // Three groups. The visitor changed the first one, so the other two are stale. The
+        // combination keeping both stale values must not outrank the one keeping the fresh pick.
+        $threeGroups = [
+            7001 => ['attributes' => [self::SIZE_40, self::COTTON, self::MATT], 'quantity' => 0, 'default' => 0],
+            7002 => ['attributes' => [self::SIZE_40, self::LINEN, self::GLOSS], 'quantity' => 5, 'default' => 0],
+            7003 => ['attributes' => [self::SIZE_44, self::COTTON, self::MATT], 'quantity' => 9, 'default' => 1],
+        ];
+
+        yield 'two stale attributes do not outvote the one just picked' => [
+            $threeGroups,
+            [self::SIZE_GROUP, self::MATERIAL_GROUP, self::FINISH_GROUP],
+            7001,
+            self::SIZE_40,
+            7002,
+            'the combination keeping both stale attributes won over the one keeping the fresh pick',
+        ];
+    }
+
+    /**
+     * @param array<int, array{attributes: array<int, int>, quantity: int, default: int}> $combinations
+     * @param array<int, int> $groups attribute group ids, in attribute group position order
+     */
+    private function fallbackFor(array $combinations, array $groups, int $requestedIdProductAttribute): int
+    {
+        $product = new class() extends Product {
+            /** @var array<int, array<string, mixed>> */
+            public array $combinationRows = [];
+
+            public function getAttributeCombinations($id_lang = null, $groupByIdAttributeGroup = true)
+            {
+                return $this->combinationRows;
+            }
+        };
+        $product->id = 999999;
+        $product->out_of_stock = 0;
+        $product->combinationRows = $this->buildRows($combinations, $groups);
+
+        $controller = (new ReflectionClass(ProductController::class))->newInstanceWithoutConstructor();
+
+        $productProperty = new ReflectionProperty(ProductController::class, 'product');
+        $productProperty->setAccessible(true);
+        $productProperty->setValue($controller, $product);
+
+        $method = new ReflectionMethod(ProductController::class, 'tryToGetAvailableIdProductAttribute');
+        $method->setAccessible(true);
+
+        return (int) $method->invoke($controller, $requestedIdProductAttribute);
+    }
+
+    /**
+     * getAttributeCombinations() groups by combination and attribute group and orders by the group
+     * position, so a combination yields one row per group in the order the dropdowns are washed.
+     * Identifiers are rendered as strings, the way the database hands them back.
+     *
+     * @param array<int, array{attributes: array<int, int>, quantity: int, default: int}> $combinations
+     * @param array<int, int> $groups
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildRows(array $combinations, array $groups): array
+    {
+        $rows = [];
+        foreach ($combinations as $idProductAttribute => $combination) {
+            foreach ($combination['attributes'] as $slot => $idAttribute) {
+                $rows[] = [
+                    'id_product_attribute' => (string) $idProductAttribute,
+                    'id_attribute' => (string) $idAttribute,
+                    'id_attribute_group' => (string) $groups[$slot],
+                    'is_color_group' => (string) (int) (self::COLOUR_GROUP === $groups[$slot]),
+                    'quantity' => $combination['quantity'],
+                    'default_on' => (string) $combination['default'],
+                ];
+            }
+        }
+
+        return $rows;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | With `Display unavailable product attributes` off, picking an attribute whose combination is out of stock made the product page fall back to a combination that dropped the attribute just picked, so the dropdown appeared to snap back to its previous value. The fallback now keeps the attribute the visitor chose and moves one of the others instead.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shop Parameters > Product Settings > `Display unavailable product attributes on the product page` set to No. Take a product with a colour group and a size group, stocked so that the currently selected size is out of stock in the colour you are about to pick while another size is in stock in that colour. On the front office, change the colour. Before the change the colour reverts to the previous one; after it, the colour is kept and the size moves instead.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #32125, Fixes #33720
| Related PRs       |
| Sponsor company   |

### What actually reproduces

The literal table in the report — sizes against warehouses, two plain attribute groups — **does not
reproduce on 9.2.x**. Driving the real `ProductController::tryToGetAvailableIdProductAttribute()` with
those quantities keeps the chosen size. That is not a case that was quietly fixed either: the method is
byte-identical from 8.1.0 through 9.2.x apart from a parameter type hint.

What does reproduce is the setup in the report's own "Steps to reproduce", which puts a **colour** group
first. Starting from White/44, with Black/40 (qty 2), White/44 (qty 1) and Black/45 (qty 1) in stock,
picking Black lands on White/44 — the colour is discarded every time, with no dependence on quantities.

### The cause

The fallback gathers alternatives from *every* attribute of the requested combination into one flat list
and ranks it by stock alone, and colour rows are excluded outright:

```php
return $elem['id_attribute'] == $attribute['id_attribute'] && !$elem['is_color_group'];
```

So "keeps the colour the visitor asked for" can never justify a candidate — only the untouched size can be
preserved, which is the snap-back. The clause arrived unexplained in #20565 (2020), whose stated purpose
was the opposite: *"if the variation is not available when the user change an attribute, look for
something similar instead of always going back to the default"*. No reviewer on that PR gives a reason for it.

Ranking by stock is the second half of the problem: a combination reachable only through an attribute the
visitor did **not** touch can outrank the one that honours the pick, purely because it holds more stock.

### The fix

The dropdowns are washed from left to right — `assignAttributesGroups()` restricts each group after the
first to values that still combine, **in stock**, with the groups before it (`ProductController.php:777`,
`INNER JOIN stock_available ... WHERE pa.quantity > 0`). An unavailable combination therefore means an
earlier group was just changed and the groups after it hold stale values.

So keep the longest leading run of requested attributes that an available combination still satisfies, and
let the stale tail be re-picked; stock only chooses among what remains. This needs no new information from
the theme, and it uses the same group ordering the cascade itself uses — `getAttributeCombinations()`
orders by `ag.position`, and `getAttributesGroups()` orders by `ag.position ASC, a.position ASC`.

**Decision and rejected alternatives.** The rule one reaches for first is "preserve whichever dropdown the
visitor changed", but the request carries only the resulting attribute set, not which value moved;
resolving it directly needs a new signal from the theme, a cross-repo contract change. I also built and
**rejected on measurement** a rule that scores candidates by how many requested attributes they keep: it
fixes the colour case, but on a three-group product a candidate keeping two stale values outranks the one
keeping the single fresh pick, turning an intermittently wrong answer into a systematically wrong one.
Measured, that rule sent a request for size 40 to size 44 in both quantity configurations tested.

### Behaviour change worth reviewing

When a colour group is first and the request is White/40 with White/40 out of stock, the fallback now
keeps White and moves the size, where before it kept the size and moved the colour. That request cannot be
produced by the dropdowns — with White selected, the size dropdown is washed to sizes in stock for White,
so 40 is not offered — but it is reachable from a hand-written query string. Pinned by
`testTheLeadingGroupWinsWhenALaterGroupIsStale` so the change is explicit rather than incidental.

### How to test

1. Shop Parameters → Product Settings → "Display unavailable attributes on the product page" → No.
2. A product with a colour group and a size group, stocked so the current size is out of stock in the
   colour you are about to pick, while another size is in stock in that colour.
3. On the front office, change the colour.

Before: the colour reverts to the previous one. After: the colour is kept and the size moves instead.

### Verification

- `tests/Integration/Classes/Controller/CombinationFallbackTest.php` — 6 tests, 12 assertions, driving the
  real protected method through reflection, with fixture rows rendered as strings the way the database
  returns them.
- **Mutation check**: with `controllers/front/ProductController.php` reverted to `upstream/9.2.x`,
  **4 of the 6 fail** — the colour case (`2003` for `2002`), the restock case (`1003` for `1002`), the
  three-group case (`7003` for `7002`) and the leading-group case (`2002` for `2003`) — while the two that
  describe unchanged behaviour still pass.
- `tests/Integration/Classes/` — **189/189 pass**. The 120 PHPUnit deprecations under this config are
  pre-existing: an untouched neighbouring test in the same directory reports the same 120.
- `php -l`, `php-cs-fixer` and `phpstan analyse -c phpstan.neon.dist` clean on both files.

Related and non-conflicting: my open #41839 and #41881 also concern `PS_DISP_UNAVAILABLE_ATTR` and default
combinations, but both touch `classes/Product.php` only. Of the five open PRs touching
`controllers/front/ProductController.php` (#42252, #41003, #40385, #39374, #30848), none touches this
method — checked across all 516 open PRs, 516/516 coverage.
