### PR TITLE
Associate the supplier when a product is created through the webservice

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7487,11 +7487,45 @@ class ProductCore extends ObjectModel
     public function addWs($autodate = true, $null_values = false)
     {
         $success = $this->add($autodate, $null_values);
-        if ($success && Configuration::get('PS_SEARCH_INDEXATION')) {
-            Search::indexation(false, $this->id);
+        if ($success) {
+            $this->addSupplierReferenceFromWebservice();
+            if (Configuration::get('PS_SEARCH_INDEXATION')) {
+                Search::indexation(false, $this->id);
+            }
         }
 
         return $success;
+    }
+
+    /**
+     * Creates the supplier association the webservice was given but never wrote.
+     *
+     * id_supplier, supplier_reference and wholesale_price are columns of the product row, so they were
+     * stored and the call answered success while product_supplier - the association the back office and
+     * the supplier pages read - stayed empty. addCombinationEntity() above already writes it at the
+     * combination level, and the CSV import does it too (AdminImportController::attributeImportOne()).
+     *
+     * Strictly additive: an existing association is left exactly as it is. A webservice request hydrates
+     * the entity from the database before applying the payload, so a call that says nothing about
+     * suppliers still arrives carrying the product row's values; writing those back would overwrite a
+     * reference and a cost price the back office owns - and the back office syncs the product row FROM
+     * the default association (ProductSupplierUpdater::updateDefaultSupplierDataForProduct()), not the
+     * other way round.
+     */
+    protected function addSupplierReferenceFromWebservice(): void
+    {
+        $idSupplier = (int) $this->id_supplier;
+
+        if ($idSupplier <= 0 || ProductSupplier::getIdByProductAndSupplier((int) $this->id, 0, $idSupplier)) {
+            return;
+        }
+
+        $this->addSupplierReference(
+            $idSupplier,
+            0,
+            $this->supplier_reference,
+            null !== $this->wholesale_price ? (float) $this->wholesale_price : null
+        );
     }
 
     /**
@@ -7510,8 +7544,11 @@ class ProductCore extends ObjectModel
         }
 
         $success = parent::update($null_values);
-        if ($success && Configuration::get('PS_SEARCH_INDEXATION')) {
-            Search::indexation(false, $this->id);
+        if ($success) {
+            $this->addSupplierReferenceFromWebservice();
+            if (Configuration::get('PS_SEARCH_INDEXATION')) {
+                Search::indexation(false, $this->id);
+            }
         }
         Hook::exec('actionProductUpdate', ['id_product' => (int) $this->id]);
 

--- a/tests/Integration/Classes/Product/WsSupplierAssociationTest.php
+++ b/tests/Integration/Classes/Product/WsSupplierAssociationTest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+use Tools;
+
+/**
+ * id_supplier, supplier_reference and wholesale_price are columns of the product row, so the webservice
+ * stored them and answered success while product_supplier - the association the back office reads - was
+ * never written.
+ */
+class WsSupplierAssociationTest extends TestCase
+{
+    private int $idSupplier = 0;
+
+    private int $otherSupplier = 0;
+
+    /** @var int[] */
+    private array $productIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $suppliers = Db::getInstance()->executeS(
+            'SELECT id_supplier FROM ' . _DB_PREFIX_ . 'supplier ORDER BY id_supplier ASC LIMIT 2'
+        );
+        if (count($suppliers) < 2) {
+            $this->markTestSkipped('Two suppliers are needed to prove the others are left alone.');
+        }
+        $this->idSupplier = (int) $suppliers[0]['id_supplier'];
+        $this->otherSupplier = (int) $suppliers[1]['id_supplier'];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->productIds as $id) {
+            Db::getInstance()->delete('product_supplier', 'id_product = ' . $id);
+            Db::getInstance()->delete('category_product', 'id_product = ' . $id);
+            (new Product($id))->delete();
+        }
+        $this->productIds = [];
+
+        parent::tearDown();
+    }
+
+    public function testCreatingAProductThroughTheWebserviceAssociatesItsSupplier(): void
+    {
+        $product = $this->webserviceProduct('ws supplier created');
+        $product->addWs();
+        $this->productIds[] = (int) $product->id;
+
+        $rows = $this->associationsOf((int) $product->id);
+        $this->assertCount(1, $rows);
+        $this->assertSame($this->idSupplier, (int) $rows[0]['id_supplier']);
+        $this->assertSame('WS-REF', $rows[0]['product_supplier_reference']);
+        $this->assertSame(4.5, (float) $rows[0]['product_supplier_price_te']);
+    }
+
+    public function testUpdatingThroughTheWebserviceAssociatesItToo(): void
+    {
+        $product = $this->webserviceProduct('ws supplier updated');
+        $product->add();
+        $this->productIds[] = (int) $product->id;
+        $this->assertCount(0, $this->associationsOf((int) $product->id), 'a plain add() leaves it unassociated');
+
+        $reloaded = new Product((int) $product->id);
+        $reloaded->id_supplier = $this->idSupplier;
+        $reloaded->supplier_reference = 'WS-REF';
+        $reloaded->wholesale_price = 4.5;
+        $reloaded->updateWs();
+
+        $rows = $this->associationsOf((int) $product->id);
+        $this->assertCount(1, $rows);
+        $this->assertSame($this->idSupplier, (int) $rows[0]['id_supplier']);
+    }
+
+    /**
+     * Repeating the call neither stacks rows up nor rewrites the one that is there.
+     */
+    public function testRepeatingTheUpdateLeavesTheAssociationAlone(): void
+    {
+        $product = $this->webserviceProduct('ws supplier repeated');
+        $product->addWs();
+        $this->productIds[] = (int) $product->id;
+
+        $again = new Product((int) $product->id);
+        $again->supplier_reference = 'WS-REF-SECOND';
+        $again->updateWs();
+
+        $rows = $this->associationsOf((int) $product->id);
+        $this->assertCount(1, $rows);
+        $this->assertSame('WS-REF', $rows[0]['product_supplier_reference']);
+    }
+
+    /**
+     * The reference and the cost price on the product row can drift from the association - the back
+     * office syncs the row FROM the association, and "Cost price" is a product field of its own. A
+     * webservice request hydrates the entity from the database, so a call that says nothing about
+     * suppliers arrives carrying those drifted values; it must not write them back.
+     */
+    public function testAWebserviceUpdateDoesNotOverwriteWhatTheBackOfficeSet(): void
+    {
+        $product = $this->webserviceProduct('ws supplier drifted');
+        $product->add();
+        $this->productIds[] = (int) $product->id;
+        $product->addSupplierReference($this->idSupplier, 0, 'BO-REF', 9.99);
+
+        Db::getInstance()->update(
+            'product',
+            ['supplier_reference' => '', 'wholesale_price' => 4.5],
+            'id_product = ' . (int) $product->id
+        );
+
+        $reloaded = new Product((int) $product->id);
+        $reloaded->updateWs();
+
+        $rows = $this->associationsOf((int) $product->id);
+        $this->assertCount(1, $rows);
+        $this->assertSame('BO-REF', $rows[0]['product_supplier_reference']);
+        $this->assertSame(9.99, (float) $rows[0]['product_supplier_price_te']);
+    }
+
+    /**
+     * A supplier a merchant attached elsewhere must survive a webservice update that says nothing about it.
+     */
+    public function testAnotherSuppliersAssociationIsLeftAlone(): void
+    {
+        $product = $this->webserviceProduct('ws supplier preserved');
+        $product->addWs();
+        $this->productIds[] = (int) $product->id;
+        $product->addSupplierReference($this->otherSupplier, 0, 'SET-IN-THE-BACK-OFFICE', 9.0);
+        $this->assertCount(2, $this->associationsOf((int) $product->id));
+
+        $again = new Product((int) $product->id);
+        $again->id_supplier = $this->idSupplier;
+        $again->supplier_reference = 'WS-REF';
+        $again->updateWs();
+
+        $rows = $this->associationsOf((int) $product->id);
+        $this->assertCount(2, $rows, 'the other supplier is still there');
+        $kept = array_values(array_filter($rows, fn ($r) => (int) $r['id_supplier'] === $this->otherSupplier));
+        $this->assertSame('SET-IN-THE-BACK-OFFICE', $kept[0]['product_supplier_reference']);
+    }
+
+    /**
+     * A payload carrying no supplier must not invent one.
+     */
+    public function testAProductWithNoSupplierGetsNoAssociation(): void
+    {
+        $product = $this->webserviceProduct('ws supplier absent');
+        $product->id_supplier = 0;
+        $product->supplier_reference = '';
+        $product->addWs();
+        $this->productIds[] = (int) $product->id;
+
+        $this->assertCount(0, $this->associationsOf((int) $product->id));
+    }
+
+    private function webserviceProduct(string $name): Product
+    {
+        $lang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $product = new Product();
+        $product->id_category_default = 2;
+        $product->name = [$lang => $name];
+        $product->link_rewrite = [$lang => Tools::str2url($name)];
+        $product->price = 10;
+        $product->id_tax_rules_group = 1;
+        $product->id_supplier = $this->idSupplier;
+        $product->supplier_reference = 'WS-REF';
+        $product->wholesale_price = 4.5;
+
+        return $product;
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function associationsOf(int $idProduct): array
+    {
+        return Db::getInstance()->executeS(
+            'SELECT id_supplier, product_supplier_reference, product_supplier_price_te
+             FROM ' . _DB_PREFIX_ . 'product_supplier WHERE id_product = ' . $idProduct
+        ) ?: [];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Creating or updating a product through the webservice stored `id_supplier`, `supplier_reference` and `wholesale_price` on the product row and answered success, but never wrote the `product_supplier` association the back office and the supplier pages read, so the supplier appeared nowhere. `addWs()` and `updateWs()` now create it when it is missing.
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #16086
| Related PRs                |
| Sponsor company            |

Builds on #20736 by @Max84.

### The bug

`id_supplier`, `supplier_reference` and `wholesale_price` are columns of `ps_product`, so a `POST`/`PUT`
on `/api/products` carrying them saved cleanly and returned the product with those values set. The
supplier association itself lives in `ps_product_supplier`, and nothing on the webservice path wrote it —
so `Product::getProductSuppliers()`, the product page's Suppliers tab and the supplier's own product list
all stayed empty, while the API kept answering with a supplier.

Reproduced on 9.2.x by replaying the webservice call path:

```
after addWs():
  product.id_supplier=1  supplier_reference='WS-REF-16086'  wholesale_price='4.500000'
  ps_product_supplier rows: 0
  getProductSuppliers():  0
after updateWs():
  ps_product_supplier rows: 0
control, addSupplierReference() (what the back office calls):
  ps_product_supplier rows: 1
```

### The fix

`addWs()` and `updateWs()` call `addSupplierReference()` on success — but **only when the association does
not already exist**.

- **Internal precedent.** `Product::addCombinationEntity()` already calls it at the combination level,
  and the CSV import does the same in `AdminImportController::attributeImportOne()`.
- **`wholesale_price` maps to `product_supplier_price_te`** on creation — the same equivalence
  `ProductImportHandler` and `GetSupplierForViewingHandler` use.
- **Strictly additive, and that guard is load-bearing.** A webservice request hydrates the entity from the
  database before applying the payload, so a `PUT` that says nothing about suppliers still arrives
  carrying the product row's `supplier_reference` and `wholesale_price`. Writing those back would
  overwrite what the back office owns: it syncs the product row **from** the default association
  (`ProductSupplierUpdater::updateDefaultSupplierDataForProduct()`), and "Cost price" is a product field
  of its own, not a copy of the supplier's price. Measured without the guard, an update that touched
  neither field turned `BO-REF` / `9.99` into `''` / `4.50`. `testAWebserviceUpdateDoesNotOverwriteWhatTheBackOfficeSet`
  pins that.

**Rejected alternative:** #20736 also called `deleteFromSupplier()` before re-adding. That deletes *every*
row for the product — including combination rows and rows for other suppliers a merchant set in the back
office — so a webservice update that says nothing about them would silently destroy them.

**Rejected alternative:** a plain upsert on every call. It fixes the reported bug too, but silently
rewrites existing shops' data as measured above. Preferred the narrower behaviour.

### How to test

1. Enable the webservice, create a key with `products` permissions.
2. `POST /api/products` with `<id_supplier>1</id_supplier>`, `<supplier_reference>WS-REF</supplier_reference>`
   and `<wholesale_price>4.5</wholesale_price>`.
3. Back office → the new product → **Suppliers**: the supplier is there with that reference and price.
   Catalog → Suppliers → the supplier: the product is listed.
4. Same via `PUT` on an existing product.

Automated: `tests/Integration/Classes/Product/WsSupplierAssociationTest.php` — 6 cases covering create,
update, repeat (no duplicate row and no rewrite), another supplier's row surviving, a drifted product row
not overwriting what the back office set, and a payload with no supplier creating nothing. Reverting
`classes/Product.php` to `upstream/9.2.x` fails 4 of the 6; the other two pass on both sides by
construction and are there as guards.
