### PR TITLE
Decide the webservice image cover against the global cover

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -1106,7 +1106,12 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                         $image->id_product = (int) $product->id;
                         $image->position = Image::getHighestPosition($product->id) + 1;
 
-                        if (!Image::getCover((int) $product->id)) {
+                        // The unique key this writes into, `id_product_cover` on the image table, is not
+                        // scoped to a shop, so the question "does a cover already exist" has to be asked
+                        // globally too. Image::getCover() reads image_shop for the current shop, and
+                        // answers no for a product whose cover belongs to another shop, which made this
+                        // insert collide with that cover.
+                        if (!Image::getGlobalCover((int) $product->id)) {
                             $image->cover = true;
                         } else {
                             $image->cover = false;

--- a/tests/Integration/Classes/Image/CoverScopeTest.php
+++ b/tests/Integration/Classes/Image/CoverScopeTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Image;
+
+use Db;
+use Image;
+use PrestaShopDatabaseException;
+use Product;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The `id_product_cover` unique key on the image table is not scoped to a shop, so anything deciding the
+ * value of that column has to ask the question globally. Image::getCover() answers it per shop, which is
+ * the mismatch behind #23777.
+ */
+class CoverScopeTest extends KernelTestCase
+{
+    private ?int $productId = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        global $kernel;
+        $kernel = self::$kernel;
+    }
+
+    protected function tearDown(): void
+    {
+        if (null !== $this->productId) {
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'image_shop WHERE id_product = ' . $this->productId);
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'image WHERE id_product = ' . $this->productId);
+            (new Product($this->productId))->delete();
+            $this->productId = null;
+        }
+        parent::tearDown();
+    }
+
+    private function makeProductWithCover(): Image
+    {
+        $product = new Product();
+        $product->name = ['1' => 'Cover scope product'];
+        $product->link_rewrite = ['1' => 'cover-scope-product'];
+        $product->price = 10.0;
+        $product->add();
+        $this->productId = (int) $product->id;
+
+        $cover = new Image();
+        $cover->id_product = $this->productId;
+        $cover->cover = true;
+        $cover->add();
+        $cover->associateTo([1]);
+
+        return $cover;
+    }
+
+    public function testGlobalCoverIsVisibleWhereTheShopScopedOneIsNot(): void
+    {
+        $this->makeProductWithCover();
+
+        self::assertNotEmpty(
+            Image::getGlobalCover($this->productId),
+            'The product carries a cover in the image table'
+        );
+
+        // A shop that has no image_shop row for this product. The cover still exists globally, so anything
+        // writing the global cover column must not conclude from this that it may claim it.
+        $unknownShopId = 1 + (int) Db::getInstance()->getValue('SELECT MAX(id_shop) FROM ' . _DB_PREFIX_ . 'shop');
+        self::assertEmpty(
+            Image::getCover($this->productId, $unknownShopId),
+            'Image::getCover() is scoped to a shop and reports no cover there'
+        );
+    }
+
+    public function testASecondGlobalCoverIsRejectedByTheDatabase(): void
+    {
+        $this->makeProductWithCover();
+
+        $second = new Image();
+        $second->id_product = $this->productId;
+        $second->cover = true;
+
+        $this->expectException(PrestaShopDatabaseException::class);
+        $second->add();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Adding an image to a product through the webservice decided whether to claim the cover with a shop-scoped lookup, while the unique key it writes into is not scoped to a shop. On a product whose cover belongs to another shop the insert claimed a cover that already existed and failed with a duplicate key.
| Type?                      | bug fix
| Category?                  | WS
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #23777
| Related PRs                |
| Sponsor company            |

### Why

`WebserviceSpecificManagementImages` decides the new image's cover like this:

```php
if (!Image::getCover((int) $product->id)) {
    $image->cover = true;
} else {
    $image->cover = false;
}
```

`Image::getCover()` reads `image_shop` filtered by the current shop:

```php
SELECT * FROM image_shop WHERE id_product = ? AND id_shop = ? AND cover = 1
```

The column it is deciding is `image.cover`, and the key guarding it is not scoped to a shop:

```sql
UNIQUE KEY `id_product_cover` (`id_product`, `cover`)
```

So for a product whose cover row belongs to another shop, the check answers "no cover" while one exists in
the table the key is on. The insert then claims the cover and fails, which is the error in the report:
`Duplicate entry '16-1' for key 'id_product_cover'` on
`INSERT INTO ps_image (id_product, position, cover) VALUES ('16', '6', '1')`.

`Image::getGlobalCover()` asks exactly the right question — same table, same column as the key — and has
no callers anywhere in the tree. This wires it up.

Non-cover images are stored with `cover = NULL` rather than `0` (`Image::add()`), and MySQL does not treat
NULLs as equal, so the key permits any number of non-cover images and exactly one cover per product. The
change only affects the case where the two lookups disagree; where they agree the outcome is identical.

### How to test

1. A product with at least one image, whose cover is registered for a shop other than the one the
   webservice request resolves to.
2. `POST /api/images/products/<id>` with a new image file.
3. Before: HTTP 400 with `Duplicate entry '<id>-1' for key 'id_product_cover'`. After: the image is added
   as a non-cover image.

```
php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/Image/CoverScopeTest.php
```

### On the test, honestly

`tests/Integration/Classes/Image/CoverScopeTest.php` pins the two facts the fix rests on: that a product's
cover is visible to `getGlobalCover()` while `getCover()` reports none for a shop without an `image_shop`
row, and that a second image claiming the cover is rejected by the database.

It does **not** execute the changed line. Reaching it needs a full webservice request with an uploaded
file, and I did not want to add a harness for that in this PR. If you would rather have that coverage
before merging, say so and I will build it.
