### PR TITLE
Cover extraction of a module template overridden by the theme

### DIFF
--- a/tests/Integration/PrestaShopBundle/Translation/Extractor/ThemeExtractorTest.php
+++ b/tests/Integration/PrestaShopBundle/Translation/Extractor/ThemeExtractorTest.php
@@ -99,6 +99,23 @@ class ThemeExtractorTest extends KernelTestCase
         $this->assertTrue($isFilesExists);
     }
 
+    /**
+     * A theme may override a third-party module's template, and strings added in that override have to
+     * reach the translation catalogue under the module's own domain — otherwise they cannot be
+     * translated anywhere. Reported as #13392.
+     */
+    public function testExtractsStringsFromAModuleTemplateOverriddenByTheTheme(): void
+    {
+        $this->themeExtractor
+            ->setOutputPath(self::$xliffFolder)
+            ->extract($this->getFakeTheme());
+
+        $this->assertTrue(
+            $this->filesystem->exists(self::$xliffFolder . '/en-US/Modules/Fakemodule/Shop.xlf'),
+            'The theme override of a module template should be extracted under the module domain'
+        );
+    }
+
     private function getFakeTheme(): Theme
     {
         $configFile = self::$rootDir . '/config/theme.yml';

--- a/tests/Resources/themes/fake-theme/modules/fakemodule/views/templates/hook/fake.tpl
+++ b/tests/Resources/themes/fake-theme/modules/fakemodule/views/templates/hook/fake.tpl
@@ -1,0 +1,6 @@
+{*
+* Theme override of a third-party module template, as described in #13392.
+*}
+<div class="fake-module">
+  <p>{l s='A string added in the theme override of a module template' d='Modules.Fakemodule.Shop'}</p>
+</div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Pins that a string added in a theme's override of a module template is extracted under the module's own domain. No production code changes.
| Type?                      | improvement
| Category?                  | TE
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #13392
| Related PRs                |
| Sponsor company            |

### Why

A theme may override a third-party module's template. Strings added in that override have to reach the
catalogue under the module's own domain, or they cannot be translated anywhere — the complaint in #13392.

The behaviour is correct today: both extractors registered in `translation.yml` hand the whole theme
directory to the Smarty extractor, so `themes/<theme>/modules/<module>/...` is walked like any other
template. Nothing asserted it, so nothing would notice if a future change narrowed that traversal to
`templates/` only.

### What it does

Adds a module override to the existing `fake-theme` fixture and one assertion that the extractor produces
`en-US/Modules/Fakemodule/Shop.xlf` for it.

### How to test

```
php vendor/bin/phpunit -c tests/Integration/phpunit.xml \
  tests/Integration/PrestaShopBundle/Translation/Extractor/ThemeExtractorTest.php
```

Removing `tests/Resources/themes/fake-theme/modules/fakemodule/views/templates/hook/fake.tpl` fails the
new assertion, so it is the override being picked up rather than something else in the theme.
