### PR TITLE
Say which field is too long when a discount name is rejected on an order

### DIFF
--- a/src/Core/Domain/Order/Command/AddCartRuleToOrderCommand.php
+++ b/src/Core/Domain/Order/Command/AddCartRuleToOrderCommand.php
@@ -7,6 +7,8 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Order\Command;
 
 use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CartRuleNameTooLongException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Invoice\ValueObject\OrderInvoiceId;
 use PrestaShop\PrestaShop\Core\Domain\Order\OrderDiscountType;
@@ -113,6 +115,13 @@ class AddCartRuleToOrderCommand
     {
         if (!is_string($cartRuleName) || empty($cartRuleName)) {
             throw new OrderConstraintException('Cart rule name cannot be empty');
+        }
+
+        // Without this the name reaches CartRule::add(), which fails on the column length and is
+        // reported as "An error occurred during the CartRule creation", saying nothing about the name.
+        $length = mb_strlen($cartRuleName, 'UTF-8');
+        if ($length > DiscountSettings::MAX_NAME_LENGTH) {
+            throw new CartRuleNameTooLongException($length, DiscountSettings::MAX_NAME_LENGTH);
         }
     }
 

--- a/src/Core/Domain/Order/Exception/CartRuleNameTooLongException.php
+++ b/src/Core/Domain/Order/Exception/CartRuleNameTooLongException.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
+
+/**
+ * Thrown when the name given for a discount added to an order is longer than the column can hold.
+ * Carries both lengths so the message shown to the employee can name them.
+ */
+class CartRuleNameTooLongException extends OrderConstraintException
+{
+    /**
+     * @var int
+     */
+    private $givenLength;
+
+    /**
+     * @var int
+     */
+    private $maxLength;
+
+    public function __construct(int $givenLength, int $maxLength)
+    {
+        parent::__construct(
+            sprintf('Cart rule name is %d characters long, it must be at most %d.', $givenLength, $maxLength),
+            OrderConstraintException::INVALID_CART_RULE_NAME
+        );
+
+        $this->givenLength = $givenLength;
+        $this->maxLength = $maxLength;
+    }
+
+    public function getGivenLength(): int
+    {
+        return $this->givenLength;
+    }
+
+    public function getMaxLength(): int
+    {
+        return $this->maxLength;
+    }
+}

--- a/src/Core/Domain/Order/Exception/OrderConstraintException.php
+++ b/src/Core/Domain/Order/Exception/OrderConstraintException.php
@@ -25,4 +25,10 @@ class OrderConstraintException extends OrderException
      * Used in add payment from BO when the payment method is invalid.
      */
     public const INVALID_PAYMENT_METHOD = 3;
+
+    /**
+     * Code is used when the cart rule name given when adding a discount to an order is longer than
+     * the column can hold.
+     */
+    public const INVALID_CART_RULE_NAME = 4;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCo
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotEditDeliveredOrderProductException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotFindProductInOrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CartRuleNameTooLongException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderInvoiceException;
@@ -2287,6 +2288,12 @@ class OrderController extends PrestaShopAdminController
         if ($e instanceof DuplicateProductInOrderInvoiceException) {
             $orderInvoiceNumber = $e->getOrderInvoiceNumber();
         }
