### PR TITLE
Store the payment method name in the order's language for BO orders

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -82,7 +82,7 @@ final class AddOrderFromBackOfficeHandler extends AbstractOrderCommandHandler im
                 (int) $cart->id,
                 $command->getOrderStateId(),
                 $cart->getOrderTotal(),
-                $paymentModule->displayName,
+                $this->getLocalizedPaymentMethodName($paymentModule),
                 '',
                 [],
                 null,
@@ -203,5 +203,32 @@ final class AddOrderFromBackOfficeHandler extends AbstractOrderCommandHandler im
         if ($isInvoiceCountryDisabled) {
             throw new OrderException(sprintf('Invoice country for cart with id "%d" is disabled.', $cart->id));
         }
+    }
+
+    /**
+     * A module translates its displayName once, in its constructor, using the language that was in the
+     * context at the time. Building the order form already asked Module::getInstanceByName() for the
+     * payment modules to fill its dropdown, which is correct for the dropdown but leaves the shared
+     * instance translated for the employee. The name given here is stored on the order and shown to the
+     * customer on the invoice and the confirmation email, so it has to be in the order's language.
+     *
+     * The cart context is applied by this point, so a throwaway instance of the same class picks it up.
+     * Module::getInstanceByName() would return the cached one, and the cache is left alone on purpose,
+     * since the rest of the request still expects the employee's language.
+     *
+     * @param PaymentModule $paymentModule
+     *
+     * @return string
+     */
+    private function getLocalizedPaymentMethodName(PaymentModule $paymentModule): string
+    {
+        $moduleClass = get_class($paymentModule);
+        $localizedModule = new $moduleClass();
+
+        if (empty($localizedModule->displayName)) {
+            return (string) $paymentModule->displayName;
+        }
+
+        return (string) $localizedModule->displayName;
     }
 }

