### PR TITLE
Let a permission slug carry an underscore in the class name

### DIFF
--- a/classes/Access.php
+++ b/classes/Access.php
@@ -120,8 +120,9 @@ class AccessCore extends ObjectModel
      */
     public static function findIdTabByAuthSlug($authSlug)
     {
+        // Same grammar as isGranted() above: the class name can carry digits and underscores.
         preg_match(
-            '/ROLE_MOD_[A-Z]+_(?P<classname>[A-Z]+)_(?P<auth>[A-Z]+)/',
+            '/ROLE_MOD_[A-Z]+_(?P<classname>[A-Z0-9_]+)_(?P<auth>[A-Z]+)/',
             $authSlug,
             $matches
         );

--- a/classes/Profile.php
+++ b/classes/Profile.php
@@ -234,8 +234,15 @@ class ProfileCore extends ObjectModel
         // Modify array to merge the class names together.
         $accessPerTab = [];
         foreach ($rolesGiven as $role) {
+            /*
+             * The class name may contain an underscore, and one of them is PrestaShop's own:
+             * ModuleTabRegister duplicates a parent tab under <ParentClass>_MTR. A group that stops at
+             * the first underscore reads that slug as the parent's, so the duplicate's own permissions
+             * are filed under the parent and its checkboxes come back empty while the rows are in place.
+             * Access::isGranted() already parses the same slugs with [A-Z0-9_]+.
+             */
             preg_match(
-                '/ROLE_MOD_[A-Z]+_(?P<classname>[A-Z][A-Z0-9]*)_[A-Z]+/',
+                '/ROLE_MOD_[A-Z]+_(?P<classname>[A-Z0-9_]+)_[A-Z]+/',
                 $role['slug'],
                 $matches
             );

--- a/tests/Integration/Classes/ProfileTest.php
+++ b/tests/Integration/Classes/ProfileTest.php
@@ -8,11 +8,72 @@ declare(strict_types=1);
 
 namespace Test\Integration\Classes;
 
+use Access;
+use Language;
 use PHPUnit\Framework\TestCase;
 use Profile;
+use Tab;
+use Tests\Resources\DatabaseDump;
 
 class ProfileTest extends TestCase
 {
+    private const TOUCHED_TABLES = ['tab', 'tab_lang', 'authorization_role', 'access'];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DatabaseDump::restoreTables(self::TOUCHED_TABLES);
+        Profile::resetStaticCache();
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(self::TOUCHED_TABLES);
+        Profile::resetStaticCache();
+
+        parent::tearDown();
+    }
+
+    /**
+     * ModuleTabRegister duplicates a lone parent tab under <ParentClass>_MTR, so a class name with an
+     * underscore is something PrestaShop produces by itself. The permission slugs of such a tab must be
+     * reported against that tab and not against the class name that precedes the underscore.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/28308
+     */
+    public function testAccessesOfATabWhoseClassNameCarriesAnUnderscoreAreReportedAgainstThatTab(): void
+    {
+        $idProfile = 2;
+        $className = 'AdminProbeParent_MTR';
+
+        $names = [];
+        foreach (Language::getIDs(false) as $idLang) {
+            $names[(int) $idLang] = 'Probe parent MTR';
+        }
+
+        $tab = new Tab();
+        $tab->class_name = $className;
+        $tab->id_parent = 0;
+        $tab->module = '';
+        $tab->active = true;
+        $tab->name = $names;
+        $this->assertTrue($tab->add());
+
+        $access = new Access();
+        foreach (['view', 'add', 'edit', 'delete'] as $action) {
+            $access->updateLgcAccess($idProfile, (int) $tab->id, $action, true);
+        }
+
+        Profile::resetStaticCache();
+        $accesses = Profile::getProfileAccesses($idProfile, 'class_name');
+
+        $this->assertArrayHasKey($className, $accesses);
+        foreach (['view', 'add', 'edit', 'delete'] as $action) {
+            $this->assertSame('1', $accesses[$className][$action], sprintf('%s on %s', $action, $className));
+        }
+    }
+
     public function testGetAccess(): void
     {
         $idProfile = 2;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Three places parse the same `ROLE_MOD_<TYPE>_<CLASS>_<ACTION>` slug and only one of them accepts the class names PrestaShop actually produces. `ModuleTabRegister` duplicates a lone parent tab under `<ParentClass>_MTR`, so an underscore in a class name is something the core creates by itself. The class-name group in `Profile::generateAccessesArrayFromPermissions()` stopped at that underscore, so the duplicate's permissions were filed against the parent tab and its own checkboxes came back empty — while the rows sat in `ps_access`, which is exactly what the report describes. `Access::findIdTabByAuthSlug()` has the same problem and additionally rejects any class name containing a digit. Both now use the group `Access::isGranted()` already uses.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Install a module declaring a tab whose `parent_class_name` is another tab of the same module, so the core creates the `_MTR` duplicate. In Team > Permissions, grant everything on the three resulting tabs for a non-super-admin profile and reload. Before the change the duplicated parent comes back with nothing ticked; after it, the grants stick. The demo module attached to the issue reproduces it directly.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #28308
| Related PRs                |
| Sponsor company            |

### Measured — the same four slugs through all three parsers

```
slug                                     expected class        isGranted   findIdTabByAuthSlug   Profile
ROLE_MOD_TAB_ADMINPRODUCTS_READ          ADMINPRODUCTS         ok          ok                    ok
ROLE_MOD_TAB_CUSTOMADMINTAB_MTR_READ     CUSTOMADMINTAB_MTR    ok          CUSTOMADMINTAB        CUSTOMADMINTAB
ROLE_MOD_TAB_ADMINMYTAB2_READ            ADMINMYTAB2           ok          (no match)            ok
ROLE_MOD_TAB_MY_CUSTOM_TAB_READ          MY_CUSTOM_TAB         ok          MY                    MY
```

`Access::isGranted()` uses `(?P<name>[A-Z0-9_]+)` and is right on all four; the other two are not. That
split is why the permission is **enforced** correctly and **displayed** wrongly — the checkbox is empty
while the access row is honoured, which is what @01generator reported as *"the access table has all the
records required, however it does not show"*.

### It explains both community findings at once

@acoalex's workaround changed `duplicateParentIfAlone()` so the `_MTR` tab is never created, which avoids
the regex rather than fixing it — he said as much himself. @01generator found that a controller name
containing an underscore breaks the same way and worked around it by renaming. Both are the same root
cause, and `_MTR` is simply PrestaShop's own underscore.

`fillCacheAccesses()` looks the parsed name up as `$accesses[strtoupper($tab['class_name'])]`, so a name
truncated at the underscore misses and the tab falls back to the all-zero default.

### Test

`tests/Integration/Classes/ProfileTest` creates a tab named `AdminProbeParent_MTR`, grants all four rights
to profile 2 through `Access::updateLgcAccess()`, and asserts `Profile::getProfileAccesses(2, 'class_name')`
reports them against that class name. It restores `tab`, `tab_lang`, `authorization_role` and `access`, and
resets `Profile`'s static access cache on both ends because it is per-request and shared.

Mutation check: both regexes reverted to `9.2.x` → `Failed asserting that two strings are identical`
(`'0'` where `'1'` is granted); restored → green. Regression: `tests/Integration/Classes` 184 tests /
2092 assertions and the Access/Profile/Permission unit tests 46 / 146, all passing.