### PR TITLE
Stop a status change from restocking units a refund already put back

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -194,33 +194,44 @@ class OrderHistoryCore extends ObjectModel
 
             // foreach products of the order
             foreach ($order->getProductsDetail() as $product) {
+                /*
+                 * Units a refund or a return has already put back must not be moved again: the customer
+                 * is only holding what was ordered minus what was reinjected. This is the quantity
+                 * OrderRefundUpdater and AbstractOrderCommandHandler::reinjectQuantity() already call
+                 * reinjectable.
+                 */
+                $reinjectableQuantity = max(
+                    0,
+                    (int) $product['product_quantity'] - (int) $product['product_quantity_reinjected']
+                );
+
                 if (Validate::isLoadedObject($old_os)) {
                     // if becoming logable => adds sale
                     if ($new_os->logable && !$old_os->logable) {
                         ProductSale::addProductSale($product['product_id'], $product['product_quantity']);
                         if (!Pack::isPack($product['product_id'])
                             && in_array($old_os->id, $error_or_canceled_statuses)) {
-                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
+                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -$reinjectableQuantity, $order->id_shop);
                         }
                     } elseif (!$new_os->logable && $old_os->logable) {
                         // if becoming unlogable => removes sale
                         ProductSale::removeProductSale($product['product_id'], $product['product_quantity']);
                         if (!Pack::isPack($product['product_id'])
                             && in_array($new_os->id, $error_or_canceled_statuses)) {
-                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
+                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], $reinjectableQuantity, $order->id_shop);
                         }
                     } elseif (!$new_os->logable && !$old_os->logable
                         && in_array($new_os->id, $error_or_canceled_statuses)
                         && !in_array($old_os->id, $error_or_canceled_statuses)
                     ) {
                         // Status is changed from not loggable status as Processing in progress etc. to Payment error/Canceled
-                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
+                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], $reinjectableQuantity, $order->id_shop);
                     } elseif (!$new_os->logable && !$old_os->logable
                         && !in_array($new_os->id, $error_or_canceled_statuses)
                         && in_array($old_os->id, $error_or_canceled_statuses)
                     ) {
                         // Status is changed from Payment error/Canceled to not loggable status as Processing in progress etc.
-                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
+                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -$reinjectableQuantity, $order->id_shop);
                     }
                 }
                 // From here, there is 2 cases : $old_os exists, and we can test shipped state evolution,

--- a/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
@@ -860,3 +860,28 @@ Feature: Refund Order from Back Office (BO)
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
     And there is 1 more "Mug The best is yet to come" in stock
+
+  @order-refund
+  @order-partial-refund
+  @order-cancel-after-refund
+  Scenario: Cancelling an order does not restock units a refund already put back
+    Given I add order "bo_order_refund" with the following details:
+      | cart                | dummy_cart             |
+      | message             | test                   |
+      | payment module name | dummy_payment          |
+      | status              | Processing in progress |
+    And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+      | product_quantity            | 2 |
+    And there are 2 less "Mug The best is yet to come" in stock
+    And there is 1 less "Mug Today is a good day" in stock
+    When I issue a partial refund on "bo_order_refund" with restock with credit slip without voucher on following products:
+      | product_name                | quantity | amount |
+      | Mug The best is yet to come | 1        | 10.5   |
+    Then product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+      | product_quantity            | 2 |
+      | product_quantity_refunded   | 1 |
+      | product_quantity_reinjected | 1 |
+    And there is 1 more "Mug The best is yet to come" in stock
+    When I update order "bo_order_refund" status to "Canceled"
+    Then there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
@@ -628,3 +628,29 @@ Feature: Refund Order from Back Office (BO)
       | total_refunded_tax_incl     | 12.610000 |
     And there is 1 more "Mug The best is yet to come" in stock
     And there is 1 more "Mug Today is a good day" in stock
