### PR TITLE
Duplicate the group reduction cache in one statement

### DIFF
--- a/classes/GroupReduction.php
+++ b/classes/GroupReduction.php
@@ -202,14 +202,20 @@ class GroupReductionCore extends ObjectModel
             return true;
         }
 
-        $query = '';
-
+        // One statement per row made this a multi statement query, which the connection is asked to
+        // refuse: config/defines.inc.php sets _PS_ALLOW_MULTI_STATEMENTS_QUERIES_ to false and DbPDO
+        // passes it to the driver. A single insert with one tuple per row does the same work without
+        // depending on that capability.
+        $values = [];
         foreach ($res as $row) {
-            $query .= 'INSERT INTO `' . _DB_PREFIX_ . 'product_group_reduction_cache` (`id_product`, `id_group`, `reduction`) VALUES ';
-            $query .= '(' . (int) $id_product . ', ' . (int) $row['id_group'] . ', ' . (float) $row['reduction'] . ') ON DUPLICATE KEY UPDATE `reduction` = ' . (float) $row['reduction'] . ';';
+            $values[] = '(' . (int) $id_product . ', ' . (int) $row['id_group'] . ', ' . (float) $row['reduction'] . ')';
         }
 
-        return Db::getInstance()->execute($query);
+        return Db::getInstance()->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'product_group_reduction_cache` (`id_product`, `id_group`, `reduction`)
+            VALUES ' . implode(', ', $values) . '
+            ON DUPLICATE KEY UPDATE `reduction` = VALUES(`reduction`)'
+        );
     }
 
     public static function deleteCategory($id_category)

