### PR TITLE
Resolve a module mail layout declared with an absolute path

### DIFF
--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -40,11 +40,15 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     /** @var bool */
     private $hasGiftWrapping;
 
+    /** @var string */
+    private $moduleDirectory;
+
     /**
      * @param Environment $twig
      * @param LayoutVariablesBuilderInterface $variablesBuilder
      * @param HookDispatcherInterface $hookDispatcher
      * @param bool $hasGiftWrapping
+     * @param string $moduleDirectory Absolute path of the modules folder, used to resolve layouts declared by modules
      *
      * @throws TypeException
      */
@@ -52,13 +56,15 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
         Environment $twig,
         LayoutVariablesBuilderInterface $variablesBuilder,
         HookDispatcherInterface $hookDispatcher,
-        bool $hasGiftWrapping
+        bool $hasGiftWrapping,
+        string $moduleDirectory = ''
     ) {
         $this->twig = $twig;
         $this->variablesBuilder = $variablesBuilder;
         $this->hookDispatcher = $hookDispatcher;
         $this->transformations = new TransformationCollection();
         $this->hasGiftWrapping = $hasGiftWrapping;
+        $this->moduleDirectory = $moduleDirectory;
     }
 
     /**
@@ -115,7 +121,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
         }
 
         try {
-            $renderedTemplate = $this->twig->render($layoutPath, $layoutVariables);
+            $renderedTemplate = $this->twig->render($this->getTwigPath($layoutPath), $layoutVariables);
         } catch (LoaderError) {
             throw new FileNotFoundException(sprintf('Could not find layout file: %s', $layoutPath));
         }
@@ -181,5 +187,24 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
         $this->transformations[] = $transformation;
 
         return $this;
+    }
+
+    /**
+     * Layouts added by a module through the actionListMailThemes hook are usually declared with the
+     * absolute file path documented on Layout::__construct, but Twig only resolves namespaced paths,
+     * so such a layout is reported as missing. Convert an absolute path inside the modules folder to
+     * the @Modules namespace, which is what FolderThemeScanner already builds for module themes.
+     *
+     * @param string $layoutPath
+     *
+     * @return string
+     */
+    private function getTwigPath(string $layoutPath): string
+    {
+        if ('' === $this->moduleDirectory || !str_starts_with($layoutPath, $this->moduleDirectory)) {
+            return $layoutPath;
+        }
+
+        return '@Modules/' . ltrim(substr($layoutPath, strlen($this->moduleDirectory)), '/');
     }
 }

--- a/src/Core/MailTemplate/Layout/Layout.php
+++ b/src/Core/MailTemplate/Layout/Layout.php
@@ -27,8 +27,9 @@ class Layout implements LayoutInterface
 
     /**
      * @param string $name Name of the layout to describe its purpose
-     * @param string $htmlPath Absolute path of the html layout file
-     * @param string $txtPath Absolute path of the txt layout file
+     * @param string $htmlPath Path of the html layout file, either a Twig namespaced path
+     *                         (@MailThemes/... or @Modules/...) or an absolute path inside the modules folder
+     * @param string $txtPath Path of the txt layout file, same accepted formats as $htmlPath
      * @param string $moduleName Which module this layout is associated to (if any)
      */
     public function __construct(

--- a/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
@@ -8,6 +8,7 @@ services:
       - '@prestashop.core.mail_template.variables_builder'
       - '@prestashop.core.hook.dispatcher'
       - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_GIFT_WRAPPING')"
+      - '%modules_dir%'
     calls:
       - method: 'addTransformation'
         arguments:

--- a/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
+++ b/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
@@ -103,6 +103,49 @@ class MailTemplateTwigRendererTest extends TestCase
         $this->assertEquals($expectedTemplate, $generatedTemplate);
     }
 
