### PR TITLE
Keep customer groups that share a name in the choice list

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/GroupByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/GroupByIdChoiceProvider.php
@@ -8,6 +8,7 @@ namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 
 use Group;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 /**
@@ -40,7 +41,6 @@ final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
      */
     public function getChoices(): array
     {
-        $choices = [];
         $groups = Group::getGroups($this->contextLangId, true);
 
         $groupsToSkip = [
@@ -48,16 +48,22 @@ final class GroupByIdChoiceProvider implements FormChoiceProviderInterface
             (int) $this->configuration->get('PS_GUEST_GROUP'),
         ];
 
+        $selectableGroups = [];
         foreach ($groups as $group) {
-            $groupId = $group['id_group'];
-
+            // NOTE: this compares the whole $groups list against the ids, so it has never matched and
+            // no group is actually skipped. Making it work would drop the Visitor and Guest groups from
+            // every form fed by this provider, which is a behaviour change rather than a bug fix, so the
+            // condition is left exactly as it was - see PrestaShop/PrestaShop#34709.
             if (in_array($groups, $groupsToSkip)) {
                 continue;
             }
 
-            $choices[$group['name']] = (int) $groupId;
+            $selectableGroups[] = $group;
         }
 
-        return $choices;
+        // WHY: choices used to be keyed by group name, so groups sharing a name overwrote each other and
+        // only the last survived - the form then applied a saved change to that one alone. FormChoiceFormatter
+        // keeps every group and disambiguates the duplicates by appending their id.
+        return FormChoiceFormatter::formatFormChoices($selectableGroups, 'id_group', 'name', false);
     }
 }

