### PR TITLE
Vary a module's Smarty cache id by device

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2415,6 +2415,10 @@ abstract class ModuleCore implements ModuleInterface
         if (isset($this->context->country)) {
             $cache_array[] = (int) $this->context->country->id;
         }
+        // A template is free to branch on Context::getDevice() or isMobile(), and the same shop is
+        // reached from phones, tablets and computers, so a cached block rendered for one of them must
+        // not be served to the others.
+        $cache_array[] = (int) $this->context->getDevice();
 
         return implode('|', $cache_array);
     }

--- a/tests/Integration/Classes/module/ModuleCacheIdDeviceTest.php
+++ b/tests/Integration/Classes/module/ModuleCacheIdDeviceTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\module;
+
+use Context;
+use Module;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A module template may branch on Context::getDevice() or isMobile(), and the same shop is reached
+ * from phones, tablets and computers. The Smarty cache id has to tell those apart, or the block
+ * rendered for the first visitor is served to all of them.
+ */
+class ModuleCacheIdDeviceTest extends TestCase
+{
+    public function testTheCacheIdDiffersBetweenDevices(): void
+    {
+        $computer = $this->cacheIdForDevice(Context::DEVICE_COMPUTER);
+        $mobile = $this->cacheIdForDevice(Context::DEVICE_MOBILE);
+        $tablet = $this->cacheIdForDevice(Context::DEVICE_TABLET);
+
+        $this->assertNotSame($computer, $mobile);
+        $this->assertNotSame($computer, $tablet);
+        $this->assertNotSame($mobile, $tablet);
+    }
+
+    public function testTheCacheIdIsStableForOneDevice(): void
+    {
+        $this->assertSame(
+            $this->cacheIdForDevice(Context::DEVICE_MOBILE),
+            $this->cacheIdForDevice(Context::DEVICE_MOBILE)
+        );
+    }
+
+    public function testTheCacheIdStillVariesByItsName(): void
+    {
+        $this->assertNotSame(
+            $this->cacheIdForDevice(Context::DEVICE_MOBILE, 'blockA'),
+            $this->cacheIdForDevice(Context::DEVICE_MOBILE, 'blockB')
+        );
+    }
+
+    private function cacheIdForDevice(int $device, ?string $name = null): string
+    {
+        $context = $this->createMock(Context::class);
+        $context->method('getDevice')->willReturn($device);
+
+        $module = new TestableCacheIdModule();
+        $module->name = 'testmodule';
+        $module->setContext($context);
+
+        return $module->cacheIdFor($name);
+    }
+}
+
+class TestableCacheIdModule extends Module
+{
+    public function __construct()
+    {
+        // The real constructor loads the module from the database, which this test has no use for.
+    }
+
+    public function setContext(Context $context): void
+    {
+        $this->context = $context;
+    }
+
+    public function cacheIdFor(?string $name): string
+    {
+        return $this->getCacheId($name);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | A module template may branch on `Context::getDevice()` or `isMobile()`, and the same shop is reached from phones, tablets and computers. `Module::getCacheId()` did not include the device, so with the Smarty cache enabled the block rendered for whichever visitor arrived first was served to all of them. The device is now part of the cache id.
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Put `{if Context::getContext()->isMobile()}mobile{else}desktop{/if}` in a module template, enable the Smarty cache in Advanced Parameters > Performance and clear it. On 9.2.x, whichever device loads the page first fixes the output for the other. With this change each device gets its own cached entry.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #21661
| Related PRs                |
| Sponsor company            |

### The change

`Module::getCacheId()` builds the key from the things a rendered block can depend on: secure mode, shop,
customer group, language, currency and country. The device was missing, and it is the one the report
branches on.

```php
$cache_array[] = (int) $this->context->getDevice();
```

### On the cost, since it is the fair objection

The other entries are each added only when that dimension can vary — `Shop::isFeatureActive()`,
`Language::isMultiLanguageActivated()`, and so on. There is no equivalent switch for the device:
`Context::getDevice()` always resolves to computer, tablet or mobile from the user agent, and any shop
can be reached from all three, so the analogous condition is always true.

The price is up to three cached entries per module block instead of one, on shops that enable the
Smarty cache. On a responsive theme that does not branch, those entries are identical, so the cost is
storage rather than correctness. On a theme that does branch, today's single entry is wrong for two
visitors out of three.

If you would rather pay that only where it is needed, the alternative is a configuration switch read
here the way the others are, which is the same line behind a condition.

### Tests

`tests/Integration/Classes/module/ModuleCacheIdDeviceTest.php` pins that the three devices produce three
different ids, that one device produces a stable id, and that the id still varies by the block name.
Removing the line turns the first red.

`phpunit -c tests/Integration/phpunit-isolated.xml --filter ModuleTest` passes unchanged, 10 tests.
