### PR TITLE
Follow the current host when building back office links in multistore

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -877,8 +877,17 @@ class LinkCore
         }
 
         if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE')) {
-            if (null === $idShop) {
+            $resolvedFromRequest = null === $idShop;
+            if ($resolvedFromRequest) {
                 $idShop = $this->getMatchingUrlShopId();
+
+                // getMatchingUrlShopId() also requires the request URI to start with the shop URI,
+                // which is a front office rule: the back office is served from the admin folder, not
+                // from under a shop's virtual URI, so that test never passes for a shop that is not
+                // mounted at the root. The host alone identifies the shop here.
+                if (null === $idShop) {
+                    $idShop = $this->getHostMatchingShopId();
+                }
             }
 
             // Use the matching shop if present, or fallback on the default one
@@ -886,6 +895,14 @@ class LinkCore
                 $shop = new Shop($idShop);
             } else {
                 $shop = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));
+            }
+
+            if ($resolvedFromRequest) {
+                // The admin folder sits at the installation root, never under the shop's virtual URI.
+                // Shop::initialize() blanks it for the same reason when it resolves the back office
+                // shop. Only done for the shop we resolved ourselves: a caller passing an explicit
+                // shop id keeps getting that shop's full base URI, as before.
+                $shop->virtual_uri = '';
             }
         } else {
             $shop = Context::getContext()->shop;
@@ -936,6 +953,33 @@ class LinkCore
         }
 
         return $this->urlShopId;
