### PR TITLE
Let the movements list use the status filter it offers

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
@@ -82,6 +82,9 @@ export const getMovements = async ({commit}: {commit: Commit}, payload: Record<s
     page_size: payload.page_size,
     page_index: payload.page_index,
     keywords: payload.keywords,
+    // The advanced filters panel is shared with the stock list and offers the status filter on both
+    // tabs, so the movements request has to carry it too.
+    active: payload.active,
     supplier_id: payload.suppliers,
     category_id: payload.categories,
     id_stock_mvt_reason: payload.id_stock_mvt_reason,

--- a/src/PrestaShopBundle/Api/QueryStockMovementParamsCollection.php
+++ b/src/PrestaShopBundle/Api/QueryStockMovementParamsCollection.php
@@ -24,6 +24,10 @@ class QueryStockMovementParamsCollection extends QueryStockParamsCollection
             'date_add',
             'id_employee',
             'id_stock_mvt_reason',
+            // The movements list offers the same status filter as the stock list, and andWhere() already
+            // maps {active} onto p.active. Leaving it out here made excludeUnknownParams() drop it before
+            // it could be used, so the filter had no effect.
+            'active',
         ];
     }
 

--- a/tests/Unit/PrestaShopBundle/Api/QueryStockMovementParamsCollectionTest.php
+++ b/tests/Unit/PrestaShopBundle/Api/QueryStockMovementParamsCollectionTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Api;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Api\QueryStockMovementParamsCollection;
+use PrestaShopBundle\Api\QueryStockParamsCollection;
+
+/**
+ * The movements list offers the same status filter as the stock list, and the shared andWhere() already
+ * maps {active} onto p.active. Leaving 'active' out of the movements collection made
+ * excludeUnknownParams() drop it before it could be used, so choosing a status changed nothing.
+ */
+class QueryStockMovementParamsCollectionTest extends TestCase
+{
+    /**
+     * @dataProvider getStatuses
+     */
+    public function testTheStatusFilterReachesTheQuery(string $active): void
+    {
+        self::assertStringContainsString(
+            '{active}',
+            $this->whereClauseFor(new QueryStockMovementParamsCollection(), $active),
+            sprintf('a status filter of %s was dropped before it could be applied', $active)
+        );
+    }
+
+    /**
+     * The two tabs share the filter, so they should build the same clause for it.
+     */
+    public function testTheMovementsTabFiltersTheSameWayAsTheStockTab(): void
+    {
+        self::assertSame(
+            $this->whereClauseFor(new QueryStockParamsCollection(), '0'),
+            $this->whereClauseFor(new QueryStockMovementParamsCollection(), '0')
+        );
+    }
+
+    /**
+     * Filters the movements list does not offer must still be discarded, so the allow list keeps working.
+     */
+    public function testAnUnknownFilterIsStillDropped(): void
+    {
+        $collection = new QueryStockMovementParamsCollection();
+        $collection->fromArray(['not_a_filter' => '1', 'page_index' => 1, 'page_size' => 10]);
+
+        $filters = $collection->getSqlFilters();
+
+        self::assertStringNotContainsString('not_a_filter', $filters[$collection::SQL_CLAUSE_WHERE]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getStatuses(): iterable
+    {
+        yield 'disabled' => ['0'];
+        yield 'enabled' => ['1'];
+    }
+
+    private function whereClauseFor(QueryStockParamsCollection $collection, string $active): string
+    {
+        $collection->fromArray(['active' => $active, 'page_index' => 1, 'page_size' => 10]);
+
+        $filters = $collection->getSqlFilters();
+
+        return $filters[$collection::SQL_CLAUSE_WHERE];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | The advanced "Status" filter on Catalog → Stock management → Movements had no effect, because the parameter was discarded before the query was built. |
| Type?                      | bug fix                                                          |
| Category?                  | BO                                                               |
| BC breaks?                 | no                                                               |
| Deprecations?              | no                                                               |
| How to test?               | See below.                                                       |
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #33842
| Related PRs                |
| Sponsor company            |

### The bug

The advanced filters panel is shared between the two tabs, so the Status radios are shown on Movements as
well, and `filters.vue` puts the value into the payload it emits (`active: this.active`). It is dropped
twice after that:

1. **The request never carries it.** `getStock()` includes `active: payload.active` in its query params;
   `getMovements()` builds a separate object and leaves it out entirely.
2. **The endpoint would have discarded it anyway.** `QueryStockParamsCollection::getValidFilterParams()`
   lists `active`, but `QueryStockMovementParamsCollection` overrides that method and omits it, so
   `QueryParamsCollection::excludeUnknownParams()` strips the parameter before the query is built.

Everything downstream already exists. The movements query joins
`LEFT JOIN {prefix}product p ON (p.id_product = sa.id_product)`, and the shared
`StockManagementRepository::andWhere()` maps the placeholder:

```php
'{active}' => 'p.active',
```

### The fix

Send the parameter from the movements request, and accept it in the movements collection. No new SQL, no
new mapping, and nothing accepted beyond the one filter the page already displays.

Building both collections from the same input then produces the same clause:

```
movements tab    WHERE clause: AND {active} = :active
stock tab        WHERE clause: AND {active} = :active
```

and without the back-end half the movements clause is empty.

### How to test

Place an order for a product, disable that product, then go to Catalog → Stock management → Movements and
use Advanced filters → Status.

Before: the list is unchanged whichever status you pick. After: it narrows to products with that status,
the same way the Stock tab already does.

### Verification

- `tests/Unit/PrestaShopBundle/Api/QueryStockMovementParamsCollectionTest.php` — 4 tests: the filter
  reaches the query for both statuses, the movements tab now builds the same clause as the stock tab, and
  an unknown filter is still discarded.
- **Mutation check**: with `QueryStockMovementParamsCollection.php` reverted to `upstream/9.2.x`, three of
  the four fail — *"a status filter of 0 was dropped before it could be applied"* — while the test that
  pins the allow list still passing shows the list was widened by exactly this one entry rather than
  opened up.
- `php -l`, `php-cs-fixer` and `phpstan analyse -c phpstan.neon.dist` clean on the PHP; `eslint` clean
  on the changed TypeScript and `tsc --noEmit` reports nothing in it (the 16 project errors are
  pre-existing and unrelated).

Related: #33681 is the same shape one level up — a filter on these screens that never reaches the query.
That one is a stringified boolean rather than a missing allow-list entry, and is prepared separately.