### PR TITLE
Keep a module override's imports when merging into an existing override

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,6 +16,9 @@ $finder = PhpCsFixer\Finder::create()->in([
     'Unit/Resources/parsed-modules/fqcn-const.php',
     'Resources/modules_tests/testtrickyconflict/override/classes/Cart.php',
     'Resources/modules_tests/override_for_unit_test/classes/Cart.php',
+    // Expected output of an override merge, compared byte for byte by ModuleManagerBuilderTest.
+    // Its import is unused on purpose: it is the assertion that the merge keeps a module's imports.
+    'Resources/modules_tests/override/controllers/admin/DummyAdminController.php',
 ]);
 
 return (new PhpCsFixer\Config())

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3019,6 +3019,79 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @return bool
      */
+    /**
+     * Copies the `use` statements a module override declares into an override file that already
+     * exists, keeping the ones it already has. Only the class body is merged, so without this the
+     * methods brought over would reference short class names nothing imports.
+     *
+     * @param array<int, string> $overrideFile lines of the existing override
+     * @param array<int, string> $moduleHeader lines of the module override above its class
+     *
+     * @return array<int, string> the override lines, with the missing imports inserted
+     */
+    protected function addMissingUseStatements(array $overrideFile, array $moduleHeader): array
+    {
+        $overrideFile = array_values($overrideFile);
+
+        $wanted = $this->extractUseStatements($moduleHeader);
+        if (empty($wanted)) {
+            return $overrideFile;
+        }
+
+        $existing = $this->extractUseStatements($overrideFile);
+        $missing = array_diff_key($wanted, $existing);
+        if (empty($missing)) {
+            return $overrideFile;
+        }
+
+        // After the last import if there is one, otherwise after the namespace or the strict_types
+        // declaration, otherwise after the opening tag, so the result stays valid whatever the existing
+        // file looks like. WHY the declare() arm: it has to be the very first statement in the file, so
+        // an import placed between `<?php` and it makes the override a parse error - which the installer
+        // only discovers when it eval()s the merged class.
+        $insertAt = null;
+        foreach ($overrideFile as $index => $line) {
+            if (preg_match('/^\s*use\s+[^;]+;/', $line)
+                || preg_match('/^\s*namespace\s+[^;]+;/', $line)
+                || preg_match('/^\s*declare\s*\(/', $line)) {
+                $insertAt = $index + 1;
+            } elseif (null === $insertAt && preg_match('/^\s*<\?php/', $line)) {
+                $insertAt = $index + 1;
+            } elseif (preg_match('/^\s*(final\s+|abstract\s+)?class\s/i', $line)) {
+                break;
+            }
+        }
+
+        if (null === $insertAt) {
+            return $overrideFile;
+        }
+
+        array_splice($overrideFile, $insertAt, 0, array_values($missing));
+
+        return $overrideFile;
+    }
+
+    /**
+     * @param array<int, string> $lines
+     *
+     * @return array<string, string> imported name => the line that imports it
+     */
+    private function extractUseStatements(array $lines): array
+    {
+        $statements = [];
+        foreach ($lines as $line) {
+            if (preg_match('/^\s*use\s+(?<import>[^;]+);/', $line, $matches)) {
+                $import = preg_replace('/\s+/', ' ', trim($matches['import']));
+                $statements[$import] = $line;
+            }
+            if (preg_match('/^\s*(final\s+|abstract\s+)?class\s/i', $line)) {
+                break;
+            }
+        }
+
+        return $statements;
+    }
+
     public function addOverride($classname)
     {
         $orig_path = $path = PrestashopAutoload::getInstance()->getClassPath($classname . 'Core');
@@ -3133,6 +3206,16 @@ abstract class ModuleCore implements ModuleInterface
             // Insert the methods from module override in override
             $copy_from = array_slice($module_file, $module_class->getStartLine() + 1, $module_class->getEndLine() - $module_class->getStartLine() - 2);
             array_splice($override_file, $override_class->getEndLine() - 1, 0, $copy_from);
+
+            // The module override's imports live above its class, so copying only the class body leaves
+            // the merged methods referring to short class names that the existing override does not
+            // import. This runs after the splice above so that it cannot shift the line the class body
+            // is inserted at.
+            $override_file = $this->addMissingUseStatements(
+                $override_file,
+                array_slice($module_file, 0, $module_class->getStartLine())
+            );
+
             $code = implode('', $override_file);
 
             file_put_contents($override_path, preg_replace($pattern_escape_com, '', $code));

--- a/tests/Resources/modules_tests/override/controllers/admin/DummyAdminController.php
+++ b/tests/Resources/modules_tests/override/controllers/admin/DummyAdminController.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use Symfony\Component\DependencyInjection\ContainerInterface;
 class DummyAdminController extends DummyAdminControllerCore
 {
     /*

--- a/tests/Unit/Classes/Module/OverrideUseStatementsTest.php
+++ b/tests/Unit/Classes/Module/OverrideUseStatementsTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Module;
+
+use Module;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Installing a module override on a class that already has one merges the class body only, so the
+ * imports the module declared above its class were dropped and the merged methods referred to short
+ * class names nothing imported.
+ */
+class OverrideUseStatementsTest extends TestCase
+{
+    public function testAnImportTheOverrideLacksIsAdded(): void
+    {
+        $result = $this->merge(
+            ["<?php\n", "\n", "class Cart extends CartCore\n", "{\n", "}\n"],
+            ["<?php\n", "\n", "use PrestaShop\\PrestaShop\\Core\\Cart\\CartRuleData;\n", "\n", "class Cart extends CartCore\n"]
+        );
+
+        $this->assertSame(
+            ["<?php\n", "use PrestaShop\\PrestaShop\\Core\\Cart\\CartRuleData;\n", "\n", "class Cart extends CartCore\n", "{\n", "}\n"],
+            $result
+        );
+    }
+
+    public function testAnImportTheOverrideAlreadyHasIsNotDuplicated(): void
+    {
+        $existing = [
+            "<?php\n",
+            "use PrestaShop\\PrestaShop\\Core\\Cart\\CartRuleData;\n",
+            "\n",
+            "class Cart extends CartCore\n",
+            "{\n",
+            "}\n",
+        ];
+
+        $result = $this->merge($existing, ["<?php\n", "use PrestaShop\\PrestaShop\\Core\\Cart\\CartRuleData;\n", "class Cart extends CartCore\n"]);
+
+        $this->assertSame($existing, $result);
+    }
+
+    public function testTheImportGoesAfterTheLastExistingOne(): void
+    {
+        $result = $this->merge(
+            ["<?php\n", "use A\\B;\n", "use C\\D;\n", "\n", "class Cart extends CartCore\n", "{\n", "}\n"],
+            ["<?php\n", "use E\\F;\n", "class Cart extends CartCore\n"]
+        );
+
+        $this->assertSame(
+            ["<?php\n", "use A\\B;\n", "use C\\D;\n", "use E\\F;\n", "\n", "class Cart extends CartCore\n", "{\n", "}\n"],
+            $result
+        );
+    }
+
+    public function testAModuleDeclaringNoImportsChangesNothing(): void
+    {
+        $existing = ["<?php\n", "class Cart extends CartCore\n", "{\n", "    use SomeTrait;\n", "}\n"];
+
+        $result = $this->merge($existing, ["<?php\n", "class Cart extends CartCore\n"]);
+
+        $this->assertSame($existing, $result);
+    }
+
+    /**
+     * A class body can contain a trait import, which is not a namespace import. Reading the existing
+     * file stops at the class declaration so that one is never mistaken for an import, and a real
+     * import is still added above.
+     */
+    public function testTheImportGoesAfterAStrictTypesDeclaration(): void
+    {
+        // declare(strict_types=1) has to be the very first statement, so an import placed between the
+        // opening tag and it makes the merged override a parse error - and the installer only finds out
+        // when it eval()s the class.
+        $result = $this->merge(
+            ["<?php\n", "\n", "declare(strict_types=1);\n", "\n", "class Cart extends CartCore\n", "{\n", "}\n"],
+            ["<?php\n", "use A\\B;\n", "class Cart extends CartCore\n"]
+        );
+
+        $this->assertSame(
+            ["<?php\n", "\n", "declare(strict_types=1);\n", "use A\\B;\n", "\n", "class Cart extends CartCore\n", "{\n", "}\n"],
+            $result
+        );
+        $declareAt = array_search("declare(strict_types=1);\n", $result, true);
+        $importAt = array_search("use A\\B;\n", $result, true);
+        $this->assertIsInt($declareAt);
+        $this->assertIsInt($importAt);
+        $this->assertLessThan($importAt, $declareAt, 'the import must not be placed before the declaration');
+        foreach (array_slice($result, 1, $declareAt - 1) as $before) {
+            $this->assertSame('', trim($before), 'nothing but blank lines may sit between the open tag and the declaration');
+        }
+    }
+
+    public function testATraitUsedInsideTheClassIsNotMistakenForAnImport(): void
+    {
+        $result = $this->merge(
+            ["<?php\n", "class Cart extends CartCore\n", "{\n", "    use SomeTrait;\n", "}\n"],
+            ["<?php\n", "use A\\B;\n", "class Cart extends CartCore\n"]
+        );
+
+        $this->assertSame(
+            ["<?php\n", "use A\\B;\n", "class Cart extends CartCore\n", "{\n", "    use SomeTrait;\n", "}\n"],
+            $result
+        );
+    }
+
+    /**
+     * @param array<int, string> $overrideFile
+     * @param array<int, string> $moduleHeader
+     *
+     * @return array<int, string>
+     */
+    private function merge(array $overrideFile, array $moduleHeader): array
+    {
+        $module = new TestableModuleOverride();
+
+        return $module->merge($overrideFile, $moduleHeader);
+    }
+}
+
+class TestableModuleOverride extends Module
+{
+    public function __construct()
+    {
+        // The real constructor boots a module context a unit test has no use for.
+    }
+
+    /**
+     * @param array<int, string> $overrideFile
+     * @param array<int, string> $moduleHeader
+     *
+     * @return array<int, string>
+     */
+    public function merge(array $overrideFile, array $moduleHeader): array
+    {
+        return $this->addMissingUseStatements($overrideFile, $moduleHeader);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Installing a module override for a class that already has an override merges the class body only, so the `use` statements the module declared above its class are dropped. The methods brought over then refer to short class names nothing imports, and the same module produces a different override file depending on whether it was installed before or after another one. `Module::addOverride()` now copies the imports the existing override lacks.
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Take two modules that each override `Cart`, one of them importing a class it uses in its method, for example `use PrestaShop\PrestaShop\Core\Cart\CartRuleData;`. Install that module on a shop with no `override/classes/Cart.php` and the import is in the generated override. Delete the override, install the other module first, then the importing one: on 9.2.x the import is missing and only its methods were copied. With this change it is present in both orders.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #18592
| Related PRs                |
| Sponsor company            |

### Where it goes wrong

`addOverride()` has two paths. With no existing override the module's file is copied whole, imports
included. With one already present it merges, and the merge takes the class body alone:

```php
$copy_from = array_slice($module_file, $module_class->getStartLine() + 1, $module_class->getEndLine() - $module_class->getStartLine() - 2);
array_splice($override_file, $override_class->getEndLine() - 1, 0, $copy_from);
```

Everything above the class, namespace and imports, is left behind. That is the asymmetry the report
describes: the same module yields a different file depending on install order.

### The change

`addMissingUseStatements()` copies the imports the existing override does not already have, placing
them after its own last import if it has any, after the namespace otherwise, and after the opening tag
if it has neither, so the result stays valid whatever the existing file looks like.

Two details worth pointing at in review:

- it runs **after** the body splice, on purpose. Inserting lines near the top of the file first would
  shift `$override_class->getEndLine()`, which is a line number from the reflection of the file as it
  was, and the class body would then be spliced in the wrong place.
- reading a file's imports stops at the class declaration, so a `use SomeTrait;` inside the class body
  is never mistaken for a namespace import. There is a test for that.

### Not addressed

The report's first question, whether uninstalling a module should remove the import it added, is left
alone. Removal is a different path with a different risk: an import can be shared by methods another
module contributed, and there is nothing recording who added it.

### Tests

`tests/Unit/Classes/Module/OverrideUseStatementsTest.php` covers five cases: a missing import is added,
an existing one is not duplicated, the insertion goes after the last existing import, a module with no
imports changes nothing, and a trait used inside the class is not treated as an import. Making the
method return the file untouched turns three of them red.

`tests/Integration/Classes/module/ModuleTest.php` already drives real fixture modules from
`tests/Resources/modules_tests` for other override cases, so an end-to-end pair could be added there if
you would rather have the behaviour pinned through an actual install.
