### PR TITLE
Stop the webservice inventing a combination for an id that names none

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6870,6 +6870,10 @@ class ProductCore extends ObjectModel
         // No hook exec
         $ids_new = [];
         foreach ($combinations as $combination) {
+            // An empty <id/> - which is what `products?schema=blank` hands back - is not a combination.
+            if (empty($combination['id'])) {
+                continue;
+            }
             $ids_new[] = (int) $combination['id'];
         }
 
@@ -6922,12 +6926,17 @@ class ProductCore extends ObjectModel
         }
 
         foreach ($to_add as $id) {
-            // Update id_product if exists else create
-            if (in_array($id, $all_ids)) {
-                Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'product_attribute` SET id_product = ' . (int) $this->id . ' WHERE id_product_attribute=' . $id);
-            } else {
-                Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'product_attribute` (`id_product`) VALUES (' . (int) $this->id . ')');
+            /*
+             * Only an existing combination can be moved onto this product. An id matching nothing used to
+             * insert a bare product_attribute row here instead - with a different id from the one asked
+             * for, and with no product_attribute_shop companion - so the product gained a combination no
+             * shop-scoped query can see, and its stock stopped behaving like a simple product's.
+             */
+            if (!in_array($id, $all_ids)) {
+                continue;
             }
+
+            Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'product_attribute` SET id_product = ' . (int) $this->id . ' WHERE id_product_attribute=' . $id);
         }
 
         return true;

--- a/tests/Integration/Classes/Product/WsCombinationAssociationTest.php
+++ b/tests/Integration/Classes/Product/WsCombinationAssociationTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+use Tools;
+
+/**
+ * setWsCombinations() used to insert a bare product_attribute row for any id it did not recognise -
+ * including the empty <id/> that `products?schema=blank` hands back - giving a simple product a
+ * combination no shop-scoped query can see.
+ */
+class WsCombinationAssociationTest extends TestCase
+{
+    /** @var int[] */
+    private array $productIds = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->productIds as $id) {
+            Db::getInstance()->delete('product_attribute', 'id_product = ' . $id);
+            Db::getInstance()->delete('stock_available', 'id_product = ' . $id);
+            (new Product($id))->delete();
+        }
+        $this->productIds = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider associationsThatNameNoExistingCombination
+     *
+     * @param array<int, array<string, string>> $association
+     */
+    public function testAnAssociationNamingNoCombinationCreatesNothing(array $association): void
+    {
+        $product = $this->newProduct('ws combination none');
+        $product->setWsCombinations($association);
+
+        $this->assertSame([], $this->combinationIdsOf((int) $product->id));
+    }
+
+    /**
+     * @return array<string, array{array<int, array<string, string>>}>
+     */
+    public function associationsThatNameNoExistingCombination(): array
+    {
+        return [
+            'the empty id that schema=blank returns' => [[['id' => '']]],
+            'an explicit zero' => [[['id' => '0']]],
+            'an id that exists nowhere' => [[['id' => '99999999']]],
+            'no entries at all' => [[]],
+        ];
+    }
+
+    /**
+     * The association still does what it is for: an existing combination is moved onto the product.
+     */
+    public function testAnExistingCombinationIsStillAssociated(): void
+    {
+        $donor = $this->newProduct('ws combination donor');
+        Db::getInstance()->insert('product_attribute', [
+            'id_product' => (int) $donor->id,
+            'reference' => 'WS-COMBI',
+            'minimal_quantity' => 1,
+        ]);
+        $idCombination = (int) Db::getInstance()->Insert_ID();
+        // A real combination also has its per-shop row; without it Shop::addSqlAssociation() hides it.
+        Db::getInstance()->insert('product_attribute_shop', [
+            'id_product' => (int) $donor->id,
+            'id_product_attribute' => $idCombination,
+            'id_shop' => 1,
+            'minimal_quantity' => 1,
+        ]);
+
+        $target = $this->newProduct('ws combination target');
+        $target->setWsCombinations([['id' => (string) $idCombination]]);
+
+        $this->assertSame([$idCombination], $this->combinationIdsOf((int) $target->id));
+        $this->assertSame([], $this->combinationIdsOf((int) $donor->id));
+
+        Db::getInstance()->delete('product_attribute_shop', 'id_product_attribute = ' . $idCombination);
+    }
+
+    private function newProduct(string $name): Product
+    {
+        $lang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $product = new Product();
+        $product->id_category_default = 2;
+        $product->name = [$lang => $name];
+        $product->link_rewrite = [$lang => Tools::str2url($name . '-' . uniqid())];
+        $product->price = 10;
+        $product->id_tax_rules_group = 0;
+        $product->add();
+        $this->productIds[] = (int) $product->id;
+
+        return $product;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function combinationIdsOf(int $idProduct): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_product_attribute FROM ' . _DB_PREFIX_ . 'product_attribute WHERE id_product = ' . $idProduct
+        ) ?: [];
+
+        return array_map(static fn (array $row): int => (int) $row['id_product_attribute'], $rows);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Creating a simple product from `products?schema=blank` gave it a phantom combination, because the combinations association inserted a `product_attribute` row for the empty `<id/>` the blank schema carries.
| Type?                      | bug fix
| Category?                  | WS
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #17748
| Related PRs                |
| Sponsor company            |

