### PR TITLE
Keep only this invoice's rows in its product taxes breakdown

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -349,14 +349,20 @@ class OrderInvoiceCore extends ObjectModel
         // 	- 'total_amount'
         $breakdown = [];
 
-        $details = $order->getProductTaxesDetails();
+        // An order can carry several invoices, and getProductTaxesDetails() returns the rows of all of
+        // them, so keep only the ones belonging to this invoice. This has to happen before the branch
+        // below: the grouping path used to filter on its own, which left the rows of every other
+        // invoice in the breakdown whenever taxes are applied one after another.
+        $details = array_filter(
+            $order->getProductTaxesDetails(),
+            function (array $row): bool {
+                return $this->id === (int) $row['id_order_invoice'];
+            }
+        );
 
         if ($sum_composite_taxes) {
             $grouped_details = [];
             foreach ($details as $row) {
-                if ($this->id !== (int) $row['id_order_invoice']) {
-                    continue;
-                }
                 if (!isset($grouped_details[$row['id_order_detail']])) {
                     $grouped_details[$row['id_order_detail']] = [
                         'tax_rate' => 0,

--- a/tests/Integration/Classes/Order/OrderInvoiceProductTaxesBreakdownTest.php
+++ b/tests/Integration/Classes/Order/OrderInvoiceProductTaxesBreakdownTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Configuration;
+use Context;
+use Currency;
+use Order;
+use OrderInvoice;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The tax breakdown of an invoice is built from the details of the whole order, so it has to keep
+ * only the rows belonging to the invoice it is rendering. An order can carry several invoices, which
+ * is what the back office does when a product is added "with a new invoice".
+ */
+class OrderInvoiceProductTaxesBreakdownTest extends TestCase
+{
+    private const FIRST_INVOICE_ID = 1;
+    private const SECOND_INVOICE_ID = 2;
+
+    /**
+     * @var Currency|null
+     */
+    private $previousCurrency;
+
+    /**
+     * The breakdown rounds with Context::getComputingPrecision(), which reads the currency precision.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $context = Context::getContext();
+        $this->previousCurrency = $context->currency;
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $this->resetComputingPrecision($context);
+    }
+
+    protected function tearDown(): void
+    {
+        $context = Context::getContext();
+        $context->currency = $this->previousCurrency;
+        $this->resetComputingPrecision($context);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Taxes applied one after another take the branch that does not group the details, which is the
+     * branch the invoice filter was missing from.
+     */
+    public function testBreakdownIgnoresAnotherInvoiceRowsWhenTaxesAreAppliedOneAfterAnother(): void
+    {
+        $invoice = $this->buildInvoice(self::SECOND_INVOICE_ID, true);
+
+        $breakdown = $invoice->getProductTaxesBreakdown($this->buildOrder());
+
+        $this->assertSame(['20.000'], array_keys($breakdown));
+        $this->assertEquals(100.0, $breakdown['20.000']['total_price_tax_excl']);
+        $this->assertEquals(20.0, $breakdown['20.000']['total_amount']);
+    }
+
+    /**
+     * The grouping branch already filtered by invoice; this pins that it still does.
+     */
+    public function testBreakdownIgnoresAnotherInvoiceRowsWhenCompositeTaxesAreSummed(): void
+    {
+        $invoice = $this->buildInvoice(self::SECOND_INVOICE_ID, false);
+
+        $breakdown = $invoice->getProductTaxesBreakdown($this->buildOrder());
+
+        $this->assertSame(['20.000'], array_keys($breakdown));
+        $this->assertEquals(100.0, $breakdown['20.000']['total_price_tax_excl']);
+        $this->assertEquals(20.0, $breakdown['20.000']['total_amount']);
+    }
+
+    /**
+     * The first invoice must not pick up the second one either, so the filter is not just "skip
+     * everything before me".
+     */
+    public function testBreakdownOfTheFirstInvoiceIgnoresTheSecondOne(): void
+    {
+        $invoice = $this->buildInvoice(self::FIRST_INVOICE_ID, true);
+
+        $breakdown = $invoice->getProductTaxesBreakdown($this->buildOrder());
+
+        $this->assertSame(['20.000'], array_keys($breakdown));
+        $this->assertEquals(50.0, $breakdown['20.000']['total_price_tax_excl']);
+        $this->assertEquals(10.0, $breakdown['20.000']['total_amount']);
+    }
+
+    /**
+     * The precision is memoised on the context, so a value cached from another currency would survive
+     * the assignment above.
+     */
+    private function resetComputingPrecision(Context $context): void
+    {
+        $property = (new ReflectionClass(Context::class))->getProperty('priceComputingPrecision');
+        $property->setAccessible(true);
+        $property->setValue($context, null);
+    }
+
+    private function buildInvoice(int $invoiceId, bool $oneAfterAnother): OrderInvoice
+    {
+        $invoice = new TestableOrderInvoice();
+        $invoice->id = $invoiceId;
+        $invoice->oneAfterAnother = $oneAfterAnother;
+
+        return $invoice;
+    }
+
+    /**
+     * One order, two invoices, one product line each, both taxed at the same rate so that a leaked
+     * row shows up as an inflated base rather than as an extra rate.
+     */
+    private function buildOrder(): Order
+    {
+        $order = $this->createPartialMock(Order::class, ['getProductTaxesDetails']);
+        $order->round_mode = 0;
+        $order->method('getProductTaxesDetails')->willReturn([
+            [
+                'id_order_detail' => 1,
+                'id_order_invoice' => self::FIRST_INVOICE_ID,
+                'id_tax' => 1,
+                'tax_rate' => 20.0,
+                'total_tax_base' => 50.0,
+                'total_amount' => 10.0,
+            ],
+            [
+                'id_order_detail' => 2,
+                'id_order_invoice' => self::SECOND_INVOICE_ID,
+                'id_tax' => 1,
+                'tax_rate' => 20.0,
+                'total_tax_base' => 100.0,
+                'total_amount' => 20.0,
+            ],
+        ]);
+
+        return $order;
+    }
+}
+
+class TestableOrderInvoice extends OrderInvoice
+{
+    /**
+     * @var bool
+     */
+    public $oneAfterAnother = false;
+
+    public function useOneAfterAnotherTaxComputationMethod()
+    {
+        return $this->oneAfterAnother;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `OrderInvoice::getProductTaxesBreakdown()` builds an invoice's tax breakdown from `Order::getProductTaxesDetails()`, which returns the rows of every invoice of the order. The filter that keeps only the current invoice's rows sat inside the branch that groups composite taxes, and that branch is skipped when taxes are applied one after another. A second invoice's breakdown then also counted the products of the first, so its Base price was the sum of both. The filter now runs on the details before either branch.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | The faulty path needs an order line whose tax uses the one-after-another method, so set a tax rules group up with two rules for the same country and give the second one the `One after another` behaviour (Improve > International > Taxes > Tax Rules), and assign it to a product. Place an order with that product, generate its invoice, then add another product to the order with a new invoice. On 9.2.x the second invoice's Base price in the tax breakdown is the sum of both invoices; with this change each invoice shows only its own. `tests/Integration/Classes/Order/OrderInvoiceProductTaxesBreakdownTest.php` covers both branches without needing that setup.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #18719
| Related PRs                |
| Sponsor company            |

### The branch that was missing the filter

```php
$details = $order->getProductTaxesDetails();

if ($sum_composite_taxes) {
    $grouped_details = [];
    foreach ($details as $row) {
        if ($this->id !== (int) $row['id_order_invoice']) {
            continue;   // <- the only place the invoice was checked
        }
        ...
    }
    $details = $grouped_details;
}

foreach ($details as $row) {   // <- reached with every invoice's rows when the branch is skipped
```

`$sum_composite_taxes` is `!useOneAfterAnotherTaxComputationMethod()`, so with the one-after-another
method the grouping branch never runs and `$details` still holds the whole order.

That method is reachable from the back office rather than being a leftover:
`TaxRuleType` offers `One after another` as one of the three behaviours of a tax rule,
`TaxRulesTaxManager` passes that behaviour straight into `new TaxCalculator($taxes, $behavior)`,
and `OrderDetail` stores it as `tax_computation_method`, which is exactly what
`useOneAfterAnotherTaxComputationMethod()` looks for.

### Measured

`OrderInvoiceProductTaxesBreakdownTest` gives one order two invoices, one line each at the same rate,
50.00 and 100.00 excluding tax:

| case | invoice | before | after |
| --- | --- | --- | --- |
| taxes one after another | second | 150.00 | 100.00 |
| taxes one after another | first | 150.00 | 50.00 |
| composite taxes summed | second | 100.00 | 100.00 |

The third row is the control: the grouping branch already filtered correctly, and it is unchanged, so
the difference is the branch and not the filter in general.

### On the fix

Filtering with `array_filter` before the branch is the smallest change that makes both paths agree,
and it removes the `continue` rather than adding a second copy of it. The comparison stays strict:
`EntityMapper` assigns `$entity->id = (int) $id` when it loads an ObjectModel, so `$this->id` is an
integer here and `===` against the cast row value is safe.

### The other callers are unaffected

`Order::getProductTaxesDetails()` returns whole-order rows on purpose, and the two other callers want
that or scope it themselves, so nothing else needed changing:

- `HTMLTemplateOrderSlip.php:264` passes `$this->order->products` as `$limitToOrderDetails`, so the
  credit slip narrows the rows through the method's own parameter.
- `Order.php:2568` rebuilds the `order_detail_tax` rows for the whole order, which is the whole-order
  case.

The asymmetry this leaves behind is worth naming: in the same tax tab,
`getShippingTaxesBreakdown()` has always scoped per invoice in its SQL
(`WHERE oit.type = "shipping" AND oit.id_order_invoice = ...`), so the shipping half of the breakdown
was already correct while the product half was only correct on one of its two branches.
