### PR TITLE
Keep the stored catalogue price when a fully loaded product is saved

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -242,6 +242,14 @@ class ProductCore extends ObjectModel
     public $base_price;
 
     /**
+     * The final price the constructor computed into $price when the product was loaded in full. Kept so
+     * update() can tell an untouched computed value from one a caller actually assigned.
+     *
+     * @var float|null
+     */
+    protected $computedPrice;
+
+    /**
      * @var int|null TaxRulesGroup identifier
      */
     public $id_tax_rules_group;
@@ -724,6 +732,7 @@ class ProductCore extends ObjectModel
             } else {
                 $this->price = Product::getPriceStatic((int) $this->id, false, null, 6, null, false, true, 1, false, null, null, null, $this->specificPrice);
             }
+            $this->computedPrice = $this->price;
             $this->tags = Tag::getProductTags((int) $this->id);
 
             $this->loadStockData();
@@ -801,9 +810,30 @@ class ProductCore extends ObjectModel
             $this->product_type = ProductType::TYPE_VIRTUAL;
         }
 
+        /*
+         * Loading a product in full replaces $price with the final price for display - ecotax included,
+         * reductions applied - and $base_price keeps the stored one. Writing the computed value back
+         * bakes it into the catalogue price, and because the next load computes on top of it, a plain
+         * new Product($id, true) followed by save() raises the price by the ecotax every single time.
+         * A price the caller actually assigned still differs from what the constructor left behind, and
+         * is saved as asked.
+         */
+        $computedPriceUntouched = null !== $this->computedPrice
+            && (string) $this->price === (string) $this->computedPrice;
+        if ($computedPriceUntouched) {
+            $this->price = $this->base_price;
+        }
+
         $return = parent::update($null_values);
+
         $this->setGroupReduction();
+        // updateUnitRatio() derives unit_price_ratio from $price, so it runs while the stored one is set,
+        // and the object then agrees with the row it just wrote.
         $this->updateUnitRatio();
+
+        if ($computedPriceUntouched) {
+            $this->price = $this->computedPrice;
+        }
 
         Hook::exec('actionProductSave', ['id_product' => (int) $this->id, 'product' => $this]);
         Hook::exec('actionProductUpdate', ['id_product' => (int) $this->id, 'product' => $this]);