### The bug

`Product::setWsCombinations()` moved an existing combination onto the product when it recognised the id,
and otherwise did this:

```php
} else {
    Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'product_attribute` (`id_product`) VALUES (' . (int) $this->id . ')');
}
```

`products?schema=blank` returns an `associations/combinations` block containing one `<combination><id/></combination>`,
so a client that posts the blank schema back — which is what the documented create flow does — sends an
empty id, which becomes `0`, matches nothing, and lands in that branch.

Measured on 9.2.x, each on a fresh simple product:

| combinations association | `product_attribute` | `product_attribute_shop` |
|---|---|---|
| `<id></id>` (blank schema) | **row created** | 0 |
| `<id>0</id>` | **row created** | 0 |
| `<id>99999</id>` | **row created** | 0 |
| no association at all | none | 0 |

Note the third row: even for a plausible-looking id the row is created with a **different**,
auto-incremented id, so the association the caller asked for is not the one they get. And no
`product_attribute_shop` companion is written in any case, so the combination is invisible to every
shop-scoped query while still making the product behave as if it had combinations — which is the stock
problem in the report.

@xonox identified this in the thread in 2021 ("the code misses to validate if the combinations are empty
and always creates an empty product attribute record") and their workaround is to `unset($product->associations->combinations)`
before posting.

### The fix

An id that matches no existing combination cannot be satisfied — the row that used to be created never
carried the requested id — so it is skipped, and all four cases above behave like the last one. The empty
id is also dropped when the requested set is built, so the intent reads directly.

Associating a combination that **does** exist still moves it onto the product, which the test pins;
deleting associations that are no longer listed is untouched.

### How to test

1. `GET /api/products?schema=blank`, fill in the minimum fields, and `POST` it back without removing the
   `combinations` association.
2. `SELECT * FROM ps_product_attribute WHERE id_product = <new id>` returns nothing. Before this it
   returned one row with no matching `ps_product_attribute_shop` entry, and the product's stock behaved
   like a product with combinations.

### Verification

- `tests/Integration/Classes/Product/WsCombinationAssociationTest.php` — 5 cases. Reverting
  `classes/Product.php` to `upstream/9.2.x` fails 3 of them (empty id, explicit zero, unknown id); the
  other two — an association with no entries, and moving a combination that exists — pass on both sides
  and are there as guards.
- `tests/Integration/Classes` — 188 tests OK.
- Behat `-s product` — 414 scenarios, 413 passed. The one failure,
  `unit_price_with_specific_price.feature:10`, fails identically on `upstream/9.2.x` when run on its own
  (`Warning: Attempt to read property "id" on null in ProductSearchContext.php line 52`), so it is not
  from this change.
- `php -l`, php-cs-fixer `Found 0 of 2`, PHPStan `[OK] No errors` on the source and the test.

One note found while writing the positive case: `$all_ids` is built with `Shop::addSqlAssociation()`, so a
`product_attribute` row with no `product_attribute_shop` companion is invisible to it — which is exactly
the kind of row the removed branch used to create. A fixture has to insert both rows to represent a real
combination.
