### PR TITLE
Keep order totals when a product or a combination was deleted from the catalogue

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -361,6 +361,12 @@ class OrderCore extends ObjectModel
         $cart_base_product_quantity = [];
         $products = $this->getProducts();
         foreach ($products as &$product) {
+            // Order detail rows are presented as cart rows. `id_product` is read from the product
+            // table, which getProductsDetail() reaches through a LEFT JOIN, so it is null once the
+            // product has been deleted from the catalogue - while the order detail still knows which
+            // product the line was for. Map it like the two fields below, otherwise the line is
+            // dropped from the list and every consumer prices it as product 0.
+            $product['id_product'] = $product['product_id'];
             $product['id_product_attribute'] = $product['product_attribute_id'];
             $product['cart_quantity'] = $product['product_quantity'];
             $product_id_list[] = $this->id_address_delivery . '_'

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -13,6 +13,7 @@ use Cache;
 use Carrier;
 use Cart;
 use CartRule;
+use Combination;
 use Currency;
 use Customer;
 use Order;
@@ -352,11 +353,14 @@ class OrderAmountUpdater
         foreach ($order->getCartProducts() as $orderProduct) {
             $orderDetail = new OrderDetail($orderProduct['id_order_detail'], null, $this->contextStateManager->getContext());
 
-            // A product deleted from the catalogue is gone from the cart as well, so there is no
-            // current price to sync this line to. Its order detail keeps the amounts it was invoiced
-            // at, which are the only meaningful ones left. Any other absence is still a desync and
-            // is reported by getProductFromCart() below.
-            if (!Product::existsInDatabase((int) $orderDetail->product_id)) {
+            // A product or a combination deleted from the catalogue is gone from the cart as well,
+            // so there is no current price to sync this line to. Its order detail keeps the amounts
+            // it was invoiced at, which are the only meaningful ones left. Any other absence is
+            // still a desync and is reported by getProductFromCart() below.
+            if (!Product::existsInDatabase((int) $orderDetail->product_id)
+                || (0 !== (int) $orderDetail->product_attribute_id
+                    && !Combination::existsInDatabase((int) $orderDetail->product_attribute_id))
+            ) {
                 continue;
             }
 

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -351,6 +351,15 @@ class OrderAmountUpdater
         $cartProducts = $cart->getProducts(true, false, null, true, $this->keepOrderPrices);
         foreach ($order->getCartProducts() as $orderProduct) {
             $orderDetail = new OrderDetail($orderProduct['id_order_detail'], null, $this->contextStateManager->getContext());
+
+            // A product deleted from the catalogue is gone from the cart as well, so there is no
+            // current price to sync this line to. Its order detail keeps the amounts it was invoiced
+            // at, which are the only meaningful ones left. Any other absence is still a desync and
+            // is reported by getProductFromCart() below.
+            if (!Product::existsInDatabase((int) $orderDetail->product_id)) {
+                continue;
+            }
+
             $cartProduct = $this->getProductFromCart($cartProducts, (int) $orderDetail->product_id, (int) $orderDetail->product_attribute_id, (int) $orderDetail->id_customization);
 
             $this->orderDetailUpdater->updateOrderDetail(

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -13,6 +13,7 @@ use AdminController;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Cart;
+use Combination;
 use Configuration;
 use Context;
 use Currency;
@@ -1858,6 +1859,28 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
         $foundProduct = $this->getProductByName($productReference);
         $product = new Product($foundProduct->getProductId());
         $product->delete();
+    }
+
+    /**
+     * @When I delete combination :combinationReference of product :productReference from catalogue
+     *
+     * @param string $combinationReference
+     * @param string $productReference
+     */
+    public function removeCombinationFromCatalogue(string $combinationReference, string $productReference)
+    {
+        $foundProduct = $this->getProductByName($productReference);
+        $product = new Product($foundProduct->getProductId());
+
+        foreach ($product->getAttributeCombinations() as $attributeCombination) {
+            if ($attributeCombination['reference'] === $combinationReference) {
+                (new Combination((int) $attributeCombination['id_product_attribute']))->delete();
+
+                return;
+            }
+        }
+
+        throw new RuntimeException(sprintf('Combination "%s" of product "%s" was not found', $combinationReference, $productReference));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_combination.feature
@@ -1,0 +1,77 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-deleted-combination
+@restore-all-tables-before-feature
+@reboot-kernel-before-feature
+@clear-cache-before-feature
+@order-deleted-combination
+Feature: Edit an order whose combination was removed from the catalogue
+  In order to keep invoiced amounts stable
+  As a BO user
+  I need to still be able to edit an order that contains a combination deleted from the catalogue
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And there is a product in the catalog named "Deleted Combination Product" with a price of 10.0 and 100 items in stock
+    And product "Deleted Combination Product" has combinations with following details:
+      | reference    | quantity | price | attributes |
+      | combination1 | 100      | 0.0   | Size:L     |
+      | combination2 | 100      | 0.0   | Size:M     |
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 2 items of combination "combination1" of the product "Deleted Combination Product" to the cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart       |
+      | message             | test             |
+      | payment module name | dummy_payment    |
+      | status              | Payment accepted |
+
+  # The pair is the point: deleting the ordered combination from the catalogue has to leave the order
+  # with exactly the amounts the control keeps when the combination is left in place.
+  Scenario: CONTROL changing the shipping address of an order whose combination still exists
+    Given order "bo_order1" should have following details:
+      | total_products | 20.00 |
+    And I create customer "controlCombinationCustomer" with following details:
+      | firstName | testFirstName                     |
+      | lastName  | testLastName                      |
+      | email     | control-combination@mailexample.eu |
+      | password  | secret                            |
+    And I add new address to customer "controlCombinationCustomer" with following details:
+      | Address alias | control-combination-address |
+      | First name    | testFirstName               |
+      | Last name     | testLastName                |
+      | Address       | Work address st. 1234567890 |
+      | City          | Birmingham                  |
+      | Country       | United States               |
+      | State         | Alabama                     |
+      | Postal code   | 12345                       |
+    When I change order "bo_order1" shipping address to "control-combination-address"
+    Then order "bo_order1" should have following details:
+      | total_products | 20.00 |
+
+  Scenario: Changing the shipping address still works once the ordered combination is deleted
+    Given order "bo_order1" should have following details:
+      | total_products | 20.00 |
+    And I create customer "deletedCombinationCustomer" with following details:
+      | firstName | testFirstName                      |
+      | lastName  | testLastName                       |
+      | email     | deleted-combination@mailexample.eu |
+      | password  | secret                             |
+    And I add new address to customer "deletedCombinationCustomer" with following details:
+      | Address alias | deleted-combination-address |
+      | First name    | testFirstName               |
+      | Last name     | testLastName                |
+      | Address       | Work address st. 1234567890 |
+      | City          | Birmingham                  |
+      | Country       | United States               |
+      | State         | Alabama                     |
+      | Postal code   | 12345                       |
+    When I delete combination "combination1" of product "Deleted Combination Product" from catalogue
+    And I change order "bo_order1" shipping address to "deleted-combination-address"
+    Then order "bo_order1" should have following details:
+      | total_products | 20.00 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_product.feature
@@ -1,0 +1,76 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-deleted-product
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@order-deleted-product
+Feature: Edit an order whose product was removed from the catalogue
+  In order to keep invoiced amounts stable
+  As a BO user
+  I need order totals to survive editing an order that contains a product deleted from the catalogue
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart       |
+      | message             | test             |
+      | payment module name | dummy_payment    |
+      | status              | Payment accepted |
+
+  # Changing the shipping address moves the tax address, so the tax included totals below are the
+  # ones the new address produces - the point of the pair is that deleting the product from the
+  # catalogue must leave the order with exactly the same amounts as leaving it in place.
+  Scenario: CONTROL changing the shipping address of an order whose products all still exist
+    Given order "bo_order1" should have following details:
+      | total_products    | 23.80 |
+      | total_products_wt | 25.23 |
+    And I create customer "controlCustomer" with following details:
+      | firstName | testFirstName          |
+      | lastName  | testLastName           |
+      | email     | control@mailexample.eu |
+      | password  | secret                 |
+    And I add new address to customer "controlCustomer" with following details:
+      | Address alias | control-address                          |
+      | First name    | testFirstName               |
+      | Last name     | testLastName                |
+      | Address       | Work address st. 1234567890 |
+      | City          | Birmingham                  |
+      | Country       | United States               |
+      | State         | Alabama                     |
+      | Postal code   | 12345                       |
+    When I change order "bo_order1" shipping address to "control-address"
+    Then order "bo_order1" should have following details:
+      | total_products    | 23.80 |
+      | total_products_wt | 23.80 |
+
+  Scenario: Changing the shipping address does not zero the totals of an order whose product is gone
+    Given order "bo_order1" should have following details:
+      | total_products    | 23.80 |
+      | total_products_wt | 25.23 |
+    And I create customer "deletedCustomer" with following details:
+      | firstName | testFirstName          |
+      | lastName  | testLastName           |
+      | email     | deleted@mailexample.eu |
+      | password  | secret                 |
+    And I add new address to customer "deletedCustomer" with following details:
+      | Address alias | deleted-address                          |
+      | First name    | testFirstName               |
+      | Last name     | testLastName                |
+      | Address       | Work address st. 1234567890 |
+      | City          | Birmingham                  |
+      | Country       | United States               |
+      | State         | Alabama                     |
+      | Postal code   | 12345                       |
+    When I delete product "Mug The best is yet to come" from catalogue
+    And I change order "bo_order1" shipping address to "deleted-address"
+    Then order "bo_order1" should have following details:
+      | total_products    | 23.80 |
+      | total_products_wt | 23.80 |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Order::getCartProducts()` presents order detail rows as cart rows, mapping `product_attribute_id` onto `id_product_attribute` and `product_quantity` onto `cart_quantity` — but it read `id_product` straight from the product table, which `getProductsDetail()` reaches through a `LEFT JOIN`. Once the product is deleted from the catalogue that column is `null`, the key the method builds from it matches nothing, and the line is dropped from the returned list. `OrderAmountUpdater` then recomputes the order from an empty product list, so every total collapses to `0` the moment the order is edited. Mapping `product_id` onto `id_product` fixes the drop and the pricing at once, because `CartRow::getProductPrice()` casts `id_product` to int and was pricing the line as product `0`. `OrderAmountUpdater::updateOrderDetails()` additionally skips re-pricing a line whose product no longer exists — the cart cannot produce it, and the order detail already holds the amounts it was invoiced at. Any other product missing from the cart is still reported as a desync.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Place an order, set it to Payment accepted so an invoice is generated, delete one of its products from the catalogue, then edit the order — changing the shipping address is enough. Before this change the order's Total products drops to 0; after it the amounts are the ones the order was invoiced at. Automated coverage: two scenarios in `tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_product.feature`, run with `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-deleted-product`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #35062, Fixes #28888
| Related PRs                |
| Sponsor company            |

### Measured

The feature is a pair: the same shipping-address change, once with every product still in the catalogue and once with one deleted. On `upstream/9.2.x` the control passes and the other fails:

```
Scenario: CONTROL changing the shipping address of an order whose products all still exist   passed
Scenario: Changing the shipping address does not zero the totals ... product is gone
  Invalid order field total_products, expected 23.80 instead of 0.000000
2 scenarios (1 passed, 1 failed)
```

With the change, **2 scenarios (2 passed), 31 steps**.

Instrumenting `Order::getCartProducts()` on the unfixed code shows the mismatch directly — the key built in the second loop against the list built in the first:

```
key=6__0_0  id_product=NULL  product_id=6  in_list=false  list=6_6_0_0
```

and once the line survives, `CartRow` was still pricing it as product `0`, which is the second half of the same `null`.

Three mutations:

| Mutation                                   | Result |
| ------------------------------------------- | ------ |
| drop the `id_product` mapping                 | red — `total_products` back to `0.000000` |
| drop the `existsInDatabase()` skip            | red — `Could not find the product in cart, meaning Order and Cart are out of sync` |
| map `id_product` to `0` instead of `product_id` | red — **both** scenarios, including the control |

The third is the one that matters: it shows the mapping has to carry the real product id, not merely be non-null.

Suites: `order` **262 scenarios (262 passed), 7379 steps**; `cart` **242 scenarios (242 passed), 3538 steps**.

### On the tax-included total

The two scenarios expect `total_products_wt` to become `23.80` after the address change, not the `25.23` the order started with. That is not part of this bug: the control scenario, with every product present, produces exactly the same figure, because changing the shipping address moves the tax address and the fixture's new address is in a state with no tax rule. The pair is written so that the deleted-product case has to match the intact case, which is the property the report is actually about.
