### PR TITLE
Subscribe to toggleCheckbox only in trees that have checkboxes

### DIFF
--- a/admin-dev/themes/new-theme/js/app/widgets/ps-tree/ps-tree-item.vue
+++ b/admin-dev/themes/new-theme/js/app/widgets/ps-tree/ps-tree-item.vue
@@ -168,13 +168,19 @@
       },
     },
     mounted() {
-      EventEmitter.on('toggleCheckbox', (tag: any) => {
-        const checkbox = this.$refs[tag];
+      // Only a tree that renders checkboxes can answer this, and only the stock filters emit it.
+      // Every node used to subscribe, so a tree of more than ten nodes - the back office
+      // translations sidebar, which passes no checkboxes at all - filled the shared emitter
+      // with listeners that had nothing to toggle, and Node warned about the eleventh.
+      if (this.hasCheckbox) {
+        EventEmitter.on('toggleCheckbox', (tag: any) => {
+          const checkbox = this.$refs[tag];
 
-        if (checkbox) {
-          (<VCheckbox>checkbox).$data.checked = !(<VCheckbox>checkbox).$data.checked;
-        }
-      });
+          if (checkbox) {
+            (<VCheckbox>checkbox).$data.checked = !(<VCheckbox>checkbox).$data.checked;
+          }
+        });
+      }
       EventEmitter.on('expand', () => {
         this.open = true;
       });


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PSTreeItem` registered a `toggleCheckbox` listener on the shared `EventEmitter` in `mounted()`. The component renders itself recursively, so a tree adds one listener per node, and the translations sidebar builds its tree from the translation domains — 164 of them on a default install. Node's `EventEmitter` warns once past ten, which is the `MaxListenersExceededWarning` reported on that page.<br><br>None of those listeners could ever fire there. The handler toggles the `PSCheckbox` rendered under `v-if="hasCheckbox"`, the translations sidebar renders `PSTree` without `has-checkbox` so the prop keeps its `false` default, and `toggleCheckbox` is only emitted by the stock page filters. The subscription is now made only when the tree actually renders checkboxes.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open Improve > International > Translations, pick a language and translation type, and watch the browser console while the page loads. Before this change it logs `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 toggleCheckbox listeners added.`; after, it does not. The stock page filters (Catalog > Stocks, supplier and category trees) still tick and untick from their tag list, which is the only place the event is emitted.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33816
| Related PRs       |
| Sponsor company   |

### Why the count reaches the limit

`admin-dev/themes/new-theme/js/components/event-emitter.ts` exports a single shared Node `EventEmitter`,
so its default limit of ten applies across every component that subscribes. `PSTreeItem` is recursive —
it renders `<PSTreeItem>` for each child — so the number of listeners is the number of nodes.

The translations sidebar feeds `PSTree` with the domain tree. On a default install that is:

```
translations/default/*.xlf     164 domains
  Admin    48
  Modules  96
  Shop     16
  Emails    2
```

so the tree is far past ten nodes, and Node emits the warning once, on the eleventh.

### Why the guard is the right place

Three independent facts make the subscription dead weight on that page:

```
ps-tree.vue:68-71                 hasCheckbox defaults to false
translations/.../sidebar/index.vue  renders <PSTree> with no has-checkbox
filter-component.vue:167          the only emit('toggleCheckbox') in the theme (stock filters)
```

and the handler's target, `<PSCheckbox :ref="model.name" v-if="hasCheckbox">`, does not exist when the
prop is false. So on the stock page nothing changes — `hasCheckbox` is true there — and on the
translations page the listeners simply stop being created.

Raising the limit with `setMaxListeners()`, as the warning message suggests, would have hidden the count
rather than removing listeners that cannot fire.

### Checks

`npx eslint js/app/widgets/ps-tree/ps-tree-item.vue` exits 0. `npx tsc --noEmit` reports 16 errors both
with and without this change — byte-identical lists — so they are pre-existing and none are in this file.

### Verification limit

The theme's mocha suite covers plain TypeScript utilities and has no Vue component harness
(`@vue/test-utils` is not a dependency), so the listener count was not asserted in a test. The domain
count above is measured; the chain from it to the warning is read from the three files quoted.

### Adjacent, deliberately not included

`PSTreeItem` also registers `expand`, `reduce` and `setCurrentElement` on the same shared emitter and
never removes any of them — there is no `beforeUnmount` in the component, and no `EventEmitter.off` call
anywhere in the theme. That is a real leak across tree re-renders, separate from the reported warning,
and it affects the other twelve components that subscribe to this emitter too. It wants its own change
rather than being folded in here.
