### PR TITLE
Stop the quickview product from shadowing the template globals

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -459,8 +459,20 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         $this->setQuickViewMode();
 
+        /*
+         * getEmbeddedAttributes() returns the whitelisted properties that have already been resolved on
+         * the lazy array, so resolve them all first. Until now this happened as a side effect of handing
+         * the serialised product to render() below.
+         */
+        $productForTemplate->jsonSerialize();
+
         $this->ajaxRender(json_encode([
-            'quickview_html' => $this->render('catalog/_partials/quickview', $productForTemplate->jsonSerialize()),
+            /*
+             * Only $product is passed. The serialised product used to be spread over the template scope,
+             * where each of its keys shadowed the global of the same name - $link became the product URL
+             * instead of the Link service, and $category a category slug instead of the category.
+             */
+            'quickview_html' => $this->render('catalog/_partials/quickview', ['product' => $productForTemplate]),
             'product' => $productForTemplate->getEmbeddedAttributes(),
         ]));
     }

--- a/tests/Integration/Controllers/Front/ProductQuickviewTest.php
+++ b/tests/Integration/Controllers/Front/ProductQuickviewTest.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Controllers\Front;
+
+use Configuration;
+use Context;
+use Currency;
+use Language;
+use Link;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
+use ProductControllerCore;
+use Smarty_Internal_Data;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The quickview is rendered through FrontController::render(), which assigns every key of the array it
+ * is handed as a template variable. Passing the serialised product therefore overwrote the globals of
+ * the same name: $link stopped being the Link service inside the quickview and everything it includes,
+ * and $category became a slug.
+ */
+class ProductQuickviewTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // getRoundedDisplayPrice() reads the context currency, which the CLI context leaves unset.
+        Context::getContext()->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+    }
+
+    public function testTheQuickviewIsRenderedWithTheProductAlone(): void
+    {
+        $this->assertSame(['product'], array_keys($this->renderQuickview()['params']));
+    }
+
+    /**
+     * @dataProvider globalsTheProductWouldHaveShadowed
+     */
+    public function testTheProductDoesNotShadowAGlobal(string $variable): void
+    {
+        $params = $this->renderQuickview()['params'];
+
+        $this->assertArrayNotHasKey($variable, $params);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public function globalsTheProductWouldHaveShadowed(): array
+    {
+        return [
+            'link' => ['link'],
+            'category' => ['category'],
+            'id' => ['id'],
+        ];
+    }
+
+    public function testTheGlobalLinkServiceSurvivesInTheQuickviewScope(): void
+    {
+        $scope = $this->scopeAsRenderBuildsIt($this->renderQuickview()['params']);
+
+        $this->assertInstanceOf(
+            Link::class,
+            $scope->getTemplateVars('link'),
+            '$link must stay the Link service, not the product URL'
+        );
+    }
+
+    public function testTheQuickviewScopeStillCarriesTheProduct(): void
+    {
+        $scope = $this->scopeAsRenderBuildsIt($this->renderQuickview()['params']);
+
+        $this->assertSame(1, (int) $scope->getTemplateVars('product')['id_product']);
+    }
+
+    /**
+     * The JSON payload the theme's JavaScript reads must not shrink: getEmbeddedAttributes() only
+     * returns whitelisted properties that have already been resolved on the lazy array. Until now that
+     * resolution happened as a side effect of serialising the product for render(); this guards the
+     * explicit call that replaced it. Green on both sides of the fix by design.
+     */
+    public function testTheEmbeddedAttributesAreResolvedBeforeTheyAreRead(): void
+    {
+        $embedded = $this->renderQuickview()['embedded'];
+
+        // The three that disappear if nothing resolves the lazy array before it is read.
+        foreach (['features', 'attachments', 'attribute_price'] as $attribute) {
+            $this->assertArrayHasKey($attribute, $embedded);
+        }
+    }
+
+    /**
+     * Runs displayAjaxQuickview() against a real presented product, capturing what it hands to
+     * render() and what it puts in the JSON payload.
+     *
+     * @return array{params: array<string, mixed>, embedded: array<string, mixed>}
+     */
+    private function renderQuickview(): array
+    {
+        $product = $this->presentedProduct();
+
+        $controller = new class($product) extends ProductControllerCore {
+            /** @var array<string, mixed> */
+            public array $renderParameters = [];
+
+            /** @var array<string, mixed> */
+            public array $payload = [];
+
+            public function __construct(private ProductLazyArray $presented)
+            {
+                parent::__construct();
+            }
+
+            public function getTemplateVarProduct(): ProductLazyArray
+            {
+                return $this->presented;
+            }
+
+            protected function render($template, array $params = [])
+            {
+                $this->renderParameters = $params;
+
+                return '';
+            }
+
+            protected function ajaxRender($value = null, $controller = null, $method = null)
+            {
+                $this->payload = json_decode((string) $value, true) ?? [];
+
+                return true;
+            }
+        };
+
+        $level = ob_get_level();
+        ob_start();
+        $controller->displayAjaxQuickview();
+        while (ob_get_level() > $level) {
+            ob_end_clean();
+        }
+
+        return [
+            'params' => $controller->renderParameters,
+            'embedded' => $controller->payload['product'] ?? [],
+        ];
+    }
+
+    /**
+     * Builds the template scope the same way FrontController::render() does, so the assertions are made
+     * on the variables the template actually sees.
+     *
+     * @param array<string, mixed> $params
+     */
+    private function scopeAsRenderBuildsIt(array $params): Smarty_Internal_Data
+    {
+        $smarty = Context::getContext()->smarty;
+        $smarty->assign('link', Context::getContext()->link);
+        $scope = $smarty->createData($smarty);
+        $scope->assign($params);
+
+        return $scope;
+    }
+
+    private function presentedProduct(): ProductLazyArray
+    {
+        $settings = new ProductPresentationSettings();
+        $settings->catalog_mode = false;
+        $settings->restricted_country_mode = false;
+        $settings->showPrices = true;
+
+        $imageRetriever = $this->createMock(ImageRetriever::class);
+        $imageRetriever->method('getAllProductImages')->withAnyParameters()->willReturn([
+            ['id_image' => 0, 'associatedVariants' => []],
+        ]);
+
+        $link = $this->createMock(Link::class);
+        $link->method('getAddToCartURL')->withAnyParameters()->willReturn('http://add-to-cart.url');
+        $link->method('getProductLink')->withAnyParameters()->willReturn('http://product.url');
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->withAnyParameters()->willReturn('some label');
+
+        $priceFormatter = $this->createMock(PriceFormatter::class);
+        $priceFormatter->method('convertAmount')->withAnyParameters()->willReturnArgument(0);
+        $priceFormatter->method('format')->withAnyParameters()->willReturnCallback(
+            fn (?float $price) => '#' . $price
+        );
+
+        $presenter = new ProductPresenter(
+            $imageRetriever,
+            $link,
+            $priceFormatter,
+            $this->createMock(ProductColorsRetriever::class),
+            $translator
+        );
+
+        return $presenter->present(
+            $settings,
+            [
+                'available_for_order' => true,
+                'id_product' => 1,
+                'id_product_attribute' => 0,
+                'link_rewrite' => 'hummingbird-printed-t-shirt',
+                'category' => 'clothes',
+                'reference' => 'demo_1',
+                'price' => null,
+                'price_without_reduction' => null,
+                'price_without_reduction_without_tax' => null,
+                'price_tax_exc' => null,
+                'specific_prices' => null,
+                'customizable' => false,
+                'is_virtual' => false,
+                'id_category_default' => 2,
+                'minimal_quantity' => 1,
+                'additional_delivery_times' => 0,
+                'quantity' => 1,
+                'allow_oosp' => false,
+                'online_only' => false,
+                'reduction' => false,
+                'on_sale' => false,
+                'new' => false,
+                'pack' => false,
+                'show_price' => true,
+                'active' => true,
+            ],
+            $this->createMock(Language::class)
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | The quickview was rendered by spreading the serialised product over the template scope, so every product key overwrote the global of the same name — `$link` became the product URL instead of the `Link` service. Pass only the product.
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #16488
| Related PRs                |
| Sponsor company            |

On BC: a third-party theme that overrides `quickview.tpl` (or a partial it includes) and reads a bare
product key — `{$reference}`, `{$name}`, `{$id}` — loses it, because those variables only ever existed by
accident. They were never documented, they do not exist on the product page where the same partials are
included, and the shipped themes do not use them; `{$product.reference}` is the supported form and keeps
working. The alternative is leaving `$link` and `$category` broken for every theme.

### The bug

`FrontController::render()` builds a child Smarty scope and calls `$scope->assign($params)`, which turns
every key of `$params` into a template variable. `ProductController::displayAjaxQuickview()` handed it
`$productForTemplate->jsonSerialize()` — the whole presented product — so each of its keys shadowed the
global of the same name inside `quickview.tpl` and everything it includes.

Measured on 9.2.x by rendering a probe in the quickview template:

```
before: link_is_Link_object=NO  link_scalar_value=http://localhost:8001/6-mug-the-best-is-yet-to-come.html
        category_scalar=home-accessories  id_scalar=6
after:  link_is_Link_object=YES link_scalar_value=       category_scalar=OBJECT  id_scalar=UNSET
```

So `$link` was the product URL, `$category` a category slug rather than the category, and `$id`,
`$reference` and the rest of the product leaked in as bare variables. Any theme or module template in the
quickview include chain that used `$link` got a string and broke.

### The fix

Pass `['product' => $productForTemplate]`. Nothing in the shipped templates read the flat keys — the same
partials (`product-cover-thumbnails`, `product-prices`, `product-variants`, `product-add-to-cart`) are
included from the product page, where those variables have never existed, and `$groups` comes from
`assignAttributesGroups()` on the global scope, not from the product.

`getEmbeddedAttributes()` returns whitelisted properties that have **already been resolved** on the lazy
array, and that resolution used to happen as a side effect of serialising the product for `render()`.
It is now an explicit call, so the JSON payload the theme JavaScript reads is unchanged — without it
`features`, `attachments` and `attribute_price` disappear from it.

@Quetzacoalt91 asked for exactly this fix when closing #8013 (2017):
"it would be better to find and remove the line overriding the value instead of overriding it a second
time". That PR re-assigned `$link` after the fact; this removes the assignment that clobbered it.

### How to test

1. Add `{dump($link)}` to `themes/classic/templates/catalog/_partials/quickview.tpl`.
2. Open a product page: `$link` is a `Link` instance.
3. Open the quickview of any product: `$link` is now also a `Link` instance (it used to be the product URL).

### Verification

- **Rendered output unchanged.** Quickview HTML and the JSON `product` payload are byte-identical before
  and after on four products, including three with combinations so the `$groups` / `product-variants`
  path is actually exercised (3, 1 and 1 attribute selectors rendered):

  | theme | product | html | embedded attributes |
  |---|---|---|---|
  | hummingbird | 6 (no combinations) | identical, 14883 B | identical |
  | hummingbird | 1 (3 attribute selectors) | identical, 18991 B | identical |
  | hummingbird | 2 (1 selector) | identical, 16315 B | identical |
  | hummingbird | 3 (1 selector) | identical, 16077 B | identical |
  | **classic** | 6 (no combinations) | identical, 7404 B | identical |
  | **classic** | 1 (3 attribute selectors) | identical, 9633 B | identical |
  | **classic** | 2 (1 selector) | identical, 8420 B | identical |

  Every top-level variable classic's quickview chain reads is assigned to the global scope by
  `ProductController::initContent()` — `product`, `priceDisplay`, `displayUnitPrice`, `noPackPrice`,
  `displayPackPrice` at `ProductController.php:403-421`, and `groups` at `:853` — so none of them came
  from the spread.

- `tests/Integration/Controllers/Front/ProductQuickviewTest.php` — 7 cases. Reverting
  `controllers/front/ProductController.php` to `upstream/9.2.x` fails 6 of them; the seventh guards the
  JSON payload and is green on both sides by design.
- `tests/Integration/Controllers`, `Adapter/Presenter` and `Core/Product` — 71 tests OK.
- `php -l`, php-cs-fixer `Found 0 of 2`, PHPStan `[OK] No errors` on the source **and** the test.
