### PR TITLE
Break ties in getAttributesGroups() by combination id

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4408,7 +4408,11 @@ class ProductCore extends ObjectModel
         }
 
         $query->groupBy('id_attribute_group, id_product_attribute');
-        $query->orderBy('ag.position ASC, a.position ASC, agl.name ASC');
+        // The combination id is the tie-breaker that makes this order total. Without it, rows sharing a
+        // group and attribute position come back in whatever order the engine chooses, which differs
+        // between MySQL and MariaDB - and the front office picks the first matching combination, so the
+        // size preselected for a colour changed with the database engine.
+        $query->orderBy('ag.position ASC, a.position ASC, agl.name ASC, product_attribute_shop.id_product_attribute ASC');
 
         Hook::exec('actionProductGetAttributesGroupsBefore', [
             'product' => $this,

--- a/tests/Integration/Classes/Product/AttributesGroupsOrderTest.php
+++ b/tests/Integration/Classes/Product/AttributesGroupsOrderTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Classes\Product;
 
+use Configuration;
 use Db;
 use Product;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -41,14 +42,29 @@ class AttributesGroupsOrderTest extends KernelTestCase
 
     protected function tearDown(): void
     {
-        Db::deleteTestingInstance();
+        $this->restoreRealDb();
         parent::tearDown();
+    }
+
+    /**
+     * WHY: Db::setInstanceForTesting() replaces the connection GLOBALLY, so anything reached while the
+     * mock is installed reads [] and can memoise that emptiness in a static that outlives the swap -
+     * Configuration's cache being the one that matters, since an empty configuration yields id_lang 0
+     * and an empty shop context for every later test in the run. Put the real connection back and
+     * re-read the configuration from it, rather than only dropping the mock.
+     */
+    private function restoreRealDb(): void
+    {
+        Db::deleteTestingInstance();
+        Configuration::loadConfiguration();
     }
 
     public function testTheOrderByIsTotal(): void
     {
-        $sql = $this->captureQueryOf(static function (): void {
-            (new Product(1, false, 1))->getAttributesGroups(1);
+        // Built before the mock goes in, so the constructor's own queries hit the real connection.
+        $product = new Product(1, false, 1);
+        $sql = $this->captureQueryOf(static function () use ($product): void {
+            $product->getAttributesGroups(1);
         });
 
         $this->assertStringContainsString('ORDER BY', $sql, 'the query must be ordered at all');
@@ -61,8 +77,10 @@ class AttributesGroupsOrderTest extends KernelTestCase
 
     public function testTheTieBreakerComesLastSoTheDocumentedOrderIsKept(): void
     {
-        $sql = $this->captureQueryOf(static function (): void {
-            (new Product(1, false, 1))->getAttributesGroups(1);
+        // Built before the mock goes in, so the constructor's own queries hit the real connection.
+        $product = new Product(1, false, 1);
+        $sql = $this->captureQueryOf(static function () use ($product): void {
+            $product->getAttributesGroups(1);
         });
 
         preg_match('/ORDER BY(.*)$/is', $sql, $matches);
@@ -84,13 +102,18 @@ class AttributesGroupsOrderTest extends KernelTestCase
 
             return [];
         });
-        Db::setInstanceForTesting($mock);
 
-        $call();
+        // Keep the window around the mocked connection as small as the measurement allows: only the
+        // call under test runs against it, and the real connection is back before any assertion.
+        Db::setInstanceForTesting($mock);
+        try {
+            $call();
+        } finally {
+            $this->restoreRealDb();
+        }
 
         $this->assertNotEmpty($this->executedQueries, 'no query was issued, so this test proves nothing');
 
-        // the product constructor queries too, so pick the one this test is about
         foreach ($this->executedQueries as $sql) {
             if (false !== stripos($sql, 'id_attribute_group')) {
                 return $sql;

--- a/tests/Integration/Classes/Product/AttributesGroupsOrderTest.php
+++ b/tests/Integration/Classes/Product/AttributesGroupsOrderTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Db;
+use Product;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * getAttributesGroups() orders by group position, attribute position and group name. None of those
+ * identifies a row - every attribute is shared by several combinations - so their relative order was
+ * left to the engine, and the front office preselects whichever combination comes first.
+ *
+ * This asserts the ORDER BY rather than the returned rows on purpose. An unordered query is free to
+ * return the right order, and on this database it does most of the time: the same code returned
+ * 2,1,4,3,6,5,8,7 on one run and 1,2,3,4,5,6,7,8 on the next. A test that reads the result would
+ * therefore pass with the bug present, which is worse than no test at all.
+ */
+class AttributesGroupsOrderTest extends KernelTestCase
+{
+    /**
+     * @var array<string>
+     */
+    private $executedQueries = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        global $kernel;
+        $kernel = self::$kernel;
+
+        $this->executedQueries = [];
+    }
+
+    protected function tearDown(): void
+    {
+        Db::deleteTestingInstance();
+        parent::tearDown();
+    }
+
+    public function testTheOrderByIsTotal(): void
+    {
+        $sql = $this->captureQueryOf(static function (): void {
+            (new Product(1, false, 1))->getAttributesGroups(1);
+        });
+
+        $this->assertStringContainsString('ORDER BY', $sql, 'the query must be ordered at all');
+        $this->assertMatchesRegularExpression(
+            '/ORDER BY.*id_product_attribute/is',
+            $sql,
+            'the combination id must take part in the ordering, otherwise rows sharing an attribute are returned in engine order'
+        );
+    }
+
+    public function testTheTieBreakerComesLastSoTheDocumentedOrderIsKept(): void
+    {
+        $sql = $this->captureQueryOf(static function (): void {
+            (new Product(1, false, 1))->getAttributesGroups(1);
+        });
+
+        preg_match('/ORDER BY(.*)$/is', $sql, $matches);
+        $orderBy = $matches[1] ?? '';
+
+        $this->assertNotSame('', trim($orderBy));
+        $this->assertLessThan(
+            strpos($orderBy, 'id_product_attribute'),
+            strpos($orderBy, 'position'),
+            'the tie-breaker must come after the positions, or it would override the intended ordering'
+        );
+    }
+
+    private function captureQueryOf(callable $call): string
+    {
+        $mock = $this->createMock(Db::class);
+        $mock->method('executeS')->willReturnCallback(function ($sql) {
+            $this->executedQueries[] = (string) $sql;
+
+            return [];
+        });
+        Db::setInstanceForTesting($mock);
+
+        $call();
+
+        $this->assertNotEmpty($this->executedQueries, 'no query was issued, so this test proves nothing');
+
+        // the product constructor queries too, so pick the one this test is about
+        foreach ($this->executedQueries as $sql) {
+            if (false !== stripos($sql, 'id_attribute_group')) {
+                return $sql;
+            }
+        }
+
+        $this->fail('the attributes-groups query was never issued');
+    }
+}

--- a/tests/Integration/Classes/Product/AttributesGroupsOrderTest.php
+++ b/tests/Integration/Classes/Product/AttributesGroupsOrderTest.php
@@ -8,9 +8,10 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Classes\Product;
 
-use Configuration;
+use Combination;
 use Db;
 use Product;
+use ReflectionProperty;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -22,14 +23,14 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  * return the right order, and on this database it does most of the time: the same code returned
  * 2,1,4,3,6,5,8,7 on one run and 1,2,3,4,5,6,7,8 on the next. A test that reads the result would
  * therefore pass with the bug present, which is worse than no test at all.
+ *
+ * The query is read back from the real connection rather than captured through a mocked one.
+ * Db::setInstanceForTesting() replaces the connection process-wide, so everything the call reaches
+ * while it is installed sees an empty database and can memoise that emptiness in a static that
+ * outlives the swap - which is a whole class of cross-test failure this measurement does not need.
  */
 class AttributesGroupsOrderTest extends KernelTestCase
 {
-    /**
-     * @var array<string>
-     */
-    private $executedQueries = [];
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -37,35 +38,14 @@ class AttributesGroupsOrderTest extends KernelTestCase
         global $kernel;
         $kernel = self::$kernel;
 
-        $this->executedQueries = [];
-    }
-
-    protected function tearDown(): void
-    {
-        $this->restoreRealDb();
-        parent::tearDown();
-    }
-
-    /**
-     * WHY: Db::setInstanceForTesting() replaces the connection GLOBALLY, so anything reached while the
-     * mock is installed reads [] and can memoise that emptiness in a static that outlives the swap -
-     * Configuration's cache being the one that matters, since an empty configuration yields id_lang 0
-     * and an empty shop context for every later test in the run. Put the real connection back and
-     * re-read the configuration from it, rather than only dropping the mock.
-     */
-    private function restoreRealDb(): void
-    {
-        Db::deleteTestingInstance();
-        Configuration::loadConfiguration();
+        if (!Combination::isFeatureActive()) {
+            $this->markTestSkipped('getAttributesGroups() returns early when combinations are disabled, so it builds no query.');
+        }
     }
 
     public function testTheOrderByIsTotal(): void
     {
-        // Built before the mock goes in, so the constructor's own queries hit the real connection.
-        $product = new Product(1, false, 1);
-        $sql = $this->captureQueryOf(static function () use ($product): void {
-            $product->getAttributesGroups(1);
-        });
+        $sql = $this->queryIssuedByGetAttributesGroups();
 
         $this->assertStringContainsString('ORDER BY', $sql, 'the query must be ordered at all');
         $this->assertMatchesRegularExpression(
@@ -77,11 +57,7 @@ class AttributesGroupsOrderTest extends KernelTestCase
 
     public function testTheTieBreakerComesLastSoTheDocumentedOrderIsKept(): void
     {
-        // Built before the mock goes in, so the constructor's own queries hit the real connection.
-        $product = new Product(1, false, 1);
-        $sql = $this->captureQueryOf(static function () use ($product): void {
-            $product->getAttributesGroups(1);
-        });
+        $sql = $this->queryIssuedByGetAttributesGroups();
 
         preg_match('/ORDER BY(.*)$/is', $sql, $matches);
         $orderBy = $matches[1] ?? '';
@@ -94,32 +70,25 @@ class AttributesGroupsOrderTest extends KernelTestCase
         );
     }
 
-    private function captureQueryOf(callable $call): string
+    /**
+     * Db records every statement it runs in a protected property, so the real call can be measured
+     * without standing anything in for the connection.
+     */
+    private function queryIssuedByGetAttributesGroups(): string
     {
-        $mock = $this->createMock(Db::class);
-        $mock->method('executeS')->willReturnCallback(function ($sql) {
-            $this->executedQueries[] = (string) $sql;
+        $product = new Product(1, false, 1);
+        $product->getAttributesGroups(1);
 
-            return [];
-        });
+        // setAccessible() has been a no-op since PHP 8.1 and is deprecated in 8.5.
+        $lastQuery = new ReflectionProperty(Db::class, 'last_query');
+        $sql = (string) $lastQuery->getValue(Db::getInstance());
 
-        // Keep the window around the mocked connection as small as the measurement allows: only the
-        // call under test runs against it, and the real connection is back before any assertion.
-        Db::setInstanceForTesting($mock);
-        try {
-            $call();
-        } finally {
-            $this->restoreRealDb();
-        }
+        $this->assertStringContainsString(
+            'id_attribute_group',
+            $sql,
+            'the last statement is not the attributes-groups query, so this test would prove nothing'
+        );
 
-        $this->assertNotEmpty($this->executedQueries, 'no query was issued, so this test proves nothing');
-
-        foreach ($this->executedQueries as $sql) {
-            if (false !== stripos($sql, 'id_attribute_group')) {
-                return $sql;
-            }
-        }
-
-        $this->fail('the attributes-groups query was never issued');
+        return $sql;
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Product::getAttributesGroups()` orders by `ag.position`, `a.position` and `agl.name`. None of those identifies a row - every attribute is shared by several combinations - so the relative order of those combinations is left to the database engine. `ProductController::assignAttributesGroups()` iterates that result to build the front office combination list, and the front office preselects the first match, which is why the size shown for a colour differed between MySQL and MariaDB. Adding the combination id as a last tie-breaker makes the order total. This is the query @Hlavtox was looking for in #37359 - that PR fixed the same class of problem in `getDefaultAttribute()` and was closed because "the tests still fail, there is Size-M for some reason on one db query, and I don't know where the logic comes from".
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Open the demo "Hummingbird printed t-shirt" in the front office and pick the White colour. The size that comes up must be the one belonging to the combination flagged `default_on` (S), on MySQL and on MariaDB alike. Automated coverage: `tests/Integration/Classes/Product/AttributesGroupsOrderTest.php`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #36356
| Related PRs                | #37359 fixed the same class of problem in `getDefaultAttribute()` and was closed unfinished; this is the remaining query.
| Sponsor company            |

### Measured

Same database, same engine (MySQL 8), demo product 1, printing the order in which combinations come back:

```
before   2,1,4,3,6,5,8,7      first White combination = whichever landed first
after    1,2,3,4,5,6,7,8      first White combination = 1, the one flagged default_on
```

The instability is not only across engines. The **same unmodified code** returned `2,1,4,3,6,5,8,7` on one run of this probe and `1,2,3,4,5,6,7,8` on a later one, with no schema change in between - an unordered tie is free to come back either way at any time.

### Why the test asserts the SQL rather than the rows

That last observation is also why the test checks the `ORDER BY` instead of the returned order. A query with an incomplete `ORDER BY` is free to return the right order, and on this database it usually does: a first version of this test, written against the rows, **passed with the tie-breaker removed**. Asserting the ordering clause is the only form of the check that fails when the guarantee is gone.

The tie-breaker is appended last, so the documented ordering by group and attribute position is unchanged - the second test pins that too.