+    public function testRenderHtmlOfLayoutDeclaredWithAnAbsoluteModulePath(): void
+    {
+        $moduleDirectory = '/var/www/html/modules';
+        $templatePaths = [
+            MailTemplateInterface::HTML_TYPE => $moduleDirectory . '/testmaillayout/mails/layouts/test_layout.html.twig',
+        ];
+        $expectedTemplate = 'mail_template';
+        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::HTML_TYPE, 'giftWrapping' => 1];
+        $expectedLanguage = $this->createLanguageMock();
+        $mailLayout = $this->createMailLayoutMock($templatePaths);
+
+        $generator = new MailTemplateTwigRenderer(
+            $this->createEngineMock('@Modules/testmaillayout/mails/layouts/test_layout.html.twig', $expectedVariables, $expectedTemplate),
+            $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
+            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE),
+            true,
+            $moduleDirectory
+        );
+
+        $this->assertEquals($expectedTemplate, $generator->renderHtml($mailLayout, $expectedLanguage));
+    }
+
+    public function testRenderHtmlOfLayoutOutsideTheModulesFolderIsLeftUntouched(): void
+    {
+        $templatePaths = [
+            MailTemplateInterface::HTML_TYPE => '@MailThemes/modern/core/account.html.twig',
+        ];
+        $expectedTemplate = 'mail_template';
+        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::HTML_TYPE, 'giftWrapping' => 1];
+        $expectedLanguage = $this->createLanguageMock();
+        $mailLayout = $this->createMailLayoutMock($templatePaths);
+
+        $generator = new MailTemplateTwigRenderer(
+            $this->createEngineMock($templatePaths[MailTemplateInterface::HTML_TYPE], $expectedVariables, $expectedTemplate),
+            $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
+            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE),
+            true,
+            '/var/www/html/modules'
+        );
+
+        $this->assertEquals($expectedTemplate, $generator->renderHtml($mailLayout, $expectedLanguage));
+    }
+
     public function testRenderHtmlWithFallback(): void
     {
         $templatePaths = [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Layout::__construct()` documents its two path arguments as *"Absolute path of the html layout file"*, but `MailTemplateTwigRenderer::render()` passes whatever it receives straight to `Twig\Environment::render()`, which only resolves namespaced paths. A module that adds a layout through the `actionListMailThemes` hook using the documented absolute path is therefore reported as missing, while the same layout declared as `@Modules/...` works — which is exactly the difference between the reporter's module and the workaround posted on the issue. The renderer now maps an absolute path inside the modules folder onto the `@Modules` namespace, the same conversion `FolderThemeScanner::scan()` already performs for mail themes shipped inside a module, and the `Layout` docblock now states both accepted forms.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Install a module that registers a mail layout on `actionListMailThemes` with an absolute path, e.g. `new Layout('test_layout', _PS_MODULE_DIR_ . $this->name . '/mails/layouts/test_layout.html.twig', '', $this->name)` — the sample module attached to the issue does exactly this. Go to Design > Email theme, pick the theme and a locale, and press Generate emails. Before this change it fails with `Could not find layout file: /var/www/html/modules/testmaillayout/mails/layouts/test_layout.html.twig`; after it the template is generated. Automated coverage: two cases in `tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #35214
| Related PRs                |
| Sponsor company            |

### Measured

`bin/console debug:twig` on this checkout reports the namespace the conversion targets:

```
  @Modules              modules/
  @MailThemes           mails/themes/
```

so `<modules_dir>/testmaillayout/mails/layouts/test_layout.html.twig` and `@Modules/testmaillayout/mails/layouts/test_layout.html.twig` name the same file. `bin/console debug:container` confirms the new argument resolves:

```
  Arguments        Service(twig)
                   Service(prestashop.core.mail_template.variables_builder)
                   Service(PrestaShop\PrestaShop\Core\Hook\HookDispatcher)
                   service('prestashop.adapter.legacy.configuration').getBoolean('PS_GIFT_WRAPPING')
                   /var/www/html/modules
```

`modules_dir` is `%kernel.project_dir%/modules`, with no trailing slash, which is why the conversion trims the leading separator instead of concatenating blindly.

Unit suite: **9 tests, 75 assertions**, up from 7. Two mutations, each run against the same file:

| Mutation                                                        | Result |
| --------------------------------------------------------------- | ------ |
| render `$layoutPath` directly, bypassing the conversion           | red — 1 failure (the absolute-path case) |
| drop the `str_starts_with()` guard so every path gets `@Modules/` | red — 1 failure (the `@MailThemes` case) |

The second one is what keeps the fix from swallowing theme paths: a layout outside the modules folder must be handed to Twig untouched.

### Scope

The constructor argument is optional and appended last, so an existing direct instantiation keeps working; the service definition passes `%modules_dir%`. Nothing else in the mail-template chain is changed — in particular the `actionListMailThemes` hook contract and `FolderThemeCatalog` are untouched, since the failure occurs at render time and fixing it there covers every layout the hook can add.