### PR TITLE
Send the stock filters the export actually reads

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters/low-filter.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters/low-filter.vue
@@ -48,6 +48,7 @@
   import PSCheckbox from '@app/widgets/ps-checkbox.vue';
   import {defineComponent} from 'vue';
   import translate from '@app/pages/stock/mixins/translate';
+  import stockQueryParams from '@app/pages/stock/store/query-params';
 
   export default defineComponent({
     props: {
@@ -69,10 +70,8 @@
         return window.data.stockImportUrl;
       },
       stockExportUrl(): string {
-        const filtersClone = {...this.filters};
-        const params = $.param(filtersClone);
-
-        return `${window.data.stockExportUrl}&${params}`;
+        // Same query string the listing sends, so the export covers what the merchant is looking at.
+        return `${window.data.stockExportUrl}&${stockQueryParams(this.filters)}`;
       },
     },
     methods: {

--- a/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
@@ -9,34 +9,16 @@ import {EventEmitter} from '@components/event-emitter';
 import {
   omitBy, isNil,
 } from 'lodash';
+import stockQueryParams from '@app/pages/stock/store/query-params';
 
 const isParamInvalid = (value: any) => isNil(value) || value.length <= 0;
 
 export const getStock = async ({commit}: {commit: Commit}, payload: Record<string, any>): Promise<void> => {
   const url = new URL(window.data.apiStockUrl, window.location.origin);
-  const queryParams = omitBy({
-    order: payload.order,
-    page_size: payload.page_size,
-    page_index: payload.page_index,
-    keywords: payload.keywords,
-    active: payload.active,
-    low_stock: payload.low_stock,
-  }, isParamInvalid);
 
-  Object.entries(queryParams).forEach(([key, value]) => {
-    url.searchParams.append(key, String(value));
+  stockQueryParams(payload).forEach((value, key) => {
+    url.searchParams.append(key, value);
   });
-
-  if (payload.suppliers) {
-    payload.suppliers.forEach((v: string) => {
-      url.searchParams.append('supplier_id[]', v);
-    });
-  }
-  if (payload.categories) {
-    payload.categories.forEach((v: string) => {
-      url.searchParams.append('category_id[]', v);
-    });
-  }
 
   try {
     const response = await fetch(url);

--- a/admin-dev/themes/new-theme/js/app/pages/stock/store/query-params.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/store/query-params.ts
@@ -1,0 +1,38 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+import {isNil, omitBy} from 'lodash';
+
+const isParamInvalid = (value: any) => isNil(value) || value.length <= 0;
+
+/**
+ * Turns the page's own filter object into the query string the stock API accepts.
+ *
+ * The two sets of names differ: the page keeps `suppliers` and `categories`, while
+ * QueryStockParamsCollection whitelists `supplier_id` and `category_id` and silently ignores anything
+ * else. Building that mapping in more than one place is how the CSV export came to send the page's
+ * names and export the whole catalogue, so both the listing and the export read it from here.
+ */
+export default function stockQueryParams(filters: Record<string, any>): URLSearchParams {
+  const params = new URLSearchParams();
+
+  const scalars = omitBy(
+    {
+      order: filters.order,
+      page_size: filters.page_size,
+      page_index: filters.page_index,
+      keywords: filters.keywords,
+      active: filters.active,
+      low_stock: filters.low_stock,
+    },
+    isParamInvalid,
+  );
+
+  Object.entries(scalars).forEach(([key, value]) => params.append(key, String(value)));
+
+  (filters.suppliers ?? []).forEach((id: string) => params.append('supplier_id[]', id));
+  (filters.categories ?? []).forEach((id: string) => params.append('category_id[]', id));
+
+  return params;
+}

--- a/admin-dev/themes/new-theme/tests/pages/stock/query-params.spec.js
+++ b/admin-dev/themes/new-theme/tests/pages/stock/query-params.spec.js
@@ -1,0 +1,55 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+import { expect } from 'chai';
+import stockQueryParams from '../../../js/app/pages/stock/store/query-params';
+
+describe('stockQueryParams', () => {
+  it('uses the names the stock API accepts for suppliers and categories', () => {
+    const params = stockQueryParams({ suppliers: [3, 7], categories: [12] });
+
+    expect(params.getAll('supplier_id[]')).to.deep.equal(['3', '7']);
+    expect(params.getAll('category_id[]')).to.deep.equal(['12']);
+    expect(params.has('suppliers')).to.equal(false);
+    expect(params.has('categories')).to.equal(false);
+  });
+
+  it('keeps the paging, ordering and search parameters', () => {
+    const params = stockQueryParams({
+      order: 'product',
+      page_size: 30,
+      page_index: 2,
+      keywords: 'mug',
+      active: '1',
+      low_stock: 1,
+    });
+
+    expect(params.get('order')).to.equal('product');
+    expect(params.get('page_size')).to.equal('30');
+    expect(params.get('page_index')).to.equal('2');
+    expect(params.get('keywords')).to.equal('mug');
+    expect(params.get('active')).to.equal('1');
+    expect(params.get('low_stock')).to.equal('1');
+  });
+
+  it('omits empty values instead of sending them', () => {
+    const params = stockQueryParams({
+      order: 'product',
+      keywords: '',
+      active: null,
+      suppliers: [],
+      categories: undefined,
+    });
+
+    expect(params.get('order')).to.equal('product');
+    expect(params.has('keywords')).to.equal(false);
+    expect(params.has('active')).to.equal(false);
+    expect(params.has('supplier_id[]')).to.equal(false);
+    expect(params.has('category_id[]')).to.equal(false);
+  });
+
+  it('returns nothing for an empty filter set', () => {
+    expect(stockQueryParams({}).toString()).to.equal('');
+  });
+});


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | The Stocks CSV export serialised the page's own filter object into the query string, sending `suppliers[]` and `categories[]` where the API accepts `supplier_id[]` and `category_id[]`, so it exported the whole catalogue whatever was filtered on screen.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #20412
| Related PRs                |
| Sponsor company            |

### The bug

`low-filter.vue` built the export link with `$.param({...this.filters})` — the page's own filter object,
whose keys are `suppliers` and `categories`. `store/actions.ts` translated those names before calling the
listing API, and the export never did. `QueryStockParamsCollection::getValidFilterParams()` whitelists
`supplier_id` and `category_id` and **silently drops** anything else, so the export produced no `WHERE`
clause at all.

Measured by feeding both query strings to the collection the export controller itself uses:

```
supplier_id[]=3&category_id[]=12
  where  : AND {supplier_id} IN (:supplier_id_0)
           AND EXISTS(SELECT 1 FROM {table_prefix}category_product cp
                      WHERE cp.id_product=p.id_product AND FIND_IN_SET(cp.id_category, :categories_ids))
  params : {"supplier_id_0":3,":categories_ids":"12"}

suppliers[]=3&categories[]=12          <- what the export sent
  where  : ""
  params : {}
```

That empty `WHERE` is the whole catalogue, which is exactly what @rflorent reported, and their diagnosis
of the difference between the two URLs was right.

### The fix

Both the listing and the export now build the query string with one helper,
`js/app/pages/stock/store/query-params.ts`, because keeping that mapping in two places is what let them
drift apart. `getStock()` loses its inline copy and the export computed property becomes one line.

**Builds on #32263 by @codeeshop-oc**, which fixed the same thing and was closed after an accidental merge
pulled 285 files into it; @kpodemski asked for it to be recreated and it never was. That version renamed
the keys inside the export component, which would have left a *third* copy of the mapping —
`getMovements()` has its own — so this centralises it instead.

### How to test

1. Catalog → Stocks, filter by a supplier or a category.
2. Click the export icon. The CSV now contains only the filtered rows; before it contained every product.

### Verification

- `admin-dev/themes/new-theme/tests/pages/stock/query-params.spec.js` — 4 cases pinning the names, the
  paging/ordering/search parameters, empty-value omission, and the empty filter set.
  **In fairness these cannot be red on `upstream/9.2.x`**: the helper they cover is new in this PR, and
  the repository has no `@vue/test-utils`, so the export component's computed property cannot be mounted
  without adding a dev dependency. The before/after evidence above is the server-side measurement instead.
- `npm run test` in `admin-dev/themes/new-theme` — **125 passing** (121 before).
- `npm run lint` — clean; `tsc --noEmit` reports nothing in project files (the remaining errors are all
  inside `node_modules` and present on the base branch).
- `admin-dev/themes/new-theme/public` is not tracked, so no built bundle is committed.
