### PR TITLE
Mirror the category tree's arrow and indentation in RTL

### DIFF
--- a/admin-dev/themes/new-theme/scss/rtl.scss
+++ b/admin-dev/themes/new-theme/scss/rtl.scss
@@ -207,6 +207,34 @@ ul {
 .material-choice-tree-container {
   ul {
     &.choice-tree {
+      // The glyphs were already mirrored here, but none of the directional properties that place
+      // them were: the arrow is positioned with `left` and the nesting indents with `padding-left`,
+      // so in RTL the arrow stayed pinned to the left edge of a right-aligned label and every level
+      // indented away from the text. This theme has no automatic RTL flip, so each one needs saying.
+      li {
+        .checkbox,
+        .radio {
+          padding-right: 20px;
+          padding-left: 0;
+        }
+
+        ul {
+          padding-right: 1rem;
+          padding-left: 0;
+        }
+      }
+
+      .collapsed,
+      .expanded {
+        >.checkbox,
+        >.radio {
+          &::before {
+            right: -0.1rem;
+            left: auto;
+          }
+        }
+      }
+
       .collapsed {
         >.checkbox {
           &::before {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `rtl.scss` already flipped the choice tree's arrow **glyph** — `\E5CC` becomes `\E5CB` — but none of the directional properties that place it. In `_material_choice_tree.scss` the arrow is positioned with `left: -0.1rem`, the label reserves its space with `padding-left: 20px`, and every nested level indents with `padding-left: 1rem`. The admin theme has no automatic RTL flip, so each of those needs a hand-written mirror, and these three never got one: in RTL the arrow stayed pinned to the left edge of a right-aligned label and the tree indented away from its own text. That is the "Add categories: the arrow's destination is wrong" of the report.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Install with Arabic, enable it in the back office, then Catalog > Products > edit a product > Description > Add categories. Before this change the expand arrow sits on the left of each right-aligned label and sub-categories step outward; after it the arrow sits at the start of the label and each level steps inward from the right.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | See #36350
| Related PRs                |
| Sponsor company            |

### Measured

Auditing `_material_choice_tree.scss` against the `.material-choice-tree-container` block in `rtl.scss`, the LTR component has four directional declarations and the RTL file overrode none of them — only the two `content:` glyphs:

```
padding-left: 20px    line 26   label's reserve for the arrow    not mirrored
left: 3px             line 46   checkmark inside the control     not mirrored
padding-left: 1rem    line 56   nesting indentation              not mirrored
left: -0.1rem         line 72   the arrow itself                 not mirrored
```

Reproducing those rules under `dir="rtl"` and reading the boxes back from the browser:

```
                              as shipped        with the mirror
arrow offset                  left: -1.6px      right: -1.6px
label reserve                 padding-left 20   padding-right 20
nested item, from the right    40px outward      16px inward (= 1rem)
```

`stylelint` reports 0 problems on the file.

### Scope

Only the three declarations that place the arrow and the nesting are mirrored. The fourth, `left: 3px` on the checkmark inside the checkbox control, is left alone: it sits in a fixed 16px box and mirroring it changes nothing a user can see, so it is noise in the diff rather than a fix.

The report lists two other symptoms in the Combinations tab — overlapping controls and an empty size column. Those are a different component and are not addressed here; `rtl.scss` does carry a `.combinations-filters-dropdown` block, so the same audit is worth repeating there.

### Verification limit

Measured on a standalone reproduction of these rules under `dir="rtl"`, not on the real back office page, which needs an employee session and an installed Arabic pack.