--- a/tests/Integration/Classes/Product/SaveKeepsStoredPriceTest.php
+++ b/tests/Integration/Classes/Product/SaveKeepsStoredPriceTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Configuration;
+use Context;
+use Db;
+use Product;
+use SpecificPrice;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tools;
+
+/**
+ * Loading a product in full replaces $price with the final price for display, ecotax included. Writing
+ * that back into the catalogue price made a plain new Product($id, true) followed by save() raise the
+ * price by the ecotax on every call, compounding.
+ */
+class SaveKeepsStoredPriceTest extends KernelTestCase
+{
+    private const STORED_PRICE = 10.0;
+    private const ECOTAX = 2.0;
+    private const UNIT_PRICE = 5.0;
+
+    private int $idProduct = 0;
+
+    /** @var string|false */
+    private $previousEcotaxSetting;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+
+        $this->previousEcotaxSetting = Configuration::get('PS_USE_ECOTAX');
+        Configuration::updateValue('PS_USE_ECOTAX', 1);
+
+        $lang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $product = new Product();
+        $product->id_category_default = 2;
+        $product->name = [$lang => 'save keeps stored price'];
+        $product->link_rewrite = [$lang => Tools::str2url('save keeps stored price')];
+        $product->price = self::STORED_PRICE;
+        $product->ecotax = self::ECOTAX;
+        $product->unit_price = self::UNIT_PRICE;
+        $product->id_tax_rules_group = 0;
+        $product->add();
+        $this->idProduct = (int) $product->id;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->idProduct) {
+            (new Product($this->idProduct))->delete();
+            $this->idProduct = 0;
+        }
+        Configuration::updateValue('PS_USE_ECOTAX', $this->previousEcotaxSetting);
+        Product::resetStaticCache();
+
+        parent::tearDown();
+    }
+
+    public function testSavingAFullyLoadedProductDoesNotRaiseItsPrice(): void
+    {
+        foreach ([1, 2, 3] as $pass) {
+            Product::resetStaticCache();
+            (new Product($this->idProduct, true, (int) Configuration::get('PS_LANG_DEFAULT')))->save();
+
+            $this->assertSame(
+                self::STORED_PRICE,
+                $this->storedPrice(),
+                sprintf('the catalogue price moved on save number %d', $pass)
+            );
+        }
+    }
+
+    public function testTheUnitPriceRatioStaysDerivedFromTheStoredPrice(): void
+    {
+        Product::resetStaticCache();
+        (new Product($this->idProduct, true, (int) Configuration::get('PS_LANG_DEFAULT')))->save();
+
+        // Ecotax is on, so the ratio is (price + ecotax) / unit_price.
+        $this->assertSame(
+            (self::STORED_PRICE + self::ECOTAX) / self::UNIT_PRICE,
+            (float) $this->storedColumn('unit_price_ratio')
+        );
+    }
+
+    public function testTheSavedObjectAgreesWithTheRowItWrote(): void
+    {
+        Product::resetStaticCache();
+        $product = new Product($this->idProduct, true, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $product->save();
+
+        $this->assertSame(
+            (float) $this->storedColumn('unit_price_ratio'),
+            (float) $product->unit_price_ratio,
+            'the object must not report a different ratio from the one it stored'
+        );
+    }
+
+    /**
+     * The constructor's price also has reductions applied, so a specific price used to be baked in the
+     * same way - downwards, and compounding.
+     */
+    public function testASpecificPriceIsNotBakedIntoTheStoredPrice(): void
+    {
+        $specificPrice = new SpecificPrice();
+        $specificPrice->id_product = $this->idProduct;
+        $specificPrice->id_shop = 0;
+        $specificPrice->id_shop_group = 0;
+        $specificPrice->id_currency = 0;
+        $specificPrice->id_country = 0;
+        $specificPrice->id_group = 0;
+        $specificPrice->id_customer = 0;
+        $specificPrice->id_product_attribute = 0;
+        $specificPrice->price = -1.0;
+        $specificPrice->from_quantity = 1;
+        $specificPrice->reduction = 0.5;
+        $specificPrice->reduction_type = 'percentage';
+        $specificPrice->reduction_tax = 0;
+        $specificPrice->from = '0000-00-00 00:00:00';
+        $specificPrice->to = '0000-00-00 00:00:00';
+        $specificPrice->add();
+
+        try {
+            foreach ([1, 2, 3] as $pass) {
+                Product::resetStaticCache();
+                SpecificPrice::flushCache();
+                (new Product($this->idProduct, true, (int) Configuration::get('PS_LANG_DEFAULT')))->save();
+
+                $this->assertSame(
+                    self::STORED_PRICE,
+                    $this->storedPrice(),
+                    sprintf('the catalogue price moved on save number %d', $pass)
+                );
+            }
+        } finally {
+            $specificPrice->delete();
+            SpecificPrice::flushCache();
+        }
+    }
+
+    public function testAPriceTheCallerAssignedIsStillSaved(): void
+    {
+        Product::resetStaticCache();
+        $product = new Product($this->idProduct, true, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $product->price = 42.0;
+        $product->save();
+
+        $this->assertSame(42.0, $this->storedPrice());
+    }
+
+    /**
+     * A product loaded without the full flag never gets a computed price, so nothing is restored.
+     */
+    public function testAPartiallyLoadedProductIsUnaffected(): void
+    {
+        Product::resetStaticCache();
+        $product = new Product($this->idProduct);
+        $product->save();
+
+        $this->assertSame(self::STORED_PRICE, $this->storedPrice());
+    }
+
+    private function storedPrice(): float
+    {
+        return (float) $this->storedColumn('price');
+    }
+
+    private function storedColumn(string $column): string
+    {
+        return (string) Db::getInstance()->getValue(
+            'SELECT `' . $column . '` FROM ' . _DB_PREFIX_ . 'product WHERE id_product = ' . $this->idProduct,
+            false
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `new Product($id, true)` followed by `save()` writes the computed display price into the catalogue price, so the ecotax is baked in and the price grows on every save. `update()` now writes the stored price back unless the caller actually assigned a new one.
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #17560
| Related PRs                |
| Sponsor company            |

### The bug

`Product::__construct()` with `$full = true` keeps the stored price in `$base_price` and then replaces
`$price` with the final price for display:

```php
$this->base_price = $this->price;
...
$this->price = Product::getPriceStatic((int) $this->id, false, null, 6, null, false, true, 1, false, null, null, null, $this->specificPrice);
```

`ObjectModel::update()` then persists `$price`, so the computed value becomes the catalogue price — and
the next load computes on top of it. Measured on 9.2.x with `price = 10.00`, `ecotax = 2.00`,
`unit_price = 5.00`, three consecutive `new Product($id, true); save();`:

| `PS_USE_ECOTAX` | ecotax | start | save 1 | save 2 | save 3 |
|---|---|---|---|---|---|
| 0 | 2.00 | 10.00 | **12.00** | **14.00** | **16.00** |
| 1 | 2.00 | 10.00 | **12.00** | **14.00** | **16.00** |
| 1 | 0.00 | 10.00 | 10.00 | 10.00 | 10.00 |
| 0 | 0.00 | 10.00 | 10.00 | 10.00 | 10.00 |

The ecotax rows are the defect and the zero-ecotax rows are the control that identifies it.

It is not only the ecotax. `getPriceStatic()` is also called with `$use_reduc = true`, so a reduction is
baked in the same way and drifts **downward**: with a 50% specific price on top of the same product, the
first save turns `10.00` into `6.00` — `(10 + 2) × 0.5` — and the next one computes on that.

Two things worth correcting from the thread: it happens **whether or not `PS_USE_ECOTAX` is enabled** —
`getPriceStatic()` is called with `$with_ecotax = true` either way — so @Hlavtox's 2023 note that
"with ecotax disabled, everything seems to stay the same" no longer holds on 9.2.x. And
`unit_price_ratio` drifts with it, because `updateUnitRatio()` recomputes from the row that was just
corrupted.

### The fix

`update()` restores `$base_price` for the write when `$price` still holds **exactly** what the constructor
put there, and puts the computed value back afterwards so the object the caller is holding does not change
under them. The constructor records what it injected in a new protected `$computedPrice` so the two cases
can be told apart.

- **A price the caller assigned is still saved.** It differs from the constructor's value, so nothing is
  restored. Covered by a test.
- **A product loaded without `$full`** never gets a computed price, so the guard never fires. Covered by a
  test.
- **The restore happens after `updateUnitRatio()`**, which derives `unit_price_ratio` from `$price`, so
  the object ends up agreeing with the row it just wrote instead of reporting a ratio computed from the
  display price. `setGroupReduction()` in between does not read `$price`. Covered by a test.
- **No core caller is affected.** Only four places in the tree build a product with `$full = true` —
  `ProductController`, `CartController`, `Pack` and `UpdateProductQuantityInCartHandler` — and all four
  read; none saves.

This does not preclude @Hlavtox's preferred direction of gradually emptying the constructor. It stops the
data corruption in the meantime, without changing what `$product->price` means to any existing reader.

### How to test

1. A product with a non-zero ecotax.
2. Run `$p = new Product($id, true); $p->save();` three times.
3. The catalogue price in the back office is unchanged; before this it rose by the ecotax each time.

### Verification

- `tests/Integration/Classes/Product/SaveKeepsStoredPriceTest.php` — 6 cases. Reverting
  `classes/Product.php` to `upstream/9.2.x` fails 3 of them
  (`12.0` instead of `10.0`, ratio `2.8` instead of `2.4`, and `6.0` instead of `10.0` with the specific
  price); the other three are the guards described above and pass on both sides by construction.
- `tests/Integration/Classes` — 187 tests OK.
- Behat `-s product` — 414 scenarios, 413 passed. The one failure,
  `unit_price_with_specific_price.feature:10`, fails identically on `upstream/9.2.x` when run on its own
  (`Warning: Attempt to read property "id" on null in ProductSearchContext.php line 52`), so it is not
  from this change.
- php-cs-fixer `Found 0 of 2`, PHPStan `[OK] No errors` on the source and the test.
