### PR TITLE
Let guest tracking reach every order of a split cart

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1557,25 +1557,49 @@ class OrderCore extends ObjectModel
     }
 
     /**
-     * The combination (reference, email) should be unique, of multiple entries are found, then we take the first one.
+     * A cart split over several carriers produces one order per package, all sharing the same reference,
+     * so (reference, email) is not unique. getUniqReference() tells those apart with a #N suffix, and
+     * passing that number back here selects the matching one. Without it the first order is returned.
      *
      * @param string $reference Order reference
      * @param string $email customer email address
+     * @param int|null $uniqueReferenceNumber The number behind the # in a unique reference, if any
      *
-     * @return Order The first order found
+     * @return Order The matching order, or the first one found
      */
-    public static function getByReferenceAndEmail($reference, $email)
+    public static function getByReferenceAndEmail($reference, $email, ?int $uniqueReferenceNumber = null)
     {
         $sql = '
-          SELECT id_order
+          SELECT o.`id_order`
             FROM `' . _DB_PREFIX_ . 'orders` o
             LEFT JOIN `' . _DB_PREFIX_ . 'customer` c ON (o.`id_customer` = c.`id_customer`)
                 WHERE o.`reference` = \'' . pSQL($reference) . '\' AND c.`email` = \'' . pSQL($email) . '\'
+                ORDER BY o.`id_order` ASC
         ';
 
-        $id = (int) Db::getInstance()->getValue($sql);
+        $rows = Db::getInstance()->executeS($sql);
+        if (empty($rows)) {
+            return new Order(0);
+        }
 
-        return new Order($id);
+        $orderIds = array_map('intval', array_column($rows, 'id_order'));
+
+        if (null === $uniqueReferenceNumber || $uniqueReferenceNumber < 1) {
+            return new Order($orderIds[0]);
+        }
+
+        // Ask getUniqReference() itself which order carries that number rather than recomputing its
+        // arithmetic here. It counts from the lowest id_order of the order's own cart, so the suffix is
+        // an offset and not a position, and a concurrent checkout in between makes the numbers skip.
+        $wantedReference = $reference . '#' . $uniqueReferenceNumber;
+        foreach ($orderIds as $orderId) {
+            $order = new Order($orderId);
+            if ($order->getUniqReference() === $wantedReference) {
+                return $order;
+            }
+        }
+
+        return new Order(0);
     }
 
     public function getTotalWeight()