--- a/tests/Integration/Adapter/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php
+++ b/tests/Integration/Adapter/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Form\ChoiceProvider;
+
+use Doctrine\DBAL\Connection;
+use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\GroupByIdChoiceProvider;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GroupByIdChoiceProviderTest extends KernelTestCase
+{
+    private const CONTEXT_LANG_ID = 1;
+    private const DUPLICATE_NAME = 'Duplicate group name';
+
+    private Connection $connection;
+    private string $dbPrefix;
+    private GroupByIdChoiceProvider $choiceProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->dbPrefix = self::getContainer()->getParameter('database_prefix');
+        $this->choiceProvider = new GroupByIdChoiceProvider(
+            self::getContainer()->get(ConfigurationInterface::class),
+            self::CONTEXT_LANG_ID
+        );
+    }
+
+    /**
+     * Symfony choice lists are keyed by the label, so building them straight from the group name drops
+     * every group that shares a name with another one - the form then shows a single entry and saving it
+     * applies the change to the last group only.
+     */
+    public function testGroupsSharingANameAreAllOffered(): void
+    {
+        $firstId = $this->insertGroup(self::DUPLICATE_NAME);
+        $secondId = $this->insertGroup(self::DUPLICATE_NAME);
+
+        try {
+            $choices = $this->choiceProvider->getChoices();
+            $ids = array_values($choices);
+
+            $this->assertContains($firstId, $ids);
+            $this->assertContains($secondId, $ids);
+        } finally {
+            $this->deleteGroups([$firstId, $secondId]);
+        }
+    }
+
+    /**
+     * The duplicates have to stay tellable apart in the list, otherwise the employee cannot know which
+     * of the two rows they are editing.
+     */
+    public function testGroupsSharingANameAreLabelledWithTheirId(): void
+    {
+        $firstId = $this->insertGroup(self::DUPLICATE_NAME);
+        $secondId = $this->insertGroup(self::DUPLICATE_NAME);
+
+        try {
+            $choices = $this->choiceProvider->getChoices();
+
+            $this->assertArrayHasKey(sprintf('%s (%d)', self::DUPLICATE_NAME, $firstId), $choices);
+            $this->assertArrayHasKey(sprintf('%s (%d)', self::DUPLICATE_NAME, $secondId), $choices);
+            $this->assertArrayNotHasKey(self::DUPLICATE_NAME, $choices);
+        } finally {
+            $this->deleteGroups([$firstId, $secondId]);
+        }
+    }
+
+    /**
+     * A group with a name of its own keeps that name as its label.
+     */
+    public function testGroupWithAUniqueNameKeepsItsPlainName(): void
+    {
+        $groupId = $this->insertGroup('Unique group name');
+
+        try {
+            $choices = $this->choiceProvider->getChoices();
+
+            $this->assertSame($groupId, $choices['Unique group name'] ?? null);
+        } finally {
+            $this->deleteGroups([$groupId]);
+        }
+    }
+
+    private function insertGroup(string $name): int
+    {
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'group (reduction, price_display_method, show_prices, date_add, date_upd)
+             VALUES (0, 0, 1, NOW(), NOW())'
+        );
+        $groupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'group_lang (id_group, id_lang, name) VALUES (:group, :lang, :name)',
+            ['group' => $groupId, 'lang' => self::CONTEXT_LANG_ID, 'name' => $name]
+        );
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'group_shop (id_group, id_shop) VALUES (:group, 1)',
+            ['group' => $groupId]
+        );
+
+        return $groupId;
+    }
+
+    /**
+     * @param int[] $groupIds
+     */
+    private function deleteGroups(array $groupIds): void
+    {
+        foreach (['group_shop', 'group_lang', 'group'] as $table) {
+            $this->connection->executeStatement(
+                'DELETE FROM ' . $this->dbPrefix . $table . ' WHERE id_group IN (:ids)',
+                ['ids' => $groupIds],
+                ['ids' => Connection::PARAM_INT_ARRAY]
+            );
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Adapter\Form\ChoiceProvider\GroupByIdChoiceProvider` built its list as `$choices[$group['name']] = $id`. A Symfony choice list is keyed by the label, so two groups sharing a name overwrote each other and only the last one reached the form — saving it then applied the change to that group alone and left the others behind, which is exactly what the report describes. `FormChoiceFormatter::formatFormChoices()` already solves this for the Core provider by appending the id to duplicate labels; this provider now uses it too. It feeds `CustomerType` and `Sell\Customer\GroupType`.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Create two customer groups with the exact same name, then open Customers > edit a customer, or Customers > Groups. Before this change the group selector shows one entry for the pair; after it both appear, labelled `<name> (<id>)`. Automated coverage: `tests/Integration/Adapter/Form/ChoiceProvider/GroupByIdChoiceProviderTest.php`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #34709
| Related PRs                |
| Sponsor company            |

### Measured

The two ways of building the list, given five groups of which three share a name:

```
FormChoiceFormatter                      naive keying by name
'Visitor'      => 1                      'Visitor'  => 1
'Guest'        => 2                      'Guest'    => 2
'Customer (3)' => 3                      'Customer' => 5
'Customer (4)' => 4
'Customer (5)' => 5
```

Two groups vanish, and the survivor is the last one created — the report's *"you'll only see the last created group"*.

Three integration cases against the real provider. On `upstream/9.2.x`:

```
1) testGroupsSharingANameAreAllOffered        Failed asserting that an array contains 14.
2) testGroupsSharingANameAreLabelledWithTheirId  Failed asserting that an array has the key 'Duplicate group name (16)'.
Tests: 3, Assertions: 3, Failures: 2
```

With the change: **3 tests, 6 assertions, green**. The third case — a group whose name is unique keeps its plain label — passes both ways, so it is a control on the change not disturbing ordinary lists.

Suites: `customer` 13/13, `customer_group` 3/3. PHPStan and php-cs-fixer clean.

### The reported page is already fine

The payment preferences form named in the report is fed by `prestashop.core.form.choice_provider.group_by_id`, the **Core** provider, which has used `FormChoiceFormatter` for a while. What still had the defect is the identically named provider in `Adapter\Form\ChoiceProvider`, behind the customer and group forms — which matches the reporter's follow-up that *"all the forms are affected"*.

### Left alone deliberately

The same method carries a second, older defect:

```php
if (in_array($groups, $groupsToSkip)) {
```

It tests the whole `$groups` list against a list of ids, so it never matches and the unidentified and guest groups are never skipped. Making it work would remove Visitor and Guest from every form fed by this provider — a behaviour change rather than a bug fix, and one that needs a product decision, so the condition is left byte-for-byte as it was with a note pointing at this issue.