### PR TITLE
Drop the multistore checkbox from the ecotax field that is never saved

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
@@ -152,6 +152,9 @@ class CombinationPriceImpactType extends TranslatorAwareType
                         'class' => 'ecotax-tax-excluded',
                     ],
                 ])
+                // No modify_all_shops here on purpose: only ecotax_tax_excluded is sent to the
+                // command (UpdateCombinationCommandsBuilder maps it to setEcoTax), so a checkbox on
+                // this field would control nothing.
                 ->add('ecotax_tax_included', MoneyType::class, [
                     'label' => $this->trans('Ecotax (tax incl.)', 'Admin.Catalog.Feature'),
                     'help' => $helpMessage,
@@ -161,7 +164,6 @@ class CombinationPriceImpactType extends TranslatorAwareType
                         new PositiveOrZero(),
                     ],
                     'currency' => $this->defaultCurrency->iso_code,
-                    'modify_all_shops' => true,
                     'attr' => [
                         'data-tax-rate' => (string) $ecotaxRate,
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
@@ -221,6 +221,9 @@ class RetailPriceType extends TranslatorAwareType
             if ($this->isTaxEnabled) {
                 $helpMessage = $this->trans('Ecotax rate %rate%%', 'Admin.Catalog.Feature', ['%rate%' => $ecotaxRate->round(2)]);
             }
+            // No modify_all_shops here on purpose: only ecotax_tax_excluded is sent to the command
+            // (UpdateProductCommandsBuilder maps it to setEcotax), so a checkbox on this field would
+            // control nothing, exactly as price_tax_included has none either.
             $builder->add('ecotax_tax_included', MoneyType::class, [
                 'label' => $this->trans('Ecotax (tax incl.)', 'Admin.Catalog.Feature'),
                 'help' => $helpMessage,
@@ -230,7 +233,6 @@ class RetailPriceType extends TranslatorAwareType
                     new PositiveOrZero(),
                 ],
                 'currency' => $this->defaultCurrency->iso_code,
-                'modify_all_shops' => true,
                 'attr' => [
                     'data-tax-rate' => (string) $ecotaxRate,
                 ],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Both ecotax fields on the product and combination forms carried `modify_all_shops`, so each had its own "modify all shops" checkbox. Only `ecotax_tax_excluded` is ever sent to the command, so the checkbox on the tax included field controlled nothing: ticking only that one and saving left the ecotax unapplied on the other shop. The option is removed from the field that is not saved, matching how the retail price pair already behaves.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Enable the ecotax and multistore, create a second shop, edit a product's Pricing tab. On 9.2.x both ecotax fields show a "modify all shops" checkbox; tick the one on **Ecotax (tax incl.)**, save, switch shop, and the ecotax is not applied there. With this change only **Ecotax (tax excl.)** offers the checkbox, and it is the one that saves. The same applies to a combination's price impact.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #29333
| Related PRs                |
| Sponsor company            |

### Why the second checkbox did nothing

The command builders read one field of the pair:

```php
// UpdateProductCommandsBuilder
->addMultiShopField('[pricing][retail_price][ecotax_tax_excluded]', 'setEcotax', DataField::TYPE_STRING)

// UpdateCombinationCommandsBuilder
->addMultiShopField('[price_impact][ecotax_tax_excluded]', 'setEcoTax', DataField::TYPE_STRING)
```

`addMultiShopField` looks for the checkbox belonging to the field it names, so it reads
`modify_all_shops_ecotax_tax_excluded` and never the included one. The tax included value is derived in
the browser from the excluded one through its `data-tax-rate`, and is not submitted to the command at
all.

That is both reported symptoms: ticking the box on the excluded field appears to leave the included
one unticked because they were never linked, and ticking only the included one saves nothing.

### Why removing rather than linking

The retail price pair in the same form already works this way. `price_tax_excluded` carries
`modify_all_shops`; `price_tax_included`, which is likewise derived and not sent, carries nothing. The
ecotax pair was the odd one out. Linking the two checkboxes in JavaScript would keep a control that
still cannot affect what is saved.

### On the absence of a test

The change is the removal of a form option, so a test that fails without it has to assert form
configuration, which means building the product form with its data providers. The behaviour it relies
on is already pinned: `UpdateProductCommandsBuilderTest` submits `ecotax_tax_excluded` and no included
counterpart, because that is the only key the builder reads.

`tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product` (214 tests) and
`tests/Integration/PrestaShopBundle/Form/Admin/Sell/Product` (97 tests) both pass unchanged.