### PR TITLE
Filter payment modules by every carrier a split cart uses

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -797,6 +797,32 @@ class HookCore extends ObjectModel
      *
      * @throws PrestaShopDatabaseException
      */
+    /**
+     * The references of the carriers a cart is actually being delivered by, read from its chosen
+     * delivery option because `id_carrier` only holds one and stays empty when the cart is split.
+     *
+     * @param Cart $cart
+     *
+     * @return int[] unique carrier references
+     */
+    protected static function getCartCarrierReferences(Cart $cart): array
+    {
+        $references = [];
+        foreach ($cart->getDeliveryOption(null, false, false) as $optionKey) {
+            foreach (explode(',', (string) $optionKey) as $carrierId) {
+                if ('' === trim($carrierId)) {
+                    continue;
+                }
+                $carrier = new Carrier((int) $carrierId);
+                if (Validate::isLoadedObject($carrier)) {
+                    $references[(int) $carrier->id_reference] = (int) $carrier->id_reference;
+                }
+            }
+        }
+
+        return array_values($references);
+    }
+
     public static function getHookModuleExecList($hookName = null)
     {
         $allHookRegistrations = self::getAllHookRegistrations(
@@ -1408,7 +1434,22 @@ class HookCore extends ObjectModel
             }
             if (Validate::isLoadedObject($context->cart)) {
                 $carrier = new Carrier($context->cart->id_carrier);
+                // A cart whose products share no carrier keeps id_carrier empty, because that column
+                // only mirrors a delivery option holding a single carrier. The restriction was then
+                // skipped altogether and every payment module was offered, including ones the merchant
+                // withheld from the carriers actually being used. Fall back to the carriers of the
+                // chosen delivery option, and require the module to be allowed by each of them, since
+                // one payment covers the whole cart.
+                $carrierReferences = [];
                 if (Validate::isLoadedObject($carrier)) {
+                    $carrierReferences[] = (int) $carrier->id_reference;
+                } else {
+                    foreach (Hook::getCartCarrierReferences($context->cart) as $carrierReference) {
+                        $carrierReferences[] = $carrierReference;
+                    }
+                }
+
+                foreach ($carrierReferences as $carrierReference) {
                     $sql->where(
                         '(
                             h.`name` IN ("displayPayment", "displayPaymentEU", "paymentOptions")
@@ -1419,14 +1460,14 @@ class HookCore extends ObjectModel
                             'module_carrier` mcar
                                 WHERE mcar.`id_module` = m.`id_module`
                                 AND `id_reference` = ' .
-                            (int) $carrier->id_reference .
+                            $carrierReference .
                             '
                                 AND `id_shop` = ' .
                             (int) $shop->id .
                             '
                                 LIMIT 1
                             ) = ' .
-                            (int) $carrier->id_reference .
+                            $carrierReference .
                             ')'
                     );
                 }

--- a/tests/Integration/Classes/Hook/CartCarrierReferencesTest.php
+++ b/tests/Integration/Classes/Hook/CartCarrierReferencesTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Hook;
+
+use Cart;
+use Hook;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Payment modules are filtered by the carrier the cart uses, read from `id_carrier`. That column only
+ * mirrors a delivery option holding a single carrier, so a cart split across carriers leaves it empty
+ * and the restriction was skipped entirely. The carriers are now read from the delivery option.
+ */
+class CartCarrierReferencesTest extends TestCase
+{
+    public function testTheReferencesOfASingleCarrierOptionAreReturned(): void
+    {
+        $this->assertSame([1], $this->referencesFor([1 => '1,']));
+    }
+
+    public function testEveryCarrierOfASplitCartIsReturned(): void
+    {
+        $this->assertSame([1, 2], $this->referencesFor([1 => '1,', 2 => '2,']));
+    }
+
+    public function testACarrierIsNotRepeatedWhenSeveralPackagesShareIt(): void
+    {
+        $this->assertSame([2], $this->referencesFor([1 => '2,', 2 => '2,']));
+    }
+
+    public function testAnOptionKeyHoldingSeveralCarriersIsSplit(): void
+    {
+        $this->assertSame([2, 3], $this->referencesFor([1 => '2,3,']));
+    }
+
+    public function testACarrierThatNoLongerExistsIsIgnored(): void
+    {
+        $this->assertSame([1], $this->referencesFor([1 => '1,999999,']));
+    }
+
+    public function testNoDeliveryOptionYieldsNoReference(): void
+    {
+        $this->assertSame([], $this->referencesFor([]));
+    }
+
+    /**
+     * @param array<int, string> $deliveryOption
+     *
+     * @return int[]
+     */
+    private function referencesFor(array $deliveryOption): array
+    {
+        $cart = $this->createMock(Cart::class);
+        $cart->method('getDeliveryOption')->willReturn($deliveryOption);
+
+        return TestableHook::references($cart);
+    }
+}
+
+class TestableHook extends Hook
+{
+    /**
+     * @return int[]
+     */
+    public static function references(Cart $cart): array
+    {
+        return self::getCartCarrierReferences($cart);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Payment modules restricted to particular carriers are filtered on `$context->cart->id_carrier`. That column only mirrors a delivery option holding a single carrier, so a cart whose products share no carrier leaves it empty, `new Carrier(0)` does not load, and the restriction was skipped altogether: every payment module was offered, including ones the merchant had withheld from both carriers in use. The carriers are now read from the chosen delivery option in that case, and the module has to be allowed by each of them.
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Create two products, each shippable by a different carrier, so the cart splits. Restrict a payment module away from one of those carriers (Payment > Preferences). Put both products in a cart and go to checkout: on 9.2.x the restricted module is offered, because the filter is skipped entirely. With this change it is not.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #20619
| Related PRs                |
| Sponsor company            |

### Why the restriction disappears exactly when it matters

`Hook::getHookModuleExecList()` does:

```php
$carrier = new Carrier($context->cart->id_carrier);
if (Validate::isLoadedObject($carrier)) {
    $sql->where(/* module_carrier restriction for that carrier */);
}
```

`Cart::setDeliveryOption()` writes `id_carrier` from `getIdCarrierFromDeliveryOption()`, which returns
a carrier only when the chosen option holds exactly one. A split cart therefore stores 0, the object
does not load, and the `where()` never runs. The result is not "a wrong carrier is used" but "no
carrier restriction is applied at all", on precisely the carts that have more than one.

### The question left open on the original pull request

@marionf asked there what should happen when the carriers disagree about a payment module. This takes
the intersection: a module has to be allowed by every carrier in the cart. One payment covers the whole
cart even when the order is split afterwards, so a module the second carrier forbids cannot be a valid
way to pay for its half. It is also strictly closer to the merchant's configuration than today, which
applies none of their restrictions.

### Cost

The single-carrier path is untouched, including its cost. The new branch runs only when `id_carrier`
does not load, and reads `getDeliveryOption(null, false, false)`, whose result the cart has already
computed by the time payment options are being listed.

### Tests

`tests/Integration/Classes/Hook/CartCarrierReferencesTest.php` covers six cases: one carrier, two
packages with different carriers, two packages sharing a carrier, one option key holding several
carriers, a carrier that no longer exists, and no delivery option at all. Returning only the first
carrier turns two of them red.
