### PR TITLE
Store the resolved carrier on a cart ordered from the back office

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -73,6 +73,8 @@ final class AddOrderFromBackOfficeHandler extends AbstractOrderCommandHandler im
         $this->setCartContext($this->contextStateManager, $cart);
 
         try {
+            $this->persistDeliveryOption($cart);
+
             $orderMessage = $command->getOrderMessage();
             if (!empty($orderMessage)) {
                 $this->addOrderMessage($cart, $orderMessage);
@@ -108,6 +110,30 @@ final class AddOrderFromBackOfficeHandler extends AbstractOrderCommandHandler im
         }
 
         return new OrderId($orderId);
+    }
+
+    /**
+     * A back office cart only gets a usable delivery option once the employee changes the carrier
+     * selector: selecting the addresses re-applies the carrier the cart currently has, which is still
+     * none, so the cart keeps id_carrier = 0 and a delivery option pointing at carrier 0.
+     * PaymentModule::validateOrder() resolves a valid option on its own, so the order ends up with a
+     * carrier the cart does not have and both the cart list and the customer page show none for it.
+     *
+     * @param Cart $cart
+     */
+    private function persistDeliveryOption(Cart $cart): void
+    {
+        if ((int) $cart->id_carrier || $cart->isVirtualCart()) {
+            return;
+        }
+
+        $deliveryOption = $cart->getDeliveryOption(null, false, false);
+        if (empty($deliveryOption)) {
+            return;
+        }
+
+        $cart->setDeliveryOption($deliveryOption);
+        $cart->update();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -37,6 +37,9 @@ Feature: Order from Back Office (BO)
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
 
+  Scenario: A cart ordered from the back office keeps the carrier the order was created with
+    Then cart "dummy_cart" should have "default_carrier" as a carrier
+
   # Even without a customer message, the employee who created the order from the BO must be
   # recorded in the order messages block (regression from 1.6, see issue #9676).
   Scenario: An order created from the BO with no customer message still records its creating employee


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Nothing writes `cart.id_carrier` on the create-order page unless the employee actively changes the delivery-option selector: `create-order-page.ts:292` binds the AJAX call to `change`. On top of that, `UpdateCartAddressesHandler:49` re-applies `$cart->id_carrier` when the addresses are selected, which is still `0`, leaving the cart with `delivery_option = {"4":"0,"}` — an option pointing at no carrier. `PaymentModule::validateOrder()` then repairs that locally and gives the *order* a valid carrier, so the order looks right while the cart keeps `id_carrier = 0`. Both the Shopping carts grid and the customer page's Carts block read `c.id_carrier` (`CartQueryBuilder:52` selects `ca.name AS carrier_name` through `LEFT JOIN ps_carrier ca ON c.id_carrier = ca.id_carrier`), so both show an empty carrier. `AddOrderFromBackOfficeHandler` now persists the delivery option the order is about to use, before validating it.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | BO > Orders > Add new order, pick a customer, add a product, leave the Shipping block on the carrier it already proposes, choose a payment and a status, create the order. Then open Orders > Shopping carts, and the customer's page > Carts block. Before this change both show an empty Carrier column for that cart; after it they show the carrier the order was created with. Automated coverage: `tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature`, run with `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-from-bo`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #35223
| Related PRs                |
| Sponsor company            |

### Measured

On `upstream/9.2.x`, every cart ordered from the back office keeps no carrier while its order has one. Reading the integration database straight after a run of `--tags order-from-bo` against the unmodified handler:

```
id_cart  cart.id_carrier  cart.delivery_option  order.id_carrier
47       0                (empty)               2
46       0                {"4":"0,"}            2
45       0                (empty)               2
44       0                {"4":"0,"}            2
```

Two shapes, both ending at `0`. The `{"4":"0,"}` rows are the carts that went through the address selection, which re-applies the cart's current (absent) carrier; the empty ones never got a delivery option at all. This is why the guard has to be `id_carrier`, not `delivery_option` — an emptiness check would skip exactly the carts the address step has already touched.

The new scenario fails on that state with

```
Then cart "dummy_cart" should have "default_carrier" as a carrier
  Cart dummy_cart has no carrier defined (RuntimeException)
```

Instrumenting the handler shows the sequence exactly: the cart arrives holding `{"4":"0,"}`, `Cart::getDeliveryOption()` rejects that key and auto-selects `{"4":"2,"}`, `setDeliveryOption()` derives `id_carrier = 2`, and the row reloaded from the database reads `2`.

With the change: `order` suite **261 scenarios (261 passed), 7357 steps**; `cart` suite **242 scenarios (242 passed), 3538 steps** — the latter run because `Cart::setDeliveryOption()` also re-evaluates automatic cart rules.

Two mutations, each against the same scenario:

| Mutation                                              | Result |
| ----------------------------------------------------- | ------ |
| drop the `persistDeliveryOption()` call                 | red — `Cart dummy_cart has no carrier defined` |
| keep it but force `id_carrier = 1` after the resolution | red — `expected id_carrier to be 2 but is 1 instead` |

The second one is the one that matters: the assertion pins the carrier the order actually used, not merely a non-zero value.

### Not changed

The `change`-only binding in `admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts:292` is the proximate trigger, but fixing the handler covers every route into back office order creation, including the ones with no browser at all — which is what the behat measurement above exercises. `Cart::setDeliveryOption()` writes `id_carrier` only for a single delivery address; multi-address carts, whose feature is described as gone in `Cart::getDeliveryOptionList()`, still keep `0` there.