### PR TITLE
Keep untaxed products out of the tax breakdown base

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2491,6 +2491,30 @@ class OrderCore extends ObjectModel
                 $tax_rates[$tax->id] = $tax->rate;
             }
 
+            /*
+             * A line carrying no tax never enters the loop below, so it never reaches
+             * $actual_total_base either, while $this->total_products counted it into
+             * $expected_total_base. The difference then looks like a rounding error and is added to
+             * the base of a rate this product does not belong to. Take the line back out, rounded
+             * the way the taxed lines below are, so the two totals stay comparable.
+             */
+            if (empty($tax_calculator->taxes)) {
+                switch ($round_type) {
+                    case Order::ROUND_ITEM:
+                        $expected_total_base -= $quantity * Tools::ps_round($discounted_price_tax_excl, Context::getContext()->getComputingPrecision(), $this->round_mode);
+
+                        break;
+                    case Order::ROUND_LINE:
+                        $expected_total_base -= Tools::ps_round($quantity * $discounted_price_tax_excl, Context::getContext()->getComputingPrecision(), $this->round_mode);
+
+                        break;
+                    case Order::ROUND_TOTAL:
+                        $expected_total_base -= $quantity * $discounted_price_tax_excl;
+
+                        break;
+                }
+            }
+
             foreach ($tax_calculator->getTaxesAmount($discounted_price_tax_excl) as $id_tax => $unit_amount) {
                 $total_tax_base = $total_amount = 0;
                 switch ($round_type) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -773,6 +773,38 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * A product that carries no tax must not show up in the base of a rate it does not belong to.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/28487
+     *
+     * @Then the product tax breakdown of order :orderReference should be:
+     */
+    public function productTaxBreakdownShouldBe(string $orderReference, TableNode $table)
+    {
+        $order = new Order(SharedStorage::getStorage()->get($orderReference));
+
+        $actual = [];
+        foreach ($order->getInvoicesCollection() as $invoiceRow) {
+            $invoice = new OrderInvoice((int) $invoiceRow->id);
+            foreach ($invoice->getProductTaxesBreakdown($order) as $rate => $row) {
+                $actual[] = sprintf(
+                    '%s|%s|%s',
+                    (float) $rate,
+                    round((float) $row['total_price_tax_excl'], 2),
+                    round((float) $row['total_amount'], 2)
+                );
+            }
+        }
+
+        $expected = [];
+        foreach ($table->getColumnsHash() as $row) {
+            $expected[] = sprintf('%s|%s|%s', (float) $row['rate'], (float) $row['base'], (float) $row['amount']);
+        }
+
+        Assert::assertSame($expected, $actual);
+    }
+
+    /**
      * @Then order :orderReference has status :status
      *
      * @param string $orderReference

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_tax_breakdown_untaxed_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_tax_breakdown_untaxed_product.feature
@@ -1,0 +1,36 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-tax-breakdown-untaxed
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@order-tax-breakdown-untaxed
+Feature: Tax breakdown of an order that mixes a taxed and an untaxed product
+  As a merchant
+  I must not see a product that carries no tax counted in the base of a rate it does not belong to
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+    And there is a product in the catalog named "taxedProduct" with a price of 11.90 and 1000 items in stock
+    And there is a product in the catalog named "untaxedProduct" with a price of 10.00 and 1000 items in stock
+    And product "untaxedProduct" has following tax rule group id: 0
+
+  Scenario: The untaxed product must not appear in any taxed rate's base
+    # 3 units of the untaxed product, because the earlier attempt at this fix subtracted a unit price
+    # rather than the line, so it only ever removed one of them.
+    Given I am logged in as "test@prestashop.com" employee
+    And I create an empty cart "tax_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "tax_cart"
+    And I add 1 product "taxedProduct" to the cart "tax_cart"
+    And I add 3 products "untaxedProduct" to the cart "tax_cart"
+    And I add order "tax_order" with the following details:
+      | cart                | tax_cart         |
+      | message             | test             |
+      | payment module name | dummy_payment    |
+      | status              | Payment accepted |
+    Then the product tax breakdown of order "tax_order" should be:
+      | rate  | base  | amount |
+      | 6.000 | 11.90 | 0.71   |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Order::getProductTaxesDetails()` seeds `$expected_total_base` from `total_products`, which counts every line, and later compares it with `$actual_total_base`, which only the taxed lines feed. A line carrying no tax never enters the loop that fills the breakdown, so its price stays in the difference; the difference is treated as a rounding error and added to the base of a rate the product does not belong to. That base is what the invoice prints in the `Products` row, which is the amount in the report. The untaxed line is now taken back out of `$expected_total_base`, rounded the way the taxed lines are so the two totals stay comparable.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Create two products, one in a tax rules group and one with none. Order both, several units of the untaxed one, and open the invoice. Before the change the taxed rate's `Basic price` includes the untaxed product's total; after it, only the taxed product. The tax amount is unchanged either way.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #28487
| Related PRs                | #20474 attempted this in 2020 and is not in any shipped release
| Sponsor company            |

### Measured on 9.2.x

One product at 11.90 taxed at 6%, plus **three units** of an untaxed product at 10.00, order status
`Payment accepted` so an invoice exists:

```
                       before          after
6% row, base           41.90           11.90
6% row, tax amount     0.71            0.71
```

41.90 is 11.90 + 3 x 10.00 — the whole untaxed line, not a rounding artefact. The tax amount was right all
along, which is why the totals of the order look correct and only the breakdown is wrong.

### On #20474

@d33x pointed at that PR in 2022 and reported it only removed one unit. Two things are worth recording.
It subtracted `$discounted_price_tax_excl`, which is a **unit** price, with no `$quantity` factor — that is
exactly the one-unit behaviour described. And it is not in the product: `empty($tax_calculator->getTaxesAmount(`
appears in **none** of 1.7.7.8, 1.7.8.0 through 1.7.8.7, 8.0.0, 9.0.0, 9.2.x or `develop`, even though its
merge commit `eb1668ca751` is an ancestor of the 1.7.8.0 tag. So the earlier fix neither shipped nor,
had it shipped, would have handled quantity. This branch multiplies by `$quantity` and mirrors the same
`ROUND_ITEM` / `ROUND_LINE` / `ROUND_TOTAL` switch the taxed lines use, which is why the scenario orders
three units rather than one.

### Test

`tests/Integration/Behaviour/Features/Scenario/Order/order_tax_breakdown_untaxed_product.feature` builds
exactly that order and asserts the breakdown through `OrderInvoice::getProductTaxesBreakdown()`, with a new
`OrderFeatureContext` step that compares rate, base and amount numerically.

Mutation check: source reverted to `9.2.x` → `'6|11.9|0.71'` expected, `'6|41.9|0.71'` produced; restored →
green. Regression: full `order` suite 261 scenarios / 7361 steps and full `cart` suite 242 / 3538, both
passing.