### PR TITLE
Take the Choose layouts heading from the same catalogue as the button

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
@@ -11,7 +11,7 @@
       <div class="card">
         <h3 class="card-header">
           <i class="material-icons">settings</i>
-          {{ 'Choose layouts'|trans({}, 'Admin.Actions') }}
+          {{ 'Choose layouts'|trans({}, 'Admin.Design.Feature') }}
         </h3>
         <div class="card-body">
           <table class="table">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | The "Choose layouts" label was pulled from three different translation catalogues, so a language that translated the one it could see still showed English elsewhere on the same screen. |
| Type?                      | bug fix                                                          |
| Category?                  | BO                                                               |
| BC breaks?                 | no                                                               |
| Deprecations?              | no                                                               |
| How to test?               | See below.                                                       |
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #30708
| Related PRs                |
| Sponsor company            |

### The bug

One visible label, three catalogues:

| where | domain |
|---|---|
| `ThemeController:395`, the page title | `Admin.Navigation.Menu` |
| `Blocks/layouts_configuration.html.twig:22`, the button | `Admin.Design.Feature` |
| `customize_page_layouts.html.twig:14`, the card heading | `Admin.Actions` |

A translator who fills in the string where it is offered gets one of them, and the others keep showing
English on the very same screen. That matches the report: *"Translation in .xlf files but not displayed
in BO"*.

### The fix

The heading now uses `Admin.Design.Feature`, the same catalogue as the button that leads to it, so both
in-page occurrences are satisfied by one translation. The page title keeps `Admin.Navigation.Menu`, which
is what every controller uses for `layoutTitle` (Invoices, Credit slips, New order, Delivery slips and the
rest), so that one is deliberately left alone rather than made to match.

`Admin.Design.Feature` is also the convention here rather than my preference: card headers in
`Improve/Design` use it 13 times against 2 for `Admin.Actions`, and across the whole back office only 7 of
133 card headers use `Admin.Actions`, which is otherwise the catalogue for buttons and actions.

No language loses anything: `Admin.Design.Feature` already carries this string for the button, so any
language that had the button translated now gets the heading for free.

### The second half of the report no longer applies

The issue also reports that the "Pages Configuration" and "Advanced Customization" tabs have no
translatable strings at all. Those tabs do not exist any more — neither literal appears anywhere in the
repository, and the Theme & Logo page is now built from `index.html.twig` plus the
`logo_configuration`, `layouts_configuration`, `rtl_configuration` and `multishop_switch` blocks, whose
strings all go through `trans()`. That half can be closed with this fix.

### How to test

Design → Theme & Logo in a language other than English, with "Choose layouts" translated. The button and
the heading on the page it opens now show the same translated wording; before, one of them stayed English
depending on which catalogue the language had filled.

### Verification

- `bin/console lint:twig` on the Theme views — all 12 files valid.
- After the change the label resolves from two catalogues instead of three, and the remaining split is the
  intended one: `Admin.Design.Feature` twice for the two in-page labels, `Admin.Navigation.Menu` once for
  the page title.

No automated test accompanies this one, and the reason is that there is nothing to assert: the change
swaps which catalogue a string is read from, and with only en-US installed both catalogues return the same
text, so any assertion would pass equally before and after. Reproducing the visible symptom needs a
partially translated non-English pack.