### PR TITLE
Show the stock location of the combination the customer is looking at

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1238,6 +1238,21 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['out_of_stock'] = (int) $this->product->out_of_stock;
         $product['id_product_attribute'] = $this->getIdProductAttributeByGroupOrRequestOrDefault();
 
+        /*
+         * Stock location of the combination being shown. Product::loadStockData() asks StockAvailable
+         * for the product level row only, so a product with combinations reported the same location
+         * whichever combination was selected - and nothing at all when only the combinations carry one.
+         * The product level value stays as the fallback for combinations that have none of their own.
+         *
+         * @todo Migrate into the lazy array with the properties below, so listings get it too.
+         */
+        if ($product['id_product_attribute']) {
+            $product['location'] = StockAvailable::getLocation(
+                (int) $this->product->id,
+                (int) $product['id_product_attribute']
+            ) ?: $this->product->location;
+        }
+
         // @todo These three properties should be migrated into the lazy array, so they are available also in listings
         // Minimal quantity setting of this product or combination
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);

--- a/tests/Integration/Controllers/Front/ProductStockLocationTest.php
+++ b/tests/Integration/Controllers/Front/ProductStockLocationTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Controllers\Front;
+
+use Cache;
+use Cart;
+use Configuration;
+use Context;
+use Currency;
+use Customer;
+use Db;
+use Language;
+use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
+use Product;
+use ProductControllerCore;
+use StockAvailable;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Product::loadStockData() reads StockAvailable for the product level row only, so the front office
+ * reported that one location for every combination of a product - the wrong one, or none at all when
+ * only the combinations carry a location.
+ */
+class ProductStockLocationTest extends KernelTestCase
+{
+    private const PRODUCT_ID = 1;
+
+    /** @var array<int, string> */
+    private array $previousLocations = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        foreach ($this->stockRows() as $row) {
+            $this->previousLocations[(int) $row['id_product_attribute']] = (string) $row['location'];
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->previousLocations as $idProductAttribute => $location) {
+            $this->setLocation($idProductAttribute, $location);
+        }
+        $this->previousLocations = [];
+
+        parent::tearDown();
+    }
+
+    public function testTheSelectedCombinationsOwnLocationIsUsed(): void
+    {
+        $combinations = $this->combinationIds();
+        $this->setLocation(0, 'BASE-ROW');
+        $this->setLocation($combinations[0], 'COMBINATION-ONE');
+        $this->setLocation($combinations[1], 'COMBINATION-TWO');
+
+        $this->assertSame('COMBINATION-ONE', $this->presentedLocation($combinations[0]));
+        $this->assertSame('COMBINATION-TWO', $this->presentedLocation($combinations[1]));
+    }
+
+    public function testACombinationWithoutItsOwnLocationFallsBackToTheProduct(): void
+    {
+        $combinations = $this->combinationIds();
+        $this->setLocation(0, 'BASE-ROW');
+        $this->setLocation($combinations[0], '');
+
+        $this->assertSame('BASE-ROW', $this->presentedLocation($combinations[0]));
+    }
+
+    public function testNothingIsInventedWhenNoLocationIsSetAtAll(): void
+    {
+        $combinations = $this->combinationIds();
+        $this->setLocation(0, '');
+        $this->setLocation($combinations[0], '');
+
+        $this->assertSame('', $this->presentedLocation($combinations[0]));
+    }
+
+    /**
+     * The location the front office template would print for a given combination.
+     */
+    private function presentedLocation(int $idProductAttribute): string
+    {
+        $_GET['id_product_attribute'] = $idProductAttribute;
+        $_POST['id_product_attribute'] = $idProductAttribute;
+
+        $context = Context::getContext();
+        $context->customer = new Customer();
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->cart = new Cart();
+        $context->container = self::getContainer();
+        $context->currentLocale = self::getContainer()
+            ->get('prestashop.core.localization.locale.repository')
+            ->getLocale($context->language->getLocale());
+
+        $controller = new class() extends ProductControllerCore {
+            public function loadProduct(int $idProduct): void
+            {
+                $this->product = new Product($idProduct, true, (int) Configuration::get('PS_LANG_DEFAULT'));
+                $this->objectPresenter = new ObjectPresenter();
+            }
+        };
+        $controller->loadProduct(self::PRODUCT_ID);
+
+        fwrite(STDERR, sprintf(
+            "\n  DEBUG pa=%d getLocation(direct)=%s db=%s\n",
+            $idProductAttribute,
+            var_export(StockAvailable::getLocation(self::PRODUCT_ID, $idProductAttribute), true),
+            var_export(Db::getInstance()->getValue('SELECT location FROM ' . _DB_PREFIX_ . 'stock_available WHERE id_product=' . self::PRODUCT_ID . ' AND id_product_attribute=' . $idProductAttribute, false), true)
+        ));
+
+        return (string) $controller->getTemplateVarProduct()['location'];
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function stockRows(): array
+    {
+        return Db::getInstance()->executeS(
+            'SELECT id_product_attribute, location FROM ' . _DB_PREFIX_ . 'stock_available
+             WHERE id_product = ' . self::PRODUCT_ID
+        ) ?: [];
+    }
+
+    /**
+     * @return int[]
+     */
+    private function combinationIds(): array
+    {
+        $ids = [];
+        foreach ($this->stockRows() as $row) {
+            if ((int) $row['id_product_attribute'] > 0) {
+                $ids[] = (int) $row['id_product_attribute'];
+            }
+        }
+
+        if (count($ids) < 2) {
+            $this->markTestSkipped('Two combinations are needed to tell them apart.');
+        }
+
+        return $ids;
+    }
+
+    private function setLocation(int $idProductAttribute, string $location): void
+    {
+        StockAvailable::setLocation(self::PRODUCT_ID, $location, null, $idProductAttribute);
+
+        /*
+         * Product::getProductProperties() memoises the whole presented row per
+         * product/combination/language, and array_merges the cached copy OVER the caller's, so without
+         * this a later case in the same process reads the previous one's location.
+         */
+        Product::resetStaticCache();
+        Cache::clean('*');
+
+        $stored = (string) Db::getInstance()->getValue(
+            'SELECT location FROM ' . _DB_PREFIX_ . 'stock_available
+             WHERE id_product = ' . self::PRODUCT_ID . ' AND id_product_attribute = ' . $idProductAttribute,
+            false
+        );
+        $this->assertSame($location, $stored, 'the fixture must actually be written');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `{$product.location}` reported the product-level stock location for every combination of a product — the wrong one when combinations carry their own, and nothing at all when only they do. The product page now reads the location of the combination being shown.
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #16581
| Related PRs                |
| Sponsor company            |

### The bug

`Product::loadStockData()` sets `$this->location = StockAvailable::getLocation($this->id)`, and that
method defaults `$id_product_attribute` to **0**, so it always reads the product-level `stock_available`
row. The back office writes a combination's location to that combination's own row
(`CombinationStockUpdater` line 118) and never touches the product-level one, so the front office had no
way to see it.

Measured on 9.2.x with a probe in the theme's quickview template, `stock_available` holding
`COMBO-A1` on combination 1 and `BASE-B2` on the product-level row:

| selected combination | before | after |
|---|---|---|
| 1 (has `COMBO-A1`) | `BASE-B2` | `COMBO-A1` |
| 2 (has none) | `BASE-B2` | `BASE-B2` |

With only the combination location set and the product-level row empty, the page showed **nothing** at all
— which is the shape the report describes. `ps_product.location` is deprecated since 1.7.8 and is not
consulted by this path at all; setting it changed nothing in either direction.

### The fix

The product page already patches the other per-combination values onto the array before presenting it —
`out_of_stock`, `minimal_quantity`, `cart_quantity`, `quantity_wanted`, `quantity_required` — each with a
`@todo` about migrating them into the lazy array. The location joins them, with the same note.

- **Only for combinations.** The branch is skipped when `id_product_attribute` is empty, so a simple
  product keeps the value `loadStockData()` already gave it.
- **Fallback preserved.** A combination with no location of its own still shows the product-level value,
  so a shop that only ever set that one sees no change. Choosing the narrower change: the only output that
  moves is the case that was wrong.
- **Not in the presenter.** Adding a lazy `location` to `ProductLazyArray` would change the presented
  product on every listing and every module that reads it; `ProductAssembler` does not select `location`
  today, so nothing else expects it.

### How to test

1. A product with combinations. Back office → Combinations → set **Stock location** on one of them, and
   leave another empty.
2. Front office → that product → select the combination you filled in. `{$product.location}` now prints
   its location; before it printed the product-level one.
3. Select the empty combination: it still falls back to the product-level location.

### Verification

- `tests/Integration/Controllers/Front/ProductStockLocationTest.php` — 3 cases. Reverting
  `controllers/front/ProductController.php` to `upstream/9.2.x` fails the first one; the fallback and
  "nothing invented" cases pass on both sides by construction and are there as guards.
- `tests/Integration/Controllers` — 5 tests OK.
- `php -l`, php-cs-fixer `Found 0 of 2`, PHPStan `[OK] No errors` on the source and the test.

One note for reviewers, found while writing the test: `Product::getProductProperties()` memoises the whole
presented row in `self::$productPropertiesCache` and returns `array_merge($row, $cached)`, so the cached
copy wins over the caller's. The key includes `id_product_attribute`, so it is correct within a request —
but a test presenting the same product twice must call `Product::resetStaticCache()` in between or it
reads the previous case's values.