+        $cartRuleNameLength = 0;
+        $cartRuleNameMaxLength = 0;
+        if ($e instanceof CartRuleNameTooLongException) {
+            $cartRuleNameLength = $e->getGivenLength();
+            $cartRuleNameMaxLength = $e->getMaxLength();
+        }
 
         return [
             ProductSearchEmptyPhraseException::class => $this->trans(
@@ -2452,6 +2459,16 @@ class OrderController extends PrestaShopAdminController
             CannotFindProductInOrderException::class => $this->trans(
                 'You cannot edit the price of a product that no longer exists in your catalog.',
                 [],
+                'Admin.Notifications.Error'
+            ),
+            CartRuleNameTooLongException::class => $this->trans(
+                'The length of property %1$s is currently %2$d chars. It must be between %3$d and %4$d chars.',
+                [
+                    '%1$s' => 'name',
+                    '%2$d' => $cartRuleNameLength,
+                    '%3$d' => 1,
+                    '%4$d' => $cartRuleNameMaxLength,
+                ],
                 'Admin.Notifications.Error'
             ),
         ];

--- a/tests/Unit/Core/Domain/Order/Command/AddCartRuleToOrderCommandNameLengthTest.php
+++ b/tests/Unit/Core/Domain/Order/Command/AddCartRuleToOrderCommandNameLengthTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Order\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CartRuleNameTooLongException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Order\OrderDiscountType;
+
+/**
+ * A name longer than the column used to reach CartRule::add() and come back as "An error occurred
+ * during the CartRule creation", which says nothing about the name being the problem.
+ */
+class AddCartRuleToOrderCommandNameLengthTest extends TestCase
+{
+    public function testANameLongerThanTheColumnIsRejectedWithBothLengths(): void
+    {
+        $length = DiscountSettings::MAX_NAME_LENGTH + 1;
+
+        try {
+            $this->buildCommand(str_repeat('a', $length));
+            $this->fail('A name longer than the maximum should have been rejected');
+        } catch (CartRuleNameTooLongException $e) {
+            $this->assertSame($length, $e->getGivenLength());
+            $this->assertSame(DiscountSettings::MAX_NAME_LENGTH, $e->getMaxLength());
+            $this->assertSame(OrderConstraintException::INVALID_CART_RULE_NAME, $e->getCode());
+        }
+    }
+
+    public function testANameOfExactlyTheMaximumIsAccepted(): void
+    {
+        $name = str_repeat('a', DiscountSettings::MAX_NAME_LENGTH);
+
+        $command = $this->buildCommand($name);
+
+        $this->assertSame($name, $command->getCartRuleName());
+    }
+
+    /**
+     * The limit is on characters, not bytes, so a multibyte name of the allowed length must pass.
+     */
+    public function testAMultibyteNameOfTheMaximumLengthIsAccepted(): void
+    {
+        $name = str_repeat('é', DiscountSettings::MAX_NAME_LENGTH);
+
+        $command = $this->buildCommand($name);
+
+        $this->assertSame($name, $command->getCartRuleName());
+    }
+
+    public function testAnEmptyNameIsStillRejectedAsBefore(): void
+    {
+        $this->expectException(OrderConstraintException::class);
+
+        $this->buildCommand('');
+    }
+
+    private function buildCommand(string $name): AddCartRuleToOrderCommand
+    {
+        return new AddCartRuleToOrderCommand(1, $name, OrderDiscountType::DISCOUNT_AMOUNT, '10');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Adding a discount to an order with a name longer than the column produced `An error occurred during the CartRule creation`, which does not say that the name is the problem or how long it may be. The name is now checked where `AddCartRuleToOrderCommand` already checks that it is not empty, and the resulting exception is mapped to the message the object model itself uses for a field that is too long, so the employee is told the property, the length given and the bounds.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Open an order in the back office, add a discount, and give it a name longer than 255 characters. On 9.2.x the page reports `An error occurred during the CartRule creation`. With this change it reports `The length of property name is currently 256 chars. It must be between 1 and 255 chars.` A name of exactly 255 characters is still accepted, and an empty name still reports that it cannot be empty.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #20635
| Related PRs                |
| Sponsor company            |

### Where the unclear message came from

`AddCartRuleToOrderCommand` validated only that the name was not empty, so a longer one reached
`AddCartRuleToOrderHandler`, which builds a `CartRule` and does:

```php
try {
    if (!$cartRuleObj->add()) {
        throw new OrderException('An error occurred during the CartRule creation');
    }
} catch (PrestaShopException $e) {
    throw new OrderException('An error occurred during the CartRule creation', 0, $e);
}
```

The object model had already produced a precise message about the field length; the handler replaced
it with a generic one. Validating in the command keeps the handler as it is and stops the value before
it reaches the model at all.

### The wording

`Admin.Notifications.Error` already contains the string the object model uses,
`The length of property %1$s is currently %2$d chars. It must be between %3$d and %4$d chars.`, which
@Junebyun proposed on the issue. Reusing it means no new source string for translators, and the
employee gets the same phrasing for this field as for every other one that is too long.

Feeding it the real numbers needs the lengths at the point the message is built, so
`CartRuleNameTooLongException` carries them, in the same shape as
`InvalidCancelProductException::getRefundableQuantity()` and
`DuplicateProductInOrderInvoiceException::getOrderInvoiceNumber()`, which `getErrorMessages()` already
pulls out behind an `instanceof` guard before assembling the map.

### On the limit

The issue says 254 characters. The bound in code is `DiscountSettings::MAX_NAME_LENGTH`, which is 255
and is what `CartRule`'s `name` field declares as its size, so that is what the check and the message
use rather than a literal.

### Measured

`AddCartRuleToOrderCommandNameLengthTest` covers four cases: one character over the maximum is rejected
and carries both lengths and the constraint code, exactly the maximum is accepted, a multibyte name of
the maximum length is accepted because the limit is counted in characters rather than bytes, and an
empty name is still rejected as before. Reverting the check turns the first red and leaves the others
green.

`behat -s order --tags order-cart-rules` passes unchanged, 12 scenarios and 420 steps.
