### PR TITLE
Fix supplier ID type in SetSuppliersCommand

### DIFF
--- a/src/Core/Domain/Product/Supplier/Command/SetSuppliersCommand.php
+++ b/src/Core/Domain/Product/Supplier/Command/SetSuppliersCommand.php
@@ -71,7 +71,7 @@ class SetSuppliersCommand
 
         $this->supplierIds = [];
         foreach ($supplierIds as $supplierId) {
-            $this->supplierIds[] = new SupplierId($supplierId);
+            $this->supplierIds[] = new SupplierId((int) $supplierId);
         }
     }
 }

--- a/tests/Unit/Core/Domain/Product/Supplier/Command/SetSuppliersCommandTest.php
+++ b/tests/Unit/Core/Domain/Product/Supplier/Command/SetSuppliersCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Product\Supplier\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\SetSuppliersCommand;
+
+final class SetSuppliersCommandTest extends TestCase
+{
+    public function testNumericStringSupplierIdsAreConvertedToIntegers(): void
+    {
+        $command = new SetSuppliersCommand(15, ['1', '2']);
+
+        $supplierIds = $command->getSupplierIds();
+
+        self::assertCount(2, $supplierIds);
+        self::assertSame(1, $supplierIds[0]->getValue());
+        self::assertSame(2, $supplierIds[1]->getValue());
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.2.x
| Description?      | Fixes a `TypeError` when supplier IDs are provided as numeric strings to `SetSuppliersCommand`. Supplier IDs are now explicitly normalized to integers before creating `SupplierId` value objects. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | See below 👇 |
| UI Tests |  | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/33949889855
| Fixed issue or discussion? | https://github.com/PrestaShop/PrestaShop/issues/42599 |
| Related PRs | #42475 |
| Sponsor company | Codencode snc |

---
## How to test

1. Go to **BO > Catalog > Products**.
2. Open product ID `15`, which already has a supplier associated by default.
3. Make any editable change.
4. Save the product and verify that it is saved successfully without any supplier ID type error.

### Reproducing the affected PDO behavior

This issue occurs on environments where PDO returns numeric database values as strings.

If your environment already reproduces this behavior, no additional setup is required.

If your environment uses `mysqlnd` and numeric values are returned as native PHP types, you can temporarily simulate the affected behavior.

In `classes/db/DbPDO.php`, inside the `getPDO()` method, replace:

```php
return new PDO(
    $dsn,
    $user,
    $password,
    $options
);
```

with:

```php
$pdo = new PDO(
    $dsn,
    $user,
    $password,
    $options
);

$pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);

return $pdo;
```

> **Important**
>
> This modification is only required to simulate the affected PDO behavior and must not be committed.

With `PDO::ATTR_STRINGIFY_FETCHES` enabled:

* Without this PR, saving product ID `15` should reproduce the `TypeError` in `SupplierId::__construct()`.
* With this PR applied, the product should be saved successfully without supplier ID type-related errors.

After testing, revert the temporary modification in `classes/db/DbPDO.php`.


cc @SharakPL 
