### PR TITLE
Associate the default category when the webservice creates a product

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7487,11 +7487,33 @@ class ProductCore extends ObjectModel
     public function addWs($autodate = true, $null_values = false)
     {
         $success = $this->add($autodate, $null_values);
-        if ($success && Configuration::get('PS_SEARCH_INDEXATION')) {
-            Search::indexation(false, $this->id);
+        if ($success) {
+            $this->addDefaultCategoryFromWebservice();
+
+            if (Configuration::get('PS_SEARCH_INDEXATION')) {
+                Search::indexation(false, $this->id);
+            }
         }
 
         return $success;
+    }
+
+    /**
+     * A product created through the webservice carries `id_category_default` as a plain column, and
+     * nothing writes the `category_product` row the front office needs to reach it, so the product was
+     * created invisible until it was saved again from the back office.
+     *
+     * A `categories` association in the same payload still wins: it is applied after this and
+     * `setWsCategories()` deletes the existing associations before inserting its own.
+     */
+    protected function addDefaultCategoryFromWebservice(): void
+    {
+        $categoryId = (int) $this->id_category_default;
+        if ($categoryId <= 0 || !Category::categoryExists($categoryId)) {
+            return;
+        }
+
+        $this->addToCategories([$categoryId]);
     }
 
     /**

--- a/tests/Integration/Classes/Product/WsDefaultCategoryTest.php
+++ b/tests/Integration/Classes/Product/WsDefaultCategoryTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+
+/**
+ * A product created through the webservice stored `id_category_default` but no `category_product` row,
+ * so it belonged to no category and the front office could not reach it until it was saved again from
+ * the back office.
+ */
+class WsDefaultCategoryTest extends TestCase
+{
+    /**
+     * @var int[]
+     */
+    private array $createdProductIds = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdProductIds as $productId) {
+            (new Product($productId))->delete();
+        }
+        $this->createdProductIds = [];
+
+        parent::tearDown();
+    }
+
+    public function testTheDefaultCategoryIsAssociatedOnCreation(): void
+    {
+        $homeCategoryId = (int) Configuration::get('PS_HOME_CATEGORY');
+
+        $product = $this->createThroughWebservice($homeCategoryId);
+
+        $this->assertSame(
+            [$homeCategoryId],
+            $this->associatedCategoryIds((int) $product->id),
+            'The default category must be associated so the product is reachable'
+        );
+    }
+
+    /**
+     * A payload naming its own categories is applied after this and replaces them, so the default one
+     * must not survive as an extra association.
+     */
+    public function testCategoriesGivenInThePayloadReplaceTheDefaultOne(): void
+    {
+        $homeCategoryId = (int) Configuration::get('PS_HOME_CATEGORY');
+        $rootCategoryId = (int) Configuration::get('PS_ROOT_CATEGORY');
+
+        $product = $this->createThroughWebservice($homeCategoryId);
+        $product->setWsCategories([$rootCategoryId]);
+
+        $this->assertSame([$rootCategoryId], $this->associatedCategoryIds((int) $product->id));
+    }
+
+    public function testAnUnknownDefaultCategoryAssociatesNothing(): void
+    {
+        $product = $this->createThroughWebservice(999999);
+
+        $this->assertSame([], $this->associatedCategoryIds((int) $product->id));
+    }
+
+    private function createThroughWebservice(int $defaultCategoryId): Product
+    {
+        $product = new Product();
+        $product->name = [(int) Configuration::get('PS_LANG_DEFAULT') => 'Webservice category probe'];
+        $product->link_rewrite = [(int) Configuration::get('PS_LANG_DEFAULT') => 'webservice-category-probe'];
+        $product->price = 10;
+        $product->active = true;
+        $product->id_category_default = $defaultCategoryId;
+        $product->addWs();
+
+        $this->createdProductIds[] = (int) $product->id;
+
+        return $product;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function associatedCategoryIds(int $productId): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_category FROM ' . _DB_PREFIX_ . 'category_product WHERE id_product = ' . $productId . ' ORDER BY id_category'
+        ) ?: [];
+
+        return array_map(static fn (array $row): int => (int) $row['id_category'], $rows);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | A product created through the webservice stored `id_category_default` as a plain column, and nothing wrote the `category_product` row the front office needs to reach it. The product existed, was active, visible and indexed, and belonged to no category, so it stayed invisible until it was saved again from the back office. `Product::addWs()` now associates the default category.
| Type?                      | bug fix
| Category?                  | WS
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | `POST /api/products` with `id_category_default` set to the Home category and no `categories` association. On 9.2.x the product does not appear in the front office and `ps_category_product` holds no row for it; opening and saving it in the back office makes it appear. With this change the association is written on creation.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #28586
| Related PRs                |
| Sponsor company            |

### Measured

Creating a product through `addWs()` and reading what it ends up with:

| | |
| --- | --- |
| `product_shop` | 1 |
| `product_lang` | 2 |
| `stock_available` | 1 |
| `active` | 1 |
| `state` | 1 |
| `visibility` | both |
| `indexed` | 1 |
| **`category_product`** | **0** |

Everything the front office checks is right except the one thing that makes the product reachable.

### Why it belongs in `addWs()`

The webservice saves the object first and applies associations afterwards
(`WebserviceRequest`: `$object->{$objectMethod}()`, then the `associations` loop calling the configured
setters). So a payload that names its own `categories` still wins: `setWsCategories()` begins with
`$this->deleteCategories()` and replaces the lot, which the second test pins.

An unknown `id_category_default` associates nothing rather than creating a dangling row, which the
third test pins.

### Tests

`tests/Integration/Classes/Product/WsDefaultCategoryTest.php`: the default category is associated on
creation, a `categories` payload replaces it, and an unknown default associates nothing. Removing the
call turns the first red. The suite cleans up the products it creates.