### PR TITLE
Fall back to the shop language when a product has no name in the employee's

### DIFF
--- a/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
+++ b/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
@@ -10,6 +10,7 @@ namespace PrestaShop\PrestaShop\Adapter\Product\Grid\Data\Factory;
 
 use Currency;
 use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
 use PrestaShop\PrestaShop\Adapter\Product\Pack\Repository\ProductPackRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
@@ -119,6 +120,7 @@ class ProductGridDataFactoryDecorator implements GridDataFactoryInterface
         ShopRepository $shopRepository,
         ProductRepository $productRepository,
         private ProductPackRepository $productPackRepository,
+        private Configuration $configuration,
     ) {
         $this->productGridDataFactory = $productGridDataFactory;
 
@@ -165,9 +167,54 @@ class ProductGridDataFactoryDecorator implements GridDataFactoryInterface
      *
      * @return array
      */
+    /**
+     * The grid reads product_lang with the employee's language, so a shop whose data is written in
+     * another language shows nothing to fall back on and every row ends up as "N/A". Read the missing
+     * names once, in the shop's default language, before that happens.
+     *
+     * Only the rows that came back without a name are looked up, so a shop whose data is complete pays
+     * nothing, and a page that needs it pays one query rather than a join on every row.
+     *
+     * @param array<int, array<string, mixed>> $products
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function fillNamesMissingInTheEmployeeLanguage(array $products, ShopSearchCriteriaInterface $searchCriteria): array
+    {
+        $missingIds = [];
+        foreach ($products as $product) {
+            if (empty($product['name']) && !empty($product['id_product'])) {
+                $missingIds[] = (int) $product['id_product'];
+            }
+        }
+
+        if (empty($missingIds)) {
+            return $products;
+        }
+
+        $defaultLanguageId = $this->configuration->getInt('PS_LANG_DEFAULT');
+        $shopConstraint = $searchCriteria->getShopConstraint();
+        $shopId = null !== $shopConstraint->getShopId() ? $shopConstraint->getShopId()->getValue() : null;
+
+        $names = $this->productRepository->getProductNames($missingIds, $defaultLanguageId, $shopId);
+        if (empty($names)) {
+            return $products;
+        }
+
+        foreach ($products as $i => $product) {
+            $productId = (int) ($product['id_product'] ?? 0);
+            if (empty($product['name']) && !empty($names[$productId])) {
+                $products[$i]['name'] = $names[$productId];
+            }
+        }
+
+        return $products;
+    }
+
     private function applyModification(array $products, ShopSearchCriteriaInterface $searchCriteria): array
     {
         $currency = new Currency($this->defaultCurrencyId);
+        $products = $this->fillNamesMissingInTheEmployeeLanguage($products, $searchCriteria);
         foreach ($products as $i => $product) {
             if (empty($product['name'])) {
                 $products[$i]['name'] = $this->translator->trans('N/A', [], 'Admin.Global');

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Repository;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception as ExceptionAlias;
@@ -829,6 +830,47 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
         ;
 
         return $qb->executeQuery()->fetchAllAssociative();
+    }
+
+    /**
+     * Reads the names of the given products in one language, for the rows the back office grid needs
+     * when the employee's own language has none.
+     *
+     * @param int[] $productIds
+     * @param int $languageId
+     * @param int|null $shopId null falls back to each product's default shop, like the grid does when
+     *                         no single shop is in context
+     *
+     * @return array<int, string> product id => name
+     */
+    public function getProductNames(array $productIds, int $languageId, ?int $shopId = null): array
+    {
+        if (empty($productIds)) {
+            return [];
+        }
+
+        $qb = $this->connection->createQueryBuilder()
+            ->select('pl.id_product, pl.name')
+            ->from($this->dbPrefix . 'product_lang', 'pl')
+            ->innerJoin('pl', $this->dbPrefix . 'product', 'p', 'p.id_product = pl.id_product')
+            ->where('pl.id_product IN (:productIds)')
+            ->andWhere('pl.id_lang = :languageId')
+            ->setParameter('productIds', array_map('intval', $productIds), ArrayParameterType::INTEGER)
+            ->setParameter('languageId', $languageId)
+        ;
+
+        if (null !== $shopId) {
+            $qb->andWhere('pl.id_shop = :shopId')->setParameter('shopId', $shopId);
+        } else {
+            $qb->andWhere('pl.id_shop = p.id_shop_default');
+        }
+
+        $names = [];
+        foreach ($qb->executeQuery()->fetchAllAssociative() as $row) {
+            $names[(int) $row['id_product']] = (string) $row['name'];
+        }
+
+        return $names;
     }
 
     public function hasAnyProduct(): bool

--- a/tests/Unit/Adapter/Product/Grid/Data/Factory/ProductGridNameFallbackTest.php
+++ b/tests/Unit/Adapter/Product/Grid/Data/Factory/ProductGridNameFallbackTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Product\Grid\Data\Factory;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Product\Grid\Data\Factory\ProductGridDataFactoryDecorator;
+use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
+use PrestaShop\PrestaShop\Adapter\Product\Pack\Repository\ProductPackRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository;
+use PrestaShop\PrestaShop\Adapter\Tax\TaxComputer;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Grid\Data\Factory\GridDataFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Search\ShopSearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * A back office whose employee language holds no product data used to show "N/A" on every row of the
+ * product grid, because the grid reads product_lang with that language and nothing else. The rows
+ * that come back without a name are now looked up once in the shop's default language.
+ */
+class ProductGridNameFallbackTest extends TestCase
+{
+    private const DEFAULT_LANGUAGE_ID = 1;
+    private const SHOP_ID = 2;
+
+    /**
+     * @var ProductRepository&MockObject
+     */
+    private $productRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->productRepository = $this->createMock(ProductRepository::class);
+    }
+
+    public function testTheDefaultLanguageNameReplacesAnEmptyOne(): void
+    {
+        $this->productRepository
+            ->expects($this->once())
+            ->method('getProductNames')
+            ->with([7], self::DEFAULT_LANGUAGE_ID, self::SHOP_ID)
+            ->willReturn([7 => 'Hummingbird printed t-shirt']);
+
+        $products = $this->fillNames([
+            ['id_product' => 5, 'name' => 'Mug'],
+            ['id_product' => 7, 'name' => ''],
+        ]);
+
+        $this->assertSame('Mug', $products[0]['name']);
+        $this->assertSame('Hummingbird printed t-shirt', $products[1]['name']);
+    }
+
+    /**
+     * A shop whose data is complete must not pay for the lookup at all.
+     */
+    public function testNoLookupHappensWhenEveryRowHasAName(): void
+    {
+        $this->productRepository->expects($this->never())->method('getProductNames');
+
+        $products = $this->fillNames([
+            ['id_product' => 5, 'name' => 'Mug'],
+            ['id_product' => 7, 'name' => 'Notebook'],
+        ]);
+
+        $this->assertSame(['Mug', 'Notebook'], array_column($products, 'name'));
+    }
+
+    /**
+     * When the default language has nothing either, the row is left empty so that the caller still
+     * renders "N/A" rather than something invented here.
+     */
+    public function testARowStaysEmptyWhenTheDefaultLanguageHasNoNameEither(): void
+    {
+        $this->productRepository
+            ->method('getProductNames')
+            ->willReturn([]);
+
+        $products = $this->fillNames([
+            ['id_product' => 7, 'name' => ''],
+        ]);
+
+        $this->assertSame('', $products[0]['name']);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $products
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function fillNames(array $products): array
+    {
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('getInt')->with('PS_LANG_DEFAULT')->willReturn(self::DEFAULT_LANGUAGE_ID);
+
+        $localeRepository = $this->createMock(LocaleRepository::class);
+        $localeRepository->method('getLocale')->willReturn(
+            $this->createMock(\PrestaShop\PrestaShop\Core\Localization\Locale::class)
+        );
+
+        $decorator = new TestableProductGridDataFactoryDecorator(
+            $this->createMock(GridDataFactoryInterface::class),
+            $localeRepository,
+            'en-US',
+            1,
+            $this->createMock(TaxComputer::class),
+            1,
+            $this->createMock(ProductImagePathFactory::class),
+            $this->createMock(TranslatorInterface::class),
+            true,
+            false,
+            0,
+            $this->createMock(ShopRepository::class),
+            $this->productRepository,
+            $this->createMock(ProductPackRepository::class),
+            $configuration
+        );
+
+        $searchCriteria = $this->createMock(ShopSearchCriteriaInterface::class);
+        $searchCriteria->method('getShopConstraint')->willReturn(ShopConstraint::shop(self::SHOP_ID));
+
+        return $decorator->fillNames($products, $searchCriteria);
+    }
+}
+
+class TestableProductGridDataFactoryDecorator extends ProductGridDataFactoryDecorator
+{
+    /**
+     * @param array<int, array<string, mixed>> $products
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function fillNames(array $products, ShopSearchCriteriaInterface $searchCriteria): array
+    {
+        return $this->fillNamesMissingInTheEmployeeLanguage($products, $searchCriteria);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | The product grid reads `product_lang` with the back office language (`ProductQueryBuilder` binds `langId` to the context language), so a shop whose catalogue is written in another language shows `N/A` on every row. That is the normal setup for a merchant who installs one language to read the back office in and keeps the catalogue in the shop's own. The rows that come back without a name are now looked up once, in the shop's default language, before the `N/A` placeholder is applied.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Install a second language, leave the catalogue named in the first, and set the employee language to the second (the reported case is a Czech back office over a Slovak catalogue). Open Catalog > Products. On 9.2.x every row shows `N/A`; with this change each row shows its name in the shop's default language. A catalogue that is fully translated is unaffected, and a product with no name in either language still shows `N/A`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #19777
| Related PRs                |
| Sponsor company            |

### Where the placeholder comes from

`ProductGridDataFactoryDecorator::applyModification()` already had the only line that knows a name is
missing:

```php
if (empty($product['name'])) {
    $products[$i]['name'] = $this->translator->trans('N/A', [], 'Admin.Global');
}
```

so the fallback goes in front of it rather than into the grid SQL.

### Why not in the query

Adding the fallback to `ProductQueryBuilder` means a second `product_lang` join plus `COALESCE`, and
the same again for `category_lang` and `image_lang`, all evaluated on every row before the LIMIT of the
busiest listing in the back office. Doing it after the fact costs one query, only on pages that
actually have a row without a name, and nothing at all on a shop whose catalogue is complete —
`getProductNames()` returns early on an empty id list and is never called when every row has a name.

### Scope, stated rather than implied

Only the displayed name changes. The **name filter** still matches on the employee-language name,
because that is a `WHERE` on the grid query and moving it would put the join back. So on such a shop a
row can be visible with a fallback name and not be found by typing that name into the filter. That is
a smaller gap than every row reading `N/A`, but it is a real one and belongs in the SQL if the project
wants it closed.

`category` and the image `legend` come from `category_lang` and `image_lang` on the same `langId` and
are left alone here, for the same reason.

### Multistore

`getProductNames()` takes the shop from the grid's own `ShopConstraint`: a single-shop context scopes
`pl.id_shop` to that shop, and both the all-shops and shop-group contexts fall back to
`p.id_shop_default`. That matches `ProductQueryBuilder::addShopCondition()` exactly for the single-shop
and all-shops cases; for a shop group the builder picks `MIN(id_shop)` within the group where this
picks the product's default shop, which can differ only for a product whose name is missing in the
employee's language in the first place.

### Measured

`ProductGridNameFallbackTest` covers the three cases: an empty name is replaced from the default
language, no lookup is issued when every row already has a name, and a row whose default language has
no name either is left empty so the `N/A` placeholder still applies. Reverting the fill (returning the
rows untouched) turns the first case red on the assertion, not on a missing method.

`bin/console debug:container` confirms the new `Configuration` dependency is autowired into both
`ProductGridDataFactoryDecorator` and the `ProductShopsGridDataFactoryDecorator` that extends it, with
no change to the service definitions.
