### PR TITLE
Announce the stock change when the webservice updates a quantity

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -89,7 +89,30 @@ class StockAvailableCore extends ObjectModel
      */
     public function updateWs()
     {
-        return $this->update();
+        $previousQuantity = (int) Db::getInstance()->getValue(
+            'SELECT `quantity` FROM `' . _DB_PREFIX_ . 'stock_available` WHERE `id_stock_available` = ' . (int) $this->id
+        );
+
+        if (!$this->update()) {
+            return false;
+        }
+
+        // A stock change is normally announced by setQuantity(), but the webservice writes the row
+        // through the model, so listeners such as the customer availability alerts of ps_emailalerts
+        // never heard about a restock made this way.
+        Hook::exec(
+            'actionUpdateQuantity',
+            [
+                'id_product' => (int) $this->id_product,
+                'id_product_attribute' => (int) $this->id_product_attribute,
+                'quantity' => (int) $this->quantity,
+                'delta_quantity' => (int) $this->quantity - $previousQuantity,
+                'id_shop' => (int) $this->id_shop,
+            ]
+        );
+        Cache::clean('StockAvailable::getQuantityAvailableByProduct_' . (int) $this->id_product . '*');
+
+        return true;
     }
 
     public static function getStockAvailableIdByProductId($id_product, $id_product_attribute = null, $id_shop = null)

--- a/tests/Integration/Classes/Stock/StockAvailableWebserviceUpdateTest.php
+++ b/tests/Integration/Classes/Stock/StockAvailableWebserviceUpdateTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Stock;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+use StockAvailable;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+/**
+ * StockAvailable::setQuantity() announces a stock change with actionUpdateQuantity, which is what the
+ * customer availability alerts of ps_emailalerts listen to. The webservice does not go through it: the
+ * stock_availables resource maps update to updateWs(), which wrote the row through the model and
+ * announced nothing, so a restock made over the API reached no one.
+ */
+class StockAvailableWebserviceUpdateTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    // The dispatch itself is not asserted here: Hook::getHookModuleExecList() returns false under the
+    // integration bootstrap even with ps_emailalerts installed, active and registered for the shop in
+    // context, so Hook::exec() returns before it records anything. What is asserted is the state the
+    // update leaves behind, including the cache drop that sits immediately after the dispatch.
+
+    private int $productId;
+
+    private int $stockAvailableId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        $product = new Product(null, false, 1);
+        $product->name = 'Stock alert product';
+        $product->price = 12.0;
+        $product->link_rewrite = 'stock-alert-product-' . uniqid();
+        $product->save();
+        $this->productId = (int) $product->id;
+
+        StockAvailable::setQuantity($this->productId, 0, 0);
+        $this->stockAvailableId = (int) StockAvailable::getStockAvailableIdByProductId($this->productId);
+        self::assertGreaterThan(0, $this->stockAvailableId, 'the product should have a stock_available row');
+    }
+
+    protected function tearDown(): void
+    {
+        (new Product($this->productId))->delete();
+        Db::getInstance()->execute(
+            'DELETE FROM ' . _DB_PREFIX_ . 'stock_available WHERE id_product = ' . $this->productId
+        );
+
+        parent::tearDown();
+    }
+
+    /**
+     * The announcement is worth nothing if the row did not actually move.
+     */
+    public function testTheStoredQuantityIsUpdatedToo(): void
+    {
+        $stockAvailable = new StockAvailable($this->stockAvailableId);
+        $stockAvailable->quantity = 7;
+        $stockAvailable->updateWs();
+
+        self::assertSame(7, $this->storedQuantity());
+    }
+
+    /**
+     * setQuantity() drops its cached quantity when it changes stock. Doing the same here keeps a listener
+     * that asks StockAvailable for the quantity from being handed the value from before the update.
+     */
+    public function testTheCachedQuantityDoesNotSurviveTheUpdate(): void
+    {
+        StockAvailable::setQuantity($this->productId, 0, 2);
+        self::assertSame(2, (int) StockAvailable::getQuantityAvailableByProduct($this->productId));
+
+        $stockAvailable = new StockAvailable($this->stockAvailableId);
+        $stockAvailable->quantity = 9;
+        $stockAvailable->updateWs();
+
+        self::assertSame(
+            9,
+            (int) StockAvailable::getQuantityAvailableByProduct($this->productId),
+            'a listener would have been given the quantity from before the webservice update'
+        );
+    }
+
+    private function storedQuantity(): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT quantity FROM ' . _DB_PREFIX_ . 'stock_available WHERE id_stock_available = ' . $this->stockAvailableId
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Updating a quantity through the webservice changed the stock silently, so modules listening for stock movements — the customer availability alerts of Mail Alerts among them — were never told, and no notification was sent. |
| Type?                      | bug fix                                                          |
| Category?                  | WS                                                               |
| BC breaks?                 | no                                                               |
| Deprecations?              | no                                                               |
| How to test?               | See below.                                                       |
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #26272
| Related PRs                |
| Sponsor company            |

