### PR TITLE
Regenerate the category tree with an UPDATE instead of an INSERT

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -517,13 +517,34 @@ class CategoryCore extends ObjectModel
         if (isset($categoriesArray[0]['subcategories'][0])) {
             $queries = Category::computeNTreeInfos($categoriesArray, $categoriesArray[0]['subcategories'][0], $n);
 
-            // update by batch of 5000 categories
+            /*
+             * Every id here was read out of the category table a few lines above, so there is nothing to
+             * insert. The statement used to be an INSERT ... ON DUPLICATE KEY UPDATE naming only
+             * id_category, nleft and nright, which a strict SQL mode rejects outright - id_parent,
+             * date_add and date_upd are NOT NULL with no default - even when every row is a duplicate and
+             * nothing would actually be inserted.
+             *
+             * update by batch of 5000 categories
+             */
             $chunks = array_chunk($queries, 5000);
             foreach ($chunks as $chunk) {
-                $sqlChunk = array_map(function ($value) { return '(' . rtrim(implode(',', $value)) . ')'; }, $chunk);
-                Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'category` (id_category, nleft, nright)
-                VALUES ' . rtrim(implode(',', $sqlChunk), ',') . '
-                ON DUPLICATE KEY UPDATE nleft=VALUES(nleft), nright=VALUES(nright)');
+                $ids = [];
+                $nleftCases = '';
+                $nrightCases = '';
+
+                foreach ($chunk as $categoryNTreeInfos) {
+                    [$idCategory, $left, $right] = $categoryNTreeInfos;
+                    $idCategory = (int) $idCategory;
+
+                    $ids[] = $idCategory;
+                    $nleftCases .= ' WHEN ' . $idCategory . ' THEN ' . (int) $left;
+                    $nrightCases .= ' WHEN ' . $idCategory . ' THEN ' . (int) $right;
+                }
+
+                Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'category`
+                SET `nleft` = CASE `id_category`' . $nleftCases . ' END,
+                    `nright` = CASE `id_category`' . $nrightCases . ' END
+                WHERE `id_category` IN (' . implode(',', $ids) . ')');
             }
         }
     }

--- a/tests/Integration/Classes/CategoryNTreeTest.php
+++ b/tests/Integration/Classes/CategoryNTreeTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Category;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Tests\Resources\DatabaseDump;
+
+class CategoryNTreeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DatabaseDump::restoreTables(['category']);
+    }
+
+    protected function tearDown(): void
+    {
+        // The connection is shared, so put back the mode PrestaShop sets on connect.
+        Db::getInstance()->execute("SET SESSION sql_mode = ''");
+        DatabaseDump::restoreTables(['category']);
+
+        parent::tearDown();
+    }
+
+    /**
+     * PrestaShop clears sql_mode on its own connection, which is the only reason the previous
+     * INSERT ... ON DUPLICATE KEY UPDATE survived: it named id_category, nleft and nright while
+     * id_parent, date_add and date_upd are NOT NULL with no default. Any strict session rejects
+     * that statement, and the Doctrine connection is strict.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/28335
+     */
+    public function testTheTreeIsRegeneratedUnderAStrictSqlMode(): void
+    {
+        $db = Db::getInstance();
+        $db->execute('UPDATE `' . _DB_PREFIX_ . 'category` SET `nleft` = 0, `nright` = 0');
+        $this->assertSame(0, $this->countCategoriesWithATree());
+
+        $db->execute("SET SESSION sql_mode = 'STRICT_TRANS_TABLES'");
+        $this->assertSame('STRICT_TRANS_TABLES', $db->getValue('SELECT @@session.sql_mode'));
+
+        Category::regenerateEntireNtree();
+
+        $this->assertGreaterThan(0, $this->countCategoriesWithATree());
+        $this->assertSame(0, $this->countCategoriesWithABrokenTree());
+    }
+
+    private function countCategoriesWithATree(): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'category` WHERE `nleft` > 0 AND `nright` > `nleft`'
+        );
+    }
+
+    private function countCategoriesWithABrokenTree(): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'category` WHERE `nright` <= `nleft`'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Category::regenerateEntireNtree()` wrote the nested set back with an `INSERT ... ON DUPLICATE KEY UPDATE` naming only `id_category`, `nleft` and `nright`. `id_parent`, `date_add` and `date_upd` are `NOT NULL` with no default, so a strict SQL mode rejects that statement outright — measured on MySQL 8.4, and **even when every row is a duplicate and nothing would actually be inserted**. Every id in the batch was read out of the category table a few lines above, so there is nothing to insert: a batched `UPDATE` with a `CASE` per column does the same work in the same number of statements and is valid under any `sql_mode`.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | With a session in a strict SQL mode, blank `nleft`/`nright` on `ps_category` and call `Category::regenerateEntireNtree()`. Before the change it throws `Field 'id_parent' doesn't have a default value`; after it, the tree is rebuilt. On a stock install the legacy connection is not strict, so the everyday path is unchanged — see below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #28335
| Related PRs                |
| Sponsor company            |

### Why this has not been failing for everyone

The legacy connection clears the mode on connect — `DbMySQLi.php:71` and `DbPDO.php:120` both run
`SET SESSION sql_mode = ''` — which is the only reason the statement survives. Measured on a stock 9.2
install:

```
PrestaShop legacy Db connection   sql_mode = ''
Doctrine DBAL connection          sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,...'
MySQL global                      sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,...'
```

So the statement's validity depends entirely on which connection happens to run it, and one of the two
connections in the same application is strict. It also explains the reporters: on a host where the session
cannot clear `sql_mode` — `init_connect`, a proxy, a locked-down MariaDB — the call fails, which is what
@venditdevs and @jasminagp saw and what QA could not reproduce on a default install.

### Measured

The exact statement shape, with **only existing ids**, through a strict session:

```
ERROR 1364 (HY000): Field 'id_parent' doesn't have a default value
```

Through PrestaShop's own connection, the same statement returns `true`. That difference is the whole issue.

### Approach

This is @Hlavtox's recommendation from 2023 on the thread — *"remove that INSERT part and just keep the
UPDATE, because I think we can't just magically insert new category with any information"*. His open
question, *"I am not sure when exactly the entry in ps_category doesn't exist"*, turns out not to matter:
the statement is rejected whether or not a row is missing, because a strict mode validates the column list
rather than the outcome.

The batching stays as it was, 5000 rows per statement.

### Test

`tests/Integration/Classes/CategoryNTreeTest` blanks the tree, switches the session to
`STRICT_TRANS_TABLES`, regenerates, and asserts the tree is rebuilt and internally consistent
(`nright > nleft` everywhere). It restores `sql_mode = ''` in `tearDown()` because the connection is shared.

Mutation check: source reverted to `9.2.x` →
`PrestaShopDatabaseException: Field 'id_parent' doesn't have a default value`, the reporter's exact error;
restored → green.

Regression: `category` behat suite 19 scenarios / 456 steps, all passing. `product` suite 413 of 414 — the
single red, `Product/SpecificPrice/unit_price_with_specific_price.feature:10`, was re-run on unpatched
`upstream/9.2.x` and fails there too, so it is pre-existing and unrelated.