### PR TITLE
Fall back to the last populated page when a grid offset is out of range

### DIFF
--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -14,8 +14,11 @@ use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Query\QueryParserInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteria;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+use PrestaShop\PrestaShop\Core\Search\Pagination;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
@@ -62,8 +65,20 @@ class DoctrineGridDataFactory implements GridDataFactoryInterface
             'search_criteria' => $searchCriteria,
         ]);
 
-        $records = $searchQueryBuilder->executeQuery()->fetchAllAssociative();
         $recordsTotal = (int) $countQueryBuilder->executeQuery()->fetchOne();
+
+        // The offset lives in the URL and in the employee's saved filters, so removing the last rows of
+        // the page being viewed leaves it pointing past the end of the result set. Running the search with
+        // it returns nothing and the grid says there is no record at all, while the earlier pages still
+        // hold some. Fall back to the last page that does, and rebuild the data from there.
+        if (Pagination::isOffsetOutOfRange($recordsTotal, (int) $searchCriteria->getOffset())) {
+            return $this->getData($this->withOffset(
+                $searchCriteria,
+                Pagination::computeValidOffset($recordsTotal, (int) $searchCriteria->getLimit())
+            ));
+        }
+
+        $records = $searchQueryBuilder->executeQuery()->fetchAllAssociative();
 
         if ($this->extraPropertiesGridQueryBuilderModifier) {
             $records = $this->extraPropertiesGridQueryBuilderModifier->castExtraProperties($records, $this->gridId);
@@ -98,5 +113,29 @@ class DoctrineGridDataFactory implements GridDataFactoryInterface
         $sqlFormatter = new SqlFormatter(new NullHighlighter());
 
         return $sqlFormatter->format($query);
+    }
+
+    /**
+     * Returns the same search criteria carrying a different offset.
+     *
+     * Filters keep extra state the grid relies on, so those are cloned rather than rebuilt; anything else
+     * only exposes the SearchCriteriaInterface getters, which is all a plain SearchCriteria needs.
+     */
+    private function withOffset(SearchCriteriaInterface $searchCriteria, int $offset): SearchCriteriaInterface
+    {
+        if ($searchCriteria instanceof Filters) {
+            $newSearchCriteria = clone $searchCriteria;
+            $newSearchCriteria->add(['offset' => $offset]);
+
+            return $newSearchCriteria;
+        }
+
+        return new SearchCriteria(
+            $searchCriteria->getFilters(),
+            $searchCriteria->getOrderBy(),
+            $searchCriteria->getOrderWay(),
+            $offset,
+            $searchCriteria->getLimit()
+        );
     }
 }

--- a/src/Core/Search/Pagination.php
+++ b/src/Core/Search/Pagination.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search;
+
+/**
+ * Resolves paginated offsets that no longer point at any record.
+ *
+ * A grid keeps its offset in the URL and in the employee's saved filters, so deleting the last rows of
+ * the page being viewed leaves an offset past the end of the result set. The query then returns nothing
+ * and the grid reports that there is no record at all, while the earlier pages still hold some.
+ */
+final class Pagination
+{
+    /**
+     * Whether the offset points past the last record.
+     */
+    public static function isOffsetOutOfRange(int $recordsTotal, int $offset): bool
+    {
+        return $offset > 0 && $offset >= $recordsTotal;
+    }
+
+    /**
+     * Offset of the last page that still holds records, or 0 when there are none left.
+     *
+     * The result is always a multiple of the limit and strictly lower than $recordsTotal whenever there
+     * is at least one record, so applying it cannot be out of range in turn.
+     */
+    public static function computeValidOffset(int $recordsTotal, int $limit): int
+    {
+        if ($recordsTotal <= 0 || $limit <= 0) {
+            return 0;
+        }
+
+        return (int) (floor(($recordsTotal - 1) / $limit) * $limit);
+    }
+}