### The bug

Every other way of changing stock announces it. `StockAvailable::setQuantity()` ends with:

```php
Hook::exec('actionUpdateQuantity', [
    'id_product' => $id_product,
    'id_product_attribute' => $id_product_attribute,
    'quantity' => $stock_available->quantity,
    'delta_quantity' => $deltaQuantity ?? null,
    'id_shop' => $id_shop,
]);
Cache::clean('StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '*');
```

and `ProductStockUpdater`, `CombinationStockUpdater` and `StockManager` all dispatch the same hook.
The `stock_availables` webservice resource does not go through any of them — it maps `update` to:

```php
public function updateWs()
{
    return $this->update();
}
```

which writes the row and tells nobody. `ps_emailalerts` registers on `actionUpdateQuantity` and sends the
"back in stock" notification from there, so a restock made over the API never triggers one.

Measured on a 9.2 shop with Mail Alerts installed and registered:

```
listeners for actionUpdateQuantity : ps_emailalerts
quantity 2399 -> 2404 via updateWs()
actionUpdateQuantity announced    : NO       <- before
actionUpdateQuantity announced    : YES      <- after
```

### The fix

Dispatch the same hook the other paths dispatch, with the delta measured against the row as it was before
the write, and drop the cached quantity the way `setQuantity()` does. The delta matters rather than being
decoration: `ps_emailalerts::hookActionUpdateQuantity()` opens with

```php
if (isset($params['delta_quantity']) && (int) $params['delta_quantity'] === 0) {
    return;
}
```

so an absent or wrong delta would either suppress a real notification or announce a change that did not
happen. The cache drop matters for the same reason the original has it — a listener that asks
`StockAvailable::getQuantityAvailableByProduct()` would otherwise be handed the value from before the
update.

A failed `update()` returns early and announces nothing.

### Not changed

`$webserviceParameters` also maps `add` to `addWs`, and neither `StockAvailable` nor `ObjectModel`
defines that method. Creating a `stock_available` over the API therefore looks like it would fatal on an
undefined method. That is a separate defect from the one reported here and I have not touched it.

### How to test

1. Install Mail Alerts and enable the customer notification for product availability.
2. As a customer, ask to be notified about an out of stock product (a row appears in
   `ps_mailalert_customer_oos`).
3. Restock that product with a `PUT` on `/api/stock_availables`.

Before: the stock changes and no email is sent. After: the notification goes out, the same as when the
stock is changed from the back office.

### Verification

- `tests/Integration/Classes/Stock/StockAvailableWebserviceUpdateTest.php` — 2 tests: the row really moves,
  and the cached quantity does not survive the update.
- **Mutation check**: with `classes/stock/StockAvailable.php` reverted to `upstream/9.2.x`, the cache test
  fails — *"a listener would have been given the quantity from before the webservice update"*,
  `Failed asserting that 2 is identical to 9` — while the test that pins unchanged behaviour passes.
- **End to end**, on a 9.2 shop rather than the test harness, with `ps_emailalerts` resolved as a real
  listener: the announcement goes from `NO` to `YES` across the same change, as quoted above.
- `tests/Integration/Classes/` — 185/185.
- `php -l`, `php-cs-fixer`, `phpstan analyse -c phpstan.neon.dist` clean.

Note for reviewers on why the dispatch is not asserted in the test file: under the integration bootstrap,
`Hook::getHookModuleExecList('actionUpdateQuantity')` returns `false` even with `ps_emailalerts`
installed, active and registered for the shop in context, so `Hook::exec()` returns before it records
anything and no listener can be observed. In a normal CLI context on the same code it resolves
`["ps_emailalerts"]`, which is where the before/after above was measured.