### PR TITLE
Check a pack against what its contents allow when editing an order

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -22,6 +22,7 @@ use Order;
 use OrderCarrier;
 use OrderDetail;
 use OrderInvoice;
+use Pack;
 use PrestaShop\PrestaShop\Adapter\Cart\Comparator\CartProductsComparator;
 use PrestaShop\PrestaShop\Adapter\Cart\Comparator\CartProductUpdate;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
@@ -573,10 +574,10 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         // check if product is available in stock
         if (!Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($command->getProductId()->getValue()))) {
             $combinationId = null !== $command->getCombinationId() ? $command->getCombinationId()->getValue() : 0;
-            $availableQuantity = StockAvailable::getQuantityAvailableByProduct(
-                $command->getProductId()->getValue(),
-                $combinationId,
-                $shopId
+            $availableQuantity = $this->getAvailableQuantity(
+                (int) $command->getProductId()->getValue(),
+                (int) $combinationId,
+                (int) $shopId
             );
 
             if ($availableQuantity < $command->getProductQuantity()) {
@@ -621,5 +622,25 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $invoiceNumber = $orderInvoice->getInvoiceNumberFormatted((int) Configuration::get('PS_LANG_DEFAULT'), $order->id_shop);
             throw new DuplicateProductInOrderInvoiceException($invoiceNumber, 'You cannot add this product in this invoice as it is already present');
         }
+    }
+
+    /**
+     * A pack that decrements the products it contains is not limited by its own stock row but by what its
+     * contents allow, and Pack::getQuantity() is what knows the difference. Reading the pack's own row let
+     * an order be raised past what the pack could actually be assembled from.
+     *
+     * @param int $productId
+     * @param int $combinationId
+     * @param int $shopId
+     *
+     * @return int
+     */
+    private function getAvailableQuantity(int $productId, int $combinationId, int $shopId): int
+    {
+        if (Pack::isPack($productId)) {
+            return (int) Pack::getQuantity($productId, $combinationId);
+        }
+
+        return (int) StockAvailable::getQuantityAvailableByProduct($productId, $combinationId, $shopId);
     }
 }

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -14,6 +14,7 @@ use Hook;
 use Order;
 use OrderDetail;
 use OrderInvoice;
+use Pack;
 use PrestaShop\PrestaShop\Adapter\Configuration as AdapterConfiguration;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Order\OrderDetailUpdater;
@@ -173,10 +174,10 @@ final class UpdateProductInOrderHandler extends AbstractOrderCommandHandler impl
 
         // check if product is available in stock
         if (!Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($orderDetail->product_id))) {
-            $availableQuantity = StockAvailable::getQuantityAvailableByProduct(
-                $orderDetail->product_id,
-                $orderDetail->product_attribute_id,
-                $orderDetail->id_shop
+            $availableQuantity = $this->getAvailableQuantity(
+                (int) $orderDetail->product_id,
+                (int) $orderDetail->product_attribute_id,
+                (int) $orderDetail->id_shop
             );
             $quantityDiff = $command->getQuantity() - (int) $orderDetail->product_quantity;
 
@@ -229,5 +230,25 @@ final class UpdateProductInOrderHandler extends AbstractOrderCommandHandler impl
             $invoiceNumber = $orderInvoice->getInvoiceNumberFormatted((int) Configuration::get('PS_LANG_DEFAULT'), $order->id_shop);
             throw new DuplicateProductInOrderInvoiceException($invoiceNumber, 'You cannot add this product in this invoice as it is already present');
         }
+    }
+
+    /**
+     * A pack that decrements the products it contains is not limited by its own stock row but by what its
+     * contents allow, and Pack::getQuantity() is what knows the difference. Reading the pack's own row let
+     * an order be raised past what the pack could actually be assembled from.
+     *
+     * @param int $productId
+     * @param int $combinationId
+     * @param int $shopId
+     *
+     * @return int
+     */
+    private function getAvailableQuantity(int $productId, int $combinationId, int $shopId): int
+    {
+        if (Pack::isPack($productId)) {
+            return (int) Pack::getQuantity($productId, $combinationId);
+        }
+
+        return (int) StockAvailable::getQuantityAvailableByProduct($productId, $combinationId, $shopId);
     }
 }

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -18,6 +18,7 @@ use LogicException;
 use Order;
 use OrderDetail;
 use OrderInvoice;
+use Pack;
 use PrestaShop\PrestaShop\Adapter\Cart\Comparator\CartProductsComparator;
 use PrestaShop\PrestaShop\Adapter\Cart\Comparator\CartProductUpdate;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
@@ -422,10 +423,10 @@ class OrderProductQuantityUpdater
     {
         // check if product is available in stock
         if (!Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($orderDetail->product_id))) {
-            $availableQuantity = StockAvailable::getQuantityAvailableByProduct(
-                $orderDetail->product_id,
-                $orderDetail->product_attribute_id,
-                $orderDetail->id_shop
+            $availableQuantity = $this->getAvailableQuantity(
+                (int) $orderDetail->product_id,
+                (int) $orderDetail->product_attribute_id,
+                (int) $orderDetail->id_shop
             );
             $quantityDiff = $newQuantity - (int) $orderDetail->product_quantity;
 
@@ -433,5 +434,25 @@ class OrderProductQuantityUpdater
                 throw new ProductOutOfStockException('Not enough products in stock');
             }
         }
