### PR TITLE
Invalidate the legacy query cache when product carriers are written

### DIFF
--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Repository;
 
+use Cache;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception as ExceptionAlias;
@@ -312,6 +313,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('shopIds', $shopIds, Connection::PARAM_INT_ARRAY)
             ->executeStatement()
         ;
+        $this->invalidateLegacyQueryCache($deleteQb->getSQL());
 
         $insertValues = [];
         foreach ($carrierReferenceIds as $referenceId) {
@@ -339,6 +341,21 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
         ';
 
         $this->connection->executeStatement($stmt);
+        $this->invalidateLegacyQueryCache($stmt);
+    }
+
+    /**
+     * Writes made through this connection bypass the legacy Db class, which is what normally calls
+     * Cache::deleteQuery on every write. Without this the legacy cached reads of the tables written
+     * here keep serving the rows that were just replaced, for as long as the cache holds them.
+     */
+    private function invalidateLegacyQueryCache(string $sql): void
+    {
+        if (!defined('_PS_CACHE_ENABLED_') || !_PS_CACHE_ENABLED_) {
+            return;
+        }
+
+        Cache::getInstance()->deleteQuery($sql);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ProductRepository::setCarrierReferences()` writes `product_carrier` through the Doctrine connection, which bypasses the legacy `Db` class. `Db` is what calls `Cache::deleteQuery()` after every write, so nothing invalidates the cached reads of that table — `Product::getCarriers()` and the query behind `Carrier::getAvailableCarrierList()` keep serving the rows that were just replaced. With a cache backend enabled the product page reloads the previous selection after saving, which is the report.<br><br>This invalidates after each statement, exactly as `Db` does on the legacy path.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable a cache system in Advanced Parameters > Performance > Caching, then edit a product's Shipping tab, change the available carriers and save. Before this change the selection reverts to the previous one; after, it keeps what was saved.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34389
| Related PRs       |
| Sponsor company   |

### Measured

The two write paths were driven against the same cached read, in one process, with the cache genuinely
enabled (`ps_cache_enable => true`) and a `Cache` double installed through core's own
`Cache::setInstanceForTesting()`, since no cache extension is available in this container. Counts are
calls to `Cache::deleteQuery()` during the write:

```
                                      deleteQuery   db rows   getCarriers()
V2 page, ProductRepository (before)         1         1,2       (none)   <- stale
V2 page, ProductRepository (after)          3         1,2       1,2
legacy Product::setCarriers (control)       2         1,2       1,2
```

The single call in the "before" row is not the carrier write at all — printing the statements shows it is
an unrelated `INSERT INTO ps_log` from the logger. So the count of invalidations for `product_carrier` on
that path is zero, and the read keeps the empty result it cached before the save. After the change the
same run shows the two statements that matter:

```
-> DELETE FROM ps_product_carrier WHERE (id_product = :productId) AND (id_shop IN (:shopIds))
-> INSERT INTO ps_product_carrier ( id_product, id_carrier_reference, id_shop ) VALUES ...
```

which is the same shape the legacy path produces. Reverting the change with the cache still enabled
brings `(none)` back, so the invalidation is what moved it.

### One wrong measurement worth recording

The first "after" run still showed the stale result, which looked like the fix not working. It was the
probe: it forced `Db::$is_cache_enabled` on by reflection while `_PS_CACHE_ENABLED_` — the constant the
new guard reads — was still `0`, a combination that cannot occur in a real shop. Enabling
`ps_cache_enable` properly made both sides agree. The "before" numbers above are from a re-run under the
same enabled-cache conditions, not the earlier invalid one.

### Scope

Only the carrier write is fixed here, because that is what the issue reports and what could be measured.
The underlying asymmetry is broader: every write the CQRS layer makes through the Doctrine connection
bypasses `Cache::deleteQuery()`, so any legacy cached read of a table written that way can go stale the
same way. `grep -rn deleteQuery src/` returns nothing, so there is no existing precedent for handling it,
and `PrestaShopBundle\Doctrine\DatabaseConnection` — already a wrapper around the DBAL connection, though
currently only for platform detection — would be the natural place to solve it once for every repository.
That is a bigger change than this issue justifies and is a maintainer call; flagged rather than attempted.

### Verification limits

- Measured through the repository method the V2 product page calls, not by clicking through the back
  office, which needs an employee session.
- The cache backend is a test double. It exercises the real `Cache::deleteQuery()`, `getTables()` and
  query-hash logic from the base class; only `_set`/`_get`/`_delete` are in-memory. No cache extension
  (apcu, memcached) is installed here.
- The second report on the thread, from AleksandraGHAG on 2026-06-10, describes the same symptom with
  **no cache enabled**, in a per-shop carrier setup. That cannot be this mechanism, since without a cache
  there is nothing stale to serve. It was not investigated and is probably a separate multistore bug.

### Checks

`php -l` clean; php-cs-fixer with the repo config reports 0 of 1 after applying its import-order fix;
PHPStan with `phpstan.neon.dist` reports `[OK] No errors`. No hunk overlap with the two open PRs touching
this file (#42190 at line 817, #41825 at line 249; this change is at 8, 313 and 341).
