### PR TITLE
Cover that a redeemed voucher survives an order edit

### DIFF
--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rule_exhausted.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rule_exhausted.feature
@@ -1,0 +1,56 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-cart-rule-exhausted
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@order-cart-rule-exhausted
+Feature: Editing an order whose voucher ran out of uses
+  A voucher applied to an order was redeemed when the order was placed, so re-validating it against
+  today's remaining quantity is wrong: CartRule::checkValidity() exempts an already ordered cart from
+  the availability checks. Without that exemption OrderAmountUpdater::updateOrderCartRules() finds the
+  rule missing from the recomputed cart and hard deletes the order_cart_rule row, silently changing the
+  total of a paid order.
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
+    And there is a cart rule "orderVoucher" with following properties:
+      | name[en-US]     | Order voucher |
+      | description     | Order voucher |
+      | priority        | 1             |
+      | code            | ORDER_VOUCHER |
+      | discount_amount | 5             |
+      | total_quantity  | 10            |
+    And I use a voucher "orderVoucher" on the cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart       |
+      | message             | test             |
+      | payment module name | dummy_payment    |
+      | status              | Payment accepted |
+
+  Scenario: A redeemed voucher survives an address change even after it runs out of uses
+    Given order "bo_order1" should have 1 cart rules
+    And I create customer "otherCustomer" with following details:
+      | firstName | testFirstName       |
+      | lastName  | testLastName        |
+      | email     | other@mailexample.eu|
+      | password  | secret              |
+    And I add new address to customer "otherCustomer" with following details:
+      | Address alias | other-address               |
+      | First name    | testFirstName               |
+      | Last name     | testLastName                |
+      | Address       | Work address st. 1234567890 |
+      | City          | Birmingham                  |
+      | Country       | United States               |
+      | State         | Alabama                     |
+      | Postal code   | 12345                       |
+    When I update quantity for cart rule "orderVoucher" to 0
+    And I change order "bo_order1" shipping address to "other-address"
+    Then order "bo_order1" should have 1 cart rules


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Test only. #34750 reports that editing an order's address deletes a voucher that has run out of uses. That no longer happens: `CartRule::checkValidity()` skips the availability checks for an already ordered cart (`if (!$useOrderPrices)` on 9.x, `if (!$alreadyInCart)` on 8.2.x), and `OrderAmountUpdater::updateOrderCartRules()` calls `CartRule::autoRemoveFromCart(null, true)`, so the rule stays in the recomputed cart. Nothing pins that exemption though, and removing it hard deletes the `order_cart_rule` row — silently changing the total of a paid order — with every suite still green. This adds the missing regression scenario.
| Type?                      | improvement
| Category?                  | TE
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-cart-rule-exhausted`. To see it fail, change the `if (!$useOrderPrices)` guard in `classes/CartRule.php` to `if (true)` and run it again.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | See #34750
| Related PRs                |
| Sponsor company            |

### Measured

The scenario places an order with a voucher, sets that voucher's remaining quantity to 0, then changes the order's shipping address:

```
1 scenario (1 passed), 20 steps
```

on `upstream/9.2.x` as it stands — so the reported bug is fixed there. It is the exemption that fixes it, and the scenario is what proves the exemption is load bearing. With `if (!$useOrderPrices)` replaced by `if (true)`:

```
Then order "bo_order1" should have 1 cart rules
  Invalid number of cart rules for order bo_order1, expected 1 but got 0 instead (RuntimeException)
```

Full `order` suite with the scenario added: **261 scenarios (261 passed), 7364 steps**.

### On the issue itself

Both maintained branches carry the exemption, in different shapes: 9.2.x guards the block with `if (!$useOrderPrices)` and 8.2.x with `if (!$alreadyInCart)`, and `autoRemoveFromCart()` passes `true` for both parameters. The reports were filed against 8.1.0 and 8.1.1, which are end of life. So the issue can be closed on the code, and what is genuinely missing is the coverage in this branch.