+    }
+
+    /**
+     * A pack that decrements the products it contains is not limited by its own stock row but by what its
+     * contents allow, and Pack::getQuantity() is what knows the difference. Reading the pack's own row let
+     * an order be raised past what the pack could actually be assembled from.
+     *
+     * @param int $productId
+     * @param int $combinationId
+     * @param int $shopId
+     *
+     * @return int
+     */
+    private function getAvailableQuantity(int $productId, int $combinationId, int $shopId): int
+    {
+        if (Pack::isPack($productId)) {
+            return (int) Pack::getQuantity($productId, $combinationId);
+        }
+
+        return (int) StockAvailable::getQuantityAvailableByProduct($productId, $combinationId, $shopId);
     }
 }

--- a/tests/Integration/Classes/Pack/PackAvailableQuantityTest.php
+++ b/tests/Integration/Classes/Pack/PackAvailableQuantityTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Pack;
+
+use Pack;
+use Product;
+use StockAvailable;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A pack that decrements the products it contains can only be assembled as many times as its contents
+ * allow, which is not what its own stock row says. Anything checking whether a pack can be ordered has to
+ * ask Pack::getQuantity(), not the row. See #24531.
+ */
+class PackAvailableQuantityTest extends KernelTestCase
+{
+    /** @var int[] */
+    private array $createdProductIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        global $kernel;
+        $kernel = self::$kernel;
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdProductIds as $id) {
+            (new Product($id))->delete();
+        }
+        $this->createdProductIds = [];
+        parent::tearDown();
+    }
+
+    private function makeProduct(string $name, int $quantity): int
+    {
+        $product = new Product();
+        $product->name = ['1' => $name];
+        $product->link_rewrite = ['1' => strtolower(str_replace(' ', '-', $name))];
+        $product->price = 10.0;
+        $product->add();
+        $this->createdProductIds[] = (int) $product->id;
+        StockAvailable::setQuantity((int) $product->id, 0, $quantity);
+
+        return (int) $product->id;
+    }
+
+    public function testAPackDecrementingItsContentsIsLimitedByThemNotByItsOwnStockRow(): void
+    {
+        $itemA = $this->makeProduct('Pack item A ' . uniqid(), 10);
+        $itemB = $this->makeProduct('Pack item B ' . uniqid(), 10);
+
+        $pack = new Product();
+        $pack->name = ['1' => 'Pack of two ' . uniqid()];
+        $pack->link_rewrite = ['1' => 'pack-of-two-' . uniqid()];
+        $pack->price = 30.0;
+        $pack->cache_is_pack = true;
+        $pack->pack_stock_type = Pack::STOCK_TYPE_PRODUCTS_ONLY;
+        $pack->add();
+        $packId = (int) $pack->id;
+        $this->createdProductIds[] = $packId;
+
+        Pack::addItem($packId, $itemA, 2);
+        Pack::addItem($packId, $itemB, 2);
+        // The pack's own row claims plenty, which is exactly the number the order checks used to read.
+        StockAvailable::setQuantity($packId, 0, 10);
+
+        // isPack() memoises per request and the product was created before it had any contents.
+        Pack::resetStaticCache();
+
+        self::assertSame(
+            10,
+            (int) StockAvailable::getQuantityAvailableByProduct($packId, 0),
+            'the pack stock row is unaware of what the pack contains'
+        );
+
+        // Two of each item, ten of each in stock, so the pack can be assembled five times.
+        self::assertSame(
+            5,
+            (int) Pack::getQuantity($packId),
+            'Pack::getQuantity() is limited by the contents'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | A pack that decrements the products it contains could be added to an order, or have its quantity raised, beyond what those products allow, because the stock checks in the order editing path read the pack's own stock row instead of asking what the pack can be assembled from.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #24531
| Related PRs                |
| Sponsor company            |

### Why

Three places in the order editing path ask the same question and all read the same wrong number:

- `AddProductToOrderHandler::checkProductInStock()`
- `UpdateProductInOrderHandler`
- `OrderProductQuantityUpdater::assertValidProductQuantity()`

each calling `StockAvailable::getQuantityAvailableByProduct()`. For a pack whose stock type decrements the
products it contains, that row is not the constraint: the pack can only be assembled as many times as its
contents allow. With ten of each of two items and two of each per pack, the row can say ten while only
five packs exist, which is the report.

`Pack::getQuantity()` is the accessor that knows this — it reads `pack_stock_type` and derives the number
from the contents. `Product::getQuantity()` already delegates to it for packs, but it does not take a shop
id, and these three checks pass one explicitly, so the change keeps the existing lookup for ordinary
products and only routes packs to `Pack::getQuantity()`.

### How to test

1. Two products with 10 in stock each.
2. A pack containing 2 of each, its own quantity set to 10, pack quantities set to "decrement products in
   the pack" or "decrement both".
3. Order the pack, then edit the order and raise the quantity above 5.
4. Before: accepted. After: rejected as out of stock.

```
php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/Pack/PackAvailableQuantityTest.php
```

### On the test

`PackAvailableQuantityTest` builds that exact pack and asserts the two numbers the fix chooses between:
the pack's own row reports **10** while `Pack::getQuantity()` reports **5**. That is the divergence the bug
rests on.

It does not drive the three order handlers themselves — there is no behat step for editing an order
product's quantity, nor one for building a pack, so covering it end to end means adding both. Worth saying
rather than implying the handlers are exercised.