### PR TITLE
Align every foreign id column with the unsigned key it references

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -697,7 +697,7 @@ CREATE TABLE `PREFIX_customer_group` (
 /* Customer support private messaging */
 CREATE TABLE `PREFIX_customer_message` (
   `id_customer_message` int(10) unsigned NOT NULL auto_increment,
-  `id_customer_thread` int(11) DEFAULT NULL,
+  `id_customer_thread` int(11) unsigned DEFAULT NULL,
   `id_employee` int(10) unsigned DEFAULT NULL,
   `id_product` int(10) unsigned DEFAULT NULL,
   `message` MEDIUMTEXT NOT NULL,
@@ -753,7 +753,7 @@ CREATE TABLE `PREFIX_customization` (
   `id_product_attribute` int(10) unsigned NOT NULL DEFAULT '0',
   `id_address_delivery` int(10) UNSIGNED NOT NULL DEFAULT '0',
   `id_cart` int(10) unsigned NOT NULL,
-  `id_product` int(10) NOT NULL,
+  `id_product` int(10) unsigned NOT NULL,
   `quantity` int(10) NOT NULL,
   `quantity_refunded` INT NOT NULL DEFAULT '0',
   `quantity_returned` INT NOT NULL DEFAULT '0',
@@ -798,7 +798,7 @@ CREATE TABLE `PREFIX_customized_data` (
   `type` tinyint(1) NOT NULL,
   `index` int(3) NOT NULL,
   `value` varchar(1024) NOT NULL,
-  `id_module` int(10) NOT NULL DEFAULT '0',
+  `id_module` int(10) unsigned NOT NULL DEFAULT '0',
   `price` decimal(20, 6) NOT NULL DEFAULT '0',
   `weight` decimal(20, 6) NOT NULL DEFAULT '0',
   PRIMARY KEY (
@@ -1228,7 +1228,7 @@ CREATE TABLE `PREFIX_module_country` (
 CREATE TABLE `PREFIX_module_currency` (
   `id_module` int(10) unsigned NOT NULL,
   `id_shop` INT(11) UNSIGNED NOT NULL DEFAULT '1',
-  `id_currency` int(11) NOT NULL,
+  `id_currency` int(11) unsigned NOT NULL,
   PRIMARY KEY (
     `id_module`, `id_shop`, `id_currency`
   ),
@@ -1329,8 +1329,8 @@ CREATE TABLE `PREFIX_orders` (
 
 /* Order tax detail */
 CREATE TABLE `PREFIX_order_detail_tax` (
-  `id_order_detail` int(11) NOT NULL,
-  `id_tax` int(11) NOT NULL,
+  `id_order_detail` int(11) unsigned NOT NULL,
+  `id_tax` int(11) unsigned NOT NULL,
   `unit_amount` DECIMAL(16, 6) NOT NULL DEFAULT '0.00',
   `total_amount` DECIMAL(16, 6) NOT NULL DEFAULT '0.00',
   KEY (`id_order_detail`),
@@ -1340,7 +1340,7 @@ CREATE TABLE `PREFIX_order_detail_tax` (
 /* list of invoice */
 CREATE TABLE `PREFIX_order_invoice` (
   `id_order_invoice` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `id_order` int(11) NOT NULL,
+  `id_order` int(11) unsigned NOT NULL,
   `number` int(11) NOT NULL,
   `delivery_number` int(11) NOT NULL,
   `delivery_date` datetime,
@@ -1364,9 +1364,9 @@ CREATE TABLE `PREFIX_order_invoice` (
 
 /* global invoice tax */
 CREATE TABLE IF NOT EXISTS `PREFIX_order_invoice_tax` (
-  `id_order_invoice` int(11) NOT NULL,
+  `id_order_invoice` int(11) unsigned NOT NULL,
   `type` varchar(15) NOT NULL,
-  `id_tax` int(11) NOT NULL,
+  `id_tax` int(11) unsigned NOT NULL,
   `amount` decimal(10, 6) NOT NULL DEFAULT '0.000000',
   KEY `id_tax` (`id_tax`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
@@ -1375,7 +1375,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_order_invoice_tax` (
 CREATE TABLE `PREFIX_order_detail` (
   `id_order_detail` int(10) unsigned NOT NULL auto_increment,
   `id_order` int(10) unsigned NOT NULL,
-  `id_order_invoice` int(11) DEFAULT NULL,
+  `id_order_invoice` int(11) unsigned DEFAULT NULL,
   `id_warehouse` int(10) unsigned DEFAULT '0',
   `id_shop` int(11) unsigned NOT NULL,
   `product_id` int(10) unsigned NOT NULL,
@@ -1648,7 +1648,7 @@ CREATE TABLE `PREFIX_order_payment` (
   `card_expiration` CHAR(7) NULL,
   `card_holder` VARCHAR(254) NULL,
   `date_add` DATETIME NOT NULL,
-  `id_employee` INT NULL,
+  `id_employee` INT UNSIGNED NULL,
   PRIMARY KEY (`id_order_payment`),
   KEY `order_reference`(`order_reference`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
@@ -2236,20 +2236,20 @@ CREATE TABLE `PREFIX_memcached_servers` (
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
 CREATE TABLE `PREFIX_product_country_tax` (
-  `id_product` int(11) NOT NULL,
-  `id_country` int(11) NOT NULL,
-  `id_tax` int(11) NOT NULL,
+  `id_product` int(11) unsigned NOT NULL,
+  `id_country` int(11) unsigned NOT NULL,
+  `id_tax` int(11) unsigned NOT NULL,
   PRIMARY KEY (`id_product`, `id_country`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
 CREATE TABLE `PREFIX_tax_rule` (
   `id_tax_rule` int(11) NOT NULL AUTO_INCREMENT,
   `id_tax_rules_group` int(11) NOT NULL,
-  `id_country` int(11) NOT NULL,
-  `id_state` int(11) NOT NULL,
+  `id_country` int(11) unsigned NOT NULL,
+  `id_state` int(11) unsigned NOT NULL,
   `zipcode_from` VARCHAR(12) NOT NULL,
   `zipcode_to` VARCHAR(12) NOT NULL,
-  `id_tax` int(11) NOT NULL,
+  `id_tax` int(11) unsigned NOT NULL,
   `behavior` int(11) NOT NULL,
   `description` VARCHAR(100) NOT NULL,
   PRIMARY KEY (`id_tax_rule`),
@@ -2272,7 +2272,7 @@ CREATE TABLE `PREFIX_tax_rules_group` (
 
 CREATE TABLE `PREFIX_specific_price_priority` (
   `id_specific_price_priority` INT NOT NULL AUTO_INCREMENT,
-  `id_product` INT NOT NULL,
+  `id_product` INT UNSIGNED NOT NULL,
   `priority` VARCHAR(80) NOT NULL,
   PRIMARY KEY (
     `id_specific_price_priority`, `id_product`
@@ -2728,7 +2728,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_risk_lang` (
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
 CREATE TABLE `PREFIX_category_shop` (
-  `id_category` int(11) NOT NULL,
+  `id_category` int(11) unsigned NOT NULL,
   `id_shop` int(11) NOT NULL,
   `position` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_category`, `id_shop`)
@@ -2736,7 +2736,7 @@ CREATE TABLE `PREFIX_category_shop` (
 
 CREATE TABLE `PREFIX_module_preference` (
   `id_module_preference` int(11) NOT NULL auto_increment,
-  `id_employee` int(11) NOT NULL,
+  `id_employee` int(11) unsigned NOT NULL,
   `module` varchar(191) NOT NULL,
   `interest` tinyint(1) DEFAULT NULL,
   `favorite` tinyint(1) DEFAULT NULL,
@@ -2746,7 +2746,7 @@ CREATE TABLE `PREFIX_module_preference` (
 
 CREATE TABLE `PREFIX_tab_module_preference` (
   `id_tab_module_preference` int(11) NOT NULL auto_increment,
-  `id_employee` int(11) NOT NULL,
+  `id_employee` int(11) unsigned NOT NULL,
   `id_tab` int(11) NOT NULL,
   `module` varchar(191) NOT NULL,
   PRIMARY KEY (`id_tab_module_preference`),
@@ -3002,7 +3002,7 @@ CREATE TABLE `PREFIX_shop` (
   `id_shop_group` INT          NOT NULL,
   `name`          VARCHAR(64)  NOT NULL,
   `color`         VARCHAR(50)  NOT NULL,
-  `id_category`   INT          NOT NULL,
+  `id_category`   INT UNSIGNED NOT NULL,
   `theme_name`    VARCHAR(255) NOT NULL,
   `active`        TINYINT(1) NOT NULL,
   `deleted`       TINYINT(1) NOT NULL,
@@ -3040,8 +3040,8 @@ CREATE TABLE `PREFIX_shop_group` (
 
 CREATE TABLE `PREFIX_module_history` (
   `id`          INT AUTO_INCREMENT NOT NULL,
-  `id_employee` INT      NOT NULL,
-  `id_module`   INT      NOT NULL,
+  `id_employee` INT UNSIGNED NOT NULL,
+  `id_module`   INT UNSIGNED NOT NULL,
   `date_add`    DATETIME NOT NULL,
   `date_upd`    DATETIME NOT NULL,
   PRIMARY KEY (`id`)
@@ -3078,11 +3078,11 @@ CREATE TABLE `PREFIX_api_client` (
 
 CREATE TABLE `PREFIX_stock_mvt` (
   `id_stock_mvt`        BIGINT AUTO_INCREMENT NOT NULL,
-  `id_stock`            INT                      NOT NULL,
-  `id_order`            INT            DEFAULT NULL,
-  `id_supply_order`     INT            DEFAULT 0,
-  `id_stock_mvt_reason` INT                      NOT NULL,
-  `id_employee`         INT                      NOT NULL,
+  `id_stock`            INT UNSIGNED             NOT NULL,
+  `id_order`            INT UNSIGNED   DEFAULT NULL,
+  `id_supply_order`     INT UNSIGNED   DEFAULT 0,
+  `id_stock_mvt_reason` INT UNSIGNED             NOT NULL,
+  `id_employee`         INT UNSIGNED             NOT NULL,
   `employee_lastname`   VARCHAR(255)   DEFAULT NULL,
   `employee_firstname`  VARCHAR(255)   DEFAULT NULL,
   `physical_quantity`   INT UNSIGNED NOT NULL,
@@ -3108,8 +3108,8 @@ CREATE TABLE `PREFIX_access` (
 
 CREATE TABLE `PREFIX_shipment` (
   `id_shipment` int(10) AUTO_INCREMENT NOT NULL,
-  `id_order` int(10) NOT NULL,
-  `id_carrier` int(10) NOT NULL,
+  `id_order` int(10) unsigned NOT NULL,
+  `id_carrier` int(10) unsigned NOT NULL,
   `id_delivery_address` int(10) DEFAULT NULL,
   `shipping_cost_tax_excl` NUMERIC(20, 6) DEFAULT '0.000000',
   `shipping_cost_tax_incl` NUMERIC(20, 6) DEFAULT '0.000000',
@@ -3127,7 +3127,7 @@ CREATE TABLE `PREFIX_shipment` (
 CREATE TABLE `PREFIX_shipment_product` (
   `id_shipment_product` INT AUTO_INCREMENT NOT NULL,
   `id_shipment` int(10) NOT NULL,
-  `id_order_detail` int(10) NOT NULL,
+  `id_order_detail` int(10) unsigned NOT NULL,
   `quantity` int(10) DEFAULT NULL,
   PRIMARY KEY (id_shipment_product)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | An `id_*` column declared signed while the auto-increment column it references is unsigned is a schema mismatch: the child accepts a range the parent can never produce, and the two sides compare and index as different types. The report named `category_shop`, but deriving the class from the schema instead of from a list shows it is not a two-column problem - **32 columns across 20 tables** are signed against an unsigned parent key. All of them are aligned here.<br><br>The mirror class is deliberately left alone: **123 columns are unsigned while the key they reference is signed at its source** (`id_shop`, `id_lang`, `id_shop_group`). There the parents are the outliers, so changing them is a decision about the whole set, not a bug fix. That is also why the `ALTER` proposed on the issue is only half right - `category_shop.id_shop` should stay signed, because `shop.id_shop` is signed.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Load `install-dev/data/db_structure.sql` into MySQL and compare each `id_*` column's signedness against the auto-increment column of the same name. Before this change 32 of them are signed against an unsigned parent; after it, none are, and the 123 columns of the mirror class are unchanged.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #17544
| Related PRs       |
| Sponsor company   |

### The 32 columns

```
category_shop.id_category                 order_invoice_tax.id_order_invoice
customer_message.id_customer_thread       order_invoice_tax.id_tax
customization.id_product                  order_payment.id_employee
customized_data.id_module                 product_country_tax.id_country
module_currency.id_currency               product_country_tax.id_product
module_history.id_employee                product_country_tax.id_tax
module_history.id_module                  shipment.id_carrier
module_preference.id_employee             shipment.id_order
order_detail.id_order_invoice             shipment_product.id_order_detail
order_detail_tax.id_order_detail          shop.id_category
order_detail_tax.id_tax                   specific_price_priority.id_product
order_invoice.id_order                    stock_mvt.id_employee
                                          stock_mvt.id_order
                                          stock_mvt.id_stock
                                          stock_mvt.id_stock_mvt_reason
                                          stock_mvt.id_supply_order
                                          tab_module_preference.id_employee
                                          tax_rule.id_country
                                          tax_rule.id_state
                                          tax_rule.id_tax
```

### Verification

Measured on a 9.2.x database and on the modified schema:

```
negative values across all 32 columns          0   (tables populated: tax_rule 145 rows, order_detail 70)
negative assignments in classes/, src/, controllers/   0
modified schema loaded into MySQL 8.4          244 tables created, exit 0
target columns unsigned after load             32 / 32
remaining child-signed / parent-unsigned       0
mirror class (child-unsigned / parent-signed)  123, unchanged
```

Existing shops are not migrated by this file. Core no longer ships `install-dev/upgrade/`, so the
matching migration for already-installed shops belongs in `PrestaShop/autoupgrade`'s `upgrade/sql/9.2.0.sql`,
which is still open since 9.2.0 is unreleased.

Nine more columns are in the same class but live in module-owned tables, so they are not core's to
change here - measured against the live schema:

```
ps_ganalytics.id_customer                              -> ps_customer.id_customer      (ps_googleanalytics)
ps_ganalytics.id_order                                 -> ps_orders.id_order
ps_ganalytics_data.id_cart                             -> ps_cart.id_cart
ps_layered_indexable_feature.id_feature                -> ps_feature.id_feature        (ps_facetedsearch)
ps_layered_indexable_feature_lang_value.id_feature     -> ps_feature.id_feature
ps_layered_indexable_feature_value_lang_value.id_feature_value -> ps_feature_value.id_feature_value
ps_layered_price_index.id_country                      -> ps_country.id_country
ps_layered_price_index.id_currency                     -> ps_currency.id_currency
ps_layered_price_index.id_product                      -> ps_product.id_product
```
