### PR TITLE
Do not restock products a refund already put back when an order is canceled

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -194,33 +194,36 @@ class OrderHistoryCore extends ObjectModel
 
             // foreach products of the order
             foreach ($order->getProductsDetail() as $product) {
+                // Products already sent back to stock by a refund must not be restocked twice by a status change
+                $quantityToRestock = max(0, (int) $product['product_quantity'] - (int) $product['product_quantity_reinjected']);
+
                 if (Validate::isLoadedObject($old_os)) {
                     // if becoming logable => adds sale
                     if ($new_os->logable && !$old_os->logable) {
                         ProductSale::addProductSale($product['product_id'], $product['product_quantity']);
                         if (!Pack::isPack($product['product_id'])
                             && in_array($old_os->id, $error_or_canceled_statuses)) {
-                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
+                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -$quantityToRestock, $order->id_shop);
                         }
                     } elseif (!$new_os->logable && $old_os->logable) {
                         // if becoming unlogable => removes sale
                         ProductSale::removeProductSale($product['product_id'], $product['product_quantity']);
                         if (!Pack::isPack($product['product_id'])
                             && in_array($new_os->id, $error_or_canceled_statuses)) {
-                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
+                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], $quantityToRestock, $order->id_shop);
                         }
                     } elseif (!$new_os->logable && !$old_os->logable
                         && in_array($new_os->id, $error_or_canceled_statuses)
                         && !in_array($old_os->id, $error_or_canceled_statuses)
                     ) {
                         // Status is changed from not loggable status as Processing in progress etc. to Payment error/Canceled
-                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
+                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], $quantityToRestock, $order->id_shop);
                     } elseif (!$new_os->logable && !$old_os->logable
                         && !in_array($new_os->id, $error_or_canceled_statuses)
                         && in_array($old_os->id, $error_or_canceled_statuses)
                     ) {
                         // Status is changed from Payment error/Canceled to not loggable status as Processing in progress etc.
-                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
+                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -$quantityToRestock, $order->id_shop);
                     }
                 }
                 // From here, there is 2 cases : $old_os exists, and we can test shipped state evolution,

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_stock.feature
@@ -62,3 +62,49 @@ Feature: Stock management of order from Back Office (BO)
       | index | order_status |
       | 1     | Shipped      |
       | 2     | Delivered    |
