### PR TITLE
Match Tab::icon's declared size to its column

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -58,7 +58,7 @@ class TabCore extends ObjectModel
             'route_name' => ['type' => self::TYPE_STRING, 'required' => false, 'size' => 256],
             'active' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'enabled' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
-            'icon' => ['type' => self::TYPE_STRING, 'size' => 64],
+            'icon' => ['type' => self::TYPE_STRING, 'size' => 32],
             'wording' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'allow_null' => true, 'size' => 255],
             'wording_domain' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'allow_null' => true, 'size' => 255],
             /* Lang fields */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `Tab::$definition` declares `icon` with `'size' => 64` while the column is `VARCHAR(32)`. It is the only field of that definition whose declared size disagrees with the shipped schema, so `ObjectModel::validateField()` accepts a value the column cannot store and MySQL then truncates or rejects it depending on the mode. The longest icon anywhere in the codebase is 22 characters, so narrowing the declaration to 32 is the safe direction: validation agrees with the column and no schema change is needed. Found while verifying #38937, whose own defect is already fixed.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Set a tab's `icon` to a 40-character string through `Tab` and save. Before this change `validateField()` passes and the value is silently cut to 32 by the column; after it, validation reports the field as too long.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | See #38937
| Related PRs                |
| Sponsor company            |

### Measured

Every string field of `Tab::$definition` against `CREATE TABLE PREFIX_tab` in `install-dev/data/db_structure.sql`:

```
field            definition   column   match
module                   64       64   OK
class_name               64       64   OK
route_name              256      256   OK
icon                     64       32   MISMATCH
wording                 255      255   OK
wording_domain          255      255   OK
```

After the change all six agree. The longest icon value shipped is `account_balance_wallet` at 22 characters, and the longest one present in an installed shop's `ps_tab` is 21, so nothing real is near the limit either way. `php -cs-fixer` and PHPStan are clean on the file.

### The reported bug is already fixed

#38937 itself — menu entries disappearing when `ps_tab.icon` is `NULL` after an upgrade — was fixed by #39062, merged into `9.0.x` on 2025-09-16, and both templates on `9.2.x` carry it:

```twig
{% if level1.icon is not empty %}
```

in `Admin/Component/Layout/nav_bar.html.twig:35` and `Admin/Component/LegacyLayout/nav_bar.html.twig:35`, replacing the `is not same as ''` that treated `NULL` as "hide". `8.2.x` does not have those templates at all, which matches the report that 8.2.1 was unaffected. So the issue can be closed on its own subject; this branch is only the adjacent mismatch found while checking.