+
+  @order-refund
+  @order-standard-refund
+  @order-cancel-after-standard-refund
+  Scenario: Cancelling an order does not restock units a standard refund already put back
+    Given I add order "bo_order_refund" with the following details:
+      | cart                | dummy_cart       |
+      | message             | test             |
+      | payment module name | dummy_payment    |
+      | status              | Payment accepted |
+    And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+      | product_quantity            | 2 |
+    And there are 2 less "Mug The best is yet to come" in stock
+    And there is 1 less "Mug Today is a good day" in stock
+    And return product is enabled
+    When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come | 2        |
+    Then product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+      | product_quantity            | 2 |
+      | product_quantity_refunded   | 2 |
+      | product_quantity_reinjected | 2 |
+    And there are 2 more "Mug The best is yet to come" in stock
+    When I update order "bo_order_refund" status to "Canceled"
+    Then there are 0 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Moving an order to Canceled or Payment error puts the whole ordered quantity back into stock, ignoring what a refund or a return already reinjected, so a partial refund with re-stock followed by a cancellation leaves the shop holding more units than before the order existed.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #16869
| Related PRs                |
| Sponsor company            |

### The bug

`OrderHistory::changeIdOrderState()` moves stock on four status transitions, and each one passes the raw
`product_quantity`:

```php
StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
```

Nothing there consults `product_quantity_reinjected`, so units a refund or a return already put back are
put back a second time. Twenty lines below, in the same loop, the stock-movement block does subtract what
has already come back — the two halves of the method disagree.

Measured on 9.2.x, order of 2 units, partial refund of 1 with re-stock, then Canceled:

```
after the order          -2   (stock is 2 lower, as expected)
after the refund         +1   (the refunded unit comes back)
after the cancellation   +2   <- expected +1
net                      +1 unit the shop never had
```

That is @aniszr's video and @BenTen's report: "you will see you have more products in stock then when the
order was made".

### The fix

All four calls now move the **reinjectable** quantity, `product_quantity - product_quantity_reinjected`,
floored at 0. That is not a new concept: `OrderRefundUpdater` (line 47) and
`AbstractOrderCommandHandler::reinjectQuantity()` (line 41) already compute exactly this value under
exactly this name, and `Order::getProductsDetail()` already selects the column.

- An order with nothing reinjected behaves exactly as before, so no existing shop's numbers move unless
  they were wrong.
- The increment and decrement sites use the same expression, so cancelling and then un-cancelling still
  move the same number of units. Repeating the pair is stable.
- A refund made **without** re-stock leaves `product_quantity_reinjected` at 0, so cancelling still
  returns that unit — the merchant's "do not re-stock" decision applies to the refund, and cancelling the
  whole order is a separate instruction.

**Deliberately out of scope.** The thread also discusses `IssuePartialRefundHandler` line 125,
`$shouldReinjectProducts = !$order->hasBeenDelivered() || $command->restockRefundedProducts();`, which
ignores the "Re-stock products" checkbox for orders that have not been delivered. That is a different
question with a genuine design argument on both sides — stock is decremented at order validation, so
undelivered goods never physically left — and the previous attempt at it (#28938 by @aecarlosae, closed as
stale) was shown by @Kero34 to stop delivered orders from re-stocking at all. It is left alone here so the
accounting fix can be judged on its own.

### How to test

1. Note a product's stock. Place an order for 2 of it and set the order to "Processing in progress".
2. Partially refund 1 unit **with** "Re-stock products". Stock is now 1 lower than at the start.
3. Set the order to "Canceled". Stock returns to exactly the starting value; before this it went 1 above.

### Verification

- Two new Behat scenarios, one per refund type, because `product_quantity_reinjected` has to be a complete
  ledger for this to be correct:
  - `partial_refund.feature`, *"Cancelling an order does not restock units a refund already put back"*
    (`--tags order-cancel-after-refund`) — on `upstream/9.2.x` it fails with
    `Invalid difference for product Mug The best is yet to come expected 1, got 2 instead`.
  - `standard_refund.feature`, *"Cancelling an order does not restock units a standard refund already put
    back"* (`--tags order-cancel-after-standard-refund`) — `IssueStandardRefundHandler` reinjects
    unconditionally, and this pins that it still records the reinjection (it passes `true` as the restock
    flag to `updateRefundData()` at line 163). Also red on `upstream/9.2.x`.

  The three handlers that reinject all feed the column: partial refund passes `$shouldReinjectProducts`
  (line 154), return passes `restockRefundedProducts()` (line 154), standard passes `true` (line 163).
  `OrderProductQuantityUpdater` moves stock by a delta and rewrites `product_quantity` itself, so the
  difference stays right there too.
- Full Behat order suite: **262 scenarios, 7391 steps, all passed.**
- php-cs-fixer `Found 0 of 1`, PHPStan `[OK] No errors`.
