### PR TITLE
Keep the edited product out of its own redirect target suggestions

### DIFF
--- a/admin-dev/themes/new-theme/js/components/entity-search-input.ts
+++ b/admin-dev/themes/new-theme/js/components/entity-search-input.ts
@@ -139,6 +139,10 @@ export default class EntitySearchInput {
     // Apply special options to components when needed
     if (optionName === 'remoteUrl' && this.entityRemoteSource) {
       (<Record<string, any>> this.entityRemoteSource).remote.url = this.options.remoteUrl;
+    } else if (optionName === 'filteredIdentities') {
+      // Cast all IDs into string to avoid not matching because of different types, the same way
+      // buildOptions does it, since identities are compared with the string cast response identifier
+      this.options.filteredIdentities = Array.isArray(value) ? value.map(String) : [];
     }
   }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | On the product page SEO tab, choosing "Permanent redirection to a product (301)" and typing a search phrase returned the product being edited among the suggestions, so it could be set to redirect to itself. |
| Type?                      | bug fix                                                          |
| Category?                  | BO                                                               |
| BC breaks?                 | no                                                               |
| Deprecations?              | no                                                               |
| How to test?               | See below.                                                       |
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #31209
| Related PRs                |
| Sponsor company            |

### The bug

The exclusion already exists and was already wired up. `RedirectOptionType` passes the edited product's
id as `data-product-filtered` (and the home category id as `data-category-filtered`), and
`EntitySearchInput` drops any suggestion whose identifier is in `filteredIdentities`.

It breaks on a type mismatch that only affects one of the two paths that set that option.

`buildOptions()` ends with a deliberate normalisation, with its reason in the comment:

```ts
// Cast all IDs into string to avoid not matching because of different types
this.options.filteredIdentities = this.options.filteredIdentities.map(String);
```

because `transform()` compares against a string-cast identifier:

```ts
const responseIdentifier: string = String(responseItem[this.options.identifierField]);
const isFiltered = this.options.filteredIdentities.includes(responseIdentifier);
```

`setOption()` is the second way into that same field and it stored the value raw:

```ts
setOption(optionName: string, value: unknown): void {
  this.options[optionName] = value;
  ...
}
```

`redirect-option-manager.ts` uses exactly that path when the redirect type changes:

```ts
this.entitySearchInput.setOption('filteredIdentities', this.$redirectTargetInput.data('productFiltered'));
```

The attribute is rendered by `json_encode([$options['product_id']])`, so it is `[12]`, and jQuery's
`.data()` runs `JSON.parse` on any value matching `^\[...\]$` (`jquery.js:4487`). The array therefore
arrives as **numbers**, and `[12].includes("12")` is `false`. The product is never filtered out.

This is also why the bug looks intermittent. On page load the server side is correct:
`RedirectOptionListener` presets `filtered_identities` on the cloned `target` field, the twig renders
`data-filtered-identities`, and the constructor normalises it. Only changing the dropdown goes through
`setOption`, and that is precisely the sequence the report describes.

### The fix

Normalise in the setter as well, so the invariant holds however the option is written:

```ts
} else if (optionName === 'filteredIdentities') {
  // Cast all IDs into string to avoid not matching because of different types, the same way
  // buildOptions does it, since identities are compared with the string cast response identifier
  this.options.filteredIdentities = Array.isArray(value) ? value.map(String) : [];
}
```

Fixing it in the component rather than in `RedirectOptionType` (which could have emitted
`["12"]` instead) keeps the guarantee for every caller. It also covers the category branch of the same
manager, where the home category stopped being filtered out after a type switch for the same reason.

`filterSelected`, one line above in the same method, is not affected: `getSelectedIds()` builds its
array from `input.value`, which is always a string.

### How to test

1. Catalog → Products → edit any product → SEO tab.
2. Set "Redirection when offline" to "Permanent redirection to a product (301)".
3. Type part of that same product's own name in "Target product".

Before: the product being edited appears in the suggestion list and can be selected as its own redirect
target. After: it is absent, while other matches are still listed.

Also worth checking, same tab, that the fix is not one-directional: switch to "Permanent redirection to
a category (301)" and search — the home category stays excluded.

### Verification

- Mechanism reproduced against the shipped sources rather than from a description: jQuery's `getData()`
  (`node_modules/jquery/dist/jquery.js:4468-4492`) and `transform()`
  (`entity-search-input.ts:352-366`) were run on the real attribute value `[12]`.
  Before: suggestions `12, 15`, edited product offered as its own target — `true`.
  After: suggestions `15` — `false`.
- `eslint -c .eslintrc.js js/components/entity-search-input.ts` — clean.
- `tsc --noEmit -p tsconfig.json` — 16 errors, all pre-existing; **the same 16 on `upstream/9.2.x`
  with the file reverted**, and none of them in the changed file.

No unit test accompanies this one, and the reason is specific rather than an omission: this theme's
mocha suite has no DOM environment (`jsdom` is not a dependency), and `entity-search-input.ts` cannot be
imported under `ts-node/register` at all — it fails on pre-existing `TS7053` at lines 221/223 and
`TS2339` at lines 314/356, none of which this change touches. Making the component testable means
adding a dev dependency and clearing those errors first, which does not belong in a trivial bug fix.
The behaviour is covered by UI tests, which are not being dispatched at the moment.