### PR TITLE
Size TinyMCE editors again when their tab becomes visible

### DIFF
--- a/admin-dev/themes/new-theme/js/components/tinymce-editor.js
+++ b/admin-dev/themes/new-theme/js/components/tinymce-editor.js
@@ -182,6 +182,22 @@ class TinyMCEEditor {
 
       $(textareaLinkSelector).click();
     });
+
+    // The autoresize plugin sizes an editor when it initializes and whenever its content
+    // changes. Both can happen while the editor sits in a hidden tab, where it measures as
+    // empty and collapses to the minimum height, and nothing sizes it again once the tab is
+    // shown. So ask for a size again on every tab change, for the editors visible by then.
+    // 'setcontent' is one of the events the plugin sizes on, and firing it without changing
+    // the content leaves the content, the undo stack and the dirty flag alone.
+    $(document).on('shown.bs.tab', () => {
+      window.tinyMCE.editors.forEach((editor) => {
+        const container = editor.getContainer();
+
+        if (container && $(container).is(':visible')) {
+          editor.fire('setcontent', {});
+        }
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The `autoresize` plugin sizes an editor on init and on every content change. Both happen while an editor can be inside a hidden tab, where its body measures as empty, so it collapses to the minimum height — and nothing sizes it again once the tab is shown. The field stays a one-line strip until the merchant types in it, which is exactly what the report describes.<br><br>The existing language-tab reset in `watchTabChanges()` makes it worse rather than better: `EventEmitter.on('languageSelected')` clicks the locale link in **every** translations block, including blocks whose form tab is hidden, so `setContent()` runs on a hidden editor and collapses one that had been correct. That is Roxayl's repro on this thread — switch to a tab without an editor, change language, come back.<br><br>This recomputes the size on any tab change, for the editors that are visible by then.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Edit a product on a multilanguage shop. Switch to a tab with no editor (Details), change the language, then go back to Description. Before this change the description editor is a collapsed one-line strip and stays that way until you type in it; after, it is its full height. The Categories and CMS forms use the same `#form-nav` tab widget from `prestashop_ui_kit_base.html.twig`, so they should behave the same way — worth checking, see the limits below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #35680
| Related PRs       | #35709 fixed the legacy V1 product page only, on 8.2.x
| Sponsor company   |

### Measured

Real browser, the shipped `js/tiny_mce/tinymce.min.js` and its real `autoresize` plugin, two editors
with identical content — one in a visible pane, one in a pane that is `display:none` at init.
`iframeH` is the editor iframe's height, `bodyScrollH` what its content needs.

```
                                                    iframeH   bodyScrollH
editor initialised in a visible pane                   821         805
editor initialised in a hidden pane                     16           0
  ... after its tab is shown                            16         805   <- collapsed, content is there
```

Then the reported sequence, with the editor healthy to begin with:

```
                                                    iframeH   with this change
on its tab, sized correctly                            821      821
left the tab; language reset fires while hidden         16       16
came back to the tab                                    16      821
came back a second time                                 16      821
```

Nothing in the current code sizes it again, which is why the report says you have to type in the field
to recover it — a keystroke is one of the four events the plugin listens to.

### Asking for the size

The plugin sizes on `change setcontent paste keyup`, so firing `setcontent` without changing anything
asks for a size through its own event surface. Measured on the collapsed editor, and then fired twice
more to check it costs nothing:

```
fire('setcontent', {})   16px -> 821px
content identical        yes            (1726 chars before and after)
undo levels              1 -> 1
isDirty                  false -> false
'change' listeners       never fired
```

That matters because the two obvious alternatives both have a cost. `setContent(getContent())` — what
the language-tab handler does today — round-trips the content through the parser and disturbs the undo
stack. `execCommand('mceAutoResize', true)` works, but only by a quirk described below, and it would
need that paragraph as a comment.

### The plugin ignores its own command without an argument

Worth recording because it makes one line of the merged V1 fix dead. `plugin.min.js` registers
`mceAutoResize` as the same handler it binds to `change setcontent paste keyup`, and that handler
opens with:

```js
!u||!i||"setcontent"===i.type&&i.initial|| ... ||(  /* resize */  )
```

`i` is the triggering event, so a call with no argument returns immediately. Measured on a collapsed
editor, with the plugin's own `autoresize_on_init` retry ladder (20x100ms then 5x1000ms) long
exhausted:

```
editor.execCommand('mceAutoResize')          16px -> 16px    no effect
editor.execCommand('mceAutoResize', true)    16px -> 821px   resized
```

`execCommand`'s second argument arrives as the handler's first, so a truthy value gets past the guard —
which is exactly why this PR fires the event instead of exploiting that. The same reading applies to
#35709's `editor.execCommand('mceAutoResize')` on the V1 page: it does nothing, and what actually works
there is the `mceInsertContent` line above it, which fires a real `setcontent`.

This also corrected my own first reading of the measurement. An earlier run appeared to show the
no-argument command working; it was the plugin's init retry ladder firing during the wait. Re-running
after the ladder was exhausted separated the two.

### Verification limits

Measured against the real TinyMCE library and its real plugin, in a reproduction of the hidden-tab
structure. Two things were not measured and should be named rather than implied:

- Not measured on the real product page, which needs an employee session.
- The harness fires `shown.bs.tab` on `document` directly. That the event Bootstrap raises from
  `ul.nav-tabs#form-nav` actually bubbles to `document` in the back office is the one hop the
  reproduction does not cover, and it is what the Categories and CMS coverage rests on.

### Notes

- `admin-dev/themes/new-theme/public/*` is gitignored, so no rebuilt bundle belongs in the diff.
  `npx eslint js/components/tinymce-editor.js` exits 0.
- No hunk overlap with the two open boo-code PRs on this file (#42335 and #41879 touch lines 36-75;
  this is in `watchTabChanges` at ~185).
- `initTinyMCE()` can run twice on a page — `setupTinyMCE()` calls `loadAndInitTinyMCE()`, which calls
  `setupTinyMCE()` again once the library has loaded — so the document handler can be registered twice.
  The second firing is a no-op: the plugin only writes a height when the value it computes differs from
  the one it last applied. Deduplicating it would cost more code than the double call does.
