### PR TITLE
Count HTML entities the way the editor's counter does

### DIFF
--- a/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
+++ b/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
@@ -65,7 +65,14 @@ class TinyMceMaxLengthValidator extends ConstraintValidator
             "\n\r",
             "\r\n",
         ];
-        $str = str_replace($replaceArray, [''], strip_tags($value));
+        // WHY: the editor's counter reads editor.getBody().textContent (see updateCount() in
+        // admin-dev/themes/new-theme/js/components/tinymce-editor.js), which returns DECODED text, so
+        // "&eacute;" is one character there. strip_tags() leaves the entity intact, so the same content
+        // was counted as eight - a description of accented text could be rejected while the counter still
+        // showed it well inside the limit. Decode after stripping the tags, never before, or an escaped
+        // "&lt;p&gt;" would turn into markup and be removed.
+        // @see https://github.com/PrestaShop/PrestaShop/issues/37229
+        $str = str_replace($replaceArray, [''], html_entity_decode(strip_tags($value), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
 
         if (iconv_strlen($str) > $constraint->max) {
             $message = $constraint->message ?? $this->translator->trans(

--- a/tests/Unit/PrestaShopBundle/Form/Validator/TinyMceMaxLengthValidatorTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Validator/TinyMceMaxLengthValidatorTest.php
@@ -98,6 +98,14 @@ class TinyMceMaxLengthValidatorTest extends ConstraintValidatorTestCase
             [$this->generateRandomTinyMceText(0), 0],
             [$this->generateRandomTinyMceText(154), 200],
             ['Valid text', self::MAX_LENGTH],
+            // The editor's counter reads decoded text, so an entity is one character there. These stay
+            // valid only if the validator decodes too - "Café & crème brûlée" is 19 characters, while the
+            // raw entities are 55. @see https://github.com/PrestaShop/PrestaShop/issues/37229
+            ['<p>Caf&eacute; &amp; cr&egrave;me&nbsp;br&ucirc;l&eacute;e</p>', 19],
+            ['<p>A&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;B</p>', 7],
+            // An escaped tag is content, not markup: it must survive strip_tags and then be counted as
+            // the three characters the editor shows.
+            ['&lt;p&gt;', 3],
             ['Valid text too long only because of HTML', self::MAX_LENGTH],
             ['<p>Valid text too long only because of HTML</p>', self::MAX_LENGTH],
             [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `TinyMceMaxLengthValidator` documents itself as matching the count shown by the editor — *"This computation is made to match the one from the TinyMce text count"* — but the component reads `editor.getBody().textContent` (`tinymce-editor.js:252`), which is **decoded**, while the validator ran `strip_tags()` and left entities intact. So `&eacute;` was one character in the counter and eight in the validator. A description of accented text could be refused while the counter still showed it well inside the limit, which is exactly the screenshot in the report: *1173 of 21844* and a rejection. The value is now decoded after `strip_tags()` — never before, or an escaped `&lt;p&gt;` would turn into markup and be stripped as if it were a tag.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Catalog > Products, edit a product with the v2 page, paste HTML containing entities into the Description as source code — @Hlavtox's `example.txt` on the issue works — and save. Before this change the counter reads well under the limit while saving fails with "This field must not exceed 21844 characters"; after it, the counter and the validator agree and the product saves. Automated coverage: `tests/Unit/PrestaShopBundle/Form/Validator/TinyMceMaxLengthValidatorTest.php`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #37229
| Related PRs                | Follows the merged #37281 and #37771, which fixed the constraint but not the counting
| Sponsor company            |

### Measured

The same four samples counted both ways — the browser's `textContent.length`, which is what the counter shows, against the validator:

```
sample           counter   validator (before)   validator (after)
entities              19                   55                  19
nbsp run               7                   32                   7
entity + newlines     14                   25                  11
newlines only         28                   26                  26
```

Entity-heavy content was counted up to **4.6x** its displayed length, which is why a description that looks like a thousand characters is rejected against a twenty-thousand limit. After the change the two agree exactly on the entity cases.

The `entity + newlines` and `newlines only` rows show the one remaining difference, in the opposite and harmless direction: `textContent` keeps the line breaks between block elements while the validator strips `\n` and `\r` deliberately, so the validator counts a little *less* than the counter shows. That is the generous side of the discrepancy and is left alone.

Tests: **31 tests, 39 assertions** green with the change; against the unmodified validator the three new cases fail with `Failed asserting that 1 is identical to 0` — a violation raised where the counter shows none. PHPStan and php-cs-fixer clean.

### Why the earlier fixes did not close it

#37281 and #37771 are both merged and did the part @jolelievre described in this thread — the description field now goes through `FormattedTextareaType`'s `limit` option, which attaches `TinyMceMaxLength` instead of a plain `Length`. That fixed *which* constraint runs. What was left is *how it counts*, which is the half @Hlavtox kept the issue open for.