### PR TITLE
List each employee once in the stock movements filter

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
@@ -220,14 +220,23 @@ class StockMovementRepository extends StockManagementRepository
      */
     public function getEmployees()
     {
+        // Each movement keeps the name the employee had when it was recorded, so DISTINCT over the
+        // name would list somebody once per name they have ever used. Group by the employee instead,
+        // and prefer their current name, falling back to the recorded one for employees who are gone.
         $query = str_replace(
             '{table_prefix}',
             $this->tablePrefix,
-            'SELECT DISTINCT sm.id_employee, CONCAT(sm.employee_lastname, \' \', sm.employee_firstname) AS name
+            'SELECT sm.id_employee, TRIM(CONCAT(
+                COALESCE(e.lastname, MAX(sm.employee_lastname)),
+                \' \',
+                COALESCE(e.firstname, MAX(sm.employee_firstname))
+            )) AS name
             FROM {table_prefix}stock_mvt sm
             INNER JOIN {table_prefix}stock_available sa ON (sa.id_stock_available = sm.id_stock)
+            LEFT JOIN {table_prefix}employee e ON (e.id_employee = sm.id_employee)
             WHERE
             sa.id_shop = :shop_id
+            GROUP BY sm.id_employee, e.lastname, e.firstname
             ORDER BY name ASC'
         );
 

