### PR TITLE
Let the shop's session handler start the file manager's session

### DIFF
--- a/admin-dev/filemanager/config/config.php
+++ b/admin-dev/filemanager/config/config.php
@@ -24,7 +24,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-session_start();
+// The session is deliberately not started here. config.inc.php below installs the session handler,
+// which applies the shop's cookie parameters including SameSite, and SessionHandler::init() returns
+// early when a session is already active. Starting one first left the file manager with a session
+// created from PHP's defaults.
 
 if (!defined('_PS_ADMIN_DIR_')) {
     // Properly assign admin directory path, we don't want to use relative traversal here,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `admin-dev/filemanager/config/config.php` called `session_start()` before requiring `config.inc.php`. `SessionHandler::init()` returns early when a session is already active, so the handler never ran for the file manager and its session was created from PHP's defaults, without the shop's cookie parameters and without SameSite. The premature call is removed so `config.inc.php` establishes the session as it does everywhere else in the back office.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Set Shop Parameters > General > Cookie SameSite to `Lax` or `Strict`, then open the file manager (the media picker in any rich text field) and inspect the session cookie it sets. On 9.2.x it carries no SameSite attribute and none of the shop's other cookie parameters, because the handler bailed out. With this change it matches the rest of the back office.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #30215
| Related PRs                |
| Sponsor company            |

### Why the handler never ran

`config.inc.php` builds the handler with the shop's settings and calls `init()`:

```php
$sessionHandler = new SessionHandler(
    $cookie_lifetime,
    $force_ssl,
    Configuration::get('PS_COOKIE_SAMESITE'),
    Context::getContext()->shop->physical_uri
);
$sessionHandler->init();
```

and `init()` begins:

```php
if ($this->isSessionDisabled() || $this->isSessionStarted()) {
    return;
}

session_set_cookie_params([... 'samesite' => $this->sameSite]);
```

So a session that is already active makes the whole thing a no-op. That is what the file manager did to
itself one line before the require.

It cannot be repaired after the fact either: `session_set_cookie_params()` has no effect on a session
that is already running. Measured, calling it after `session_start()` leaves `samesite` empty and
`secure` and `httponly` false.

### Safety of the removal

Nothing between the removed call and the `require_once` touches `$_SESSION`; the only statement is the
`_PS_ADMIN_DIR_` define. The file manager's own uses of `$_SESSION` (`dialog.php`, `upload.php`,
`execute.php`) all come after this file has been included, and the handler starts the session through
`PhpBridgeSessionStorage`, which is the native `$_SESSION`.

### On the absence of a test

This is a bootstrap file included by a procedural entry point, so exercising it means an HTTP request to
the file manager with an authenticated back office session. The mechanism above is a code path rather
than a behaviour I can pin from a unit test, and I would rather say that than add one that asserts
something else.