+    }
+
+    /**
+     * Returns the id of an active shop served by the current host, ignoring the request URI.
+     *
+     * Used for back office links only, where the request URI cannot discriminate between shops.
+     * The host is still resolved against ps_shop_url rather than trusted as-is, so a forged Host
+     * header cannot make PrestaShop generate links to an arbitrary domain. Ports are handled the
+     * same way as Shop::initialize(): the host without its port first, then with it.
+     *
+     * @return int|null
+     */
+    private function getHostMatchingShopId(): ?int
+    {
+        foreach ([Tools::getHttpHost(false, false, true), Tools::getHttpHost()] as $host) {
+            try {
+                $result = Shop::findShopByHost($host);
+            } catch (PrestaShopDatabaseException $e) {
+                return null;
+            }
+
+            if (!empty($result)) {
+                return (int) $result[0]['id_shop'];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1358,13 +1358,15 @@ class ShopCore extends ObjectModel
     }
 
     /**
+     * Returns the active shop URLs served by the given host, longest URI first.
+     *
      * @param string $host
      *
      * @return array
      *
      * @throws PrestaShopDatabaseException
      */
-    private static function findShopByHost($host)
+    public static function findShopByHost($host)
     {
         $sql = 'SELECT s.id_shop, CONCAT(su.physical_uri, su.virtual_uri) AS uri, su.domain, su.main
                     FROM ' . _DB_PREFIX_ . 'shop_url su

--- a/tests/Integration/Classes/LinkAdminBaseLinkTest.php
+++ b/tests/Integration/Classes/LinkAdminBaseLinkTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Context;
+use Db;
+use Link;
+use PHPUnit\Framework\TestCase;
+use Shop;
+
+/**
+ * The back office is served from the admin folder, not from under a shop's virtual URI, so the
+ * request URI cannot tell which shop the employee is working on - only the host can. These tests
+ * pin that Link::getAdminBaseLink() follows the host the back office was reached on instead of
+ * falling back to the default shop's domain, which would log the employee out on a multi-domain
+ * installation.
+ */
+class LinkAdminBaseLinkTest extends TestCase
+{
+    private const HOST = 'second-shop.test';
+
+    /** @var int */
+    private $idShop;
+
+    /** @var int */
+    private $originalMultishop;
+
+    /** @var array */
+    private $originalServer;
+
+    /** @var int */
+    private $originalShopContext;
+
+    /** @var int|null */
+    private $originalShopContextId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalServer = $_SERVER;
+        $this->originalShopContext = Shop::getContext();
+        // CONTEXT_SHOP and CONTEXT_GROUP cannot be restored without their id.
+        $this->originalShopContextId = Shop::CONTEXT_GROUP === $this->originalShopContext
+            ? Shop::getContextShopGroupID()
+            : Shop::getContextShopID();
+        $this->originalMultishop = (int) Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');
+        Configuration::updateValue('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!empty($this->idShop)) {
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'shop_url WHERE id_shop = ' . (int) $this->idShop);
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'shop WHERE id_shop = ' . (int) $this->idShop);
+            $this->idShop = 0;
+        }
+
+        Configuration::updateValue('PS_MULTISHOP_FEATURE_ACTIVE', $this->originalMultishop);
+        $_SERVER = $this->originalServer;
+        Shop::resetStaticCache();
+        Shop::setContext($this->originalShopContext, $this->originalShopContextId);
+        Context::getContext()->shop = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider provideShopUrls
+     */
+    public function testAdminBaseLinkFollowsTheHostTheBackOfficeWasReachedOn(
+        string $physicalUri,
+        string $virtualUri,
+        string $host,
+        string $expectedBase
+    ): void {
+        $this->createSecondShop($physicalUri, $virtualUri);
+        $this->enterAllShopsContextOnHost($host);
+
+        // A fresh Link per case: getMatchingUrlShopId() memoises its result on the instance.
+        self::assertSame($expectedBase, (new Link())->getAdminBaseLink());
+    }
+
+    public function provideShopUrls(): iterable
+    {
+        // Plain multi-domain: already worked, pinned so the fix does not regress it.
+        yield 'shop mounted at the root' => ['/', '', self::HOST, 'http://' . self::HOST . '/'];
+
+        // The shop URI never prefixes the admin folder, so the request URI cannot match it.
+        yield 'shop with a virtual URI' => ['/', 'boutique/', self::HOST, 'http://' . self::HOST . '/'];
+
+        // PrestaShop installed in a subdirectory: the admin folder lives under the physical URI,
+        // so that part must be kept while the virtual URI is dropped.
+        yield 'shop in a subdirectory' => ['/subfolder/', '', self::HOST, 'http://' . self::HOST . '/subfolder/'];
+
+        // Shop::initialize() resolves the host without its port first; Link now agrees.
+        yield 'host carrying a port' => ['/', '', self::HOST . ':8080', 'http://' . self::HOST . '/'];
+    }
+
+    public function testAnExplicitShopIdKeepsReturningThatShopsFullBaseUri(): void
+    {
+        $this->createSecondShop('/', 'boutique/');
+        $this->enterAllShopsContextOnHost(self::HOST);
+
+        // Only the shop resolved from the request is treated as the back office one. A caller asking
+        // for a given shop still gets its full base URI, which is what it got before this change.
+        self::assertSame(
+            'http://' . self::HOST . '/boutique/',
+            (new Link())->getAdminBaseLink($this->idShop)
+        );
+    }
+
+    public function testUnknownHostFallsBackToTheDefaultShop(): void
+    {
+        $this->createSecondShop('/', '');
+        $this->enterAllShopsContextOnHost('attacker.example');
+
+        // The host is resolved against ps_shop_url, so a Host header naming no known shop cannot
+        // make PrestaShop build back office links pointing at it.
+        $defaultShop = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));
+        self::assertSame('http://' . $defaultShop->domain . '/', (new Link())->getAdminBaseLink());
+    }
+
+    public function testVirtualUriIsNotAppendedToTheAdminFolder(): void
+    {
+        $this->createSecondShop('/', 'boutique/');
+        $this->enterAllShopsContextOnHost(self::HOST);
+
+        // The front office of that shop lives under /boutique/, the back office does not.
+        // Asserted as an exact string: a "does not contain boutique" check also passes on the
+        // unfixed code, where the link is the default shop's domain.
+        self::assertSame('/boutique/', (new Shop($this->idShop))->getBaseURI());
+        self::assertSame('http://' . self::HOST . '/', (new Link())->getAdminBaseLink());
+    }
+
+    private function createSecondShop(string $physicalUri, string $virtualUri): void
+    {
+        $idDefaultShop = (int) Configuration::get('PS_SHOP_DEFAULT');
+        $defaultShop = new Shop($idDefaultShop);
+
+        Db::getInstance()->execute('
+            INSERT INTO ' . _DB_PREFIX_ . 'shop (id_shop_group, name, color, id_category, theme_name, active, deleted)
+            VALUES (' . (int) $defaultShop->id_shop_group . ", 'Second shop', '', "
+            . (int) $defaultShop->id_category . ", '" . pSQL($defaultShop->theme_name) . "', 1, 0)");
+        $this->idShop = (int) Db::getInstance()->Insert_ID();
+
+        Db::getInstance()->execute('
+            INSERT INTO ' . _DB_PREFIX_ . 'shop_url (id_shop, domain, domain_ssl, physical_uri, virtual_uri, main, active)
+            VALUES (' . $this->idShop . ", '" . pSQL(self::HOST) . "', '" . pSQL(self::HOST) . "', '"
+            . pSQL($physicalUri) . "', '" . pSQL($virtualUri) . "', 1, 1)");
+    }
+
+    /**
+     * Reproduces an employee working in the "all shops" context on a shop that is not the default
+     * one: the context shop is the default shop, while the request was served by another host.
+     */
+    private function enterAllShopsContextOnHost(string $host): void
+    {
+        $_SERVER['HTTP_HOST'] = $host;
+        $_SERVER['SERVER_NAME'] = $host;
+        $_SERVER['REQUEST_URI'] = '/' . basename(_PS_ADMIN_DIR_) . '/index.php?controller=AdminDashboard';
+
+        Shop::resetStaticCache();
+        Shop::setContext(Shop::CONTEXT_ALL);
+        Context::getContext()->shop = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | On a multi-domain installation, back office links could be generated on the default shop's domain instead of the one the employee actually reached the back office on, sending them to another domain where their session cookie does not apply. `Link::getAdminBaseLink()` resolves the shop through `getMatchingUrlShopId()`, which requires the request URI to start with the shop's `physical_uri + virtual_uri`. That is a front office rule: the back office is served from the admin folder, never from under a shop's virtual URI, so the test cannot pass for any shop that is not mounted at the root, and generation silently fell back to the default shop. The admin base link now resolves the shop by host, and drops the virtual URI the way `Shop::initialize()` already does when it resolves the back office shop. The host is still looked up in `ps_shop_url`, so a forged `Host` header cannot make PrestaShop generate links to an arbitrary domain.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Enable multistore and give a second shop its own domain plus a virtual URI (Shop Parameters > Multistore > URL: keep the physical URI at `/` and set the virtual URI to e.g. `boutique/`). Log into the back office on that second domain and stay in the "all shops" context. Before this change the menu and quick-access links carry the default shop's domain; after it they stay on the domain you are working on. A shop mounted at the root keeps working exactly as before.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #28106
| Related PRs                |
| Sponsor company            |

### Measured on 9.2.x, all shops context, back office reached on `shop2.test`

Default shop domain `localhost:8001`. `getAdminBaseLink()` before and after:

```
shop_url of the second shop            before                    after
physical / , virtual (none)            http://shop2.test/        http://shop2.test/     unchanged
physical / , virtual boutique/         http://localhost:8001/    http://shop2.test/     fixed
physical /subfolder/ , virtual (none)  http://localhost:8001/    http://shop2.test/subfolder/  fixed
host shop2.test:8080, domain shop2.test  http://localhost:8001/  http://shop2.test/     fixed
```

The first row is the reporter's literal setup and it already worked before this change - a plain
multi-domain shop mounted at `/` resolves correctly on 9.2.x. What still breaks is any shop that is
not at the root, which is why the URI test is the wrong test for a back office path.

### Why the virtual URI has to be dropped

`getAdminBaseLink()` appends `Shop::getBaseURI()`, which is `physical_uri . virtual_uri`. Resolving the
shop by host alone without dropping the virtual part would produce `http://shop2.test/boutique/admin-dev/`,
a 404 - the admin folder sits at the installation root. `Shop::initialize()` blanks `virtual_uri` on the
shop it hands the back office for exactly this reason (`classes/shop/Shop.php:397`); this change follows it.
The physical URI is kept, since PrestaShop installed in a subdirectory does serve its admin folder there.

### Not changed on purpose

**`getAdminBaseLink($idShop)` with an explicit shop id.** The virtual URI is dropped only for the shop
this method resolves from the request; a caller that names a shop still gets that shop's full base URI,
exactly as before. Otherwise a public method would quietly return a different string for existing callers,
which is what `BC breaks? no` in the table is asserting. Pinned by
`testAnExplicitShopIdKeepsReturningThatShopsFullBaseUri`.

`getBaseLink()` and `Tools::getShopDomain()` still return the default shop's domain in an all shops
context. Those build front office links, where "which shop" is genuinely ambiguous when no shop is
selected, and picking one is a spec decision rather than a bug fix. The issue carries `Needs Specs`
partly for that question and it stays open.

### Checks

- `Shop::findShopByHost()` was already the same query `Link::getMatchingUrlShopId()` inlines; it is now
  `public static` and reused instead of adding a third copy. `getMatchingUrlShopId()` itself is untouched,
  so no front office behaviour changes.
- Mutation check: both source files reverted to `9.2.x`, 4 of 7 tests fail with `http://localhost/` where
  the shop's own domain is expected; restored, green.
- `tests/Integration/Classes` 190 tests / 2082 assertions, unit `Link|Shop|Url` 1068 / 3859, php-cs-fixer
  `Found 0 of 3 files that can be fixed`, PHPStan `[OK] No errors`.