### PR TITLE
Name the hook and the module when a hook fails

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -466,7 +466,14 @@ class HookCore extends ObjectModel
                 '\\PrestaShop\\PrestaShop\\Adapter\\Environment'
             );
             if ($environment->isDebug()) {
-                throw new CoreException($e->getMessage(), $e->getCode(), $e);
+                // WHY: this wrapper is thrown from Hook.php, so that is the location the debug page
+                // reports. Naming the hook and the module here is what tells the reader which module
+                // to look at; the original exception stays reachable as the previous one.
+                throw new CoreException(
+                    sprintf('Hook "%s" failed in module "%s": %s', $hookName, $module->name, $e->getMessage()),
+                    $e->getCode(),
+                    $e
+                );
             }
         }
 
@@ -1226,7 +1233,12 @@ class HookCore extends ObjectModel
                 '\\PrestaShop\\PrestaShop\\Adapter\\Environment'
             );
             if ($environment->isDebug()) {
-                throw new CoreException($e->getMessage(), $e->getCode(), $e);
+                // Same reason as in callHookOn(): identify the widget's hook and module.
+                throw new CoreException(
+                    sprintf('Widget hook "%s" failed in module "%s": %s', $hook_name, $module->name, $e->getMessage()),
+                    $e->getCode(),
+                    $e
+                );
             }
         }
 

--- a/tests/Integration/Classes/HookTest.php
+++ b/tests/Integration/Classes/HookTest.php
@@ -7,7 +7,14 @@
 namespace Tests\Integration\Classes;
 
 use Hook;
+use Module;
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\ServiceLocator;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use ReflectionClass;
+use ReflectionMethod;
+use RuntimeException;
+use Throwable;
 
 class HookTest extends TestCase
 {
@@ -24,5 +31,45 @@ class HookTest extends TestCase
     public function testIsDisplayHookNameHeaderIsNotADisplayHook(): void
     {
         $this->assertFalse(Hook::isDisplayHookName('header'));
+    }
+
+    /**
+     * A module throwing inside a hook is wrapped in a CoreException thrown from Hook.php, so the
+     * debug page reports Hook.php as the location. The message is the only thing that can say which
+     * module and which hook were involved, so it has to name both (see issue #40399).
+     */
+    public function testAModuleFailingInAHookIsReportedWithTheHookAndModuleNames(): void
+    {
+        $environment = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\Environment');
+        $this->assertTrue(
+            $environment->isDebug(),
+            'This test needs debug mode, which is the only mode where the hook exception propagates.'
+        );
+
+        /** @var Module $module */
+        $module = (new ReflectionClass(HookTestThrowingModule::class))->newInstanceWithoutConstructor();
+        $module->name = 'hooktest_throwing_module';
+
+        $callHookOn = new ReflectionMethod(Hook::class, 'callHookOn');
+        $callHookOn->setAccessible(true);
+
+        try {
+            $callHookOn->invoke(null, $module, 'actionHookTestThrows', []);
+            $this->fail('Expected the module exception to be wrapped and rethrown in debug mode.');
+        } catch (Throwable $e) {
+            $this->assertInstanceOf(CoreException::class, $e);
+            $this->assertStringContainsString('actionHookTestThrows', $e->getMessage());
+            $this->assertStringContainsString('hooktest_throwing_module', $e->getMessage());
+            $this->assertStringContainsString('boom raised inside the module hook', $e->getMessage());
+            $this->assertInstanceOf(RuntimeException::class, $e->getPrevious());
+        }
+    }
+}
+
+class HookTestThrowingModule extends Module
+{
+    public function hookActionHookTestThrows(array $params): void
+    {
+        throw new RuntimeException('boom raised inside the module hook');
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When a module throws inside a hook and the shop is in debug mode, `Hook::callHookOn()` and `Hook::coreRenderWidget()` re-throw the module's exception wrapped in a `CoreException` carrying only the original message. The wrapper is thrown from `classes/Hook.php`, so that is the file and line the debug page reports, and nothing in the message says which hook ran or which module failed.<br><br>Both wrappers now name the hook and the module in the message. The original exception is still passed as `$previous`, so the underlying stack trace is unchanged and reachable.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With `_PS_MODE_DEV_` on, make an installed module throw from a hook it is registered on, for example by adding `throw new \RuntimeException('boom');` to its `hookDisplayHome()`, and load the front page. Before this change the error reads `boom` and points at `classes/Hook.php`; after it, it reads `Hook "displayHome" failed in module "<module>": boom`.<br><br>`tests/Integration/Classes/HookTest.php` covers it.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #40399
| Related PRs       |
| Sponsor company   |
