### PR TITLE
Honour a random sort order on the best sellers provider

### DIFF
--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -46,10 +46,13 @@ class ProductSaleCore
      * @param int $idLang Language id
      * @param int $pageNumber Start from (optional)
      * @param int $nbProducts Number of products to return (optional)
+     * @param string|null $orderBy Legacy order by field (optional)
+     * @param string|null $orderWay Legacy order way (optional)
+     * @param bool $random Return one page of randomly picked best sellers instead of an ordered one
      *
      * @return array|bool
      */
-    public static function getBestSales($idLang, $pageNumber = 0, $nbProducts = 10, $orderBy = null, $orderWay = null)
+    public static function getBestSales($idLang, $pageNumber = 0, $nbProducts = 10, $orderBy = null, $orderWay = null, $random = false)
     {
         $context = Context::getContext();
         if ($pageNumber < 1) {
@@ -121,7 +124,12 @@ class ProductSaleCore
             WHERE cp.`id_product` = p.`id_product`)';
         }
 
-        if ($finalOrderBy != 'price') {
+        if ($random) {
+            // Same shape as Category::getProducts() in random mode: one page of randomly picked products.
+            $sql .= '
+					ORDER BY RAND()
+					LIMIT ' . (int) $nbProducts;
+        } elseif ($finalOrderBy != 'price') {
             $sql .= '
 					ORDER BY ' . (!empty($orderTable) ? '`' . pSQL($orderTable) . '`.' : '') . '`' . pSQL($orderBy) . '` ' . pSQL($orderWay) . '
 					LIMIT ' . (int) (($pageNumber - 1) * $nbProducts) . ', ' . (int) $nbProducts;

--- a/src/Adapter/BestSales/BestSalesProductSearchProvider.php
+++ b/src/Adapter/BestSales/BestSalesProductSearchProvider.php
@@ -44,19 +44,20 @@ class BestSalesProductSearchProvider implements ProductSearchProviderInterface
         ProductSearchContext $context,
         ProductSearchQuery $query
     ) {
-        // If provided sort order is unsupported random, we set a fallback
-        if ($query->getSortOrder()->isRandom()) {
-            $query->setSortOrder((new SortOrder('product', 'sales', 'desc'))->setLabel(
-                $this->translator->trans('Sales, highest to lowest', [], 'Shop.Theme.Catalog')
-            ));
-        }
+        /*
+         * A random order is honoured rather than replaced by the default one, the way
+         * CategoryProductSearchProvider already does it: silently answering a different order than the
+         * caller asked for gave a caller no way to tell it had been ignored.
+         */
+        $random = $query->getSortOrder()->isRandom();
 
         if (!$products = ProductSale::getBestSales(
             $context->getIdLang(),
             $query->getPage(),
             $query->getResultsPerPage(),
-            $query->getSortOrder()->toLegacyOrderBy(),
-            $query->getSortOrder()->toLegacyOrderWay()
+            $random ? null : $query->getSortOrder()->toLegacyOrderBy(),
+            $random ? null : $query->getSortOrder()->toLegacyOrderWay(),
+            $random
         )) {
             $products = [];
         }

--- a/tests/Integration/Adapter/BestSales/BestSalesRandomSortTest.php
+++ b/tests/Integration/Adapter/BestSales/BestSalesRandomSortTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\BestSales;
+
+use Configuration;
+use Context;
+use Currency;
+use Customer;
+use Db;
+use PrestaShop\PrestaShop\Adapter\BestSales\BestSalesProductSearchProvider;
+use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
+use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
+use PrestaShop\PrestaShop\Core\Product\Search\SortOrder;
+use ProductSale;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The provider used to replace a random sort order with "sales, highest to lowest" and answer that
+ * instead, so a caller asking for a random selection of best sellers silently got the same list every
+ * time. CategoryProductSearchProvider has always honoured a random order.
+ */
+class BestSalesRandomSortTest extends KernelTestCase
+{
+    /** @var int[] */
+    private array $seeded = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        $context = Context::getContext();
+        $context->container = self::getContainer();
+        // ProductSearchContext reads currency and customer off the context; the CLI one has neither.
+        $context->currency = $context->currency ?? new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->customer = $context->customer ?? new Customer();
+
+        // Enough sellers that a random order is very unlikely to match the sales order by chance.
+        $products = Db::getInstance()->executeS(
+            'SELECT p.id_product FROM ' . _DB_PREFIX_ . 'product p
+             INNER JOIN ' . _DB_PREFIX_ . 'product_shop ps ON ps.id_product = p.id_product AND ps.id_shop = 1
+             WHERE ps.active = 1 AND ps.visibility != "none" LIMIT 12'
+        ) ?: [];
+
+        if (count($products) < 8) {
+            $this->markTestSkipped('Not enough active products to tell two orderings apart.');
+        }
+
+        $quantity = 100;
+        foreach ($products as $row) {
+            $id = (int) $row['id_product'];
+            if (ProductSale::getNbrSales($id) > 0) {
+                continue;
+            }
+            Db::getInstance()->insert('product_sale', [
+                'id_product' => $id,
+                'quantity' => $quantity--,
+                'sale_nbr' => 1,
+                'date_upd' => date('Y-m-d H:i:s'),
+            ]);
+            $this->seeded[] = $id;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->seeded as $id) {
+            Db::getInstance()->delete('product_sale', 'id_product = ' . $id);
+        }
+        $this->seeded = [];
+
+        parent::tearDown();
+    }
+
+    public function testARandomSortOrderIsNotReplacedBySalesOrder(): void
+    {
+        $salesOrder = $this->idsFor(new SortOrder('product', 'sales', 'desc'));
+        $this->assertGreaterThanOrEqual(8, count($salesOrder), 'the fixture must return enough products');
+
+        // A random order that never differs from the sales order over this many draws is not random.
+        $sawADifferentOrder = false;
+        for ($draw = 0; $draw < 12 && !$sawADifferentOrder; ++$draw) {
+            $sawADifferentOrder = $this->idsFor(SortOrder::random()) !== $salesOrder;
+        }
+
+        $this->assertTrue($sawADifferentOrder, 'a random sort order produced the sales order every time');
+    }
+
+    /**
+     * The non-random path is untouched: a field whose direction is not forced still reverses.
+     */
+    public function testAnExplicitSortOrderIsStillHonoured(): void
+    {
+        $ascending = $this->idsFor(new SortOrder('product', 'reference', 'asc'));
+        $descending = $this->idsFor(new SortOrder('product', 'reference', 'desc'));
+
+        $this->assertNotSame([], $ascending);
+        // The two directions pick different ends of the catalogue, so the pages differ.
+        $this->assertNotSame(
+            $ascending,
+            $descending,
+            'ascending and descending must not return the same page'
+        );
+    }
+
+    /**
+     * getBestSales() forces DESC when ordering by sales, random or not - pinned so the random branch
+     * cannot be blamed for it later.
+     */
+    public function testOrderingBySalesIsAlwaysDescending(): void
+    {
+        $this->assertSame(
+            $this->idsFor(new SortOrder('product', 'sales', 'desc')),
+            $this->idsFor(new SortOrder('product', 'sales', 'asc'))
+        );
+    }
+
+    /**
+     * @return int[]
+     */
+    private function idsFor(SortOrder $sortOrder): array
+    {
+        $provider = new BestSalesProductSearchProvider(self::getContainer()->get(TranslatorInterface::class));
+
+        $query = new ProductSearchQuery();
+        $query->setResultsPerPage(10)->setPage(1)->setSortOrder($sortOrder);
+
+        $result = $provider->runQuery(new ProductSearchContext(Context::getContext()), $query);
+
+        return array_map(
+            static fn (array $product): int => (int) $product['id_product'],
+            $result->getProducts()
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `BestSalesProductSearchProvider` replaced a random sort order with "sales, highest to lowest" and answered that instead, so a caller asking for a random selection of best sellers got the same list every time. It is now honoured, the way `CategoryProductSearchProvider` already does.
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #21600
| Related PRs                |
| Sponsor company            |

### The bug

The provider used to open with:

```php
// If provided sort order is unsupported random, we set a fallback
if ($query->getSortOrder()->isRandom()) {
    $query->setSortOrder((new SortOrder('product', 'sales', 'desc'))->setLabel(...));
}
```

The original report was broader — on 1.7.6.x **any** order was dropped when the `order` query parameter
was falsy — and that half is already fixed. What remains is the reporter's actual case: they asked for
`SortOrder::random()`, and still get the sales order, now by design rather than by accident.

"Unsupported" is not true of the abstraction, only of this one implementation.
`CategoryProductSearchProvider` (line 62) has always honoured a random order, routing to
`Category::getProducts()` in random mode, which orders by `RAND()` (`classes/Category.php:1068`). Two
providers behind the same `ProductSearchProviderInterface` answer a random query differently, and the one
that ignores it gives the caller no signal.

### The fix

`ProductSale::getBestSales()` takes an optional `$random` flag and, when set, orders by `RAND()` for a
single page — the same shape `Category::getProducts()` uses in random mode. The provider passes the flag
instead of rewriting the query.

- **BC.** A new optional sixth parameter; the only caller of `getBestSales()` in the tree is this
  provider. An explicit sort order takes exactly the path it did before, so `ps_bestsellers` — which asks
  for `sales/desc` — is unaffected.
- **The validator is left alone.** #24349 (closed unmerged 2021, author's account since deleted) made
  `Validate::isOrderWay()` accept `'random'` and interpolated `RAND()` into the `ORDER BY` through
  `pSQL()`. Passing an explicit flag keeps that validator to `ASC`/`DESC`, which is what the rest of the
  codebase relies on it for. Credited in the commit.

### How to test

```php
$provider = new BestSalesProductSearchProvider($translator);
$query = (new ProductSearchQuery())->setResultsPerPage(10)->setPage(1)->setSortOrder(SortOrder::random());
$result = $provider->runQuery(new ProductSearchContext($context), $query);
```

Repeat it: the product order changes. Before this it was the sales order every time.

### Verification

- `tests/Integration/Adapter/BestSales/BestSalesRandomSortTest.php` — 3 cases. Reverting both source
  files to `upstream/9.2.x` fails the random one with
  *"a random sort order produced the sales order every time"*. The random case seeds sales for a dozen
  products and draws up to twelve times, so it does not depend on a single draw differing.
  The other two are guards that pass on both sides: that a direction which is **not** forced still
  reverses the page (ordering by `reference`, since ordering by `sales` is forced to `DESC` inside
  `getBestSales()`), and — pinned separately so the random branch cannot be blamed for it later — that
  ordering by `sales` is descending whichever way is asked for.
- `tests/Integration/Adapter` — 171 tests OK.
- `php -l`, php-cs-fixer `Found 0 of 3`, PHPStan `[OK] No errors` on both sources and the test.
