### PR TITLE
Drop the name placeholders from the classic log alert email

### DIFF
--- a/mails/themes/classic/core/log_alert.html.twig
+++ b/mails/themes/classic/core/log_alert.html.twig
@@ -4,7 +4,7 @@
 <tr>
   <td align="center" class="titleblock">
     <font size="2" face="{{ languageDefaultFont }}Open-sans, sans-serif" color="#555454">
-      <span class="title">{{ 'Hi {firstname} {lastname},'|trans({}, 'Emails.Body', locale) }}</span>
+      <span class="title">{{ 'Hi,'|trans({}, 'Emails.Body', locale) }}</span>
     </font>
   </td>
 </tr>

--- a/tests/Unit/Classes/LogAlertMailTemplateTest.php
+++ b/tests/Unit/Classes/LogAlertMailTemplateTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * PrestaShopLogger::sendByMail() sends log_alert with an empty template variable list:
+ *
+ *     Mail::Send(
+ *         (int) Configuration::get('PS_LANG_DEFAULT'),
+ *         'log_alert',
+ *         ... ,
+ *         [],          // no variables
+ *         $to
+ *     );
+ *
+ * Nothing can substitute a placeholder in that template, so any {placeholder} it contains reaches the
+ * merchant's inbox verbatim. The modern theme was changed to a plain greeting when this was reported;
+ * the classic theme kept "Hi {firstname} {lastname}," and still showed it literally.
+ */
+class LogAlertMailTemplateTest extends TestCase
+{
+    /**
+     * @dataProvider getLogAlertTemplates
+     */
+    public function testTheTemplateUsesNoVariableTheSenderCannotProvide(string $templatePath): void
+    {
+        $contents = file_get_contents($templatePath);
+        self::assertIsString($contents, sprintf('%s could not be read', $templatePath));
+
+        preg_match_all('/\{[a-z][a-z0-9_]*\}/', $contents, $matches);
+
+        self::assertSame(
+            [],
+            array_values(array_unique($matches[0])),
+            sprintf(
+                '%s uses mail placeholders, but PrestaShopLogger::sendByMail() passes no variables, '
+                . 'so they are delivered literally.',
+                str_replace(_PS_ROOT_DIR_ . '/', '', $templatePath)
+            )
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getLogAlertTemplates(): iterable
+    {
+        foreach (glob(_PS_ROOT_DIR_ . '/mails/themes/*/core/log_alert.html.twig') ?: [] as $templatePath) {
+            $theme = basename(dirname($templatePath, 2));
+
+            yield $theme => [$templatePath];
+        }
+    }
+
+    /**
+     * Guards the provider itself: an empty glob would make every case above vacuously pass.
+     */
+    public function testEveryShippedThemeIsCovered(): void
+    {
+        $themes = array_keys(iterator_to_array(self::getLogAlertTemplates()));
+
+        self::assertContains('classic', $themes);
+        self::assertContains('modern', $themes);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | The log alert email greeted the merchant with the literal text "Hi {firstname} {lastname}," because the sender provides no template variables.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #22091
| Related PRs                |
| Sponsor company            |

### The bug

`PrestaShopLogger::sendByMail()` sends the template with an empty variable list:

```php
Mail::Send(
    (int) Configuration::get('PS_LANG_DEFAULT'),
    'log_alert',
    ... ,
    [],
    $to
);
```

Nothing can substitute a placeholder, so whatever the template contains is delivered verbatim. That last
step is not an assumption: substitution is `strtr($templateHtml, $templateVars)`
(`classes/Mail.php:586-604`), and PHP's array form of `strtr` replaces only the keys it is given, leaving
unknown tokens untouched. The only variables `Mail::Send` adds on its own are shop-level
(`{shop_logo}`, `{shop_name}`, `{shop_url}`, `{my_account_url}`, `{guest_tracking_url}`, `{history_url}`,
`{order_slip_url}`, `{color}` — `:544-563`), and nothing strips leftover braces afterwards:

```
strtr('Hi {firstname} {lastname}, shop {shop_name}', ['{shop_name}' => 'My Shop'])
=> Hi {firstname} {lastname}, shop My Shop
```

which is the text in the screenshots on the issue. The classic theme still contained the greeting:

```twig
{{ 'Hi {firstname} {lastname},'|trans({}, 'Emails.Body', locale) }}
```

@LouiseBonnard's decision on this issue was to use a plain `Hi,` for merchant-facing emails, and that was
applied to the **modern** theme, which already reads `{{ 'Hi,'|trans({}, 'Emails.Body', locale) }}`. The
classic theme was left behind, which is why @florine2623 still saw it on 8.1.x after the converter PR was
merged, and why @matks suspected the theme needed rebuilding.

### The fix

One line, making classic agree with modern. `'Hi,'` is an existing `Emails.Body` string already used by
four other templates, so no new translation is introduced.

### Scope: the other templates on the list were checked and are correct

The issue also lists `forward_msg`, `productoutofstock`, `reply_msg` and `test`. Each of those senders
**does** supply the variables, so their placeholders resolve and must stay:

| template | sender | supplies `{firstname}` |
|---|---|---|
| `log_alert` | `PrestaShopLogger::sendByMail()` | **no — passes `[]`** |
| `productoutofstock` | `StockManager` (per employee) | yes |
| `forward_msg` | `ForwardCustomerThreadHandler` | yes |
| `reply_msg` | `ReplyToCustomerThreadHandler` | yes |
| `test` | `MailPreviewVariablesBuilder:126-127` | yes |
| `contact_form` | `contactform` module | yes (empty string for guests) |

Comparing the two themes for every core template shows the divergence runs both ways —
`contact_form`, `productoutofstock` and `test` carry the placeholder in **modern** and not in classic —
but since those senders provide the variables, only `log_alert` is actually broken. Changing the others
would remove working personalisation.

One cosmetic leftover, deliberately not touched: `contact_form` initialises `{firstname}` to `''` and only
fills it for a logged-in customer, so a guest submission renders "Hi ,". That is a different defect from
the literal placeholder reported here.

### How to test

Advanced Parameters → Logs, set "Minimum severity level" to 1 and a recipient, then trigger a logged
action. Before: the email opens with the literal `Hi {firstname} {lastname},`. After: `Hi,`.

### Verification

- `tests/Unit/Classes/LogAlertMailTemplateTest.php` — asserts the `log_alert` template of **every** shipped
  theme contains no `{placeholder}` token, since the sender provides none, plus a guard that the data
  provider actually found both themes (an empty glob would make the cases vacuously pass).
- **Mutation check**: with the template reverted to `upstream/9.2.x`, the `classic` case fails —
  *"mails/themes/classic/core/log_alert.html.twig uses mail placeholders, but
  PrestaShopLogger::sendByMail() passes no variables, so they are delivered literally"* — while `modern`
  and the coverage guard still pass.
- `tests/Unit/` — 5435 tests. The single failure, `ModuleRepositoryTest::testGetList` (11 vs 12), is
  **pre-existing**: it reproduces identically with this branch not checked out, on a detached
  `upstream/9.2.x`. It is caused by a local symlinked fixture under `tests/Resources/modules`, unrelated to
  this change.
- `php -l`, `php-cs-fixer`, `phpstan analyse -c phpstan.neon.dist` clean.
