### PR TITLE
Round the tax excluded line total when rounding type is line

### DIFF
--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -254,12 +254,22 @@ class CartRow
         $quantity = (int) $rowData['cart_quantity'];
         $this->initialUnitPrice = $this->getProductPrice($cart, $rowData);
 
-        // store not rounded values, except in round_mode_item, we still need to round individual items
+        // store not rounded values, except in round_mode_item and round_mode_line, where the row
+        // must already carry the amount applyRound() will produce
         if ($this->roundType == self::ROUND_MODE_ITEM) {
             $tools = new Tools();
             $this->initialTotalPrice = new AmountImmutable(
                 $tools->round($this->initialUnitPrice->getTaxIncluded(), $this->precision) * $quantity,
                 $tools->round($this->initialUnitPrice->getTaxExcluded(), $this->precision) * $quantity
+            );
+        } elseif ($this->roundType == self::ROUND_MODE_LINE) {
+            // WHY: Calculator::getRowTotalWithoutDiscount() re-rounds only the tax included side of
+            // each row, so leaving the tax excluded side raw here made Cart::BOTH sum unrounded lines
+            // while Cart::ONLY_PRODUCTS summed rounded ones, and the two totals drifted by a cent.
+            $tools = new Tools();
+            $this->initialTotalPrice = new AmountImmutable(
+                $tools->round($this->initialUnitPrice->getTaxIncluded() * $quantity, $this->precision),
+                $tools->round($this->initialUnitPrice->getTaxExcluded() * $quantity, $this->precision)
             );
         } else {
             $this->initialTotalPrice = new AmountImmutable(

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/RoundingType/round_line.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/RoundingType/round_line.feature
@@ -16,11 +16,13 @@ Feature: Cart calculation with rounding type LINE
   Scenario: one product in cart, quantity 1
     When I add 1 items of product "product1" in my cart
     Then my cart total should be precisely 26.81 tax included
+    And my cart total should be precisely 26.81 tax excluded
     And my cart total shipping fees should be 7.0 tax included
 
   Scenario: one product in cart, quantity 3
     When I add 3 items of product "product1" in my cart
     Then my cart total should be precisely 66.44 tax included
+    And my cart total should be precisely 66.44 tax excluded
     And my cart total shipping fees should be 7.0 tax included
 
   Scenario: 3 products in cart, several quantities
@@ -28,6 +30,7 @@ Feature: Cart calculation with rounding type LINE
     And I add 3 items of product "product1" in my cart
     And I add 1 items of product "product3" in my cart
     Then my cart total should be precisely 162.41 tax included
+    And my cart total should be precisely 162.41 tax excluded
     And my cart total shipping fees should be 7.0 tax included
 
   @restore-cart-rules-after-scenario
@@ -38,6 +41,7 @@ Feature: Cart calculation with rounding type LINE
       | discount_percentage | 15        |
     When I add 3 items of product "product1" in my cart
     Then my cart total should be precisely 57.52 tax included
+    And my cart total should be precisely 57.52 tax excluded
     And my cart total shipping fees should be 7.0 tax included
 
   Scenario: one product in cart, quantity 3 with an amount cart rule
@@ -49,4 +53,5 @@ Feature: Cart calculation with rounding type LINE
       | discount_includes_tax | false     |
     When I add 3 items of product "product1" in my cart
     Then my cart total should be precisely 61.44 tax included
+    And my cart total should be precisely 61.44 tax excluded
     And my cart total shipping fees should be 7.0 tax included


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | With rounding type "round on each line", `Cart::getOrderTotal(Cart::BOTH)` and `Cart::getOrderTotal(Cart::ONLY_PRODUCTS)` could disagree by a cent on the tax excluded side, so an invoice printed a "Total Tax" that its own tax detail table did not sum to.<br><br>`CartRow::processCalculation()` stored the line total unrounded for every mode except `ROUND_MODE_ITEM`. `Calculator::getRowTotalWithoutDiscount()` then re-rounds only the tax **included** side of each row. Under `ROUND_MODE_LINE` that left the tax excluded side as the one place where no per-line rounding happened, so one total summed rounded lines and the other summed raw ones.<br><br>The row now carries the rounded amount for `ROUND_MODE_LINE` as well, on both sides, which is what `applyRound()` would produce anyway. `ROUND_MODE_ITEM` and `ROUND_MODE_TOTAL` are untouched and already satisfied the invariant.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set Preferences > General > Round mode to "Round on each line", with a tax rule that produces a fractional tax. Add two units of a product priced so the per-line tax excluded amount needs rounding, then compare `getOrderTotal(Cart::BOTH)` against `getOrderTotal(Cart::ONLY_PRODUCTS)` plus shipping. Before this change they differ by 0.01; after it they agree.<br><br>The added scenario in `tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/RoundingType/round_line.feature` covers it and fails on the base branch.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #17161
| Related PRs       |
| Sponsor company   |

The two rounding modes that already agreed are the argument that this is a defect rather than an inherent rounding limit: measured on one order with no shipping and no discount, `item` gives 8.33/8.33 and `total` gives 8.32/8.32, while `line` gave 8.32 against 8.33.
