### PR TITLE
Expose virtual product files in the web service

### DIFF
--- a/classes/ProductDownload.php
+++ b/classes/ProductDownload.php
@@ -60,6 +60,22 @@ class ProductDownloadCore extends ObjectModel
     ];
 
     /**
+     * @see ObjectModel::$webserviceParameters
+     *
+     * filename is the obfuscated name the file is stored under in download/, derived when the file is
+     * uploaded. It is exposed so a client can correlate a record with its file, but it is not settable:
+     * writing it would repoint a record at a file that was uploaded for another product.
+     */
+    protected $webserviceParameters = [
+        'objectsNodeName' => 'product_downloads',
+        'objectNodeName' => 'product_download',
+        'fields' => [
+            'id_product' => ['xlink_resource' => 'products'],
+            'filename' => ['setter' => false],
+        ],
+    ];
+
+    /**
      * Build a virtual product.
      *
      * @param int $idProductDownload Existing productDownload id in order to load object (optional)

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -318,6 +318,7 @@ class WebserviceRequestCore
             'shop_urls' => ['description' => 'Shop URLs from multi-shop feature', 'class' => 'ShopUrl'],
             'product_customization_fields' => ['description' => 'Customization Field', 'class' => 'CustomizationField'],
             'customizations' => ['description' => 'Customization values', 'class' => 'Customization'],
+            'product_downloads' => ['description' => 'The downloadable files of virtual products', 'class' => 'ProductDownload'],
         ];
 
         // An array [module_name => module_output] will be returned

--- a/tests/Integration/Classes/WebserviceProductDownloadTest.php
+++ b/tests/Integration/Classes/WebserviceProductDownloadTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use PHPUnit\Framework\TestCase;
+use ProductDownload;
+use WebserviceRequest;
+
+/**
+ * The file attached to a virtual product had no representation in the web service at all, so there
+ * was no way to read it through the API even though the product itself was exposed.
+ */
+class WebserviceProductDownloadTest extends TestCase
+{
+    public function testVirtualProductFilesAreExposedAsAWebserviceResource(): void
+    {
+        $resources = WebserviceRequest::getResources();
+
+        self::assertArrayHasKey('product_downloads', $resources);
+        self::assertSame('ProductDownload', $resources['product_downloads']['class']);
+    }
+
+    public function testTheResourceIsNamedConsistentlyWithItsEntity(): void
+    {
+        $parameters = (new ProductDownload())->getWebserviceParameters();
+
+        self::assertSame('product_downloads', $parameters['objectsNodeName']);
+        self::assertSame('product_download', $parameters['objectNodeName']);
+    }
+
+    public function testTheResourceLinksBackToItsProduct(): void
+    {
+        $parameters = (new ProductDownload())->getWebserviceParameters();
+
+        self::assertSame('products', $parameters['fields']['id_product']['xlink_resource']);
+    }
+
+    /**
+     * filename is the obfuscated name the file is stored under in download/. Writing it through the
+     * API would repoint a record at a file uploaded for another product, so it is readable only -
+     * same treatment as Customer::$secure_key.
+     */
+    public function testTheStoredFilenameIsExposedButNotSettable(): void
+    {
+        $parameters = (new ProductDownload())->getWebserviceParameters();
+
+        self::assertArrayHasKey('filename', $parameters['fields']);
+        self::assertFalse($parameters['fields']['filename']['setter']);
+    }
+
+    /**
+     * @dataProvider provideExpectedFields
+     */
+    public function testTheFieldsAMerchantNeedsAreReadable(string $field): void
+    {
+        $parameters = (new ProductDownload())->getWebserviceParameters();
+
+        self::assertArrayHasKey($field, $parameters['fields']);
+        // Everything but filename stays writable, so the API can manage an existing file's settings.
+        self::assertArrayNotHasKey('setter', $parameters['fields'][$field]);
+    }
+
+    public function provideExpectedFields(): iterable
+    {
+        yield 'display name shown to the customer' => ['display_filename'];
+        yield 'expiration date' => ['date_expiration'];
+        yield 'days the link stays valid' => ['nb_days_accessible'];
+        yield 'allowed number of downloads' => ['nb_downloadable'];
+        yield 'active' => ['active'];
+        yield 'shareable' => ['is_shareable'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | develop
| Description?               | A virtual product's downloadable file had no representation in the web service. `ProductDownload` declared no `$webserviceParameters` and no resource was registered for it, so a client could read the product through the API but never the file bound to it, and there was no endpoint to create or update one. This registers it as `product_downloads`, following the `product_suppliers` / `ProductSupplier` pattern. `filename` is readable but not settable - it is the obfuscated name the file is stored under in `download/`, derived at upload time, and letting a client write it would repoint a record at a file uploaded for another product. `Customer::$secure_key` and `Employee::$last_passwd_gen` already use the same `'setter' => false`.
| Type?                      | new feature
| Category?                  | WS
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Create a virtual product and attach a file to it. With a web service key granting the new `product_downloads` resource, `GET /api/product_downloads` lists the records and `GET /api/product_downloads/{id}` returns one, with `id_product` as an xlink back to `/api/products/{id}`. `PUT` can change `display_filename`, `date_expiration`, `nb_days_accessible`, `nb_downloadable`, `active` and `is_shareable`; sending `filename` leaves the stored value untouched. Existing resources are unaffected.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #27834
| Related PRs                |
| Sponsor company            |

### Why this is on `develop`

It adds a new public API resource rather than correcting an existing one, so it is a feature even though
the ticket is labelled `Bug`. QA confirmed the gap twice (@hibatallahAouadni in 2022 with the full XML of a
virtual product showing no file, @silentyak again on 8.1.2 in 2024), so the report is accurate - the API
simply never covered this object.

### Exposed shape (measured, not written from the source)

```
objectsNodeName=product_downloads  objectNodeName=product_download
  id                  sqlId=id_product_download
  id_product          xlink_resource=products, required
  filename            setter=false, validate=isSha1
  display_filename    validate=isGenericName
  date_add / date_expiration / nb_days_accessible / nb_downloadable / active / is_shareable
```

### Naming

`product_downloads` matches the table (`product_download`) and the legacy class, which is the convention the
other resources follow (`product_suppliers`, `product_options`). PS 9 calls the same object
`VirtualProductFile` in the modern layer; if maintainers would rather the resource carry that name I can
rename it - it is one line in each file, and better decided before it ships than after.

### Checks

- 10 integration tests in `tests/Integration/Classes/WebserviceProductDownloadTest.php` covering the
  registration, the node names, the xlink, the read-only `filename` and the writable fields.
- Mutation check: both source files reverted to `develop` -> 3 failures; restored -> green.
- Regression: `tests/Integration/Classes` 196 tests with the change against 186 without, and the **same**
  5 pre-existing failures either way (`GetFrontFeaturesStaticTest` x3, `CartRuleTest` x2) - measured on
  pristine `develop`, so unrelated to this change.
- php-cs-fixer `Found 0 of 3 files that can be fixed`, PHPStan `[OK] No errors`.