### PR TITLE
Resize the dashboard charts when the help panel is toggled

### DIFF
--- a/admin-dev/themes/default/js/help.js
+++ b/admin-dev/themes/default/js/help.js
@@ -12,8 +12,14 @@ $(() => {
     storage = getStorageAvailable();
   }
 
+  // Opening or closing the help narrows #main to 70% and back. Widgets that size
+  // themselves from their container - the dashboard charts among them - only listen
+  // to window resize, so without this they keep the width they had before the toggle.
+  const notifyLayoutChange = () => window.dispatchEvent(new Event('resize'));
+
   window.initHelp = function () {
     $('#main').addClass('helpOpen');
+    notifyLayoutChange();
     // first time only
     if ($('#help-container').length === 0) {
       // add css
@@ -53,6 +59,7 @@ $(() => {
       );
     } else {
       $('#main').removeClass('helpOpen');
+      notifyLayoutChange();
       $('#help-container').html('');
       $('.toolbarBox a.btn-help i').removeClass('process-icon-close').addClass('process-icon-help');
       if (storage) storage.setItem('helpOpen', false);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `#main.helpOpen` is `width: 70%` against `100%` closed, so opening or closing the help changes the width of every widget inside it. Nothing announces that. The dashboard charts size themselves from their container through `nv.utils.windowResize()`, which is `window.addEventListener("resize", ...)` and nothing else, so after a toggle they keep the width they were last drawn at — overflowing the narrowed column, or leaving a gap once the help is closed.<br><br>This dispatches a resize event on both class changes. It reaches every widget already listening for one instead of coupling the help panel to any particular chart, which matters here because the three chart modules are separate repositories.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open the back office dashboard on a window wider than 1200px and toggle the help with the button in the toolbar. Before this change the charts keep their previous width — too wide when the help opens, too narrow when it closes. After, they follow the column.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34638
| Related PRs       |
| Sponsor company   |

### Measured

Real browser, the shipped `js/vendor/d3.v3.min.js` and `admin-dev/themes/default/js/vendor/nv.d3.min.js`,
a chart built the way `dashtrends.js:66` builds one — including its `nv.utils.windowResize(chart.update)`
— and the real `help.js` driven by clicking the real help button. `painted` is the chart's plot width, read
from its `clipPath rect`.

```
                                    container    painted
baseline, help closed                  1400        1284
help opened   (unpatched)               980        1284     <- 320px wider than its column
help opened   (with this change)        980         864
help closed   (with this change)       1400        1284
```

The unpatched row is the defect: the column is 980px wide and the chart is still drawn 1284px wide.

The same numbers come out of a second harness that toggles the class directly, so they do not depend on
`help.js` being involved:

```
help opened, no resize event      container 980   painted 1284
  + dispatchEvent('resize')       container 980   painted  864
help closed, no resize event      container 1400  painted  864
  + dispatchEvent('resize')       container 1400  painted 1284
```

Dispatching synchronously right after the class change is enough — the layout is already recomputed by the
time the chart reads its container, so no `setTimeout` is needed. Verified separately.

One property worth noting: the help content is fetched by JSONP from an external domain, and in the
harness that request failed (`window.isCleanHtml is not a function`). The resize still happened, because
the class change and the event are both ahead of the fetch. The fix does not depend on the help content
loading.

### Why in `help.js` and not in the chart modules

`dashtrends`, `dashactivity` and `dashgoals` each carry the same `nv.utils.windowResize(chart.update)`
line (`dashtrends.js:66`, `dashactivity.js:42`, `dashgoals.js:111` and `:139`), and all three are separate
repositories — `prestashop/dashtrends`, `prestashop/dashactivity`, `prestashop/dashgoals` — with no files
tracked in core. Fixing them one by one would be three module PRs that still would not help any other
widget sized from its container. The help panel is the single place that knows the layout changed.

`admin-dev/themes/default/js/help.js` is served raw (`AdminController.php:4022`), so there is no build step
and nothing else to regenerate. `npx eslint -c .eslintrc.js js/help.js` exits 0.

### What else listens for resize

Dispatching a synthetic event is only safe if every subscriber tolerates one at an unchanged window
width, so here is the full list for the pages that load `help.js`. Excluding vendor and minified files
there are five, and the event was checked against each:

```
admin-dev/themes/default/js/admin-theme.js:367          mobile nav
admin-dev/themes/default/js/admin-theme.js:684          debounced padding recompute
admin-dev/themes/new-theme/js/nav_bar.ts:150            mobile nav
admin-dev/themes/new-theme/js/app/utils/datepicker.js:41  reposition an open datepicker
admin-dev/themes/new-theme/js/components/header/search-form.ts:43  quick-access overlay
```

The two mobile-nav handlers compare `$(window).width()` to a breakpoint and to the body's `mobile`
class; the window width has not changed, so neither branch runs. The padding recompute is debounced and
writes the same CSS custom properties it already held. The datepicker handler repositions a widget that
is open, which is the correct response to a layout change rather than a side effect.

`search-form.ts` is the one that does something: above 768px it calls `closeQuickaccess()`. That is a
no-op in every sequence that can reach it, because the quick-access overlay is mobile-only —
`openQuickaccess()` returns immediately unless `windowWidth <= 768` — while the help panel only opens at
all above 1200px (`help.js:43`, and the help button itself is `d-none d-md-inline-block`). The overlay
cannot be open at a width where the help panel is togglable.

`enquire.register('screen and (max-width: 1200px)')` in `admin-theme.js:499` closes the help panel by
triggering the same button, which would be the place a loop could start. It cannot be reached: enquire
uses `matchMedia`, and the two polyfills that would bind a resize listener both bail out on any browser
with native support — `matchMedia.js` is `window.matchMedia || (...)` and `matchMedia.addListener.js`
opens with "Bail out for browsers that have addListener support". Even under the polyfill its handler
only fires listeners when `matches !== mql.matches`, which a same-width resize cannot change.

Confirmed by counting: one resize event per toggle, two after open-then-close, still two after settling.

### Verification limits

- Measured on a reproduction that loads the real `help.js`, the real d3/nvd3 and the real
  `#main.helpOpen` rule, not on the back office dashboard itself, which needs an employee session.
- The report's Example 2 (reload a chart while the help is open, then close it) was **not** reproduced.
  Driving that faithfully needs the module's own AJAX refresh; re-rendering the chart by hand in the
  harness did not put it into the stale state the report describes. Example 1 was reproduced in both
  directions, and the same event reaches a chart re-rendered by any path, but that specific sequence is
  worth a QA pass rather than taken on my word.
