### PR TITLE
Let the order status actions wrap on small screens

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -34,6 +34,11 @@
 
     .card-details-actions {
       display: flex;
+      // The button carries mt-3 mt-md-0 ml-0 ml-md-3, i.e. it is meant to sit under the status
+      // selector on small screens and beside it from md up. Without wrapping it can never move
+      // down: the selector holds a min-width of 208px and the button is nowrap, so on a phone the
+      // two are forced onto one line and the selector's arrow ends up under the button.
+      flex-wrap: wrap;
       align-items: center;
 
       .btn.update-status{


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | The Update status button in the order view carries `mt-3 mt-md-0 ml-0 ml-md-3`, i.e. it is meant to sit **under** the status selector on small screens and beside it from md up. Its container, `.card-details-actions`, is `display: flex` with no `flex-wrap`, so the button can never move down. The selector holds `min-width: 208px` (`.select2-container`) and the button is `white-space: nowrap`, so neither can shrink: once the two stop fitting, the button is pushed outside the container and ends up over the selector's arrow. Adding `flex-wrap: wrap` lets the markup's own responsive margins do what they were written for.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Open any order in the back office on a phone-sized viewport (or DevTools device toolbar at 360px) and look at the Update status control under the History tab. Before this change the button sits on top of the selector and the status cannot be changed; after it the button drops below the selector, which is what the `mt-3` on it always intended.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #34669
| Related PRs                |
| Sponsor company            |

### Measured

The two children were reproduced standalone under the same constraints the stylesheet imposes — selector `min-width: 208px; max-width: 100%`, button `white-space: nowrap`, container `display: flex; align-items: center` — and the available width was shrunk while reading the boxes back from the browser:

```
content width   without flex-wrap                     with flex-wrap
328px           one row, no overflow                  one row, no overflow
300px           button overflows the box by 16px      button stacked, no overflow
280px           button overflows the box by 36px      button stacked, no overflow
260px           button overflows the box by 56px      button stacked, no overflow
240px           button overflows the box by 76px      button stacked, no overflow
220px           button overflows the box by 96px      button stacked, no overflow
```

The threshold is 316px of content width — 208 for the selector plus 108 for the button — which a 360px phone falls under once the card's horizontal padding is taken off. Below it the current rule pushes the button out of its container instead of onto a second line; with `flex-wrap: wrap` the button stacks and the overflow is zero at every width tested.

`flex-wrap: wrap` is already used twice elsewhere in the same stylesheet, and `stylelint` reports 0 problems on the file.

### Verification limit

The layout was measured on a standalone reproduction of the two boxes, not on the real back office page, which needs an employee session. What is measured is the box behaviour of the exact constraints the stylesheet sets; what is read from the source is that those constraints are the ones applied to this control, and that the button's `mt-3 mt-md-0` classes describe the stacked arrangement the container prevents.