### PR TITLE
Describe the product hooks by what they actually do

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -138,8 +138,8 @@
     </hook>
     <hook id="actionProductAdd">
       <name>actionProductAdd</name>
-      <title>Product creation</title>
-      <description>This hook is displayed after a product is created</description>
+      <title>Product duplication</title>
+      <description>This hook is called after a product is duplicated. Despite its name it is not called when a product is created: use actionObjectProductAddAfter for that</description>
     </hook>
     <hook id="actionProductUpdate">
       <name>actionProductUpdate</name>
@@ -5385,8 +5385,8 @@
     </hook>
     <hook id="actionAdminDuplicateAfter">
       <name>actionAdminDuplicateAfter</name>
-      <title/>
-      <description/>
+      <title>Product duplication</title>
+      <description>This hook is called after a product is duplicated, with the ids of the original and of the copy</description>
     </hook>
     <hook id="actionSearch">
       <name>actionSearch</name>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `actionProductAdd` is dispatched from one place, `ProductDuplicator`, so it fires when a product is duplicated and never when one is created. Its title said "Product creation" and its description "This hook is displayed after a product is created", which is exactly what sends developers to it and leaves them with a hook that never runs. `actionAdminDuplicateAfter`, dispatched two lines below for the same event, had an empty title and description. Both are now described by what they do, and the creation case points at `actionObjectProductAddAfter`.
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Design > Positions, search for `actionProductAdd`: it is listed as "Product creation" with a description that says it runs when a product is created. Register a module on it and create a product from the back office: nothing runs. With this change the hook is described as running on duplication, `actionAdminDuplicateAfter` is described rather than blank, and the description names `actionObjectProductAddAfter` for the creation case. The upgrade script updates existing shops.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #20764
| Related PRs                |
| Sponsor company            |

### What this does and does not do

@jolelievre's analysis on the issue ends with three items: update the documentation, update the hook
descriptions in the core, and deprecate `actionProductAdd` in favour of a new `actionProductDuplicate`
with an alias. This covers the second, and only that.

The third deserves a second look before anyone writes it, because of something the 2020 analysis does
not mention: **`actionAdminDuplicateAfter` already exists and is dispatched for the same event**, two
lines below, in the same method:

```php
$this->hookDispatcher->dispatchWithParameters(
    'actionProductAdd',
    ['id_product_old' => $oldProductId, 'id_product' => $newProductId, 'product' => $newProduct]
);

$this->hookDispatcher->dispatchWithParameters(
    'actionAdminDuplicateAfter',
    ['id_product' => $oldProductId, 'id_product_new' => $newProductId]
);
```

Adding `actionProductDuplicate` would make three names for one dispatch point. The reason nobody uses
the one that already says what it means is that it shipped with an empty title and description, which
is what this changes.

### The upgrade script

Hook titles and descriptions live in the `hook` table, seeded from `install-dev/data/xml/hook.xml` at
install, so the fixture change only reaches new shops. The autoupgrade branch updates existing ones,
conditionally on the rows still holding the shipped values, so a merchant or a module that changed them
keeps their own text. Verified against a 9.2 shop: both rows update, and a second run changes nothing.
