### PR TITLE
Limit tag length per tag instead of capping the whole input

### DIFF
--- a/admin-dev/themes/new-theme/js/components/taggable-field.ts
+++ b/admin-dev/themes/new-theme/js/components/taggable-field.ts
@@ -98,13 +98,23 @@ export default class TaggableField {
    * allow to add token on focus out action. See bootstrap-tokenfield docs for more information.
    */
   constructor({tokenFieldSelector, options = {}}: TaggableFieldParams) {
-    $(tokenFieldSelector).tokenfield(options);
-
     const maxCharacters: number = options.maxCharacters || 0;
+    const $field = $(tokenFieldSelector);
 
     if (maxCharacters > 0) {
-      const $inputFields = $(tokenFieldSelector).siblings('.token-input');
-      $inputFields.prop('maxlength', maxCharacters);
+      // WHY: this used to set maxlength on the token input, which caps the WHOLE input. Pasting a
+      // comma separated list longer than maxCharacters was then truncated by the browser before
+      // tokenfield could split it, even when every single tag was short enough. The limit describes
+      // one tag, so check it when a token is created and let the rest of the list through.
+      $field.on('tokenfield:createtoken', (event: JQuery.TriggeredEvent) => {
+        const {attrs} = event as JQuery.TriggeredEvent & {attrs?: {value: string}};
+
+        if (attrs && attrs.value.length > maxCharacters) {
+          event.preventDefault();
+        }
+      });
     }
+
+    $field.tokenfield(options);
   }
 }

--- a/admin-dev/themes/new-theme/tests/components/taggable-field.spec.js
+++ b/admin-dev/themes/new-theme/tests/components/taggable-field.spec.js
@@ -1,0 +1,75 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+import {expect} from 'chai';
+import {JSDOM} from 'jsdom';
+import {createRequire} from 'module';
+
+const require = createRequire(import.meta.url);
+
+const TAGGABLE_FIELD_MODULE = '../../js/components/taggable-field';
+
+describe('TaggableField', () => {
+  let $;
+  let TaggableField;
+
+  beforeEach(() => {
+    const dom = new JSDOM(
+      '<!doctype html><html><body><input id="tags" name="tags" type="text" value=""></body></html>',
+      {pretendToBeVisual: true},
+    );
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+
+    // jQuery binds to global.window at require time, and bootstrap-tokenfield pulls jQuery through
+    // its own require(): both have to resolve to the same instance, so drop them from the cache and
+    // load jQuery only once global.document exists.
+    delete require.cache[require.resolve('jquery')];
+    delete require.cache[require.resolve('bootstrap-tokenfield')];
+
+    $ = require('jquery');
+    dom.window.$ = $;
+    dom.window.jQuery = $;
+    global.$ = $;
+    global.jQuery = $;
+
+    require('bootstrap-tokenfield');
+
+    delete require.cache[require.resolve(TAGGABLE_FIELD_MODULE)];
+    // eslint-disable-next-line global-require
+    TaggableField = require(TAGGABLE_FIELD_MODULE).default;
+  });
+
+  /**
+   * maxlength caps the whole input, so pasting a comma separated list longer than the per tag limit
+   * is truncated by the browser before tokenfield ever splits it. The limit is about one tag.
+   */
+  it('does not cap the length of the input the tags are typed into', () => {
+    new TaggableField({tokenFieldSelector: '#tags', options: {maxCharacters: 32}});
+
+    const $tokenInput = $('#tags').siblings('.token-input');
+
+    expect($tokenInput.length).to.be.greaterThan(0);
+    expect($tokenInput.attr('maxlength')).to.equal(undefined);
+  });
+
+  it('refuses a single tag longer than the per tag limit', () => {
+    new TaggableField({tokenFieldSelector: '#tags', options: {maxCharacters: 32}});
+
+    $('#tags').tokenfield('setTokens', `short,${'x'.repeat(33)},other`);
+
+    const tokens = $('#tags').tokenfield('getTokens').map((token) => token.value);
+    expect(tokens).to.deep.equal(['short', 'other']);
+  });
+
+  it('does not restrict anything when no limit is given', () => {
+    new TaggableField({tokenFieldSelector: '#tags', options: {}});
+
+    $('#tags').tokenfield('setTokens', `${'x'.repeat(80)},tail`);
+
+    const tokens = $('#tags').tokenfield('getTokens').map((token) => token.value);
+    expect(tokens).to.deep.equal(['x'.repeat(80), 'tail']);
+  });
+});

--- a/admin-dev/themes/new-theme/tsconfig.json
+++ b/admin-dev/themes/new-theme/tsconfig.json
@@ -25,6 +25,9 @@
     },
   },
   "ts-node": {
+    // Load the ambient declarations in js/@types with the program, so a component required from a
+    // mocha spec compiles with the same globals it has under webpack (window.$ and friends).
+    "files": true,
     "compilerOptions": {
       "module": "commonjs"
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `TaggableField` kept each tag within `Tag`'s 32 character column by putting a `maxlength` attribute on the token input. `maxlength` caps the **whole** input, so pasting a comma separated list longer than 32 characters is truncated by the browser before bootstrap-tokenfield can split it on commas — the merchant loses every tag past the limit even though each one is well under it. The limit describes a single tag, so it is now checked on the `tokenfield:createtoken` event: a tag longer than `maxCharacters` is refused and the rest of the pasted list goes through. The only caller is `product-seo-manager.ts:69`, which passes `maxCharacters: 32`, matching `Tag::$definition`'s `'size' => 32`.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Catalog > Products, edit a product, open the SEO tab. Copy a comma separated list of tags whose total length is well over 32 characters, e.g. `alpha,beta,gamma,delta,epsilon,zeta,eta,theta`, and paste it into the Tags field. Before this change the paste is cut at 32 characters; after it every tag is created. Pasting a single tag longer than 32 characters still refuses that one tag. Automated coverage: `admin-dev/themes/new-theme/tests/components/taggable-field.spec.js`, run with `npm test` in `admin-dev/themes/new-theme`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #34896
| Related PRs                |
| Sponsor company            |

### Measured

The diagnosis in the issue is correct and this confirms it against `9.2.x`. Three specs, run through mocha with jsdom, on the unmodified component:

```
1) does not cap the length of the input the tags are typed into
   AssertionError: expected '32' to equal undefined
2) refuses a single tag longer than the per tag limit
   AssertionError: expected [ 'short', …(2) ] to deeply equal [ 'short', 'other' ]
```

With the change the whole suite is **124 passing**, up from 121.

Three mutations:

| Mutation                                                | Result |
| -------------------------------------------------------- | ------ |
| put `maxlength` back on the token input after init         | red — `expected '32' to equal undefined` |
| drop the `preventDefault()`                                | red — the over-long tag is accepted |
| reject every token instead of only the over-long ones      | red — the valid tags are dropped too |

The third exists because the second alone would pass for a handler that refuses everything.

### Note on the test setup

This is the first DOM backed component spec in that suite — the existing ones are pure functions. Two things were needed: jQuery and bootstrap-tokenfield have to resolve to the *same* instance, which means clearing both from the require cache and loading jQuery only once `global.document` exists; and `ts-node` needs `"files": true` so the component compiles with the ambient `window` declarations in `js/@types/global.d.ts` that it has under webpack. That key sits inside the existing `"ts-node"` section and does not affect the webpack build.

### Alternative considered

The over-long tag could be truncated to 32 characters instead of refused. Refusing was chosen because a silently shortened tag is wrong data that looks accepted; `Tag`'s column is 32, so the tag would be invalid server side anyway.