--- a/tests/Integration/Classes/GroupReductionDuplicateTest.php
+++ b/tests/Integration/Classes/GroupReductionDuplicateTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Db;
+use GroupReduction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Duplicating the group reduction cache used to emit one INSERT per row, which is a multi statement
+ * query. The connection is asked to refuse those: config/defines.inc.php sets
+ * _PS_ALLOW_MULTI_STATEMENTS_QUERIES_ to false and DbPDO passes it to the driver, so on a setup where
+ * the driver honours it, duplicating a product with more than one reduction row failed.
+ */
+class GroupReductionDuplicateTest extends TestCase
+{
+    private const SOURCE_PRODUCT_ID = 900001;
+    private const TARGET_PRODUCT_ID = 900002;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->clear();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clear();
+        parent::tearDown();
+    }
+
+    public function testEveryReductionRowIsCopied(): void
+    {
+        $this->seed([1 => 0.1, 2 => 0.2, 3 => 0.3]);
+
+        $this->assertTrue((bool) GroupReduction::duplicateReduction(self::SOURCE_PRODUCT_ID, self::TARGET_PRODUCT_ID));
+        $this->assertSame([1 => 0.1, 2 => 0.2, 3 => 0.3], $this->reductionsOf(self::TARGET_PRODUCT_ID));
+    }
+
+    public function testASingleRowStillWorks(): void
+    {
+        $this->seed([1 => 0.15]);
+
+        $this->assertTrue((bool) GroupReduction::duplicateReduction(self::SOURCE_PRODUCT_ID, self::TARGET_PRODUCT_ID));
+        $this->assertSame([1 => 0.15], $this->reductionsOf(self::TARGET_PRODUCT_ID));
+    }
+
+    public function testAProductWithNoReductionIsNotAnError(): void
+    {
+        $this->assertTrue((bool) GroupReduction::duplicateReduction(self::SOURCE_PRODUCT_ID, self::TARGET_PRODUCT_ID));
+        $this->assertSame([], $this->reductionsOf(self::TARGET_PRODUCT_ID));
+    }
+
+    /**
+     * The insert carries ON DUPLICATE KEY UPDATE, so running it twice must update rather than fail or
+     * duplicate.
+     */
+    public function testRunningItTwiceUpdatesRatherThanDuplicates(): void
+    {
+        $this->seed([1 => 0.1, 2 => 0.2]);
+
+        GroupReduction::duplicateReduction(self::SOURCE_PRODUCT_ID, self::TARGET_PRODUCT_ID);
+        GroupReduction::duplicateReduction(self::SOURCE_PRODUCT_ID, self::TARGET_PRODUCT_ID);
+
+        $this->assertSame([1 => 0.1, 2 => 0.2], $this->reductionsOf(self::TARGET_PRODUCT_ID));
+    }
+
+    /**
+     * @param array<int, float> $reductionsByGroup
+     */
+    private function seed(array $reductionsByGroup): void
+    {
+        $values = [];
+        foreach ($reductionsByGroup as $groupId => $reduction) {
+            $values[] = '(' . self::SOURCE_PRODUCT_ID . ', ' . (int) $groupId . ', ' . (float) $reduction . ')';
+        }
+
+        Db::getInstance()->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'product_group_reduction_cache` (`id_product`, `id_group`, `reduction`) VALUES ' . implode(', ', $values)
+        );
+    }
+
+    /**
+     * @return array<int, float>
+     */
+    private function reductionsOf(int $productId): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT `id_group`, `reduction` FROM `' . _DB_PREFIX_ . 'product_group_reduction_cache`
+             WHERE `id_product` = ' . $productId . ' ORDER BY `id_group`'
+        ) ?: [];
+
+        $reductions = [];
+        foreach ($rows as $row) {
+            $reductions[(int) $row['id_group']] = (float) $row['reduction'];
+        }
+
+        return $reductions;
+    }
+
+    private function clear(): void
+    {
+        Db::getInstance()->execute(
+            'DELETE FROM `' . _DB_PREFIX_ . 'product_group_reduction_cache`
+             WHERE `id_product` IN (' . self::SOURCE_PRODUCT_ID . ', ' . self::TARGET_PRODUCT_ID . ')'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `GroupReduction::duplicateReduction()` emitted one `INSERT` per row, so a product with more than one row in `product_group_reduction_cache` produced a multi statement query. The connection is asked to refuse those — `config/defines.inc.php` sets `_PS_ALLOW_MULTI_STATEMENTS_QUERIES_` to false and `DbPDO` passes it to the driver — so where the driver honours it, duplicating such a product fails. One insert with a tuple per row does the same work without depending on that capability.
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Give a product two or more rows in `product_group_reduction_cache` (two customer groups with a group reduction on its category) and duplicate it from the catalogue. On a setup whose PDO driver honours `MYSQL_ATTR_MULTI_STATEMENTS => false`, the duplication fails on 9.2.x. With this change it succeeds, and `GroupReduction::duplicateReduction()` copies every row in either case.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #31737
| Related PRs                |
| Sponsor company            |

### The shape of the query

```php
foreach ($res as $row) {
    $query .= 'INSERT INTO ... VALUES ';
    $query .= '(...) ON DUPLICATE KEY UPDATE `reduction` = ...;';
}
```

Each iteration appends a complete statement terminated by `;`. With one row that is a single statement
and works everywhere, which is why this only bites products carrying several reductions — exactly the
condition in the report.

### What I could and could not reproduce

The configuration named in the report is the default here: `Db::getInstance()` is `DbPDO` and
`_PS_ALLOW_MULTI_STATEMENTS_QUERIES_` is `false`. But a raw two statement query still executes on this
install and both rows land, so `PDO::MYSQL_ATTR_MULTI_STATEMENTS => false` is not being honoured by this
driver build, and I could not make the duplication fail here.

I am not claiming a reproduction I do not have. What is not in doubt is that the code depends on a
capability the configuration explicitly asks the driver to withhold, and that dependency is removable
without changing behaviour, which is what this does.

### Tests

`tests/Integration/Classes/GroupReductionDuplicateTest.php` covers four cases: several rows are all
copied, a single row still works, a product with no reduction is not an error, and running it twice
updates rather than duplicating, since the insert keeps `ON DUPLICATE KEY UPDATE`. `VALUES()` in that
clause is the idiom already used in `Search.php` and `Category.php`.