### PR TITLE
Fall back to the default theme when a helper template is missing

### DIFF
--- a/classes/helper/Helper.php
+++ b/classes/helper/Helper.php
@@ -82,9 +82,23 @@ class HelperCore
 
         if (isset($override_tpl_path) && file_exists($override_tpl_path)) {
             return $this->context->smarty->createTemplate($override_tpl_path, $this->context->smarty);
-        } else {
-            return $this->context->smarty->createTemplate($this->base_folder . $tpl_name, $this->context->smarty);
         }
+
+        // The helper templates are only shipped by the default back office theme, but Smarty resolves
+        // this relative path against the *current* theme - and on a Symfony page, where hooks such as
+        // displayAdminOrderTop are rendered, against no admin theme at all. Fall back to the default
+        // theme's copy rather than letting Smarty fail to find the template. Only used when the path
+        // does not resolve, so an existing theme override still wins.
+        if (defined('_PS_BO_ALL_THEMES_DIR_') && !$this->context->smarty->templateExists($this->base_folder . $tpl_name)) {
+            $defaultThemeTplPath = _PS_BO_ALL_THEMES_DIR_ . 'default' . DIRECTORY_SEPARATOR . 'template'
+                . DIRECTORY_SEPARATOR . $this->base_folder . $tpl_name;
+
+            if (file_exists($defaultThemeTplPath)) {
+                return $this->context->smarty->createTemplate($defaultThemeTplPath, $this->context->smarty);
+            }
+        }
+
+        return $this->context->smarty->createTemplate($this->base_folder . $tpl_name, $this->context->smarty);
     }
 
     /**

--- a/tests/Integration/Classes/HelperTemplateFallbackTest.php
+++ b/tests/Integration/Classes/HelperTemplateFallbackTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Context;
+use HelperForm;
+use HelperKpi;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The helper templates are only shipped by the default back office theme, while Smarty resolves the
+ * helper's relative path against whichever theme the current page uses - and on a Symfony page, such as
+ * the order view where displayAdminOrderTop is rendered, against no admin theme at all. A module calling
+ * HelperForm from an admin hook therefore hit "Unable to load template 'file:helpers/form/form.tpl'".
+ */
+class HelperTemplateFallbackTest extends TestCase
+{
+    /** @var array */
+    private $originalTemplateDirs;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalTemplateDirs = Context::getContext()->smarty->getTemplateDir();
+    }
+
+    protected function tearDown(): void
+    {
+        Context::getContext()->smarty->setTemplateDir($this->originalTemplateDirs);
+        parent::tearDown();
+    }
+
+    public function testFormTemplateResolvesOnAPageThatConfiguresNoAdminTheme(): void
+    {
+        // What a Symfony back office page leaves behind: AdminController::initSmarty never ran.
+        Context::getContext()->smarty->setTemplateDir([_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'templates']);
+
+        $template = (new HelperForm())->createTemplate('form.tpl');
+
+        self::assertTrue($template->source->exists);
+    }
+
+    public function testFormTemplateResolvesWhenTheCurrentThemeDoesNotShipIt(): void
+    {
+        Context::getContext()->smarty->setTemplateDir([$this->themeTemplateDir('new-theme')]);
+
+        $template = (new HelperForm())->createTemplate('form.tpl');
+
+        self::assertTrue($template->source->exists);
+        self::assertStringContainsString(
+            $this->themeTemplateDir('default'),
+            $template->source->filepath
+        );
+    }
+
+    /**
+     * The fallback must not shadow a theme that does provide the template - new-theme ships the KPI
+     * helper but not the form one, so it is the case that tells the two apart.
+     */
+    public function testAThemeThatShipsTheTemplateIsStillPreferred(): void
+    {
+        Context::getContext()->smarty->setTemplateDir([$this->themeTemplateDir('new-theme')]);
+
+        $template = (new HelperKpi())->createTemplate('kpi.tpl');
+
+        self::assertTrue($template->source->exists);
+        self::assertStringContainsString(
+            $this->themeTemplateDir('new-theme'),
+            $template->source->filepath
+        );
+    }
+
+    public function testTheDefaultThemeKeepsResolvingFromItsOwnTemplates(): void
+    {
+        Context::getContext()->smarty->setTemplateDir([$this->themeTemplateDir('default')]);
+
+        $template = (new HelperForm())->createTemplate('form.tpl');
+
+        self::assertTrue($template->source->exists);
+        self::assertStringContainsString(
+            $this->themeTemplateDir('default'),
+            $template->source->filepath
+        );
+    }
+
+    private function themeTemplateDir(string $theme): string
+    {
+        return _PS_BO_ALL_THEMES_DIR_ . $theme . DIRECTORY_SEPARATOR . 'template';
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Helper::createTemplate()` ends by asking Smarty for a relative path (`helpers/form/form.tpl`), which Smarty resolves against the template directories of the page being rendered. `AdminController::initSmarty()` sets those to the *current* back office theme only, and the helper templates are shipped by the **default** theme alone - `new-theme/template/helpers` contains just `kpi` and `shops_list`. Worse, on a Symfony back office page, which is where hooks like `displayAdminOrderTop` are rendered, `initSmarty()` never runs at all and no admin theme is configured. A module building a form with `HelperForm` from an admin hook therefore fails with `Unable to load template 'file:helpers/form/form.tpl'`. This resolves the default theme's copy explicitly when the relative path does not resolve; a theme that ships the template, and any override, still win.
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Use the example module attached to the issue, or any module that builds a `HelperForm` in `hookDisplayAdminOrderTop`. Open an order in the back office. Before: the page dies with `Unable to load template 'file:helpers/form/form.tpl'`. After: the form renders. A module rendering a helper on a legacy page with the default back office theme is unaffected.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #27543
| Related PRs                |
| Sponsor company            |

### Measured, three contexts, `HelperForm::createTemplate('form.tpl')`

```
context                                        before   after
Symfony page (no admin theme configured)       false    true    <- the reported case
legacy page, bo_theme = new-theme              false    true
legacy page, bo_theme = default                true     true    <- unchanged
```

The reported diagnosis ("it points at a path that does not exist") is close but not quite it: nothing
points anywhere. `Helper` hands Smarty a **relative** path and Smarty resolves it against
`AdminController`'s template dirs, which are `[<current bo_theme>/template, override/controllers/admin/templates]`
— `default/template` is never among them.

### Why not add the templates to new-theme instead

`new-theme` is the Symfony/Vue theme; the helper templates are legacy Smarty and are being retired with the
rest of `HelperForm`. Copying `form/` into it would duplicate templates the project is migrating away from,
and would still not fix the Symfony-page case, where no admin theme is configured at all. Resolving the one
existing copy is both smaller and the only option that covers both contexts.

This is also what the community workaround in the thread does by hand
(`$helper->base_folder = _PS_BO_ALL_THEMES_DIR_ . 'default/template/helpers/form/'`), so the behaviour is
already relied on - it just should not need a module author to know it.

### Note

The fallback costs one `Smarty::templateExists()` lookup per helper template that is not served by an
override. That is a source lookup, not a render, and helpers are rendered a handful of times per page.

### Checks

- 4 integration tests in `tests/Integration/Classes/HelperTemplateFallbackTest.php`, including one that
  pins a theme which **does** ship the template (`HelperKpi` on `new-theme`) still resolving to its own copy,
  so the fallback cannot shadow a theme.
- Mutation check: `Helper.php` reverted to `9.2.x` -> 2 of 4 fail; restored -> green. The other two pass on
  base by design, they are the non-regression pins.
- Regression `tests/Integration/Classes` 187 tests / 2081 assertions.
- php-cs-fixer `Found 0 of 2 files that can be fixed`, PHPStan `[OK] No errors`.