### PR TITLE
Do not fail when adding a cart rule the cart already has

### DIFF
--- a/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
@@ -59,7 +59,16 @@ final class AddCartRuleToCartHandler extends AbstractCartHandler implements AddC
         $errorMessage = $this->validateCartRule($cartRule, $cart);
 
         if ($errorMessage) {
+            // A voucher without a code is automatic: CartRule::autoAddToCart() attaches it to every cart
+            // on its own, so the back office asking for it explicitly is refused with "This voucher is
+            // already in your cart" even though the discount is applied. The requested state already
+            // holds, so report success instead of an error the employee cannot act on.
+            $alreadyApplied = $this->isCartRuleInCart($cart, (int) $cartRule->id);
             $this->contextStateManager->restorePreviousContext();
+
+            if ($alreadyApplied) {
+                return;
+            }
 
             throw new CartRuleValidityException($errorMessage);
         }
@@ -80,6 +89,23 @@ final class AddCartRuleToCartHandler extends AbstractCartHandler implements AddC
         }
 
         $this->contextStateManager->restorePreviousContext();
+    }
+
+    /**
+     * @param Cart $cart
+     * @param int $cartRuleId
+     *
+     * @return bool
+     */
+    private function isCartRuleInCart(Cart $cart, int $cartRuleId): bool
+    {
+        foreach ($cart->getCartRules(CartRule::FILTER_ACTION_ALL, false) as $appliedCartRule) {
+            if ((int) $appliedCartRule['id_cart_rule'] === $cartRuleId) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -617,6 +617,24 @@ class CartFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then I should get a cart rule validity error saying :message
+     *
+     * @param string $message
+     */
+    public function assertLastCartRuleValidityError(string $message)
+    {
+        $exception = $this->assertLastErrorIs(CartRuleValidityException::class);
+
+        if (!str_contains($exception->getMessage(), $message)) {
+            throw new RuntimeException(sprintf(
+                'Expected a cart rule validity error containing "%s", got "%s" instead',
+                $message,
+                $exception->getMessage()
+            ));
+        }
+    }
+
+    /**
      * @When I use a voucher :voucherCode which provides a gift product :productName on the cart :cartReference
      *
      * @param string $voucherCode
@@ -675,6 +693,37 @@ class CartFeatureContext extends AbstractDomainFeatureContext
         } catch (CartException $e) {
             $this->setLastException($e);
         }
+    }
+
+    /**
+     * @When I use an automatic voucher :voucherName which provides a gift product :productName on the cart :cartReference
+     *
+     * An automatic voucher is a cart rule without a code, which CartRule::autoAddToCart() applies to
+     * every cart on its own. It is what the back office "Add new voucher" form creates by default.
+     *
+     * @param string $voucherName
+     * @param string $giftProductName
+     * @param string $cartReference
+     */
+    public function useAutomaticGiftVoucherOnCart(string $voucherName, string $giftProductName, string $cartReference)
+    {
+        $productId = $this->getProductIdByName($giftProductName);
+        $cartRule = $this->createCommonCartRule($voucherName);
+        $cartRule->code = '';
+        $cartRule->gift_product = $productId;
+
+        $this->addCartRule($cartRule);
+        $cartRuleId = (int) $cartRule->id;
+
+        $this->getCommandBus()->handle(
+            new AddCartRuleToCartCommand(
+                $this->getSharedStorage()->get($cartReference),
+                $cartRuleId
+            )
+        );
+
+        $this->getSharedStorage()->set($voucherName, $cartRuleId);
+        $this->getSharedStorage()->set($giftProductName, $productId);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/BackOffice/delete_cart_rule_from_cart.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/BackOffice/delete_cart_rule_from_cart.feature
@@ -28,3 +28,29 @@ Feature: Delete cart rule from cart in Back Office (BO)
     When I delete voucher "giftFoxNotebook" from cart "dummy_cart_2"
     Then product "Mountain fox notebook" quantity in cart "dummy_cart_2" should be 3 excluding gift products
     But cart "dummy_cart_2" should not contain gift product "Mountain fox notebook"
+
+  # An automatic voucher (one without a code) is already attached to the cart by
+  # CartRule::autoAddToCart() before the back office can add it explicitly.
+  Scenario: Adding a cart rule that is already applied to the cart is not an error
+    Given I create an empty cart "dummy_cart_3" for customer "testCustomer"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart_3"
+    When I use an automatic voucher "autoGiftFoxNotebook" which provides a gift product "Mountain fox notebook" on the cart "dummy_cart_3"
+    Then cart "dummy_cart_3" should contain gift product "Mountain fox notebook"
+    And gifted product "Mountain fox notebook" quantity in cart "dummy_cart_3" should be 1
+
+  # The escape above must be limited to the rule that is already applied: a voucher the cart
+  # does not have and cannot use must still be refused.
+  Scenario: Adding a cart rule the cart cannot use is still an error
+    Given I create an empty cart "dummy_cart_4" for customer "testCustomer"
+    And I add 1 products "Mug The best is yet to come" to the cart "dummy_cart_4"
+    And there is a cart rule "expired_rule" with following properties:
+      | name[en-US]     | Expired voucher  |
+      | description     | Expired voucher  |
+      | priority        | 2                |
+      | code            | EXPIRED_VOUCHER  |
+      | discount_amount | 2                |
+      | valid_from      | 2020-01-01 00:00:00 |
+      | valid_to        | 2020-01-02 00:00:00 |
+    When I use a voucher "expired_rule" on the cart "dummy_cart_4"
+    Then I should get a cart rule validity error saying "expired"
+    And voucher "expired_rule" should not be applied to cart "dummy_cart_4"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | A voucher created without a code is *automatic*: `CartRule::autoAddToCart()` attaches it to every cart on its own, and `Cart::getCartRules()` runs that on any read (`classes/Cart.php:458`). The back office create-order page creates exactly such a voucher through its "Add new voucher" button and then asks the server to add it to the cart, so `AddCartRuleToCartHandler` always finds it already applied and throws `This voucher is already in your cart` — while the discount is in fact in the cart. The page shows the error and skips its refresh, which is why the reporter sees the total change but no line in the Vouchers block, and why re-adding fails with the same message. The handler now reports success whenever the requested cart rule is already applied to the cart, whatever validity error `checkValidity()` returned; the requested state holds, and a rule that has since become invalid is dropped by `CartRule::autoRemoveFromCart()` on the next read anyway. A validity error on a rule the cart does **not** have still throws.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | BO > Orders > Add new order, pick a customer, add a product. In the Vouchers block press "Add new voucher", give it a name, tick "Send a free gift", pick a product and save. Before this change the page reports "This voucher is already in your cart" and the Vouchers table stays empty although the gift is in the cart; after it the voucher is listed. Automated coverage: two scenarios in `tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/BackOffice/delete_cart_rule_from_cart.feature`, run with `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags bo-delete-cart-rule`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #35188
| Related PRs                |
| Sponsor company            |

### Measured

`AddCartRuleToCartCommand` is dispatched from one place in production, `CartController::addCartRuleAction` (the back office create-order page); everything else is test code. Adding an automatic gift voucher to a cart through that command on `upstream/9.2.x` fails immediately:

```
And I use an automatic voucher "autoGiftFoxNotebook" which provides a gift product "Mountain fox notebook" on the cart "dummy_cart_3"
  This voucher is already in your cart (PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\CartRuleValidityException)
```

which is the message in step 8 of the report, reached without a browser. The rule reaches the cart inside `AddCartRuleToCartHandler::validateCartRule()` itself: it calls `$cart->getCartRules()`, whose default `$autoAdd = true` applies the automatic rule, and `checkValidity()` on the next line then refuses it for being there.

Suites with the change: `cart` **244 scenarios (244 passed), 3561 steps**; `order` **260 scenarios (260 passed), 7344 steps**.

Two mutations, run against the pair of scenarios:

| Mutation                                   | Result |
| ------------------------------------------- | ------ |
| force `$alreadyApplied = false` (old behaviour) | red — `This voucher is already in your cart` |
| force `$alreadyApplied = true` (swallow every validity error) | red — the expired voucher is no longer refused |

The second scenario exists for that second mutation: a voucher the cart cannot use must still be rejected, so the escape cannot be widened into "ignore validation".

### Not fixed here

The report bundles four symptoms. This change covers the voucher not appearing in the block (step 4) and the "already in your cart" refusal (step 8).

Step 6, the voucher reappearing in the next order, is consistent with `CartRule::autoAddToCart()` selecting on `cr.id_customer = 0 OR cr.id_customer = <cart customer>` (`classes/CartRule.php:2047`) and with `AdminCartRulesController` not pre-filling a customer when the form is opened from the order page — but that is a code reading. A headless attempt to reproduce it (a second cart for a different customer) did not show the gift, because the assertion path does not trigger the auto-add the way a back office page load does, so it is left unverified rather than claimed.

Step 7 is not addressed: this change does **not** make the Remove button work for an automatic voucher. `RemoveCartRuleFromCartCommand` deletes the row, and the next `Cart::getCartRules()` re-adds it, because that is what "automatic" means. Whether the back office should refuse the removal with an explanation, or hide the button for codeless vouchers, is a product decision and is left to maintainers — measured and reported on the issue rather than guessed at here.