### PR TITLE
Read the declared field name for a pack item's combination

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7883,12 +7883,14 @@ class ProductCore extends ObjectModel
         Pack::deleteItems($this->id);
 
         foreach ($items as $item) {
-            // Combination of a product is optional, and can be omitted.
-            if (!isset($item['product_attribute_id'])) {
-                $item['product_attribute_id'] = 0;
-            }
+            // Combination of a product is optional, and can be omitted. The webservice declares this
+            // field as id_product_attribute, which is also the name getWsProductBundle returns, so a
+            // payload built from a GET response uses it. product_attribute_id was only ever read here,
+            // it is kept so that clients written against this method keep working.
+            $idProductAttribute = $item['id_product_attribute'] ?? $item['product_attribute_id'] ?? 0;
+
             if ((int) $item['id'] > 0) {
-                Pack::addItem($this->id, (int) $item['id'], (int) $item['quantity'], (int) $item['product_attribute_id']);
+                Pack::addItem($this->id, (int) $item['id'], (int) $item['quantity'], (int) $idProductAttribute);
             }
         }
 

--- a/tests/Integration/Classes/Product/WebserviceProductBundleTest.php
+++ b/tests/Integration/Classes/Product/WebserviceProductBundleTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Combination;
+use Db;
+use Pack;
+use PHPUnit\Framework\TestCase;
+use Product;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+/**
+ * The webservice declares the product_bundle association with the fields id, id_product_attribute and
+ * quantity, and getWsProductBundle() returns exactly those. A payload built from a GET response, or from
+ * the documented field list, therefore carries id_product_attribute, and setWsProductBundle() has to read
+ * the same name back.
+ *
+ * When it does not, Pack::addItem() receives 0 and substitutes the item's default combination, so every
+ * item of a pack collapses onto one row. ps_pack is keyed on
+ * (id_product_pack, id_product_item, id_product_attribute_item), which turns the second item into a
+ * duplicate entry error and the first into silently wrong data.
+ */
+class WebserviceProductBundleTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    private Product $pack;
+
+    /** @var int[] */
+    private array $combinationIds = [];
+
+    private int $itemProductId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        $this->pack = new Product(null, false, 1);
+        $this->pack->name = 'Bundle host';
+        $this->pack->price = 10.0;
+        $this->pack->link_rewrite = 'bundle-host-' . uniqid();
+        $this->pack->save();
+
+        $item = new Product(null, false, 1);
+        $item->name = 'Bundled item';
+        $item->price = 5.0;
+        $item->link_rewrite = 'bundled-item-' . uniqid();
+        $item->save();
+        $this->itemProductId = (int) $item->id;
+
+        // Three combinations, so the default one is not the only candidate.
+        foreach (range(1, 3) as $i) {
+            $combination = new Combination();
+            $combination->id_product = $this->itemProductId;
+            $combination->reference = 'bundle-combination-' . $i;
+            $combination->default_on = (1 === $i) ? true : null;
+            $combination->save();
+            $this->combinationIds[] = (int) $combination->id;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        Pack::deleteItems((int) $this->pack->id);
+        foreach ($this->combinationIds as $id) {
+            (new Combination($id))->delete();
+        }
+        (new Product($this->itemProductId))->delete();
+        $this->pack->delete();
+
+        parent::tearDown();
+    }
+
+    public function testEachRequestedCombinationIsStored(): void
+    {
+        $this->pack->setWsProductBundle($this->bundlePayload('id_product_attribute'));
+
+        self::assertSame($this->combinationIds, $this->storedCombinationIds());
+    }
+
+    /**
+     * getWsProductBundle() is what a client reads before writing back, so the two have to agree.
+     */
+    public function testTheFieldNamesMatchWhatTheGetterReturns(): void
+    {
+        $this->pack->setWsProductBundle($this->bundlePayload('id_product_attribute'));
+
+        $returned = $this->pack->getWsProductBundle();
+
+        self::assertCount(3, $returned);
+        self::assertSame(['id', 'id_product_attribute', 'quantity'], array_keys($returned[0]));
+    }
+
+    /**
+     * product_attribute_id was never part of the declared association, but it was the only name this
+     * method read, so anything written against it has to keep working.
+     */
+    public function testTheUndocumentedFieldNameIsStillAccepted(): void
+    {
+        $this->pack->setWsProductBundle($this->bundlePayload('product_attribute_id'));
+
+        self::assertSame($this->combinationIds, $this->storedCombinationIds());
+    }
+
+    /**
+     * The combination is optional, and an item sent without one still has to fall back to the default.
+     */
+    public function testAnItemWithoutACombinationFallsBackToTheDefault(): void
+    {
+        $this->pack->setWsProductBundle([
+            ['id' => $this->itemProductId, 'quantity' => 1],
+        ]);
+
+        self::assertSame([(int) Product::getDefaultAttribute($this->itemProductId)], $this->storedCombinationIds());
+    }
+
+    /**
+     * @return array<int, array<string, int>>
+     */
+    private function bundlePayload(string $combinationField): array
+    {
+        $items = [];
+        foreach ($this->combinationIds as $combinationId) {
+            $items[] = [
+                'id' => $this->itemProductId,
+                $combinationField => $combinationId,
+                'quantity' => 1,
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function storedCombinationIds(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_product_attribute_item FROM ' . _DB_PREFIX_ . 'pack WHERE id_product_pack = ' . (int) $this->pack->id
+        );
+        $ids = array_map(static fn (array $row): int => (int) $row['id_product_attribute_item'], $rows ?: []);
+        sort($ids);
+
+        return $ids;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Creating a pack through the webservice ignored every item's combination, stored the item's default combination instead, and failed with a duplicate entry error as soon as two items referred to the same product.
| Type?                      | bug fix
| Category?                  | WS
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #22561, Fixes #32954, Fixes #42117
| Related PRs                |
| Sponsor company            |

### The bug

The association is declared in `Product::$webserviceParameters`:

```php
'product_bundle' => [
    'resource' => 'product',
    'api' => 'products',
    'fields' => [
        'id' => ['required' => true],
        'id_product_attribute' => [],
        'quantity' => [],
    ],
],
```

`getWsProductBundle()` returns those same three names. `setWsProductBundle()` read a fourth one:

```php
if (!isset($item['product_attribute_id'])) {
    $item['product_attribute_id'] = 0;
}
```

`product_attribute_id` appears nowhere in the declared schema, so a payload written from the documented
field list — or simply round-tripped from a GET response — always took the `isset` branch and passed 0.

That the setter really receives the XML element names is not an inference from the schema:
`WebserviceRequest::__construct()` builds each association entry straight from the child node names and
hands it to the setter unmapped (`classes/webservice/WebserviceRequest.php:1650-1656`):

```php
foreach ($fields as $fieldName => $fieldValue) {
    $entry[$fieldName] = (string) $fieldValue;
}
$values[] = $entry;
...
$setter = $this->resourceConfiguration['associations'][$association->getName()]['setter'];
if (null !== $setter && $setter && method_exists($object, $setter) && !$object->$setter($values)) {
```

So `<id_product_attribute>` arrives as `$item['id_product_attribute']`. There is no allow-list on the way
in either — the "however, these are available" check at `:1067` guards the `display=` parameter on GET, not
POST payloads — which is why `product_attribute_id` also reaches the setter today and why the fallback
below is a real BC concern rather than a theoretical one.

`Pack::addItem()` then turns that 0 into the item's **default** combination:

```php
$id_attribute_item = (int) $id_attribute_item ? (int) $id_attribute_item : Product::getDefaultAttribute((int) $id_item);
```

and `ps_pack` is keyed on `(id_product_pack, id_product_item, id_product_attribute_item)`. So a pack
listing three combinations of one product collapses onto a single row: the first item is stored with the
wrong combination and the second collides. Reproduced on 9.2.x, sending combinations 10, 11 and 12 of a
product whose default is 9:

```
Duplicate entry '19-2-9' for key 'ps_pack.PRIMARY'
INSERT INTO `ps_pack` (`id_product_pack`, `id_product_item`, `id_product_attribute_item`, `quantity`)
VALUES ('19', '2', '9', '1')
```

which matches the error in the report. Note the error is incidental: a pack with a single mis-keyed item
stores the wrong combination and reports nothing at all.

### The fix

```php
$idProductAttribute = $item['id_product_attribute'] ?? $item['product_attribute_id'] ?? 0;
```

Read the declared name, and keep accepting the old one so anything written against this method's actual
behaviour keeps working. That is the same shape `Product::addCustomizationPrice()` already uses for the
identical pair of names:

```php
$product_attribute_id = isset($product_update['id_product_attribute'])
    ? (int) $product_update['id_product_attribute']
    : (int) $product_update['product_attribute_id'];
```

**Rejected alternative:** renaming only, dropping `product_attribute_id`. It is not in the schema, but it
was the one name this method ever honoured, so anything built against observed behaviour depends on it.
The fallback costs one `??` and removes the risk.

### How to test

POST a product to `/api/products` with a `product_bundle` association listing two combinations of the
same product, using the declared `id_product_attribute` field (the payload in the issue does this).

Before: HTTP 500, `Duplicate entry … for key 'ps_pack.PRIMARY'`, and the pack holds one item with the
wrong combination. After: both items are stored with the combinations that were sent.

### Verification

- `tests/Integration/Classes/Product/WebserviceProductBundleTest.php` — 4 tests: every requested
  combination is stored; the setter's field names match what the getter returns; the undocumented name is
  still accepted; an item sent without a combination still falls back to the default.
- **Mutation check**: with `classes/Product.php` reverted to `upstream/9.2.x`, the first two error with
  `Duplicate entry '37-38-64' for key 'ps_pack.PRIMARY'` — the reported failure — while the two that pin
  unchanged behaviour still pass.
- `tests/Integration/Classes/` — **187/187 pass**.
- `php -l`, `php-cs-fixer`, `phpstan analyse -c phpstan.neon.dist` clean on both files. PHPStan caught
  `Combination::$default_on` being `bool|null` in the fixture, fixed before committing.

Non-conflicting with my open #41839 and #41881, which also touch `classes/Product.php`: their hunks are at
lines ~5473 and ~4331, in `getProductProperties()` and `getAttributesColorList()`; this one is at ~7883 in
`setWsProductBundle()`.