--- a/tests/Integration/PrestaShopBundle/Entity/Repository/StockMovementEmployeeFilterTest.php
+++ b/tests/Integration/PrestaShopBundle/Entity/Repository/StockMovementEmployeeFilterTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Entity\Repository;
+
+use Db;
+use PrestaShopBundle\Entity\Repository\StockMovementRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Every stock movement keeps the name its employee had when it was recorded, so listing the filter
+ * options with DISTINCT over that name put somebody in the dropdown once per name they had ever used,
+ * every entry filtering on the same employee.
+ */
+class StockMovementEmployeeFilterTest extends KernelTestCase
+{
+    private const PRESENT_EMPLOYEE_ID = 1;
+    private const DELETED_EMPLOYEE_ID = 999999;
+
+    private StockMovementRepository $repository;
+
+    /** @var int[] */
+    private array $movementIds = [];
+
+    private int $stockAvailableId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->repository = self::$kernel->getContainer()->get('prestashop.core.api.stock_movement.repository');
+
+        $this->stockAvailableId = (int) Db::getInstance()->getValue(
+            'SELECT id_stock_available FROM ' . _DB_PREFIX_ . 'stock_available WHERE id_shop = 1'
+        );
+        self::assertGreaterThan(0, $this->stockAvailableId, 'the shop needs at least one stock row');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->movementIds) {
+            Db::getInstance()->execute(
+                'DELETE FROM ' . _DB_PREFIX_ . 'stock_mvt WHERE id_stock_mvt IN (' . implode(',', $this->movementIds) . ')'
+            );
+        }
+        $this->movementIds = [];
+
+        parent::tearDown();
+    }
+
+    public function testAnEmployeeWhoWasRenamedIsListedOnce(): void
+    {
+        $this->recordMovement(self::PRESENT_EMPLOYEE_ID, 'Hea', 'Florine');
+        $this->recordMovement(self::PRESENT_EMPLOYEE_ID, 'Hlavacek', 'Daniel');
+
+        $listed = $this->listedEmployeeIds();
+
+        self::assertSame(
+            [self::PRESENT_EMPLOYEE_ID],
+            $listed,
+            'the same employee was offered once per name they had used'
+        );
+    }
+
+    /**
+     * The one entry should say who they are now, not who they were when the oldest movement was saved.
+     */
+    public function testTheEntryUsesTheCurrentName(): void
+    {
+        $this->recordMovement(self::PRESENT_EMPLOYEE_ID, 'Some', 'Oldname');
+
+        $current = Db::getInstance()->getRow(
+            'SELECT lastname, firstname FROM ' . _DB_PREFIX_ . 'employee WHERE id_employee = ' . self::PRESENT_EMPLOYEE_ID
+        );
+
+        self::assertSame(
+            trim($current['lastname'] . ' ' . $current['firstname']),
+            $this->nameListedFor(self::PRESENT_EMPLOYEE_ID)
+        );
+    }
+
+    /**
+     * Employees are removed outright, so their movements outlive them and the recorded name is all
+     * there is left to show.
+     */
+    public function testAMovementFromADeletedEmployeeKeepsItsRecordedName(): void
+    {
+        $this->recordMovement(self::DELETED_EMPLOYEE_ID, 'Gone', 'Employee');
+
+        self::assertSame('Gone Employee', $this->nameListedFor(self::DELETED_EMPLOYEE_ID));
+    }
+
+    /**
+     * @return int[]
+     */
+    private function listedEmployeeIds(): array
+    {
+        $ids = [];
+        foreach ($this->repository->getEmployees() as $row) {
+            if (in_array((int) $row['id_employee'], [self::PRESENT_EMPLOYEE_ID, self::DELETED_EMPLOYEE_ID], true)) {
+                $ids[] = (int) $row['id_employee'];
+            }
+        }
+
+        return $ids;
+    }
+
+    private function nameListedFor(int $employeeId): ?string
+    {
+        foreach ($this->repository->getEmployees() as $row) {
+            if ((int) $row['id_employee'] === $employeeId) {
+                return $row['name'];
+            }
+        }
+
+        return null;
+    }
+
+    private function recordMovement(int $employeeId, string $lastname, string $firstname): void
+    {
+        Db::getInstance()->insert('stock_mvt', [
+            'id_stock' => $this->stockAvailableId,
+            'id_order' => 0,
+            'id_supply_order' => 0,
+            'id_stock_mvt_reason' => 1,
+            'id_employee' => $employeeId,
+            'employee_lastname' => pSQL($lastname),
+            'employee_firstname' => pSQL($firstname),
+            'physical_quantity' => 1,
+            'date_add' => date('Y-m-d H:i:s'),
+            'sign' => 1,
+        ]);
+
+        $this->movementIds[] = (int) Db::getInstance()->Insert_ID();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Catalog → Stock management → Movements offered the same employee several times in the "filter by employee" dropdown, once per name they had used, with every entry filtering on the same person. |
| Type?                      | bug fix                                                          |
| Category?                  | BO                                                               |
| BC breaks?                 | no                                                               |
| Deprecations?              | no                                                               |
| How to test?               | See below.                                                       |
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #34074
| Related PRs                |
| Sponsor company            |

### The bug

`ps_stock_mvt` keeps the employee's name as it was when the movement was recorded, in
`employee_firstname` and `employee_lastname`. The filter options were selected like this:

```sql
SELECT DISTINCT sm.id_employee, CONCAT(sm.employee_lastname, ' ', sm.employee_firstname) AS name
FROM ps_stock_mvt sm
INNER JOIN ps_stock_available sa ON (sa.id_stock_available = sm.id_stock)
WHERE sa.id_shop = :shop_id
ORDER BY name ASC
```

`DISTINCT` applies to the **pair**, so one employee who has been renamed produces one row per name.
@Hlavtox's recipe on the issue is the shortest way to see it: record a movement, change your own name,
record another, and you are in the list twice — both entries filtering on the same id.

Run against the real schema, with two movements from employee 1 recorded under different names and one
from an employee who has since been deleted:

```
 id_employee | name
-------------+-----------------
        9999 | Gone Employee
           1 | Hea Florine        <- same person
           1 | Hlavacek Daniel    <- twice
```

### The fix

Group by the employee rather than by the name they were using, and show their **current** name, falling
back to the recorded one when the employee no longer exists — `ps_employee` has no soft-delete column, so
removing an employee leaves their movements behind and the recorded name is all there is left:

```
 id_employee | name
-------------+---------------
           1 | Beier Marc     <- once, current name
        9999 | Gone Employee  <- fallback still works
```

`CONCAT` of two NULLs stays NULL exactly as before, so movements that carry no name at all are unchanged.

### How to test

Advanced Parameters → Team, rename yourself. Record a stock movement before and after the rename, then
open Catalog → Stock management → Movements → Advanced filters → filter by employee.

Before: you appear twice, once under each name. After: once, under your current name.

### Verification

- `tests/Integration/PrestaShopBundle/Entity/Repository/StockMovementEmployeeFilterTest.php` — 3 tests:
  a renamed employee is listed once, the entry carries their current name, and a movement left by a
  deleted employee still shows the recorded one.
- **Mutation check**: with `StockMovementRepository.php` reverted to `upstream/9.2.x`, the first two fail
  — *"the same employee was offered once per name they had used"* — while the deleted-employee test passes
  on both, which is right, since that case already worked.
- Verified against MySQL with `ONLY_FULL_GROUP_BY` enabled (it is on in this environment), so the
  `GROUP BY` lists every non-aggregated column.
- `tests/Integration/PrestaShopBundle/Entity/` — 7/7.
- `php -l`, `php-cs-fixer`, `phpstan analyse -c phpstan.neon.dist` clean.