### PR TITLE
Truncate the customization field translations with their fields on import

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3822,6 +3822,7 @@ class AdminImportControllerCore extends AdminController
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'stock_mvt`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'customization`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'customization_field`');
+                Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'customization_field_lang`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_shop`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_combination`');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | "Delete all products before import" empties `customization` and `customization_field` but not `customization_field_lang`, so its rows survive pointing at field ids that no longer exist. The next import creates fields from the reset auto-increment, hits those rows on the primary key and fails. The missing table is now truncated with the other two.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Import products that carry customizations with "Delete all products" set to Yes, then repeat the same import. On 9.2.x the second run fails on duplicate customization field translations; with this change it succeeds. Checking `ps_customization_field_lang` after the first import shows the rows left behind.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #21682
| Related PRs                |
| Sponsor company            |

### Measured

Seeding one customization field with its translation and running the two truncates the Products branch
does today:

```
seeded field 2; field rows=2 lang rows=6
after the 9.2.x truncate pair: field rows=0 lang rows=6   <- orphans
```

The translations outlive their fields, and their `id_customization_field` values are exactly the ones
the next import will reuse.

### Completeness

The same shape could have been missing elsewhere in `truncateTables()`, so every branch was checked
against the schema rather than only the one in the report. Taking each `case` separately and looking
for a `_lang` companion that exists as a table but is not truncated:

| branch | tables truncated | missing `_lang` companion |
| --- | --- | --- |
| Categories | 0 | none |
| Products | 32 | **customization_field_lang** |
| Combinations | 11 | none |
| Customers | 1 | none |
| Addresses | 1 | none |
| Brands | 3 | none |
| Suppliers | 3 | none |
| Alias | 1 | none |

So this one line is the whole gap.

### On the absence of a test

`truncateTables()` has no existing coverage, and exercising its Products branch empties 32 tables
including `product`, `product_lang` and `stock_available`. A test that calls it has to dump and restore
those tables around itself; I wrote one against `DatabaseDump`, but `dumpTables()` dumps the whole
database and did not complete in my environment, and a test that leaves a catalogue truncated when it
fails is worse than no test. The evidence above is offered instead; the test can be added on top of a
narrower dump helper if that is preferred.
