### PR TITLE
Honour the EXIF orientation when the webservice writes an image with PUT

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -165,6 +165,50 @@ class ImageManagerCore
      *
      * @return bool Operation result
      */
+    /**
+     * The rotation, in degrees, that an image's EXIF orientation asks for. Zero when there is none,
+     * when the orientation needs no rotation, or when the extension is unavailable.
+     *
+     * @param string $file
+     *
+     * @return int one of 0, 90, -90 or 180
+     */
+    public static function getExifRotationDegrees(string $file): int
+    {
+        if (!function_exists('exif_read_data')) {
+            return 0;
+        }
+
+        $exif = @exif_read_data($file);
+        if (!$exif || !isset($exif['Orientation'])) {
+            return 0;
+        }
+
+        return self::getRotationForExifOrientation((int) $exif['Orientation']);
+    }
+
+    /**
+     * The rotation an EXIF orientation value asks for. The mirrored orientations, 2, 4, 5 and 7, are
+     * not rotations and are left alone, which is what resize() has always done with them.
+     *
+     * @param int $orientation
+     *
+     * @return int one of 0, 90, -90 or 180
+     */
+    public static function getRotationForExifOrientation(int $orientation): int
+    {
+        switch ($orientation) {
+            case 3:
+                return 180;
+            case 6:
+                return -90;
+            case 8:
+                return 90;
+            default:
+                return 0;
+        }
+    }
+
     public static function resize(
         $sourceFile,
         $destinationFile,

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -891,6 +891,16 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         if (!$source_width) {
             throw new WebserviceException('Image width was null', [68, 400]);
         }
+
+        // ImageManager::resize() honours the EXIF orientation and the POST path goes through it, but
+        // this method builds the image itself, so a photo taken in portrait arrived sideways when it
+        // was sent with PUT. The dimensions are swapped here, before they are used as the defaults for
+        // the destination, and the pixels are rotated once the source image exists.
+        $exifRotation = ImageManager::getExifRotationDegrees($base_path);
+        if (90 === abs($exifRotation)) {
+            [$source_width, $source_height] = [$source_height, $source_width];
+        }
+
         if ($dest_width == null) {
             $dest_width = $source_width;
         }
@@ -917,6 +927,14 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
             default:
                 $source_image = imagecreatefromjpeg($base_path);
                 break;
+        }
+
+        if (0 !== $exifRotation && $source_image) {
+            $rotated = imagerotate($source_image, $exifRotation, 0);
+            if (false !== $rotated) {
+                imagedestroy($source_image);
+                $source_image = $rotated;
+            }
         }
 
         $width_diff = $dest_width / $source_width;

--- a/tests/Unit/Classes/ImageManagerExifRotationTest.php
+++ b/tests/Unit/Classes/ImageManagerExifRotationTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use ImageManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The rotation an EXIF orientation asks for, extracted so that the webservice image writer can apply
+ * it too. It used to live inline in ImageManager::resize(), which is why the POST upload path rotated
+ * an image and the PUT one did not.
+ */
+class ImageManagerExifRotationTest extends TestCase
+{
+    /**
+     * @var string[]
+     */
+    private array $files = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->files as $file) {
+            @unlink($file);
+        }
+        $this->files = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider provideOrientations
+     */
+    public function testTheRotationMatchesTheOrientation(int $orientation, int $expected): void
+    {
+        $this->assertSame($expected, ImageManager::getRotationForExifOrientation($orientation));
+    }
+
+    /**
+     * @return iterable<string, array{0: int, 1: int}>
+     */
+    public static function provideOrientations(): iterable
+    {
+        yield 'upright needs no rotation' => [1, 0];
+        yield 'upside down' => [3, 180];
+        yield 'rotated clockwise' => [6, -90];
+        yield 'rotated counter clockwise' => [8, 90];
+        yield 'a mirrored orientation is not rotated' => [2, 0];
+        yield 'another mirrored orientation' => [5, 0];
+        yield 'an orientation outside the range' => [42, 0];
+    }
+
+    public function testAnImageWithoutExifNeedsNoRotation(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'noexif') . '.png';
+        $image = imagecreatetruecolor(4, 2);
+        imagepng($image, $path);
+        imagedestroy($image);
+        $this->files[] = $path;
+
+        $this->assertSame(0, ImageManager::getExifRotationDegrees($path));
+    }
+
+    public function testAMissingFileNeedsNoRotation(): void
+    {
+        $this->assertSame(0, ImageManager::getExifRotationDegrees('/does/not/exist.jpg'));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `ImageManager::resize()` rotates an image according to its EXIF orientation, and the webservice POST path goes through it. The PUT path calls `writeImageOnDisk()`, which builds the image with `imagecreatefrom*()` itself and never applied the orientation, so a photo taken in portrait arrived sideways. The mapping from orientation to rotation is lifted out of `resize()` so both paths use it.
| Type?                      | bug fix
| Category?                  | WS
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Take a photo whose EXIF orientation is 6 or 8 (a portrait shot from a phone) and send it to `/api/images/products/{id}/{image}` with `PUT`. On 9.2.x it is stored sideways; sending the same file with `POST` stores it upright. With this change both are upright.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #31577
| Related PRs                |
| Sponsor company            |

### Why the two methods differ

`WebserviceSpecificManagementImages::writeImageOnDisk()` creates the source itself:

```php
switch ($type) {
    case IMAGETYPE_JPEG:
    default:
        $source_image = imagecreatefromjpeg($base_path);
```

`imagecreatefromjpeg()` gives the raw pixel grid and knows nothing about EXIF, so the orientation is
lost. `ImageManager::resize()`, which the POST branch uses, reads `exif_read_data()` and rotates. Both
now use the same mapping.

### Order matters here

The rotation is decided before the destination defaults are taken:

```php
$exifRotation = ImageManager::getExifRotationDegrees($base_path);
if (90 === abs($exifRotation)) {
    [$source_width, $source_height] = [$source_height, $source_width];
}

if ($dest_width == null) {
    $dest_width = $source_width;
}
```

Doing it after would leave `$dest_width` and `$dest_height` holding the pre-rotation, landscape values
for a portrait photo, and the resize would then squash it. The pixels themselves are rotated once
`$source_image` exists.

### The extraction

`getRotationForExifOrientation()` is the switch that was inline in `resize()`, unchanged: 3 gives 180,
6 gives -90, 8 gives 90, everything else gives 0. The mirrored orientations 2, 4, 5 and 7 are not
rotations and are left alone, which is what `resize()` has always done with them.
`getExifRotationDegrees()` is the thin wrapper that reads the file.

### Tests

`tests/Unit/Classes/ImageManagerExifRotationTest.php` covers the mapping for every orientation that
matters plus two that must not rotate and one outside the range, and pins that an image with no EXIF
and a missing file both ask for no rotation. Making the mapping always return zero turns three of them
red.