### PR TITLE
Revert ps_apiresources to upstream dev-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "prestashop/hummingbird": "^2.1",
         "prestashop/pagesnotfound": "^4",
         "prestashop/productcomments": "^8.0",
-        "prestashop/ps_apiresources": "dev-41972-carrier-endpoints",
+        "prestashop/ps_apiresources": "dev-dev",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^2.0",
         "prestashop/ps_brandlist": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "029a55a42b2be1f318a520ebbeb84fcf",
+    "content-hash": "89e2352d6f6b0e1d065a196d5b00e993",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5212,16 +5212,16 @@
         },
         {
             "name": "prestashop/ps_apiresources",
-            "version": "dev-41972-carrier-endpoints",
+            "version": "dev-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_apiresources.git",
-                "reference": "2627c4dc5b5bf76e702ea3f32e48a181174206f0"
+                "reference": "9c8ee15ddd66b654d68cb6578d1cbb19bb07e9fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/2627c4dc5b5bf76e702ea3f32e48a181174206f0",
-                "reference": "2627c4dc5b5bf76e702ea3f32e48a181174206f0",
+                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/9c8ee15ddd66b654d68cb6578d1cbb19bb07e9fc",
+                "reference": "9c8ee15ddd66b654d68cb6578d1cbb19bb07e9fc",
                 "shasum": ""
             },
             "require": {
@@ -5235,6 +5235,7 @@
                 "prestashop/php-dev-tools": "^4.3",
                 "rector/rector": "^2.0"
             },
+            "default-branch": true,
             "type": "prestashop-module",
             "autoload": {
                 "psr-4": {
@@ -5305,10 +5306,10 @@
             "description": "PrestaShop - API Resources",
             "homepage": "https://github.com/PrestaShop/ps_apiresources",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_apiresources/tree/41972-carrier-endpoints",
+                "source": "https://github.com/PrestaShop/ps_apiresources/tree/dev",
                 "issues": "https://github.com/PrestaShop/ps_apiresources/issues"
             },
-            "time": "2026-08-31T17:05:51+00:00"
+            "time": "2026-09-01T16:22:03+00:00"
         },
         {
             "name": "prestashop/ps_banner",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `composer.json` still pins `prestashop/ps_apiresources` to `dev-41972-carrier-endpoints`. That branch was deleted from the module repository after [PrestaShop/ps_apiresources#350](https://github.com/PrestaShop/ps_apiresources/pull/350) was merged into `dev`, so the constraint no longer resolves and **`composer update prestashop/ps_apiresources` fails** on this branch. `composer install` still works, but only because `composer.lock` freezes `2627c4d`, a commit that survives the branch deletion — so the breakage stays invisible until someone tries to update that package. This restores the upstream default `dev-dev`. No functional change: `2627c4d` is contained in `dev` (`compare 2627c4d...dev` reports `behind_by=0`), so the lock simply moves up to the merge commit `9c8ee15`, which adds nothing but the merge itself.
| Type?             | bug fix
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/33850961410
| Fixed issue or discussion?     | No linked issue — spotted while QAing #42490 (unrelated to that PR, which touches neither `composer.json` nor `composer.lock`).
| Related PRs       | [PrestaShop/ps_apiresources#350](https://github.com/PrestaShop/ps_apiresources/pull/350) — the module PR whose branch deletion left this pin dangling. `develop` carries the exact same stale pin (identical blob) and gets fixed by the upward merge of this branch.
| Sponsor company   | N/A

## The problem

```console
$ composer update prestashop/ps_apiresources --dry-run
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires prestashop/ps_apiresources dev-41972-carrier-endpoints,
      it is satisfiable by prestashop/ps_apiresources[dev-41972-carrier-endpoints] from
      composer repo (https://repo.packagist.org) but prestashop/ps_apiresources[...,
      dev-main, ..., dev-dev, ...] from vcs repo (github https://github.com/PrestaShop/ps_apiresources)
      has higher repository priority. The packages from the higher priority repository do not
      match your constraint and are therefore not installable.
```

The branch is gone from the module repository:

```console
$ gh api repos/PrestaShop/ps_apiresources/branches/41972-carrier-endpoints
gh: Branch not found (HTTP 404)
```

## How to test

1. On `9.2.x` without this PR, run `composer update prestashop/ps_apiresources --dry-run` → it fails with the resolution error above.
2. Check out this branch and run the same command → it resolves.
3. Run `composer update prestashop/ps_apiresources` and check the move is surgical:
   ```
   - Upgrading prestashop/ps_apiresources (dev-41972-carrier-endpoints 2627c4d => dev-dev 9c8ee15)
   ```
   `Lock file operations: 0 installs, 1 update, 0 removals` — no other package moves.
4. `composer show prestashop/ps_apiresources` reports `dev-dev` at `9c8ee15`.
5. The Admin API behaves as before (identical module code): endpoints respond and `composer api-module-tests-local` passes.

## Diff notes

`composer.lock` changes only the `prestashop/ps_apiresources` entry: `version`, the two `reference` fields, the `dist` URL, `support.source` (now `tree/dev`), `time`, plus `"default-branch": true` — the latter is expected, `dev` **is** the module's default branch. `content-hash` changes because `composer.json` did. No `"platform-dev"` churn, no transitive package movement.
