### PR TITLE
Hide native number spinners in grid min/max filters

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -353,6 +353,20 @@ table {
         }
       }
 
+      // The min/max filters render two number inputs side by side in cells that are capped at 6-8rem
+      // below, so the browser's native spinners have nowhere to go: they overlap the value on Chrome
+      // and permanently reserve their width on Firefox. Suppressed the same way, and for the same
+      // reason, as the .ps-number component does.
+      input[type="number"] {
+        appearance: textfield;
+
+        &::-webkit-outer-spin-button,
+        &::-webkit-inner-spin-button {
+          margin: 0;
+          appearance: none;
+        }
+      }
+
       td[data-column-id^="id_"] {
         max-width: 8rem;
       }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | The ID and Quantity filters in the products grid are `IntegerMinMaxFilterType`, which builds two `IntegerType` fields; the UI kit form theme renders those as `input[type="number"]` (`integer_widget` sets `type\|default('number')`) and the filter type adds `min` and `step`. The two inputs sit stacked in cells the grid caps at 6-8rem, so the browser's native spin buttons have nowhere to go - they overlap the value on Chromium when the field is hovered or focused, and Firefox reserves their width permanently, which is what the report's Firefox screenshot shows. Nothing suppressed them: `.min-field` / `.max-field` carry no styling at all and the theme's only spinner rules are scoped to `.ps-number` and `.submittable-input`. This applies the same suppression to the grid filter row.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Catalog > Products, type values into the ID and Quantity filter fields. Before: hovering or focusing a field shows the spin buttons over the value on Chromium, and Firefox shows them permanently, narrowing the usable field. After: the fields behave like the rest of the grid filters. Applies to every grid using a min/max filter, not only products.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #27600
| Related PRs                |
| Sponsor company            |

### What is verified, and what is not

Verified in a real browser against the shipped `theme.css`, with the filter row's exact markup:

```
before   appearance: auto        <- native spin buttons
after    appearance: textfield   <- suppressed
type=number, min="0", step="1"   <- confirmed on the rendered input
```

**Not** verified by me visually: I could not open the real products grid, so I did not reproduce the
overlap itself. The report carries @khouloudbelguith's screenshots of it and QA marked it Verified, and
Chromium only paints the spinners on hover/focus, which is why a static harness screenshot shows nothing.
The claim I am making is narrow and measured: these inputs are `type="number"` with no suppression, and
this rule suppresses them.

### Deliberately not addressed

The report's "Expected behavior" also asks for the ID filter to be a single input rather than a min/max
range. That is a UX change - @MatShir posted a mockup in 2022 and @ElodieOS asked in January 2023 whether
the UX review was still needed, with no answer since. It is left alone here: the spinner problem affects
the Quantity range whatever is decided for ID, so this fix does not pre-empt that decision.

### Checks

- `npm run scss-lint` -> `0 problems found`.
- SCSS only. `admin-dev/themes/new-theme/public/*` is gitignored (`.gitignore:126`), so no built asset is
  in the diff.
- The rule lands at the top level (`_grid.scss:344` closes `.grid`), so it compiles to
  `table tr.column-filters input[type="number"]` and covers every grid with a min/max filter.