--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -37,7 +37,13 @@ class GuestTrackingControllerCore extends FrontController
      */
     public function postProcess(): void
     {
-        $order_reference = current(explode('#', Tools::getValue('order_reference')));
+        // A split cart produces several orders sharing one reference, told apart in the emails by a
+        // #N suffix, so keep that number instead of dropping it with the rest of the string.
+        $reference_parts = explode('#', (string) Tools::getValue('order_reference'));
+        $order_reference = current($reference_parts);
+        $unique_reference_number = isset($reference_parts[1]) && ctype_digit(trim($reference_parts[1]))
+            ? (int) trim($reference_parts[1])
+            : null;
         $email = Tools::getValue('email');
 
         if (!$email && !$order_reference) {
@@ -52,7 +58,7 @@ class GuestTrackingControllerCore extends FrontController
             return;
         }
 
-        $this->order = Order::getByReferenceAndEmail($order_reference, $email);
+        $this->order = Order::getByReferenceAndEmail($order_reference, $email, $unique_reference_number);
         if (!Validate::isLoadedObject($this->order)) {
             $this->errors[] = $this->getTranslator()->trans(
                 'We couldn\'t find your order with the information provided, please try again',

--- a/tests/Integration/Classes/Order/GuestTrackingSplitOrderTest.php
+++ b/tests/Integration/Classes/Order/GuestTrackingSplitOrderTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Customer;
+use Db;
+use Order;
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\Utility\ContextMockerTrait;
+use Tools;
+
+/**
+ * A cart split over several carriers produces one order per package, all sharing a reference. The
+ * confirmation emails tell them apart with the #N suffix from Order::getUniqReference(), so whatever that
+ * method prints has to lead back to the same order on the guest tracking page.
+ *
+ * The suffix is not an ordinal: getUniqReference() computes id_order + 1 - MIN(id_order of the cart), so
+ * an unrelated order created in between leaves a gap and the numbers skip.
+ */
+class GuestTrackingSplitOrderTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    private string $reference;
+
+    private Customer $customer;
+
+    /** @var int[] */
+    private array $orderIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        // Unique per test: a stale row from another test must never join this test's set.
+        $this->reference = 'SPLIT' . strtoupper(substr(md5(uniqid('', true)), 0, 4));
+
+        $this->customer = new Customer();
+        $this->customer->firstname = 'Guest';
+        $this->customer->lastname = 'Tracking';
+        $this->customer->email = 'guest-tracking-' . uniqid() . '@example.com';
+        $this->customer->passwd = Tools::hash('guest-tracking-test');
+        $this->customer->add();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->orderIds) {
+            Db::getInstance()->execute(
+                'DELETE FROM ' . _DB_PREFIX_ . 'orders WHERE id_order IN (' . implode(',', $this->orderIds) . ')'
+            );
+        }
+        $this->orderIds = [];
+        $this->customer->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Every order of a split cart must be reachable, not just the first one.
+     */
+    public function testEachOrderOfASplitCartIsReachableByItsOwnReference(): void
+    {
+        $cartId = $this->nextCartId();
+        $orderIds = [
+            $this->createOrder($cartId),
+            $this->createOrder($cartId),
+            $this->createOrder($cartId),
+        ];
+
+        $reached = [];
+        foreach ($orderIds as $orderId) {
+            $reached[] = $this->resolve((new Order($orderId))->getUniqReference());
+        }
+
+        self::assertSame($orderIds, $reached, 'the guest tracking page did not reach every order of the cart');
+    }
+
+    /**
+     * The gap case. An unrelated order between two orders of the same cart makes getUniqReference() skip a
+     * number, so a lookup that counts rows instead of reversing the arithmetic lands on the wrong order.
+     */
+    public function testItFollowsTheSuffixEvenWhenTheOrderIdsAreNotContiguous(): void
+    {
+        $cartId = $this->nextCartId();
+        $first = $this->createOrder($cartId);
+        $this->createOrder($this->nextCartId());       // someone else checking out in between
+        $third = $this->createOrder($cartId);
+
+        $suffixedReference = (new Order($third))->getUniqReference();
+
+        self::assertSame(
+            $this->reference . '#' . ($third + 1 - $first),
+            $suffixedReference,
+            'the suffix should be an offset from the first order of the cart'
+        );
+        self::assertNotSame($this->reference . '#2', $suffixedReference, 'the ids should not be contiguous here');
+
+        self::assertSame($third, $this->resolve($suffixedReference));
+    }
+
+    /**
+     * A cart that produced a single order has no suffix, and that must keep working unchanged.
+     */
+    public function testAReferenceWithoutASuffixStillResolves(): void
+    {
+        $orderId = $this->createOrder($this->nextCartId());
+
+        self::assertSame($this->reference, (new Order($orderId))->getUniqReference());
+        self::assertSame($orderId, $this->resolve($this->reference));
+    }
+
+    /**
+     * A number nobody issued must not quietly return somebody's order.
+     */
+    public function testAnUnknownSuffixResolvesToNothing(): void
+    {
+        $cartId = $this->nextCartId();
+        $this->createOrder($cartId);
+        $this->createOrder($cartId);
+
+        self::assertSame(0, $this->resolve($this->reference . '#99'));
+    }
+
+    /**
+     * Resolves a reference the way GuestTrackingController does.
+     */
+    private function resolve(string $uniqueReference): int
+    {
+        $parts = explode('#', $uniqueReference);
+        $number = isset($parts[1]) && ctype_digit(trim($parts[1])) ? (int) trim($parts[1]) : null;
+
+        return (int) Order::getByReferenceAndEmail(current($parts), $this->customer->email, $number)->id;
+    }
+
+    /**
+     * No ps_cart rows are created here, so MAX(id_cart) alone would hand the same id to two tests in one
+     * run. Take the orders table into account as well, and step past the ids already used.
+     */
+    private function nextCartId(): int
+    {
+        $highestCart = (int) Db::getInstance()->getValue('SELECT MAX(id_cart) FROM ' . _DB_PREFIX_ . 'cart');
+        $highestUsed = (int) Db::getInstance()->getValue('SELECT MAX(id_cart) FROM ' . _DB_PREFIX_ . 'orders');
+
+        return 1 + max($highestCart, $highestUsed) + count($this->orderIds);
+    }
+
+    private function createOrder(int $cartId): int
+    {
+        Db::getInstance()->insert('orders', [
+            'reference' => $this->reference,
+            'id_shop_group' => 1,
+            'id_shop' => 1,
+            'id_carrier' => 1,
+            'id_lang' => 1,
+            'id_customer' => (int) $this->customer->id,
+            'id_cart' => $cartId,
+            'id_currency' => 1,
+            'id_address_delivery' => 1,
+            'id_address_invoice' => 1,
+            'current_state' => 1,
+            'secure_key' => md5('guest-tracking-test'),
+            'payment' => 'Test payment',
+            'conversion_rate' => 1,
+            'date_add' => date('Y-m-d H:i:s'),
+            'date_upd' => date('Y-m-d H:i:s'),
+            'delivery_date' => '0000-00-00 00:00:00',
+            'invoice_date' => '0000-00-00 00:00:00',
+        ]);
+
+        $orderId = (int) Db::getInstance()->Insert_ID();
+        $this->orderIds[] = $orderId;
+
+        return $orderId;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | When a cart is split across carriers, every resulting order shares one reference and the emails tell them apart with a #N suffix. Guest tracking discarded that suffix, so all of the orders resolved to the same one and the others were unreachable.
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #22836
| Related PRs                |
| Sponsor company            |

### The bug

`PaymentModule::validateOrder()` generates the reference **once**, before the package loop, and re-rolls
until it is unused, so every order produced by one cart shares it and a reference identifies a cart rather
than an order. `Order::getUniqReference()` is what makes them distinguishable, and it is what the
confirmation emails print.

Guest tracking threw that away on the first line of `postProcess()`:

```php
$order_reference = current(explode('#', Tools::getValue('order_reference')));
```

and the lookup then took whichever row came first:

```php
$id = (int) Db::getInstance()->getValue($sql);   // no ORDER BY, no way to pick
```

The docblock above it states the assumption that fails: *"The combination (reference, email) should be
unique, of multiple entries are found, then we take the first one."* For a split cart it is not unique.

A side effect worth noting, since it is not in the report: because the suffix is discarded entirely,
**`REFERENCE#99` currently opens a real order**. Any number is accepted and ignored.

### The subtlety that shapes the fix

The suffix is **not an ordinal**. `getUniqReference()` computes:

```php
return $this->reference . '#' . ($this->id + 1 - $order['min']);
```

an offset from the lowest order id **of that order's cart**. If another shopper checks out between two
packages of the same cart, the ids are not contiguous and the numbers skip — two orders can be `#1` and
`#3`. A lookup that selects "the Nth row" is therefore wrong exactly when concurrent checkouts happen.

Rather than reimplement that arithmetic, the lookup asks `getUniqReference()` itself which order carries
the number:

```php
$wantedReference = $reference . '#' . $uniqueReferenceNumber;
foreach ($orderIds as $orderId) {
    $order = new Order($orderId);
    if ($order->getUniqReference() === $wantedReference) {
        return $order;
    }
}
```

That matters because the two group by different columns: `getUniqReference()` takes `MIN(id_order)` over
`id_cart`, while a lookup can only start from the reference the customer typed. Those coincide only while
one reference belongs to one cart. In core they do — `validateOrder()` generates the reference once per
cart and re-rolls until unused — but `$order_reference` is a public parameter a module could pass to reuse
one. Auditing every caller in core and the bundled modules (`Order::addWs()`,
`OrderConfirmationController`, `AddOrderFromBackOfficeHandler`, ps_wirepayment, ps_checkpayment,
ps_cashondelivery), **none passes it**; delegating to the generator means the fix stays correct even if one
did.

`getByReferenceAndEmail()` gains an optional third argument, so the signature stays backward compatible;
its only caller in core is the guest tracking controller. A reference with no suffix returns the first
order exactly as before, and a number that matches nothing returns no order rather than someone else's.

### How to test

1. Two products whose carriers force the cart to split.
2. Order both as a guest. Two confirmation emails arrive, with references like `ABCDEFGHI#1` and
   `ABCDEFGHI#2`.
3. Open guest tracking and enter each reference in turn.

Before: both show the same order, and the second one is unreachable. After: each shows its own order.

### Verification

- `tests/Integration/Classes/Order/GuestTrackingSplitOrderTest.php` — 4 tests, built as a **round trip**:
  whatever `getUniqReference()` prints for an order must resolve back to that same order. One test forces
  the non-contiguous case by creating an unrelated order between two orders of the same cart, and asserts
  the suffix really is not `#2` before checking it still resolves.
- **Mutation check**: with both source files reverted to `upstream/9.2.x`, **3 of the 4 fail** — every
  order resolving to the first, `30 is identical to 32` on the gap case, and `34 is identical to 0` for
  the unknown suffix, which is the "any number is accepted" side effect above. The fourth, which pins the
  unchanged no-suffix behaviour, passes on both.
- `tests/Integration/Classes/` — **187/187**.

An anomaly worth recording: the first full-suite run after adding the test reported 1 error (2079
assertions instead of 2081). The likely cause was in the test rather than the fix — `nextCartId()` derived
ids from `MAX(id_cart)` while these fixtures never create `ps_cart` rows, so two tests in one run could
pick the same cart id, and the reference was a shared constant, letting a stale row join the wrong set.
Both are now per-test: a unique reference each, and the next id is taken from the orders table as well.
Six further full-suite runs are clean, and no fixture rows survive (`SPLIT%` orders and
`guest-tracking-%` customers both count 0).
