### PR TITLE
Make the low stock sort respond to the flag the stock page sends

### DIFF
--- a/src/PrestaShopBundle/Api/QueryStockParamsCollection.php
+++ b/src/PrestaShopBundle/Api/QueryStockParamsCollection.php
@@ -17,7 +17,12 @@ class QueryStockParamsCollection extends QueryParamsCollection
     {
         $queryParams = parent::parseOrderParams($queryParams);
 
-        if (array_key_exists('low_stock', $queryParams) && 1 == $queryParams['low_stock']) {
+        // The stock page sends this flag as a stringified boolean, so comparing it to 1 never matched
+        // and the option silently did nothing. Read it as a flag instead, which also accepts the 1 that
+        // any other client would send.
+        if (array_key_exists('low_stock', $queryParams)
+            && filter_var($queryParams['low_stock'], FILTER_VALIDATE_BOOLEAN)
+        ) {
             array_unshift($queryParams['order'], 'product_low_stock_alert desc');
         }
 

--- a/tests/Unit/PrestaShopBundle/Api/QueryStockParamsCollectionTest.php
+++ b/tests/Unit/PrestaShopBundle/Api/QueryStockParamsCollectionTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Api;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Api\QueryStockParamsCollection;
+
+/**
+ * "Display products below low stock level first" puts product_low_stock_alert at the front of the sort.
+ * The stock page sends the flag as a stringified boolean, so a comparison against 1 never matched and
+ * ticking the box changed nothing.
+ */
+class QueryStockParamsCollectionTest extends TestCase
+{
+    /**
+     * @dataProvider getValuesThatMeanTheBoxIsTicked
+     */
+    public function testTheLowStockSortIsAppliedFirst(string $lowStock): void
+    {
+        $order = $this->sqlOrderFor(['low_stock' => $lowStock, 'order' => ['product_name asc']]);
+
+        self::assertStringContainsString(
+            '{product_low_stock_alert} DESC',
+            $order,
+            sprintf('low_stock=%s did not put low stock products first', $lowStock)
+        );
+        self::assertStringStartsWith(
+            'ORDER BY {product_low_stock_alert} DESC',
+            $order,
+            'the low stock sort has to come before the column the merchant chose'
+        );
+        self::assertStringContainsString('{product_name}', $order, 'the chosen sort must survive');
+    }
+
+    /**
+     * @dataProvider getValuesThatMeanTheBoxIsNotTicked
+     */
+    public function testTheLowStockSortIsLeftOutOtherwise(string $lowStock): void
+    {
+        $order = $this->sqlOrderFor(['low_stock' => $lowStock, 'order' => ['product_name asc']]);
+
+        self::assertStringNotContainsString('product_low_stock_alert', $order);
+    }
+
+    public function testTheSortIsLeftOutWhenTheFlagIsAbsent(): void
+    {
+        $order = $this->sqlOrderFor(['order' => ['product_name asc']]);
+
+        self::assertStringNotContainsString('product_low_stock_alert', $order);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getValuesThatMeanTheBoxIsTicked(): iterable
+    {
+        // What the stock page actually sends, through String(isChecked).
+        yield 'the stringified boolean the page sends' => ['true'];
+        yield 'the 1 another client would send' => ['1'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getValuesThatMeanTheBoxIsNotTicked(): iterable
+    {
+        yield 'cleared, as the page sends it' => ['false'];
+        yield 'cleared, as a number' => ['0'];
+        yield 'empty' => [''];
+    }
+
+    /**
+     * @param array<string, mixed> $queryParams
+     */
+    private function sqlOrderFor(array $queryParams): string
+    {
+        $collection = new QueryStockParamsCollection();
+        $collection->fromArray($queryParams);
+
+        return $collection->getSqlOrder();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Ticking "Display products below low stock level first" on Catalog → Stock management left the list in the order it was already in, because the flag never reached the sort. |
| Type?                      | bug fix                                                          |
| Category?                  | BO                                                               |
| BC breaks?                 | no                                                               |
| Deprecations?              | no                                                               |
| How to test?               | See below.                                                       |
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #33681
| Related PRs                |
| Sponsor company            |

### The bug

The sort itself is wired up correctly. `QueryStockParamsCollection::parseOrderParams()` puts
`product_low_stock_alert desc` at the front of the order list, `getSqlOrder()` turns it into
`{product_low_stock_alert} DESC`, and `StockManagementRepository::orderBy()` maps that placeholder onto
the `product_low_stock_alert` column the query already selects. Every link in that chain works.

What never happened is the flag being recognised. The stock page builds the request from a JavaScript
boolean:

```ts
onLowStockChecked(isChecked: boolean): void {
  this.filters = {...this.filters, low_stock: isChecked};
```

and `actions.ts` appends it with `url.searchParams.append(key, String(value))`, so the request carries
`low_stock=true`. The check was:

```php
if (array_key_exists('low_stock', $queryParams) && 1 == $queryParams['low_stock']) {
```

and `1 == 'true'` is **false** — PHP compares the int as a string once the other side is not numeric.
Measured on PHP 8.1:

```
checkbox ticked (String(true))   low_stock='true'    1 == value : false
if it sent 1                     low_stock=1         1 == value : true
checkbox cleared                 low_stock='false'   1 == value : false
```

So the option was inert in both states, which is why the list simply keeps whatever order it had and looks
inconsistent from click to click. Note the value is not dropped on the way either: `isParamInvalid` tests
`value.length <= 0`, and a boolean has no `length`, so `false` is sent as the string `'false'` rather than
omitted.

### The fix

Read it as a flag with `FILTER_VALIDATE_BOOLEAN`. That accepts what the page sends today and the `1` any
other API client would send, and still treats `false`, `0` and an empty value as unticked.

Fixed on the server rather than in the page: this is an API endpoint, so it should not depend on one
client's stringification, and a caller sending `low_stock=1` was already entitled to expect it to work.

### How to test

Catalog → Stock management, with at least one product below its low stock level. Tick "Display products
below low stock level first".

Before: the order does not change. After: products below their low stock level are listed first, and the
column sort you had chosen still applies underneath.

### Verification

- `tests/Unit/PrestaShopBundle/Api/QueryStockParamsCollectionTest.php` — 6 tests: the sort is applied for
  both `true` (what the page sends) and `1` (what another client would send), it is left out for `false`,
  `0`, an empty value and an absent flag, it comes **before** the merchant's chosen column, and that
  chosen column survives.
- **Mutation check**: with `QueryStockParamsCollection.php` reverted to `upstream/9.2.x`, exactly the case
  the page actually produces fails — *"low_stock=true did not put low stock products first"* — while the
  `1` case and every negative case still pass, since those already behaved correctly.
- `tests/Unit/` — 5438 tests. The single failure, `ModuleRepositoryTest::testGetList` (11 vs 12), is
  pre-existing and unrelated: it reproduces identically on a detached `upstream/9.2.x` and comes from a
  symlinked fixture under `tests/Resources/modules` in this environment.
- `php -l`, `php-cs-fixer`, `phpstan analyse -c phpstan.neon.dist` clean.