### PR TITLE
Clear a stale product update error once an update succeeds

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -187,6 +187,12 @@ function updateProduct(event, eventType, updateUrl) {
         }
       },
       success(data) {
+        // A previous update may have failed, typically on a dropped connection, and left its message on
+        // the page. Nothing removed it, so it stayed for the life of the page while every later update
+        // succeeded, and the guard in error() kept it from being refreshed. Clear it now that one has
+        // gone through.
+        $('section#main > .ajax-error').remove();
+
         // Avoid image to blink each time we modify the product quantity
         // Can not compare directly cause of HTML comments in data.
         const $newImagesContainer = $('<div>').append(


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | A failed product update on the product page leaves an error message that nothing ever removes, so it stays for the life of the page even after later updates succeed. It is now cleared when an update goes through.
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #23793
| Related PRs                |
| Sponsor company            |

### Why

Selecting a combination triggers an update request. When it fails, `themes/_core/js/product.js` appends
the message next to the add to cart button:

```js
error(jqXHR, textStatus) {
  if (textStatus !== 'abort' && $('section#main > .ajax-error').length === 0) {
    showErrorNextToAddtoCartButton();
  }
},
```

`ajax-error` appears three times in that file: twice as this "only if there is not one already" guard, and
once in the helper that appends it. **Nothing removes it.** So a request that fails once — the dropped
connection in the report — leaves the message on the page permanently. Every later selection succeeds and
updates the prices and images underneath it, while the error stays put and the guard keeps it from even
being refreshed. That is why the reporter sees it stuck after reconnecting.

### What it does

Removes the message at the start of the success handler, so the first update that goes through clears it.

### How to test

1. Product page with combinations.
2. Disable the network, select a combination, the error appears.
3. Re-enable the network, select another combination.
4. Before: the error stays, though prices and images update. After: it disappears.

### On coverage

There is no JavaScript test harness for `themes/_core` in this repository — `themes/package.json` has
`build`, `lint` and `watch` and no test script, and there are no spec files under `themes/`. So this
carries no automated test. `eslint -c .eslintrc.js _core/js/product.js` passes.
