### PR TITLE
Do not copy a supplier association a combination already has

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2577,8 +2577,16 @@ class AdminImportControllerCore extends AdminController
             $productSuppliers = ProductSupplier::getSupplierCollection($product->id);
             /** @var ProductSupplier $productSupplier */
             foreach ($productSuppliers as $productSupplier) {
-                // skip if related combination supplier already exists
-                if ((int) $productSupplier->id_product_attribute === (int) $id_product_attribute) {
+                // getSupplierCollection() groups by supplier, so the row handed back can be the product
+                // level one even when this combination already has its own association. Trusting that
+                // row's own combination id let the same association be inserted twice, which the unique
+                // key on (id_product, id_product_attribute, id_supplier) then rejected, aborting the
+                // whole import. Ask for the combination instead.
+                if (ProductSupplier::getIdByProductAndSupplier(
+                    (int) $product->id,
+                    (int) $id_product_attribute,
+                    (int) $productSupplier->id_supplier
+                )) {
                     continue;
                 }
 

--- a/tests/Integration/Classes/ProductSupplierCombinationAssociationTest.php
+++ b/tests/Integration/Classes/ProductSupplierCombinationAssociationTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use PrestaShopException;
+use ProductSupplier;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+/**
+ * When the combinations import creates a combination it copies the product's supplier associations onto
+ * it. It decided whether one already existed by looking at the combination id carried by the row it was
+ * handed, but getSupplierCollection() groups by supplier, so that row can be the product level one even
+ * when the combination already has its own association. Copying it again then breaks the unique key on
+ * (id_product, id_product_attribute, id_supplier) and aborts the whole import.
+ */
+class ProductSupplierCombinationAssociationTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    private const PRODUCT_ID = 999123;
+    private const COMBINATION_ID = 7;
+    private const SUPPLIER_ID = 3;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        $this->removeRows();
+        // What the product already has: an association at product level, and one for the combination.
+        $this->associate(0);
+        $this->associate(self::COMBINATION_ID);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRows();
+
+        parent::tearDown();
+    }
+
+    /**
+     * The row the import is handed does not tell it whether this combination is already associated.
+     */
+    public function testTheCollectionCanHandBackTheProductLevelRow(): void
+    {
+        $rows = ProductSupplier::getSupplierCollection(self::PRODUCT_ID);
+
+        $combinationIds = [];
+        foreach ($rows as $row) {
+            $combinationIds[] = (int) $row->id_product_attribute;
+        }
+
+        self::assertCount(1, $combinationIds, 'the collection is grouped by supplier');
+        self::assertSame(
+            [0],
+            $combinationIds,
+            'the row handed back is the product level one, so its combination id says nothing about ' . self::COMBINATION_ID
+        );
+    }
+
+    /**
+     * Asking for the combination does tell it.
+     */
+    public function testAskingForTheCombinationFindsTheExistingAssociation(): void
+    {
+        self::assertGreaterThan(
+            0,
+            ProductSupplier::getIdByProductAndSupplier(self::PRODUCT_ID, self::COMBINATION_ID, self::SUPPLIER_ID)
+        );
+    }
+
+    /**
+     * And this is why the difference matters: copying the association a second time is what the import
+     * did, and it is rejected the way the report describes.
+     */
+    public function testCopyingItAgainBreaksTheUniqueKey(): void
+    {
+        $this->expectException(PrestaShopException::class);
+        $this->expectExceptionMessageMatches('/Duplicate entry/');
+
+        $this->associate(self::COMBINATION_ID);
+    }
+
+    private function associate(int $combinationId): void
+    {
+        $productSupplier = new ProductSupplier();
+        $productSupplier->id_product = self::PRODUCT_ID;
+        $productSupplier->id_product_attribute = $combinationId;
+        $productSupplier->id_supplier = self::SUPPLIER_ID;
+        $productSupplier->product_supplier_reference = 'REF-' . $combinationId;
+        $productSupplier->product_supplier_price_te = 1.0;
+        $productSupplier->id_currency = 1;
+        $productSupplier->add();
+    }
+
+    private function removeRows(): void
+    {
+        Db::getInstance()->execute(
+            'DELETE FROM ' . _DB_PREFIX_ . 'product_supplier WHERE id_product = ' . self::PRODUCT_ID
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Importing combinations stopped with a technical error, `Duplicate entry '343-1-3' for key 'id_product'`, after the first combination had been created. |
| Type?                      | bug fix                                                          |
| Category?                  | BO                                                               |
| BC breaks?                 | no                                                               |
| Deprecations?              | no                                                               |
| How to test?               | See below.                                                       |
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #34613
| Related PRs                |
| Sponsor company            |

### The bug

The error names the unique key of `ps_product_supplier`:

```sql
UNIQUE KEY `id_product` (`id_product`, `id_product_attribute`, `id_supplier`)
```

so `'343-1-3'` is product 343, combination 1, supplier 3 — the import tried to associate that supplier
with that combination twice.

When a combination is created, `AdminImportController::attributeImportOne()` copies the product's supplier
associations onto it:

```php
$productSuppliers = ProductSupplier::getSupplierCollection($product->id);
foreach ($productSuppliers as $productSupplier) {
    // skip if related combination supplier already exists
    if ((int) $productSupplier->id_product_attribute === (int) $id_product_attribute) {
        continue;
    }

    $combinationSupplier = clone $productSupplier;
    $combinationSupplier->id = null;
    $combinationSupplier->id_product_attribute = $id_product_attribute;
    $combinationSupplier->add();
}
```

The guard asks whether **the row it is holding** already belongs to this combination. That is not the same
question, because `getSupplierCollection()` groups by supplier:

```php
public static function getSupplierCollection($idProduct, $groupBySupplier = true)
{
    $suppliers = new PrestaShopCollection('ProductSupplier');
    $suppliers->where('id_product', '=', (int) $idProduct);

    if ($groupBySupplier) {
        $suppliers->groupBy('id_supplier');
    }
```

so for a supplier that is associated both at product level and with the combination, the collection hands
back **one** row, and it can be the product level one. Its `id_product_attribute` is 0, which does not
equal the combination, so the guard does not skip and the association is inserted again.

That is why the import dies on the second pass over the same product rather than on the first, matching
the report: the first combination is written, then the error appears.

### The fix

Ask whether this combination and this supplier are already associated, rather than reading the combination
id off whichever row the grouping returned. `ProductSupplier::getIdByProductAndSupplier()` already answers
exactly that and is used a few hundred lines above for the product level case.

### How to test

Import a products file, then a combinations file for the same products where a supplier is set. Previously
the import aborted with the duplicate entry error once a product's supplier had already been associated
with a combination; now the association is left alone and the import continues.

### Verification

- `tests/Integration/Classes/ProductSupplierCombinationAssociationTest.php` — 3 tests, on real rows: the
  grouped collection hands back the product level row (so its combination id says nothing about the
  combination being imported), asking for the combination does find the existing association, and copying
  that association a second time raises `Duplicate entry` — the error from the report.
- `tests/Integration/Classes/` — 186/186.
- `php -l`, `php-cs-fixer`, `phpstan analyse -c phpstan.neon.dist` clean.

**What the tests do not cover, stated plainly.** They exercise the three facts the fix rests on, but not
the changed line itself: `attributeImportOne()` is a protected method on a legacy controller that needs a
CSV handle, a built admin context and cross-step state, so calling it from a test is a larger piece of work
than this fix. The tests therefore pass on `upstream/9.2.x` as well — they establish why the old guard
asks the wrong question and why the new one asks the right one, rather than pinning the controller.
Anyone reviewing should treat the import path itself as verified by the reporter's reproduction rather
than by CI.