### PR TITLE
Fix invalid shipping calculation in partial vouchers (fixes #28901)

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1293,17 +1293,7 @@ abstract class PaymentModuleCore extends Module
 
                 // Set the new voucher value
                 $voucher->reduction_amount = $remainingValue;
-                if ($voucher->reduction_tax) {
-                    // Add total shipping amount only if reduction amount > total shipping
-                    if ($voucher->free_shipping == 1 && $voucher->reduction_amount >= $order->total_shipping_tax_incl) {
-                        $voucher->reduction_amount -= $order->total_shipping_tax_incl;
-                    }
-                } else {
-                    // Add total shipping amount only if reduction amount > total shipping
-                    if ($voucher->free_shipping == 1 && $voucher->reduction_amount >= $order->total_shipping_tax_excl) {
-                        $voucher->reduction_amount -= $order->total_shipping_tax_excl;
-                    }
-                }
+
                 if ($voucher->reduction_amount <= 0) {
                     continue;
                 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |develop 
| Description?      | Everything is discussed in issue #28901
| Type?             | bug fix 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a new cart rule based on amount, partial use, with free shipping. Create a cart on the frontend and apply the discount voucher. Be sure that your cart amount is less than cart rule you're applying. Proceed to the order. Check the remaining voucher amount. Now the remaining amount is correct. 
| Fixed ticket?     | Fixes #28901
| Sponsor company   | M-Code Artisan
