### PR TITLE
Describe the created order, not the request, after a webservice POST

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1687,7 +1687,18 @@ class OrderCore extends ObjectModel
             false,
             $customer->secure_key
         );
-        $this->id = $payment_module->currentOrder;
+        $this->id = (int) $payment_module->currentOrder;
+
+        // validateOrder() builds the order from the cart, so the addresses, the totals and everything
+        // else it derives there can differ from what arrived in the payload. Without reloading them the
+        // object still holds the submitted values, and the response describes the request rather than
+        // the order that was created, which is why a GET straight afterwards disagrees with it.
+        $createdOrder = Db::getInstance()->getRow(
+            'SELECT * FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_order` = ' . (int) $this->id
+        );
+        if (!empty($createdOrder)) {
+            $this->hydrate($createdOrder);
+        }
 
         return true;
     }

--- a/tests/Integration/Classes/Order/WebserviceOrderCreationTest.php
+++ b/tests/Integration/Classes/Order/WebserviceOrderCreationTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Db;
+use Module;
+use Order;
+use PaymentModule;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+use Shop;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+/**
+ * Order::addWs() does not store the order it is given: it hands the cart to
+ * PaymentModule::validateOrder(), which builds the order from that cart. Fields the payload carried are
+ * therefore replaced by whatever the cart implies, and only the new id was read back, so the object the
+ * webservice rendered its response from still described the request. A GET straight afterwards returned
+ * different values for the same order.
+ */
+class WebserviceOrderCreationTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    private const STUB_MODULE = 'webserviceordercreationstub';
+
+    private int $createdOrderId = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        // getInstanceByName() returns whatever sits in Module::$_INSTANCE, which is how the stub takes
+        // the place of a real payment module without anything being installed.
+        $this->moduleInstances()->setValue(null, [self::STUB_MODULE => new StubPaymentModule()]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->moduleInstances()->setValue(null, []);
+
+        if ($this->createdOrderId) {
+            Db::getInstance()->execute(
+                'DELETE FROM ' . _DB_PREFIX_ . 'orders WHERE id_order = ' . $this->createdOrderId
+            );
+        }
+
+        parent::tearDown();
+    }
+
+    public function testTheObjectDescribesTheOrderThatWasStored(): void
+    {
+        $order = $this->orderAsThePayloadDescribedIt();
+        $order->addWs();
+        $this->createdOrderId = (int) $order->id;
+
+        $stored = Db::getInstance()->getRow(
+            'SELECT id_address_invoice, total_paid_real FROM ' . _DB_PREFIX_ . 'orders WHERE id_order = ' . $this->createdOrderId
+        );
+
+        self::assertSame(
+            (int) $stored['id_address_invoice'],
+            (int) $order->id_address_invoice,
+            'the object still carried the invoice address from the payload rather than the stored one'
+        );
+        self::assertSame(
+            (float) $stored['total_paid_real'],
+            (float) $order->total_paid_real,
+            'the object still carried the amount from the payload rather than the stored one'
+        );
+    }
+
+    /**
+     * The values that were submitted are the ones the cart did not confirm, so they must not survive.
+     */
+    public function testTheSubmittedValuesDoNotSurvive(): void
+    {
+        $order = $this->orderAsThePayloadDescribedIt();
+        $order->addWs();
+        $this->createdOrderId = (int) $order->id;
+
+        self::assertNotSame(5, (int) $order->id_address_invoice);
+        self::assertNotSame(999.99, (float) $order->total_paid_real);
+    }
+
+    public function testTheNewIdentifierIsStillReturned(): void
+    {
+        $order = $this->orderAsThePayloadDescribedIt();
+
+        self::assertTrue($order->addWs());
+        $this->createdOrderId = (int) $order->id;
+
+        self::assertGreaterThan(0, $this->createdOrderId);
+    }
+
+    private function orderAsThePayloadDescribedIt(): Order
+    {
+        $order = new Order();
+        $order->module = self::STUB_MODULE;
+        $order->id_cart = 1;
+        $order->id_customer = 1;
+        // What a client asked for, and what validateOrder() will not honour.
+        $order->id_address_invoice = 5;
+        $order->total_paid_real = 999.99;
+
+        return $order;
+    }
+
+    private function moduleInstances(): ReflectionProperty
+    {
+        $property = (new ReflectionClass(Module::class))->getProperty('_INSTANCE');
+        $property->setAccessible(true);
+
+        return $property;
+    }
+}
+
+/**
+ * Stands in for a payment module. validateOrder() writes the order the way the real one does, from the
+ * cart rather than from the object, so the values it stores deliberately differ from the submitted ones.
+ */
+class StubPaymentModule extends PaymentModule
+{
+    public function __construct()
+    {
+        $this->name = 'webserviceordercreationstub';
+        $this->displayName = 'Webservice order creation stub';
+    }
+
+    public function validateOrder(
+        $id_cart,
+        $id_order_state,
+        $amount_paid,
+        $payment_method = 'Unknown',
+        $message = null,
+        $extra_vars = [],
+        $currency_special = null,
+        $dont_touch_amount = false,
+        $secure_key = false,
+        ?Shop $shop = null,
+        ?string $order_reference = null
+    ) {
+        Db::getInstance()->insert('orders', [
+            'reference' => 'WSSTUB' . substr((string) time(), -4),
+            'id_shop_group' => 1,
+            'id_shop' => 1,
+            'id_carrier' => 1,
+            'id_lang' => 1,
+            'id_customer' => 1,
+            'id_cart' => (int) $id_cart,
+            'id_currency' => 1,
+            'id_address_delivery' => 2,
+            // The cart says 2; the payload asked for 5.
+            'id_address_invoice' => 2,
+            'current_state' => 1,
+            'secure_key' => md5('webservice-order-creation-stub'),
+            'payment' => 'Stub',
+            'module' => 'webserviceordercreationstub',
+            'conversion_rate' => 1,
+            // The cart says nothing has been paid; the payload claimed 999.99.
+            'total_paid_real' => 0,
+            'date_add' => date('Y-m-d H:i:s'),
+            'date_upd' => date('Y-m-d H:i:s'),
+            'delivery_date' => '0000-00-00 00:00:00',
+            'invoice_date' => '0000-00-00 00:00:00',
+        ]);
+
+        $this->currentOrder = (int) Db::getInstance()->Insert_ID();
+
+        return true;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Creating an order over the webservice returned a document describing the submitted payload rather than the order that was stored, so a GET immediately afterwards reported different values for `id_address_invoice` and `total_paid_real`. |
| Type?                      | bug fix                                                          |
| Category?                  | WS                                                               |
| BC breaks?                 | no                                                               |
| Deprecations?              | no                                                               |
| How to test?               | See below.                                                       |
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #34564
| Related PRs                |
| Sponsor company            |

### The bug

`Order::addWs()` never stores the object it is called on. It hands the **cart** to the payment module:

```php
$payment_module->validateOrder(
    $this->id_cart,
    (int) Configuration::get('PS_OS_WS_PAYMENT'),
    $this->total_paid,
    $this->payment,
    ...
);
$this->id = $payment_module->currentOrder;
```

and `validateOrder()` builds the order from that cart. The invoice address comes from
`$cart->id_address_invoice`, the amount actually paid is computed rather than taken from the request, and
so on. Only the new id was read back, so every other property of the object still held whatever the
payload had supplied.

The webservice then renders its response from that object. The result is a document that describes the
request instead of the order, which is exactly the two fields named in the report: the response echoes the
`id_address_invoice` that was sent, while the stored order has the cart's, and it echoes the submitted
`total_paid_real` rather than the computed one.

### The fix

Once the order exists, reload the stored row into the object:

```php
$createdOrder = Db::getInstance()->getRow(
    'SELECT * FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_order` = ' . (int) $this->id
);
if (!empty($createdOrder)) {
    $this->hydrate($createdOrder);
}
```

`hydrate()` is the model's own method for this and copies every stored field, so the response now matches
what a GET returns for the same order — including fields nobody has thought to check yet, rather than only
the two the acceptance test names.

### How to test

The steps in the issue: POST an order with an `id_address_invoice` that differs from the cart's, then GET
the same order.

Before: the two documents disagree on `id_address_invoice` and `total_paid_real`. After: they match, and
the acceptance test's `else if` at `02_ordersCRUD.ts#L462-L468` can become the plain `else` the issue asks
for.

### Verification

- `tests/Integration/Classes/Order/WebserviceOrderCreationTest.php` — 3 tests: the object ends up
  describing the stored row, the submitted values do not survive, and the new identifier is still
  returned. A stub payment module is placed in `Module::$_INSTANCE` so `getInstanceByName()` returns it;
  its `validateOrder()` writes an order the way the real one does, from the cart rather than the object,
  so the stored values deliberately differ from the submitted ones.
- **Mutation check**: with `classes/order/Order.php` reverted to `upstream/9.2.x`, two of the three fail —
  *"the object still carried the invoice address from the payload rather than the stored one"* — while the
  test pinning the returned identifier passes on both, since `$this->id` was already set correctly.
- `tests/Integration/Classes/` — 186/186, and no stub rows are left behind afterwards.
- `php -l`, `php-cs-fixer`, `phpstan analyse -c phpstan.neon.dist` clean.

Related: #34576 is the update side of the same resource. That one is a different defect — the back office
Payments block reads `ps_order_payment` rather than `orders.payment` — and needs a product decision, so it
is reported rather than fixed.