--- a/tests/Integration/Adapter/Order/CommandHandler/LocalizedPaymentMethodNameTest.php
+++ b/tests/Integration/Adapter/Order/CommandHandler/LocalizedPaymentMethodNameTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Order\CommandHandler;
+
+use Context;
+use Language;
+use PaymentModule;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Order\CommandHandler\AddOrderFromBackOfficeHandler;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * A module translates its displayName once, in its constructor. Building the back office order form
+ * already asks Module::getInstanceByName() for the payment modules to fill its dropdown, so the shared
+ * instance the handler receives is translated for the employee.
+ *
+ * The name the handler passes to validateOrder() is stored on the order and shown to the customer on the
+ * invoice and the confirmation email, so it has to follow the order's language instead.
+ */
+class LocalizedPaymentMethodNameTest extends TestCase
+{
+    private ?Language $originalLanguage = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalLanguage = Context::getContext()->language;
+    }
+
+    protected function tearDown(): void
+    {
+        Context::getContext()->language = $this->originalLanguage;
+
+        parent::tearDown();
+    }
+
+    public function testItIgnoresTheNameTheModuleWasBuiltWith(): void
+    {
+        [$employeeLanguage, $orderLanguage] = $this->twoDistinctLanguages();
+
+        // The order form built the module while the employee's language was active.
+        Context::getContext()->language = $employeeLanguage;
+        $moduleAsTheFormBuiltIt = new LanguageStampedPaymentModule();
+        self::assertSame(
+            'name-in-' . $employeeLanguage->iso_code,
+            $moduleAsTheFormBuiltIt->displayName,
+            'the fixture should record the language it was constructed under'
+        );
+
+        // The handler switches the context to the cart's language before validating the order.
+        Context::getContext()->language = $orderLanguage;
+
+        self::assertSame(
+            'name-in-' . $orderLanguage->iso_code,
+            $this->resolveNameFor($moduleAsTheFormBuiltIt),
+            'the order kept the payment method name translated for the employee'
+        );
+    }
+
+    /**
+     * When nothing changed the context, the answer must stay the same rather than drift.
+     */
+    public function testItKeepsTheNameWhenTheLanguageDidNotChange(): void
+    {
+        [$employeeLanguage] = $this->twoDistinctLanguages();
+
+        Context::getContext()->language = $employeeLanguage;
+        $module = new LanguageStampedPaymentModule();
+
+        self::assertSame('name-in-' . $employeeLanguage->iso_code, $this->resolveNameFor($module));
+    }
+
+    /**
+     * A module that exposes no display name at all must not turn the order's payment method into an
+     * empty string.
+     */
+    public function testItFallsBackWhenTheFreshInstanceHasNoName(): void
+    {
+        // Whatever the form handed over already carries a name; a rebuilt instance of this class does not.
+        $moduleAsTheFormBuiltIt = new NamelessPaymentModule();
+        $moduleAsTheFormBuiltIt->displayName = 'Wire payment';
+
+        self::assertSame('Wire payment', $this->resolveNameFor($moduleAsTheFormBuiltIt));
+    }
+
+    private function resolveNameFor(PaymentModule $module): string
+    {
+        $handler = (new ReflectionClass(AddOrderFromBackOfficeHandler::class))->newInstanceWithoutConstructor();
+
+        $method = new ReflectionMethod(AddOrderFromBackOfficeHandler::class, 'getLocalizedPaymentMethodName');
+        $method->setAccessible(true);
+
+        return (string) $method->invoke($handler, $module);
+    }
+
+    /**
+     * The code under test only reads the language out of the context, so these do not have to be
+     * installed. Building them in memory keeps the test meaningful on a shop with a single language,
+     * which is what the integration bootstrap provides.
+     *
+     * @return array{Language, Language}
+     */
+    private function twoDistinctLanguages(): array
+    {
+        $employeeLanguage = new Language();
+        $employeeLanguage->id = 1;
+        $employeeLanguage->iso_code = 'en';
+
+        $orderLanguage = new Language();
+        $orderLanguage->id = 2;
+        $orderLanguage->iso_code = 'de';
+
+        self::assertNotSame($employeeLanguage->iso_code, $orderLanguage->iso_code);
+
+        return [$employeeLanguage, $orderLanguage];
+    }
+}
+
+/**
+ * Stands in for a real payment module: records the context language at construction time, exactly the way
+ * a module's constructor resolves its displayName through trans(). The parent constructor is skipped on
+ * purpose, so the fixture needs no module installed on disk.
+ */
+class LanguageStampedPaymentModule extends PaymentModule
+{
+    public function __construct()
+    {
+        $this->name = 'languagestampedpaymentmodule';
+        $this->displayName = 'name-in-' . Context::getContext()->language->iso_code;
+    }
+}
+
+class NamelessPaymentModule extends PaymentModule
+{
+    public function __construct()
+    {
+        $this->name = 'namelesspaymentmodule';
+        $this->displayName = '';
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | An order created from the back office for a customer in another language stored the payment method name translated for the employee, so the invoice and the confirmation email showed the wrong language.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #23737
| Related PRs                |
| Sponsor company            |

### The bug

A module resolves its display name once, in its constructor — `ps_wirepayment` does
`$this->displayName = $this->trans('Wire payment', [], 'Modules.Wirepayment.Admin');` — so the value is
fixed to whatever language the context held at construction time.

`AddOrderFromBackOfficeHandler` passed `$paymentModule->displayName` to `validateOrder()`, which stores it
on the order (`PaymentModule.php:1102`, `$order->payment = $payment_method`). Measured on 9.2.x:

```
displayName built under en : Bank transfer
displayName built under fr : Transfert bancaire
```

The front office is unaffected because a payment module's own controller calls `validateOrder()` from a
request whose context language is already the customer's
(`modules/ps_wirepayment/controllers/front/validation.php:63`). Only the back office differs.

### Why moving the existing line would not have fixed it

The obvious fix is to build the module after `setCartContext()`. Measured, that is not enough:
`Module::getInstanceByName()` caches in `static::$_INSTANCE`, and the back office order form has already
populated it. `CartSummaryType` fills its payment dropdown through
`InstalledPaymentModulesChoiceProvider::getChoices()`, which calls `Module::getInstanceByName()` (`:27`),
and the same form is rebuilt on submit before `CartSummaryFormDataHandler` dispatches the command. So by
the time the handler runs, the shared instance already exists in the employee's language:

```
choice provider warmed the cache under en : Bank transfer
context switched to fr, cached instance   : Bank transfer
getInstanceByName() called again          : Bank transfer   (same object: true)
built fresh under fr                      : Transfert bancaire
```

### The fix

Resolve the name from an instance constructed after the cart context is applied. `$_INSTANCE` is populated
by `coreLoadModule()`, not by the constructor, so building one directly leaves the shared cache alone —
verified: the cache still holds the original object, `getInstanceByName()` still returns it, and the entry
count is unchanged. That matters, because the dropdown the employee is looking at should stay in the
employee's language; only the value stored on the order should follow the customer.

Falls back to the original instance's name if a rebuilt one exposes none, so a module with an unusual
constructor cannot turn the order's payment method into an empty string.

### Deliberately not changed

- The **payment dropdown** in the order form stays in the employee's language. That is correct.
- The reporter also mentions `Manual order -- Employee:`. That is
  `addEmployeeCreationMessage()`, which runs after `restorePreviousContext()` and writes a **private**
  message shown in the back office Messages block, so the employee's language is the right one there.
- The order **status** name is a separate mechanism (per-language rows resolved at display time) and is
  not touched here.

### How to test

Orders → Add new order, pick a customer, and set the order's language to something other than the
employee's. Create the order, then look at the invoice and the confirmation email.

Before: the payment method appears in the employee's language. After: it appears in the order's language,
matching what a front office order for the same customer produces.

### Verification

- `tests/Integration/Adapter/Order/CommandHandler/LocalizedPaymentMethodNameTest.php` — 3 tests. The
  fixture module records the context language in its own `displayName` the way a real module's constructor
  does, so the assertions do not depend on any translation catalogue, and the languages are built in memory
  rather than installed (the integration bootstrap ships a single language, which would otherwise have made
  the test skip silently).
- **Mutation check, behavioural rather than a file revert**: replacing `new $moduleClass()` with the passed
  instance makes exactly the target test fail — *"the order kept the payment method name translated for the
  employee"* — while the two that pin unchanged behaviour and the empty-name fallback still pass.
- `tests/Integration/Adapter/Order/` — 9/9.
- `behat -s order --tags order-address` — **3 scenarios, 66 steps, all passing**. Those scenarios create
  orders through this exact handler, so the real caller is exercised, not just the method.
- `php -l`, `php-cs-fixer`, `phpstan analyse -c phpstan.neon.dist` clean on both files.
