### PR TITLE
Stop adding the specific price sentinel to the recorded quantity discount

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -709,7 +709,10 @@ class OrderDetailCore extends ObjectModel
                 $this->product_quantity_discount = Tools::ps_round($unit_price, Context::getContext()->getComputingPrecision());
             }
 
-            if (isset($this->tax_calculator)) {
+            // A specific price that keeps the catalogue price stores -1 rather than a price, the same
+            // sentinel Product::getPriceStatic() reads as "no price of its own". Running it through
+            // addTaxes() and subtracting it added the taxed sentinel to the recorded discount.
+            if (isset($this->tax_calculator) && $quantity_discount['price'] >= 0) {
                 $this->product_quantity_discount -= $this->tax_calculator->addTaxes($quantity_discount['price']);
             }
         }

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_specific_price_quantity_discount.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_specific_price_quantity_discount.feature
@@ -1,0 +1,29 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-specific-price-quantity-discount
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@order-specific-price-quantity-discount
+Feature: Order detail of a product carrying a specific price
+  As a shop owner
+  When a product is ordered with a specific price that keeps the catalogue price and only applies a
+  reduction, I want the order detail to record a discount that matches the price actually charged
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+
+  Scenario: A percentage specific price does not inflate the recorded quantity discount
+    Given there is a product in the catalog named "Discounted18658" with a price of 63.05 and 100 items in stock
+    And product "Discounted18658" has a specific price named "ten_percent" with a discount of 10.0 percent
+    And I create an empty cart "cart18658" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "cart18658"
+    And I add 1 products "Discounted18658" to the cart "cart18658"
+    When I add order "bo_order18658" from cart "cart18658" with "dummy_payment" payment method and "Payment accepted" order status
+    Then product "Discounted18658" in order "bo_order18658" has following details:
+      | unit_price_tax_excl       | 56.745 |
+      | product_quantity_discount | 60.15 |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | A specific price that keeps the catalogue price stores `-1` in its `price` column rather than a price. `OrderDetail::setSpecificPrice()` ran that value through `addTaxes()` and subtracted it from the unit price, and subtracting a negative added the taxed sentinel to `product_quantity_discount`. An order line at 56.745 excluding tax recorded 61.21 where 60.15 was the taxed unit price. The subtraction now happens only when the specific price actually carries a price.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Create a product at 63.05 and give it a specific price that keeps the initial price with a 10% reduction, then order one. On 9.2.x `order_detail.product_quantity_discount` is 61.21 against a `unit_price_tax_excl` of 56.745; with this change it is 60.15, which is that unit price with the 6% tax. `Features/Scenario/Order/order_specific_price_quantity_discount.feature` covers it.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #18658
| Related PRs                |
| Sponsor company            |

### The sentinel

`SpecificPrice` stores `-1` in `price` to mean "keep the product's own price and apply only the
reduction". `Product` reads it that way in two places:

```php
if (!$specific_price || $specific_price['price'] < 0) {
```

`OrderDetail::setSpecificPrice()` did not, and treated it as a price:

```php
if (isset($this->tax_calculator)) {
    $this->product_quantity_discount -= $this->tax_calculator->addTaxes($quantity_discount['price']);
}
```

With a 6% rate, `addTaxes(-1)` is `-1.06`, and subtracting it adds 1.06 to the figure. That is the
constant offset @khouloudbelguith measured in 2020 as "always there's a 1 added", and the cause
@zuk3975 identified in 2021.

### Measured

Product at 63.05 with a 10% specific price keeping the catalogue price, one unit ordered:

| field | 9.2.x | with this change |
| --- | --- | --- |
| `unit_price_tax_excl` | 56.745 | 56.745 |
| `product_quantity_discount` | 61.21 | 60.15 |

`60.15 = 56.745 × 1.06`, and `61.21 − 60.15 = 1.06`, which is the sentinel with tax. Reverting the
guard puts the scenario back to 61.21.

### On the test used

The condition is the `-1` in the specific price rather than the reduction type, so the test is written
as an order placed through the command bus with the existing
`product "..." has a specific price named "..." with a discount of ... percent` step, which stores
`price = -1` exactly as the back office does when the price field is left alone.

Regression: `order-cart-rules` 12 scenarios, `order-from-bo` 33 scenarios, `order-cancel-product`
7 scenarios and `order-fixed-product-prices` all pass unchanged.
