### PR TITLE
Refuse a negative number of days for the new-product window

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\PositiveOrZero;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -87,6 +88,12 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'required' => false,
+                // A number of days cannot be negative. The configuration adapter only checks that the
+                // value is an int, so without this a negative one is stored and every consumer then
+                // silently falls back to its own default.
+                'constraints' => [
+                    new PositiveOrZero(),
+                ],
                 'multistore_configuration_key' => 'PS_NB_DAYS_NEW_PRODUCT',
             ])
             ->add('short_description_limit', IntegerType::class, [

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralTypeTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralTypeTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
+
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences\GeneralType;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * "Number of days for which the product is considered new" is only type checked by the configuration
+ * adapter (setAllowedTypes int), so without a constraint a negative number reaches the database and every
+ * consumer then quietly falls back to its own default instead of showing the merchant an error.
+ */
+class GeneralTypeTest extends KernelTestCase
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        global $kernel;
+        $kernel = self::$kernel;
+
+        // the multistore form extension resolves a shop context while building this type
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopId(1);
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+
+        $this->formFactory = self::getContainer()->get('form.factory');
+    }
+
+    public function testANegativeNumberOfDaysIsRejected(): void
+    {
+        $form = $this->submitNewDaysNumber('-1');
+
+        $this->assertFalse($form->isValid(), 'a negative number of days must not pass validation');
+        $this->assertGreaterThan(0, count($form->get('new_days_number')->getErrors()));
+    }
+
+    /**
+     * @dataProvider provideAcceptableValues
+     */
+    public function testAcceptableNumbersOfDaysPass(string $value): void
+    {
+        $form = $this->submitNewDaysNumber($value);
+
+        $this->assertCount(
+            0,
+            $form->get('new_days_number')->getErrors(),
+            sprintf('%s should be an acceptable number of days', $value)
+        );
+    }
+
+    public static function provideAcceptableValues(): iterable
+    {
+        yield 'zero' => ['0'];
+        yield 'one' => ['1'];
+        yield 'the default' => ['20'];
+    }
+
+    private function submitNewDaysNumber(string $value)
+    {
+        $form = $this->formFactory->create(GeneralType::class);
+        $form->submit(['new_days_number' => $value], false);
+
+        return $form;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | **Shop Parameters > Product Settings > "Number of days for which the product is considered 'new'"** had no validation constraint, and `GeneralConfiguration` only checks the submitted value is an `int` (`setAllowedTypes('new_days_number', 'int')`), so `-1` was accepted and stored. Nothing downstream reports it either: `ProductSale`, `Supplier` and `Search` each guard with `Validate::isUnsignedInt()` and silently substitute `20`, while `ps_newproducts` treats an empty value as "hide the block". The merchant is shown neither an error nor the number they typed. `PositiveOrZero` is the constraint the codebase already uses for this shape - it appears in ten other form types.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Shop Parameters > Product Settings, set the field to `-1` and save. The form now reports the value as invalid instead of storing it. `0`, `1` and `20` still save. Automated coverage: `tests/Integration/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralTypeTest.php`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Part of #35796
| Related PRs                |
| Sponsor company            |

### The field is in core, not in ps_newproducts

Worth saying because the issue is filed against the module: `ps_newproducts` has a single setting of its own, `NEW_PRODUCTS_NBR` ("Products to display"), and it already validates it with `Validate::isUnsignedInt()`. The field this report is about, `PS_NB_DAYS_NEW_PRODUCT`, is defined in core's `ProductPreferences/GeneralType` and only *read* by the module, which is why no amount of looking at `ps_newproducts` would have found it.

### Scope

This addresses the negative value. The other inputs in the report behave differently and are not all defects of the same kind - `0` is a legitimate setting that happens to make `ps_newproducts` hide its block (its guard is `empty()`), and `1 500` and `@` are handled by `IntegerType`'s own transformation, whose grouping behaviour is locale dependent. Those are worth their own decision rather than being bundled in here.