### PR TITLE
Allow a partial refund of products that cost nothing

### DIFF
--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -72,7 +72,10 @@ class OrderSlipCreator
         Order $order,
         OrderRefundSummary $orderRefundSummary
     ) {
-        if ($orderRefundSummary->getRefundedAmount() > 0) {
+        // A refund of free products moves no money but still has to be recorded. The calculator has
+        // already refused a refund carrying neither products nor an amount, so the only way to arrive
+        // here with nothing at all is a caller that bypassed it.
+        if ($orderRefundSummary->getRefundedAmount() > 0 || !empty($orderRefundSummary->getProductRefunds())) {
             $orderSlipCreated = $this->createOrderSlip(
                 $order,
                 $orderRefundSummary->getProductRefunds(),

--- a/src/Core/Domain/Order/ValueObject/OrderDetailRefund.php
+++ b/src/Core/Domain/Order/ValueObject/OrderDetailRefund.php
@@ -50,7 +50,9 @@ class OrderDetailRefund
             throw new InvalidAmountException();
         }
 
-        if ($decimalRefundedAmount->isLowerOrEqualThanZero()) {
+        // A free product refunds nothing, and refusing that made it impossible to take one back into
+        // stock. Only a negative amount is meaningless.
+        if ($decimalRefundedAmount->isLowerThanZero()) {
             throw new InvalidCancelProductException(InvalidCancelProductException::INVALID_AMOUNT);
         }
 

--- a/tests/Integration/Adapter/Order/Refund/OrderSlipCreatorFreeProductTest.php
+++ b/tests/Integration/Adapter/Order/Refund/OrderSlipCreatorFreeProductTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Order\Refund;
+
+use Configuration;
+use Db;
+use Mail;
+use Order;
+use PrestaShop\PrestaShop\Adapter\Order\Refund\OrderRefundSummary;
+use PrestaShop\PrestaShop\Adapter\Order\Refund\OrderSlipCreator;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidCancelProductException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Refunding free products moves no money, so the refunded amount is zero while products are still going
+ * back. Requiring a positive amount before recording anything meant a partial refund of a product priced
+ * at zero was refused, and the handler restocks before it gets here, so the refusal arrived after the
+ * stock had already moved.
+ */
+class OrderSlipCreatorFreeProductTest extends KernelTestCase
+{
+    private OrderSlipCreator $orderSlipCreator;
+
+    private Order $order;
+
+    private string $originalMailMethod;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        // Recording a slip notifies the customer; nothing here is about the email.
+        $this->originalMailMethod = (string) Configuration::get('PS_MAIL_METHOD');
+        Configuration::updateValue('PS_MAIL_METHOD', Mail::METHOD_DISABLE);
+
+        $orderId = (int) Db::getInstance()->getValue(
+            'SELECT id_order FROM ' . _DB_PREFIX_ . 'orders ORDER BY id_order'
+        );
+        self::assertGreaterThan(0, $orderId, 'the shop needs at least one order');
+
+        $this->order = new Order($orderId);
+        $this->orderSlipCreator = self::$kernel->getContainer()->get('prestashop.adapter.order.refund.order_slip_creator');
+    }
+
+    protected function tearDown(): void
+    {
+        Configuration::updateValue('PS_MAIL_METHOD', $this->originalMailMethod);
+
+        Db::getInstance()->execute(
+            'DELETE FROM ' . _DB_PREFIX_ . 'order_slip WHERE id_order = ' . (int) $this->order->id
+        );
+
+        parent::tearDown();
+    }
+
+    /**
+     * The guard has to stay for a refund that carries nothing at all.
+     */
+    public function testARefundOfNothingIsStillRefused(): void
+    {
+        $this->expectException(InvalidCancelProductException::class);
+
+        $this->orderSlipCreator->create($this->order, $this->summary([], 0.0));
+    }
+
+    /**
+     * Products going back with no money attached is a real refund and has to be recorded.
+     */
+    public function testFreeProductsGoingBackAreRecorded(): void
+    {
+        $before = $this->slipCount();
+
+        $this->orderSlipCreator->create($this->order, $this->summary($this->aFreeProductGoingBack(), 0.0));
+
+        self::assertSame(
+            $before + 1,
+            $this->slipCount(),
+            'a refund of free products was refused, so nothing was recorded for it'
+        );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $productRefunds
+     */
+    private function summary(array $productRefunds, float $refundedAmount): OrderRefundSummary
+    {
+        return new OrderRefundSummary(
+            [],
+            $productRefunds,
+            $refundedAmount,
+            0.0,
+            0.0,
+            false,
+            true,
+            2
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function aFreeProductGoingBack(): array
+    {
+        $orderDetail = Db::getInstance()->getRow(
+            'SELECT id_order_detail FROM ' . _DB_PREFIX_ . 'order_detail WHERE id_order = ' . (int) $this->order->id
+        );
+        self::assertNotEmpty($orderDetail, 'the order needs at least one line');
+
+        // The same shape OrderRefundCalculator produces, so the slip is built from real keys.
+        return [
+            (int) $orderDetail['id_order_detail'] => [
+                'id_order_detail' => (int) $orderDetail['id_order_detail'],
+                'quantity' => 1,
+                'amount' => 0.0,
+                'unit_price' => 0.0,
+                'total_price' => 0.0,
+            ],
+        ];
+    }
+
+    private function slipCount(): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'order_slip WHERE id_order = ' . (int) $this->order->id
+        );
+    }
+}

--- a/tests/Unit/Core/Domain/Order/ValueObject/OrderDetailRefundTest.php
+++ b/tests/Unit/Core/Domain/Order/ValueObject/OrderDetailRefundTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Order\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidCancelProductException;
+use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderDetailRefund;
+
+/**
+ * A product that costs nothing refunds nothing, and refusing a zero amount made it impossible to take one
+ * back into stock through a partial refund. Only a negative amount is meaningless.
+ */
+class OrderDetailRefundTest extends TestCase
+{
+    public function testAFreeProductCanBeRefunded(): void
+    {
+        $refund = OrderDetailRefund::createPartialRefund(1, 10, '0');
+
+        self::assertSame(1, $refund->getOrderDetailId());
+        self::assertSame(10, $refund->getProductQuantity());
+        self::assertTrue($refund->getRefundedAmount()->equalsZero());
+    }
+
+    /**
+     * @dataProvider getAmountsThatCostSomething
+     */
+    public function testAnAmountIsStillAccepted(string $amount): void
+    {
+        $refund = OrderDetailRefund::createPartialRefund(1, 1, $amount);
+
+        self::assertTrue($refund->getRefundedAmount()->isGreaterThanZero());
+    }
+
+    /**
+     * @dataProvider getAmountsThatMakeNoSense
+     */
+    public function testANegativeAmountIsStillRefused(string $amount): void
+    {
+        $this->expectException(InvalidCancelProductException::class);
+
+        OrderDetailRefund::createPartialRefund(1, 1, $amount);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getAmountsThatCostSomething(): iterable
+    {
+        yield 'a round amount' => ['10'];
+        yield 'a fractional amount' => ['0.01'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getAmountsThatMakeNoSense(): iterable
+    {
+        yield 'negative' => ['-1'];
+        yield 'a small negative amount' => ['-0.01'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | A partial refund of a product priced at zero was refused, so the merchant could not take it back into stock. |
| Type?                      | bug fix                                                          |
| Category?                  | BO                                                               |
| BC breaks?                 | no                                                               |
| Deprecations?              | no                                                               |
| How to test?               | See below.                                                       |
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #33529
| Related PRs                |
| Sponsor company            |

### The bug

Two separate guards refuse it, and both have to go for the flow to work.

**Building the command.** `OrderDetailRefund::createPartialRefund()` rejects any amount that is not above
zero:

```php
if ($decimalRefundedAmount->isLowerOrEqualThanZero()) {
    throw new InvalidCancelProductException(InvalidCancelProductException::INVALID_AMOUNT);
}
```

A free product refunds nothing, so the command cannot even be constructed and nothing happens at all.

**Recording the credit slip.** `OrderSlipCreator::create()` only records a refund whose total is above
zero, and throws otherwise:

```php
if ($orderRefundSummary->getRefundedAmount() > 0) {
    ...
} else {
    throw new InvalidCancelProductException(InvalidCancelProductException::INVALID_AMOUNT);
}
```

That one matters even more than it looks, because `IssuePartialRefundHandler` **restocks before it gets
here** — the quantities are reinjected, the carrier weight is updated, and only then is the slip created.
So with the first guard lifted but not the second, a merchant who leaves "generate credit slip" ticked
would see the refund fail after the stock had already moved.

### The fix

Refuse only a **negative** amount, and record the slip when products are going back even if no money is.

A refund carrying neither products nor an amount is still refused: `OrderRefundCalculator` already throws
`NO_REFUNDS` for that case, and the slip creator keeps its own guard for a caller that bypassed the
calculator.

### How to test

The steps in the issue: a product with stock 10 and price 0, ordered and delivered, then Partial refund
with "re-stock products" ticked.

Before: the refund is refused. After: it goes through, the stock comes back, and a credit slip for 0 is
recorded when that option is ticked.

### Verification

- `tests/Unit/Core/Domain/Order/ValueObject/OrderDetailRefundTest.php` — 5 tests: a free product can be
  refunded, ordinary amounts are still accepted, and negative amounts are still refused.
- `tests/Integration/Adapter/Order/Refund/OrderSlipCreatorFreeProductTest.php` — 2 tests calling the real
  service from the container: free products going back are recorded, and a refund carrying nothing is
  still refused. Mail is disabled for the duration and the slip is removed afterwards.
- **Mutation check, run separately for each guard.** With the two source files reverted to
  `upstream/9.2.x`: the value object test fails only on *"a free product can be refunded"*, and the slip
  test fails only on *"free products going back are recorded"*. In both files the test that pins the
  preserved behaviour keeps passing, so each change is shown to do one thing.
- `tests/Integration/Adapter/Order/` 8/8 and `tests/Unit/Core/Domain/` 684/684.
- `php -l`, `php-cs-fixer`, `phpstan analyse -c phpstan.neon.dist` clean.

One note on the fixture: the first version of the slip test omitted `id_order_detail` from its product
refund array and PHPUnit reported an *"Undefined array key"* warning from inside `OrderSlipCreator`. The
test still passed, but the shape did not match what `OrderRefundCalculator` really produces, so the key
was added rather than the warning ignored.

## Update 2026-09-21

The Behat suite showed the first version was too permissive in two places. Both are narrowed:

- A zero partial-refund amount is accepted only for a product that cost nothing (`productMaxRefund == 0` in
  `OrderRefundCalculator`). For a paid product it is refused with `INVALID_AMOUNT`, as before.
- A credit slip for a refund that moves no money is created only when every refunded product is free
  (`OrderSlipCreator::refundsOnlyFreeProducts()`). A refund that nets to zero or less because of a voucher is
  refused, as before.

Behat: partial refund 22/22, return product 17/17, standard refund 17/17.
