### PR TITLE
Fix PDO options being reindexed by array_merge

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -50,7 +50,7 @@ class DbPDOCore extends Db
          * have one solution that fits all supported PHP versions.
          */
         if (PHP_VERSION_ID >= 80500) {
-            $options = array_merge($options, [
+            $options = array_replace($options, [
                 /* @phpstan-ignore-next-line */
                 Pdo\Mysql::ATTR_USE_BUFFERED_QUERY => true,
                 /* @phpstan-ignore-next-line */
@@ -59,7 +59,7 @@ class DbPDOCore extends Db
                 Pdo\Mysql::ATTR_MULTI_STATEMENTS => _PS_ALLOW_MULTI_STATEMENTS_QUERIES_,
             ]);
         } else {
-            $options = array_merge($options, [
+            $options = array_replace($options, [
                 PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
                 PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
                 PDO::MYSQL_ATTR_MULTI_STATEMENTS => _PS_ALLOW_MULTI_STATEMENTS_QUERIES_,

--- a/tests/Integration/Classes/db/DbPDOTest.php
+++ b/tests/Integration/Classes/db/DbPDOTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Db;
+
+use Db;
+use DbPDO;
+use PrestaShopException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DbPDOTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+    }
+
+    public function testInvalidQueryThrowsException(): void
+    {
+        $db = Db::getInstance();
+
+        $this->assertInstanceOf(DbPDO::class, $db);
+
+        $this->expectException(PrestaShopException::class);
+
+        $db->executeS('SELECT * FROM', true, false);
+    }
+}

--- a/tests/Integration/Classes/db/DbPDOTest.php
+++ b/tests/Integration/Classes/db/DbPDOTest.php
@@ -11,7 +11,9 @@ namespace Tests\Integration\Classes\Db;
 
 use Db;
 use DbPDO;
-use PrestaShopException;
+use PDO;
+use PDOException;
+use ReflectionProperty;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class DbPDOTest extends KernelTestCase
@@ -23,14 +25,53 @@ class DbPDOTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testInvalidQueryThrowsException(): void
+    public function testTheConnectionKeepsTheOptionsItWasBuiltWith(): void
     {
         $db = Db::getInstance();
-
         $this->assertInstanceOf(DbPDO::class, $db);
 
-        $this->expectException(PrestaShopException::class);
+        $link = new ReflectionProperty(DbPDO::class, 'link');
+        $pdo = $link->getValue($db);
 
-        $db->executeS('SELECT * FROM', true, false);
+        $this->assertSame(
+            PDO::ERRMODE_EXCEPTION,
+            $pdo->getAttribute(PDO::ATTR_ERRMODE),
+            'The connection options were reindexed, so PDO::ATTR_ERRMODE never reached PDO.'
+        );
+    }
+
+    /**
+     * MYSQL_ATTR_MULTI_STATEMENTS is applied when the connection is opened and cannot be read back
+     * with getAttribute(), so the only way to observe it is to send a chained statement and see
+     * whether the server accepts it.
+     */
+    public function testTheConnectionRefusesChainedStatementsWhenTheyAreNotAllowed(): void
+    {
+        if (!defined('_PS_ALLOW_MULTI_STATEMENTS_QUERIES_') || _PS_ALLOW_MULTI_STATEMENTS_QUERIES_) {
+            $this->markTestSkipped('This shop is configured to allow multi statement queries.');
+        }
+
+        $db = Db::getInstance();
+        $this->assertInstanceOf(DbPDO::class, $db);
+
+        $link = new ReflectionProperty(DbPDO::class, 'link');
+        $pdo = $link->getValue($db);
+
+        try {
+            $pdo->query('SELECT 1; SELECT 2');
+        } catch (PDOException $e) {
+            $this->assertStringContainsString(
+                'syntax',
+                strtolower($e->getMessage()),
+                'The chained statement was refused, but not by the SQL parser.'
+            );
+
+            return;
+        }
+
+        $this->fail(
+            'The connection accepted "SELECT 1; SELECT 2" while _PS_ALLOW_MULTI_STATEMENTS_QUERIES_ is false, '
+            . 'so MYSQL_ATTR_MULTI_STATEMENTS never reached PDO.'
+        );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | ⚠️ This PR is blocked by #42923 and must be merged after it or together with it.<br/><br/>This PR fixes PDO options being unintentionally reindexed when creating the database connection.<br>`array_merge()` reindexes numeric array keys, while PDO options use integer constants as keys. This could result in incorrect PDO attributes being set, including `PDO::ATTR_ERRMODE` being set to silent mode.<br>The fix replaces `array_merge()` with `array_replace()` so the original PDO option keys are preserved.<br>A regression test has also been added to ensure that invalid SQL queries correctly throw a `PrestaShopException`.<br/>The regression was introduced by #39211 while adapting PDO constants for PHP 8.5.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Download and place the test script [[_test_issue_42569.php](https://github.com/user-attachments/files/31821106/_test_issue_42569.php)](https://github.com/user-attachments/files/31821106/_test_issue_42569.php) in the PrestaShop root directory.<br>Run it before applying this PR: the output should show `No exception thrown`, while `DB error number` is `1146` and `DB error message` reports that the test table does not exist. This confirms that the SQL error occurred but was not propagated as an exception.<br>Apply this PR and run the same script again.<br>The output should now show `EXCEPTION THROWN`, followed by `PrestaShopException` and the `SQLSTATE[42S02]` error. This confirms that the SQL error is correctly propagated as an exception after the fix.
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/33842270246
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/42569
| Related PRs       | #39211 <br/>locked by #42923
| Sponsor company   | Codencode snc


cc @Progi1984