### PR TITLE
Let stock_mvt_reason_lang.name use its table charset

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2435,7 +2435,7 @@ CREATE TABLE `PREFIX_stock_mvt_reason` (
 CREATE TABLE `PREFIX_stock_mvt_reason_lang` (
   `id_stock_mvt_reason` INT(11) UNSIGNED NOT NULL,
   `id_lang` INT(11) UNSIGNED NOT NULL,
-  `name` VARCHAR(255) CHARACTER SET utf8 NOT NULL,
+  `name` VARCHAR(255) NOT NULL,
   PRIMARY KEY (
     `id_stock_mvt_reason`, `id_lang`
   )

--- a/tests/Integration/Classes/db/DbColumnCollationTest.php
+++ b/tests/Integration/Classes/db/DbColumnCollationTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\db;
+
+use Db;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A character column that declares its own charset overrides the one its table declares, which
+ * silently narrows what the column can store: a VARCHAR pinned to utf8 (utf8mb3) inside a utf8mb4
+ * table rejects any 4-byte character with "Incorrect string value". It also makes the column
+ * collate differently from every other column it is compared to (see issue #16636).
+ *
+ * Tables may legitimately differ from each other - modules ship their own install SQL - so this
+ * only asserts the invariant that holds inside a single table.
+ */
+class DbColumnCollationTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+    }
+
+    public function testEveryColumnUsesTheCollationOfItsOwnTable(): void
+    {
+        $mismatches = Db::getInstance()->executeS(
+            'SELECT c.TABLE_NAME, c.COLUMN_NAME, c.COLLATION_NAME, t.TABLE_COLLATION
+             FROM information_schema.COLUMNS c
+             INNER JOIN information_schema.TABLES t
+                 ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME
+             WHERE c.TABLE_SCHEMA = DATABASE()
+                 AND c.COLLATION_NAME IS NOT NULL
+                 AND c.COLLATION_NAME != t.TABLE_COLLATION
+             ORDER BY c.TABLE_NAME, c.COLUMN_NAME'
+        );
+
+        $this->assertSame(
+            [],
+            array_map(
+                static fn (array $row): string => sprintf(
+                    '%s.%s is %s inside a %s table',
+                    $row['TABLE_NAME'],
+                    $row['COLUMN_NAME'],
+                    $row['COLLATION_NAME'],
+                    $row['TABLE_COLLATION']
+                ),
+                $mismatches ?: []
+            )
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `stock_mvt_reason_lang`.`name` is declared `VARCHAR(255) CHARACTER SET utf8`, while its own table is `DEFAULT CHARSET=utf8mb4`. It is the only column in `install-dev/data/db_structure.sql` that overrides the table charset, so a fresh install ends up with one `utf8` column in an otherwise `utf8mb4` schema.<br><br>The practical effect is that a 4-byte character in a stock movement reason name is rejected by MySQL with `ERROR 1366 Incorrect string value`, where every other translatable name accepts it. Dropping the override lets the column inherit `utf8mb4` from the table.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a fresh install, `SHOW FULL COLUMNS FROM ps_stock_mvt_reason_lang` reports `utf8mb4_*` for `name` instead of `utf8mb3_*`, and inserting a 4-byte character into that column succeeds. Run the client with `--default-character-set=utf8mb4`, otherwise the client mangles the character before MySQL sees it and the check passes for the wrong reason.<br><br>`tests/Integration/Classes/db/DbColumnCollationTest.php` asserts no column in the schema declares a charset that differs from its table's.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #16636
| Related PRs       |
| Sponsor company   |

This changes the schema that new installs create. Existing shops keep the `utf8` column until migrated, and core ships no `install-dev/upgrade/` on this branch, so that migration belongs in `PrestaShop/autoupgrade` rather than here.