--- a/tests/Unit/Core/Search/PaginationTest.php
+++ b/tests/Unit/Core/Search/PaginationTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Search;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Search\Pagination;
+
+class PaginationTest extends TestCase
+{
+    /**
+     * @dataProvider provideOffsets
+     */
+    public function testItRecognisesAnOffsetPastTheLastRecord(int $recordsTotal, int $offset, bool $expected): void
+    {
+        self::assertSame($expected, Pagination::isOffsetOutOfRange($recordsTotal, $offset));
+    }
+
+    public function provideOffsets(): iterable
+    {
+        yield 'first page always in range' => [0, 0, false];
+        yield 'first page of a full grid' => [11, 0, false];
+        yield 'second page while it holds records' => [11, 10, false];
+        yield 'second page once the 11th record is gone' => [10, 10, true];
+        yield 'far past the end' => [3, 50, true];
+        yield 'empty grid, first page' => [0, 0, false];
+    }
+
+    /**
+     * @dataProvider provideValidOffsets
+     */
+    public function testItFallsBackToTheLastPageHoldingRecords(int $recordsTotal, int $limit, int $expected): void
+    {
+        self::assertSame($expected, Pagination::computeValidOffset($recordsTotal, $limit));
+    }
+
+    public function provideValidOffsets(): iterable
+    {
+        yield '11 records, 10 per page -> second page' => [11, 10, 10];
+        yield '10 records, 10 per page -> first page' => [10, 10, 0];
+        yield '21 records, 10 per page -> third page' => [21, 10, 20];
+        yield 'exactly one page' => [3, 10, 0];
+        yield 'no records left' => [0, 10, 0];
+        yield 'a limit of zero cannot paginate' => [10, 0, 0];
+    }
+
+    /**
+     * The recursion in DoctrineGridDataFactory relies on this: the offset it falls back to must never be
+     * out of range itself, or the grid would keep asking for another one.
+     *
+     * @dataProvider provideTotalsAndLimits
+     */
+    public function testTheFallbackOffsetIsNeverOutOfRangeItself(int $recordsTotal, int $limit): void
+    {
+        $offset = Pagination::computeValidOffset($recordsTotal, $limit);
+
+        self::assertFalse(
+            Pagination::isOffsetOutOfRange($recordsTotal, $offset),
+            sprintf('offset %d is out of range for %d records', $offset, $recordsTotal)
+        );
+    }
+
+    public function provideTotalsAndLimits(): iterable
+    {
+        foreach ([0, 1, 3, 10, 11, 21, 99, 100] as $total) {
+            foreach ([1, 10, 20, 50, 300] as $limit) {
+                yield sprintf('%d records, %d per page', $total, $limit) => [$total, $limit];
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | A grid keeps its offset in the URL and in the employee's saved filters, so deleting the last rows of the page being viewed leaves the offset pointing past the end of the result set. `DoctrineGridDataFactory::getData()` then runs the search with it, gets nothing back, and the grid reports "No records found" while the earlier pages still hold records. The offset is now compared against the count before the search runs, and when it is past the end the criteria are rebuilt on the last page that still holds records.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Customers > view a customer, in the Addresses or Vouchers block set 10 per page with 11 records so there are two pages, go to page two and delete the last item. Before: "No records found". After: the block shows page one. It applies to every Doctrine backed grid, not only that block - any grid whose last page is emptied by a deletion or a filter change.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #26218
| Related PRs                |
| Sponsor company            |

### Measured, on a real grid

`prestashop.core.grid.data.factory.customer_groups`, three records:

```
              before                          after
offset 0      3 rows, total 3                 3 rows, total 3
offset 3      0 rows, total 3   <- "No records found"      3 rows, total 3
offset 53     0 rows, total 3   <- same                    3 rows, total 3
```

### This revives a reviewed PR rather than inventing an approach

@MeKeyCool's #28782 did the same thing - clamp in `DoctrineGridDataFactory` behind a small
`Core\Search\Pagination` helper - and @zuk3975 reviewed it with "your changes make sense (couldn't think of
anything better)". @matks closed it on 2023-02-10 purely for inactivity, saying he would reopen it on
request. @florine2623 confirmed the bug again on 9.0.x in December 2023.

Kept from that PR: the clamp, the helper, the `Filters` vs plain `SearchCriteria` handling.
Left out: its edits to `CurrencyInterface` and `SearchParametersInterface`, which do not relate to the
offset, and its `@TODO` comments pointing at #29131.

### The recursion is safe by construction

`computeValidOffset()` returns `floor(($recordsTotal - 1) / $limit) * $limit`, always a multiple of the
limit and strictly below `$recordsTotal` whenever a record exists, so the retried criteria cannot be out of
range and the call cannot recurse twice. That invariant is pinned by a data-provider test over 40
total/limit combinations rather than left as a comment.

### Checks

- `tests/Unit/Core/Search/PaginationTest.php` — 56 tests / 56 assertions, including the invariant above.
- Regression: unit `Grid|Search|Pagination` 337 tests / 872 assertions;
  `tests/Integration/PrestaShopBundle/Controller` 177 tests / 988 assertions.
- php-cs-fixer `Found 0 of 3 files that can be fixed`, PHPStan `[OK] No errors`.