### PR TITLE
Never send SameSite=None on a cookie that is not secure

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -382,9 +382,30 @@ class CookieCore
                 'domain' => (string) $this->_domain,
                 'secure' => $this->_secure,
                 'httponly' => true,
-                'samesite' => in_array((string) $this->_sameSite, CookieOptions::SAMESITE_AVAILABLE_VALUES) ? (string) $this->_sameSite : CookieOptions::SAMESITE_NONE,
+                'samesite' => $this->getSameSiteAttribute(),
             ]
         );
+    }
+
+    /**
+     * The SameSite attribute to send, which is never None on a cookie that is not secure.
+     *
+     * A browser discards a SameSite=None cookie that is not also Secure, and discarding the employee
+     * cookie logs the session out - which surfaces as "security compromised" on the next request, because
+     * the token no longer matches. GeneralConfiguration::validateSameSite() refuses to *save* that
+     * combination for exactly this reason, so it must not be reachable by falling back to it either.
+     */
+    protected function getSameSiteAttribute(): string
+    {
+        $sameSite = in_array((string) $this->_sameSite, CookieOptions::SAMESITE_AVAILABLE_VALUES, true)
+            ? (string) $this->_sameSite
+            : CookieOptions::SAMESITE_LAX;
+
+        if ($sameSite === CookieOptions::SAMESITE_NONE && !$this->_secure) {
+            $sameSite = CookieOptions::SAMESITE_LAX;
+        }
+
+        return $sameSite;
     }
 
     /**

--- a/tests/Unit/Classes/CookieSameSiteTest.php
+++ b/tests/Unit/Classes/CookieSameSiteTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use Cookie;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Http\CookieOptions;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * A browser discards a SameSite=None cookie that is not also Secure. For the employee cookie that means
+ * the session is lost and the next request fails its token check with "security compromised", so None
+ * must never be emitted on a cookie that is not secure - including as a fallback for an unrecognised
+ * configured value, which is what an upgraded shop can end up with.
+ */
+class CookieSameSiteTest extends TestCase
+{
+    /**
+     * @dataProvider provideUnrecognisedValues
+     *
+     * @param mixed $configured
+     */
+    public function testAnUnrecognisedValueFallsBackToLaxRatherThanNone($configured): void
+    {
+        $this->assertSame(
+            CookieOptions::SAMESITE_LAX,
+            $this->resolve($configured, false),
+            'an unusable configured value must not become the one attribute browsers refuse'
+        );
+    }
+
+    public static function provideUnrecognisedValues(): iterable
+    {
+        yield 'missing configuration' => [false];
+        yield 'empty string' => [''];
+        yield 'null' => [null];
+        yield 'wrong case' => ['lax'];
+        yield 'nonsense' => ['whatever'];
+    }
+
+    public function testNoneIsDowngradedOnAnInsecureCookie(): void
+    {
+        $this->assertSame(CookieOptions::SAMESITE_LAX, $this->resolve(CookieOptions::SAMESITE_NONE, false));
+    }
+
+    public function testNoneIsKeptOnASecureCookie(): void
+    {
+        $this->assertSame(CookieOptions::SAMESITE_NONE, $this->resolve(CookieOptions::SAMESITE_NONE, true));
+    }
+
+    /**
+     * @dataProvider provideRecognisedValues
+     */
+    public function testRecognisedValuesAreKept(string $configured): void
+    {
+        $this->assertSame($configured, $this->resolve($configured, false));
+    }
+
+    public static function provideRecognisedValues(): iterable
+    {
+        yield 'lax' => [CookieOptions::SAMESITE_LAX];
+        yield 'strict' => [CookieOptions::SAMESITE_STRICT];
+    }
+
+    /**
+     * @param mixed $configured
+     */
+    private function resolve($configured, bool $secure): string
+    {
+        $cookie = (new ReflectionClass(Cookie::class))->newInstanceWithoutConstructor();
+
+        $sameSite = new ReflectionProperty(Cookie::class, '_sameSite');
+        $sameSite->setAccessible(true);
+        $sameSite->setValue($cookie, $configured);
+
+        $secureProperty = new ReflectionProperty(Cookie::class, '_secure');
+        $secureProperty->setAccessible(true);
+        $secureProperty->setValue($cookie, $secure);
+
+        $method = new ReflectionMethod(Cookie::class, 'getSameSiteAttribute');
+        $method->setAccessible(true);
+
+        return $method->invoke($cookie);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Cookie::write()` resolved the SameSite attribute with `in_array(...) ? $configured : CookieOptions::SAMESITE_NONE`, so **any** value it does not recognise becomes `None` - and a missing, empty or differently cased `PS_COOKIE_SAMESITE` is exactly what an upgraded shop can be left with. On a shop without SSL that emits `SameSite=None` with `Secure` unset, which browsers discard outright: the employee cookie never comes back, the session is lost, and the next request fails its token check with "security compromised". `GeneralConfiguration::validateSameSite()` already refuses to *save* `None` without `PS_SSL_ENABLED`, with the comment "The SameSite=None is only working when Secure is settled" - this makes the runtime agree with the configuration layer instead of falling into the very state it forbids.
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | On a shop with `PS_SSL_ENABLED = 0`, set `PS_COOKIE_SAMESITE` to an empty string or `lax` directly in `ps_configuration` (which is the state an upgrade can leave behind, and which the back office form will not let you save). Before this change the response carries `Set-Cookie: ...; SameSite=None` without `Secure` and the browser drops it, so the back office logs you out and shows "security compromised". After it, the cookie carries `SameSite=Lax` and the session survives. Automated coverage: `tests/Unit/Classes/CookieSameSiteTest.php`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #35677
| Related PRs                |
| Sponsor company            |

### Measured

Resolving each stored value against the current code, on a shop with `PS_SSL_ENABLED = '0'`:

```
'Lax'     recognised   -> SameSite=Lax
'None'    recognised   -> SameSite=None      (dropped: no Secure)
'Strict'  recognised   -> SameSite=Strict
'lax'     unrecognised -> SameSite=None      (dropped)
''        unrecognised -> SameSite=None      (dropped)
false     unrecognised -> SameSite=None      (dropped)
null      unrecognised -> SameSite=None      (dropped)
```

Four of the seven produce a cookie the browser refuses. After the change every one of them yields `Lax` except an explicit `Strict`, and an explicit `None` is kept when - and only when - the cookie is secure.

That also fits both reports: @Hlavtox upgraded from 1.7.6, and @Prestaworks described losing the session cookie and getting fresh tokens continually, in Firefox but not Chrome - Firefox has enforced the None-requires-Secure rule the longest.

### Not claimed

I have not reproduced the back office logout end to end, since that needs a browser session. What is measured above is which attribute the code emits for each stored value, which is the step the report turns on.