### PR TITLE
Accept a price whose float stringifies as an exponent

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -280,9 +280,30 @@ class ValidateCore
      *
      * @return bool Validity is ok or not
      */
+    /**
+     * Casting a small float to string gives scientific notation - (string) 0.00002 is "2.0E-5" - which
+     * the price patterns cannot match, so such a value was rejected while 0.0002 was accepted. Render
+     * a float in plain decimal notation instead, without rounding it: a value carrying more decimals
+     * than the patterns allow still has them and is still refused.
+     *
+     * @param mixed $price
+     *
+     * @return string
+     */
+    private static function normalizePriceNotation($price): string
+    {
+        if (!is_float($price)) {
+            return (string) $price;
+        }
+
+        $decimal = rtrim(rtrim(number_format($price, 10, '.', ''), '0'), '.');
+
+        return '' === $decimal || '-' === $decimal ? '0' : $decimal;
+    }
+
     public static function isPrice($price)
     {
-        return preg_match('/^[0-9]{1,10}(\.[0-9]{1,9})?$/', $price);
+        return preg_match('/^[0-9]{1,10}(\.[0-9]{1,9})?$/', self::normalizePriceNotation($price));
     }
 
     /**
@@ -294,7 +315,7 @@ class ValidateCore
      */
     public static function isNegativePrice($price)
     {
-        return preg_match('/^[-]?[0-9]{1,10}(\.[0-9]{1,9})?$/', $price);
+        return preg_match('/^[-]?[0-9]{1,10}(\.[0-9]{1,9})?$/', self::normalizePriceNotation($price));
     }
 
     /**

--- a/tests/Unit/Classes/ValidatePriceNotationTest.php
+++ b/tests/Unit/Classes/ValidatePriceNotationTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use PHPUnit\Framework\TestCase;
+use Validate;
+
+/**
+ * Casting a small float to string gives scientific notation, so 0.00002 arrived at the price patterns
+ * as "2.0E-5" and was refused while 0.0002 was accepted.
+ */
+class ValidatePriceNotationTest extends TestCase
+{
+    /**
+     * @dataProvider providePrices
+     */
+    public function testIsPrice(mixed $value, bool $expected): void
+    {
+        $this->assertSame($expected, (bool) Validate::isPrice($value));
+    }
+
+    /**
+     * @dataProvider provideNegativePrices
+     */
+    public function testIsNegativePrice(mixed $value, bool $expected): void
+    {
+        $this->assertSame($expected, (bool) Validate::isNegativePrice($value));
+    }
+
+    /**
+     * @return iterable<string, array{0: mixed, 1: bool}>
+     */
+    public static function providePrices(): iterable
+    {
+        yield 'a float small enough to stringify as an exponent' => [0.00002, true];
+        yield 'the same value written as a string' => ['0.00002', true];
+        yield 'a float just above the exponent threshold' => [0.0002, true];
+        yield 'zero' => [0.0, true];
+        yield 'an ordinary float' => [1.5, true];
+        yield 'a negative value' => [-0.00002, false];
+        yield 'more decimals than the pattern allows' => [0.0000000001, false];
+        yield 'more integer digits than the pattern allows' => [12345678901.0, false];
+        yield 'not a number at all' => ['abc', false];
+    }
+
+    /**
+     * @return iterable<string, array{0: mixed, 1: bool}>
+     */
+    public static function provideNegativePrices(): iterable
+    {
+        yield 'a float small enough to stringify as an exponent' => [0.00002, true];
+        yield 'its negative counterpart' => [-0.00002, true];
+        yield 'the same value written as a string' => ['-0.00002', true];
+        yield 'zero' => [0.0, true];
+        yield 'more decimals than the pattern allows' => [-0.0000000001, false];
+        yield 'not a number at all' => ['abc', false];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Validate::isPrice()` and `isNegativePrice()` match a plain decimal pattern against the value as a string. PHP renders a small float in scientific notation, so `0.00002` reached the pattern as `2.0E-5` and was refused, while `0.0002` passed. Saving `0.00002` as a combination's price impact therefore failed with "Property Combination->price is not valid". The value is now rendered in plain decimal notation before matching.
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Edit a product's combination and set the impact on price (tax excl.) to `0.00002`. On 9.2.x saving fails with `Property Combination->price is not valid`; `0.0002` saves. With this change both save. `Validate::isPrice(0.00002)` returns true directly as well.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #31089
| Related PRs                |
| Sponsor company            |

### The threshold the report found

```php
php > var_dump((string) 0.00002, (string) 0.0002);
string(6) "2.0E-5"
string(6) "0.0002"
```

That is the whole difference. `preg_match('/^[0-9]{1,10}(\.[0-9]{1,9})?$/', $price)` coerces its subject
to string, so the first value never had a chance to match.

### Not rounding on the way

The value is rendered with `number_format($price, 10, '.', '')` and its trailing zeros trimmed, so a
float carrying more decimals than the patterns allow still carries them and is still refused. Measured:

| value | before | after |
| --- | --- | --- |
| `0.00002` | rejected | accepted |
| `0.0002` | accepted | accepted |
| `0.0` | accepted | accepted |
| `-0.00002` (`isNegativePrice`) | rejected | accepted |
| `0.0000000001` | rejected | rejected |
| `12345678901.0` | rejected | rejected |
| `'0.00002'` as a string | accepted | accepted |

### Both validators

The report names `isNegativePrice()`, but `isPrice()` carries the identical pattern and the identical
flaw, so both are fixed. Fixing one would leave the same value valid as a price impact and invalid as a
price.

### Tests

`tests/Unit/Classes/ValidatePriceNotationTest.php` covers the table above for both validators, fifteen
cases in all. Reverting the change turns the three exponent cases red and leaves the rest green.
`tests/Unit/Adapter/ValidateTest.php` and the rest of `tests/Unit/Classes` pass unchanged, 779 tests.