### PR TITLE
Report the real quantity on a product read through the webservice

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -591,7 +591,7 @@ class ProductCore extends ObjectModel
                 'setter' => false,
             ],
             'quantity' => [
-                'getter' => false,
+                'getter' => 'getWsQuantity',
                 'setter' => false,
             ],
             'type' => [
@@ -6949,6 +6949,20 @@ class ProductCore extends ObjectModel
         );
 
         return $result;
+    }
+
+    /**
+     * Webservice getter : get the quantity available for sale.
+     *
+     * The $quantity property is only filled by loadStockData(), which the constructor runs when a
+     * product is loaded in full. The webservice builds its objects with `new Product($id)`, so without
+     * this getter every product was reported with a quantity of 0.
+     *
+     * @return int
+     */
+    public function getWsQuantity()
+    {
+        return StockAvailable::getQuantityAvailableByProduct((int) $this->id, 0, Shop::getContextShopID());
     }
 
     /**

--- a/tests/Integration/Classes/Product/WsQuantityTest.php
+++ b/tests/Integration/Classes/Product/WsQuantityTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Cache;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+use Shop;
+use StockAvailable;
+
+/**
+ * The webservice builds its objects with `new Product($id)`, and $quantity is only filled by
+ * loadStockData(), which the constructor runs for a full load. Every product was therefore reported
+ * with a quantity of 0.
+ */
+class WsQuantityTest extends TestCase
+{
+    private const PRODUCT_ID = 1;
+
+    private int $previousQuantity = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousQuantity = (int) StockAvailable::getQuantityAvailableByProduct(self::PRODUCT_ID, 0);
+    }
+
+    protected function tearDown(): void
+    {
+        StockAvailable::setQuantity(self::PRODUCT_ID, 0, $this->previousQuantity);
+
+        parent::tearDown();
+    }
+
+    public function testTheWebserviceReportsTheAvailableQuantity(): void
+    {
+        StockAvailable::setQuantity(self::PRODUCT_ID, 0, 42);
+
+        $product = new Product(self::PRODUCT_ID);
+
+        $this->assertSame(0, (int) $product->quantity, 'a plain load still leaves the property empty');
+        $this->assertSame(42, (int) $product->getWsQuantity());
+    }
+
+    public function testItFollowsTheStockAndNotTheProductRow(): void
+    {
+        StockAvailable::setQuantity(self::PRODUCT_ID, 0, 7);
+        $this->assertSame(7, (int) (new Product(self::PRODUCT_ID))->getWsQuantity());
+
+        StockAvailable::setQuantity(self::PRODUCT_ID, 0, 0);
+        $this->assertSame(0, (int) (new Product(self::PRODUCT_ID))->getWsQuantity());
+    }
+
+    /**
+     * The field stays read-only: stock is written through the stock_availables resource.
+     */
+    public function testTheFieldIsStillReadOnly(): void
+    {
+        $parameters = (new Product())->getWebserviceParameters();
+
+        $this->assertSame('getWsQuantity', $parameters['fields']['quantity']['getter']);
+        $this->assertFalse($parameters['fields']['quantity']['setter']);
+    }
+
+    /**
+     * On a multishop install the figure must belong to the shop the request is scoped to.
+     */
+    public function testItReportsTheQuantityOfTheShopInContext(): void
+    {
+        $second = $this->addShop();
+
+        try {
+            StockAvailable::setQuantity(self::PRODUCT_ID, 0, 300, 1);
+            StockAvailable::setQuantity(self::PRODUCT_ID, 0, 77, $second);
+
+            foreach ([1 => 300, $second => 77] as $idShop => $expected) {
+                Shop::setContext(Shop::CONTEXT_SHOP, $idShop);
+                Product::resetStaticCache();
+                Cache::clean('*');
+
+                $this->assertSame(
+                    $expected,
+                    (int) (new Product(self::PRODUCT_ID))->getWsQuantity(),
+                    'shop ' . $idShop . ' must report its own quantity'
+                );
+            }
+        } finally {
+            $this->removeShop($second);
+        }
+    }
+
+    /**
+     * Turns the installation into a two-shop one for the duration of a single test.
+     */
+    private function addShop(): int
+    {
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'configuration (name, value, date_add, date_upd)
+             VALUES ("PS_MULTISHOP_FEATURE_ACTIVE", 1, NOW(), NOW())
+             ON DUPLICATE KEY UPDATE value = 1'
+        );
+        Shop::resetStaticCache();
+
+        $shop = new Shop();
+        $shop->active = true;
+        $shop->id_shop_group = 1;
+        $shop->id_category = 2;
+        $shop->theme_name = _THEME_NAME_;
+        $shop->name = 'ws quantity test shop';
+        $shop->color = 'red';
+        $shop->add();
+        Shop::resetStaticCache();
+
+        Db::getInstance()->execute(
+            'INSERT IGNORE INTO ' . _DB_PREFIX_ . 'product_shop
+                (id_product, id_shop, id_category_default, price, active, visibility, id_tax_rules_group, indexed, date_add, date_upd)
+             SELECT id_product, ' . (int) $shop->id . ', id_category_default, price, active, visibility, id_tax_rules_group, indexed, date_add, date_upd
+             FROM ' . _DB_PREFIX_ . 'product_shop WHERE id_product = ' . self::PRODUCT_ID . ' AND id_shop = 1'
+        );
+
+        return (int) $shop->id;
+    }
+
+    private function removeShop(int $idShop): void
+    {
+        Shop::setContext(Shop::CONTEXT_ALL);
+        Db::getInstance()->delete('stock_available', 'id_shop = ' . $idShop);
+        Db::getInstance()->delete('product_shop', 'id_shop = ' . $idShop);
+        Db::getInstance()->delete('shop_url', 'id_shop = ' . $idShop);
+        Db::getInstance()->delete('shop', 'id_shop = ' . $idShop);
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'configuration WHERE id_shop = ' . $idShop);
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'configuration WHERE name = "PS_MULTISHOP_FEATURE_ACTIVE"');
+        Shop::resetStaticCache();
+        Cache::clean('*');
+    }
+
+    /**
+     * The getter reads the product-level row, the one the back office and the front office show.
+     */
+    public function testItReadsTheProductLevelStockRow(): void
+    {
+        StockAvailable::setQuantity(self::PRODUCT_ID, 0, 11);
+
+        $stored = (int) Db::getInstance()->getValue(
+            'SELECT quantity FROM ' . _DB_PREFIX_ . 'stock_available
+             WHERE id_product = ' . self::PRODUCT_ID . ' AND id_product_attribute = 0',
+            false
+        );
+
+        $this->assertSame($stored, (int) (new Product(self::PRODUCT_ID))->getWsQuantity());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `GET /api/products` reported a quantity of 0 for every product, because the webservice builds its objects with `new Product($id)` and `$quantity` is only filled for a full load.
| Type?                      | bug fix
| Category?                  | WS
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #18953
| Related PRs                |
| Sponsor company            |

### The bug

`Product::$quantity` is filled by `loadStockData()`, which the constructor only runs when the product is
loaded in full. `WebserviceRequest` builds every object with
`new $className((int) $id)` (`WebserviceRequest.php:986`, `:1314`, `:1334`), so the property keeps its
default. The webservice field was declared with no getter at all:

```php
'quantity' => [
    'getter' => false,
    'setter' => false,
],
```

Measured on 9.2.x:

```
new Product(1)->quantity                              0
StockAvailable::getQuantityAvailableByProduct(1)   2400
new Product(6)->quantity                              0
StockAvailable::getQuantityAvailableByProduct(6)    300
```

### The fix

A `getWsQuantity()` getter reading the product-level stock row — the same figure the back office and the
front office display — following the pattern the other virtual webservice fields in the class already use
(`getWsProductFeatures`, `getWsPositionInCategory`, `getWsStockAvailables`, …).

**The shop is passed explicitly**, `Shop::getContextShopID()`, rather than left to the context.
`getQuantityAvailableByProduct()` builds its cache key from `(int) $id_shop`, so a `null` makes every shop
of a multishop install share one entry and read back whichever shop asked first. Measured with two shops
holding 300 and 77 of the same product: without the argument both shops report **300**; with it each
reports its own. A test creates the second shop and pins that.

The combination argument is `0` because a product resource has no combination of its own — combinations
are their own webservice resource.

The field stays **read-only**. Writing stock through `/products` is not supported; the resource for that
is `stock_availables`, and a test pins that `setter` is still `false`.

### How to test

`GET /api/products/1?output_format=JSON` reports the product's real quantity instead of `0`. So does
`/api/products?display=[id,name,quantity]`.

### Verification

- `tests/Integration/Classes/Product/WsQuantityTest.php` — 5 cases, including a multishop one that adds a
  second shop for its own duration and removes it in a `finally`. Reverting `classes/Product.php` to
  `upstream/9.2.x` fails **all five**. Dropping only the shop argument leaves the multishop case red on
  its own: *"shop N must report its own quantity — Failed asserting that 300 is identical to 77"*.
- `tests/Integration/Classes` — 187 tests OK.
- `php -l`, php-cs-fixer `Found 0 of 2`, PHPStan `[OK] No errors` on the source and the test.

### The other half of the issue

The thread also contains @thomasnares' report that a `PUT /api/stock_availables/{id}` "breaks the stocks".
That reproduces, but it is a separate defect and is not addressed here — see the issue comment for the
measurement. It belongs next to `StockAvailable::add()/update()`. The invariant is `id_shop > 0 OR id_shop_group > 0`
— `id_shop = 0` alone is legitimate, since that is how a shop group with shared stock stores a row — and
PR #41863 is currently restructuring how both of those fields are assigned, so the guard is better written
once that lands than against a moving target.