+
+  Scenario: Cancelling an order does not restock quantities that a partial refund already restocked
+    Given there is a product in the catalog named "product_restock_then_cancel" with a price of 17.0 and 100 items in stock
+    When I create an empty cart "cart_restock_then_cancel" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "cart_restock_then_cancel"
+    And I add 1 products "product_restock_then_cancel" to the cart "cart_restock_then_cancel"
+    And I add order "order_restock_then_cancel" with the following details:
+      | cart                | cart_restock_then_cancel |
+      | message             | test                     |
+      | payment module name | dummy_payment            |
+      | status              | Payment accepted         |
+    Then the available stock for product "product_restock_then_cancel" should be 99
+    When I issue a partial refund on "order_restock_then_cancel" with restock with credit slip without voucher on following products:
+      | product_name                | quantity | amount |
+      | product_restock_then_cancel | 1        | 17.0   |
+    Then the available stock for product "product_restock_then_cancel" should be 100
+    And product "product_restock_then_cancel" in order "order_restock_then_cancel" has following details:
+      | product_quantity            | 1 |
+      | product_quantity_refunded   | 1 |
+      | product_quantity_reinjected | 1 |
+    When I update order "order_restock_then_cancel" status to "Canceled"
+    Then the available stock for product "product_restock_then_cancel" should be 100
+    When I update order "order_restock_then_cancel" status to "Payment accepted"
+    Then the available stock for product "product_restock_then_cancel" should be 100
+
+  Scenario: Cancelling an order still restocks the quantity a refund without restock left out of stock
+    Given there is a product in the catalog named "product_refund_no_restock" with a price of 17.0 and 100 items in stock
+    When I create an empty cart "cart_refund_no_restock" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "cart_refund_no_restock"
+    And I add 1 products "product_refund_no_restock" to the cart "cart_refund_no_restock"
+    And I add order "order_refund_no_restock" with the following details:
+      | cart                | cart_refund_no_restock |
+      | message             | test                   |
+      | payment module name | dummy_payment          |
+      | status              | Payment accepted       |
+    Then the available stock for product "product_refund_no_restock" should be 99
+    When I update order "order_refund_no_restock" status to "Delivered"
+    And I issue a partial refund on "order_refund_no_restock" without restock with credit slip without voucher on following products:
+      | product_name             | quantity | amount |
+      | product_refund_no_restock | 1        | 17.0   |
+    Then the available stock for product "product_refund_no_restock" should be 99
+    And product "product_refund_no_restock" in order "order_refund_no_restock" has following details:
+      | product_quantity            | 1 |
+      | product_quantity_reinjected | 0 |
+    When I update order "order_refund_no_restock" status to "Canceled"
+    Then the available stock for product "product_refund_no_restock" should be 100


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `OrderHistory::changeIdOrderState()` restocks the **full ordered quantity** on every transition into or out of `PS_OS_ERROR` / `PS_OS_CANCELED`, ignoring `product_quantity_reinjected`. A partial refund with "Re-stock products" has already returned those units to stock (`OrderRefundUpdater::updateRefundData()` bumps `product_quantity_reinjected` right after `AbstractOrderCommandHandler::reinjectQuantity()` calls `StockAvailable::updateQuantity()`), so cancelling the order afterwards adds them a second time and the stock ends above its initial value. The four `StockAvailable::updateQuantity()` calls now use `product_quantity - product_quantity_reinjected` instead, clamped at zero, keeping the pair of transitions symmetric.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Follow the reporter's steps: product with 100 in stock, order 1 unit (99), status "Payment accepted", partial refund of that unit with "Re-stock products" ticked (100), then status "Canceled". Before this change the stock reads 101, after it stays at 100. Automated coverage: two scenarios in `tests/Integration/Behaviour/Features/Scenario/Order/order_stock.feature`, run with `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-stock`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #35460
| Related PRs                |
| Sponsor company            |

### Measured

On `upstream/9.2.x` with no change, the new scenario fails on its last step:

```
When I update order "order_restock_then_cancel" status to "Canceled"
Then the available stock for product "product_restock_then_cancel" should be 100
  Expects 100, got 101 instead (RuntimeException)
```

which is the reporter's 101 exactly. Every earlier step passes: 99 after the order, 100 after the refund, and `product_quantity_refunded = 1`, `product_quantity_reinjected = 1` on the order detail.

With the change, the full `order` suite is green: **262 scenarios (262 passed), 7385 steps** in 6m12s — 260 of them pre-existing, plus the two added here.

### Why `product_quantity_reinjected` and not the refunded/returned counters

Six lines below the restock branches, the stock-movement block computes `product_quantity - product_quantity_refunded - product_quantity_return`. That is the **accounting** net — what the customer was credited — and it is the wrong quantity here, because a refund without restock leaves the units off the shelf and cancelling must still return them. `product_quantity_reinjected` is the **physical** net: how much of the line is already back in stock.

Three mutations, each run against the same two scenarios, confirm the test discriminates:

| Mutation of `$quantityToRestock`                        | Result |
| ------------------------------------------------------- | ------ |
| `product_quantity` (the current code)                    | red — `Expects 100, got 101` |
| `product_quantity - product_quantity_refunded`           | red — `Expects 100, got 99` |
| `product_quantity - product_quantity_refunded - product_quantity_return` | red — `Expects 100, got 99` |

The two 99s come from the second scenario, where a refund **without** restock on a delivered order must still let the cancellation return the unit.

### Not changed

The fix does not write back to `product_quantity_reinjected`. That field feeds the remaining-refundable computation in `OrderRefundUpdater:47` and `AbstractOrderCommandHandler:41`, so updating it from a status change would alter what the merchant can still refund. The mirror sequence — cancel first, then refund with restock — therefore still over-restocks; it is a separate, pre-existing problem and is not touched here.