### PR TITLE
Make the module manager category names translatable

### DIFF
--- a/classes/lang/KeysReference/AddonsCategoryLang.php
+++ b/classes/lang/KeysReference/AddonsCategoryLang.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+// app/config/addons/categories.yml
+trans('Administration', 'Admin.Modules.Feature');
+trans('Facebook & Social Networks', 'Admin.Modules.Feature');
+trans('Product Page', 'Admin.Modules.Feature');
+trans('Specialized Platforms', 'Admin.Modules.Feature');
+trans('Customers', 'Admin.Modules.Feature');
+trans('Payment', 'Admin.Modules.Feature');
+trans('Traffic & Marketplaces', 'Admin.Modules.Feature');
+trans('Promotions & Marketing', 'Admin.Modules.Feature');
+trans('Design & Navigation', 'Admin.Modules.Feature');
+trans('Shipping & Logistics', 'Admin.Modules.Feature');
+// PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider
+trans('Theme modules', 'Admin.Modules.Feature');
+trans('Other', 'Admin.Modules.Feature');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The category names in the module manager render in English on every locale. The templates are not at fault — all three that display them already pass them through `\|trans({}, 'Admin.Modules.Feature')`. The names come from `app/config/addons/categories.yml` and reach the filter as a variable, so the string extractor never sees them: they are absent from `translations/default/AdminModulesFeature.xlf`, never reach the translation platform, and no language pack can carry them, so `trans()` returns the English source.<br><br>This declares them the way the other non-discoverable keys are declared, as a twenty-sixth file in `classes/lang/KeysReference`. No template or provider change is needed.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The visible change only appears once the strings have been translated on the platform and shipped in a language pack, since this PR adds no translations of its own. What it can be checked against today is the catalog build: after regenerating the default catalog, `translations/default/AdminModulesFeature.xlf` gains the twelve names with a `File: classes/lang/KeysReference/AddonsCategoryLang.php` note, which is what puts them in front of translators.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34570
| Related PRs       |
| Sponsor company   |

### Measured

The `<note>` provenance line in the shipped catalogs is what makes this diagnosable rather than a guess.
In the French pack, `dropdown_categories.html.twig` line 25 holds the literal `'Recently used'`, and lines
34 and 36 of the *same file* apply the *same filter* to `subMenu.name`:

```
translations/fr-FR/AdminModulesFeature.fr-FR.xlf
  <source>Recently used</source>
  <target state="final">Récemment utilisé</target>
  <note>File: .../Includes/dropdown_categories.html.twig [Line: 25]</note>
```

and for each of the twelve category names, in that file and in
`translations/default/AdminModulesFeature.xlf`:

```
Administration              0 occurrences
Facebook & Social Networks  0
Product Page                0
Specialized Platforms       0
Customers                   0
Payment                     0
Traffic & Marketplaces      0
Promotions & Marketing      0
Design & Navigation         0
Shipping & Logistics        0
Theme modules               0
Other                       0
```

A literal is extracted; a variable two lines below it is not. That is the whole bug.

### The mechanism this uses is already proven in the same domain family

`classes/lang/KeysReference/` exists for exactly this, and its README says so: *"all translation keys that
need to be referenced, but not clearly visible in code. The translation parser will be grateful to find
such readable keys, and will not delete them from the translation system."* Twenty-five files use it,
`TabLang.php` alone contributing 81 units to `Admin.Navigation.Menu` for names that live in
`install-dev/langs/en/data/tab.xml`.

The closest analogue is `AdminModuleActionsLang.php`, and it can be followed end to end:

```
classes/lang/KeysReference/AdminModuleActionsLang.php:8   trans('Update', 'Admin.Modules.Actions');
  -> translations/default/AdminModulesActions.xlf         <source>Update</source>
                                                          <note>File: classes/lang/KeysReference/AdminModuleActionsLang.php [Line: 8]</note>
  -> translations/fr-FR/AdminModulesActions.fr-FR.xlf     <target state="final">Mettre à jour</target>
```

So a string declared this way does reach a shipped language pack, in the `Admin.Modules.*` family, today.

### Safety

The file is never executed, so the bare `trans()` calls cannot fatal. `KeysReference` appears nowhere
outside its own directory; composer's autoload covers `src/` by PSR-4 and five kernels by classmap, not
`classes/`; and the legacy class index contains zero references to the directory, because these files
declare no class for it to index. `phpstan.neon.dist:38` excludes `classes/lang/KeysReference` for the
same reason, so the undefined `trans()` is not an error — confirmed by running PHPStan on both the new
file and an existing one and getting the identical "No files found to analyse".

`php -l` clean. php-cs-fixer with the repo config: 0 of 1, and 0 of 1 on an existing `KeysReference` file
as a control.

### Scope

Only the twelve names that are actually displayed: the ten top-level categories from the YAML, plus
`Theme modules` and `Other`, which `CategoriesProvider` adds as `CATEGORY_THEME_NAME` and
`CATEGORY_OTHER_NAME`. The YAML's child categories are used to resolve a module's parent by its `tab`
attribute and are never rendered, so they are left out.

`dropdown_categories_catalog.html.twig` renders the same names *without* the `trans` filter, which looks
like a second half of this bug. It is referenced from nowhere in the codebase — the Module Catalog page it
belonged to is gone — so touching it would be editing dead code, and it is left alone.

### Verification limit

This makes the strings translatable; it does not translate them. Nothing changes on screen until the
platform has them and a language pack ships them. The default catalog is regenerated by the release
process ("Update default catalog build-920-beta1" and similar commits), not edited in feature PRs, so no
catalog file is touched here.
