### PR TITLE
Read module active state from the join instead of one query per module

### DIFF
--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -123,19 +123,27 @@ class ModuleDataProvider
         $select = 'SELECT m.`id_module` as id, m.`name`, m.`version`, 1 as installed';
         $from = ' FROM `' . _DB_PREFIX_ . 'module` m';
 
+        $groupBy = '';
+
         $id_shops = (new Context())->getContextListShopID();
         if (count($id_shops) > 0) {
+            // A module counts as active when it is attached to at least one shop of the context, which
+            // is what the join below answers. Reading it here rather than per module is what keeps this
+            // to a single query: a shop with 67 modules used to run 68.
+            $select .= ', MAX(ms.`id_module` IS NOT NULL) as active';
             $from .= ' LEFT JOIN `' . _DB_PREFIX_ . 'module_shop` ms ON ms.`id_module` = m.`id_module`';
             $from .= ' AND ms.`id_shop` IN (' . implode(',', array_map('intval', $id_shops)) . ')';
+            $groupBy = ' GROUP BY m.`id_module`, m.`name`, m.`version`';
         }
 
-        $results = Db::getInstance()->executeS($select . $from);
+        $results = Db::getInstance()->executeS($select . $from . $groupBy);
         $modules = [];
 
         /** @var array{id: int, name:string, version: string, installed: int}|array{id: int, name:string, version: string, installed: int, active:int} $module */
         foreach ($results as $module) {
             $module['installed'] = (bool) $module['installed'];
-            $module['active'] = $this->isModuleActive($module['id'], $id_shops);
+            // no shop in the context means no module can be attached to one
+            $module['active'] = (bool) ($module['active'] ?? false);
             $modules[$module['name']] = $module;
         }
 
@@ -318,19 +326,5 @@ class ModuleDataProvider
         $path = _PS_MODULE_DIR_ . $name . '/' . $name . '.php';
 
         return file_exists($path);
-    }
-
-    /**
-     * Checks if the module is active on at least one shop of the context.
-     */
-    private function isModuleActive(int $id, array $id_shops): bool
-    {
-        $result = Db::getInstance()->getRow('SELECT m.`active`, ms.`id_module` as `shop_active`
-            FROM `' . _DB_PREFIX_ . 'module` m
-            LEFT JOIN `' . _DB_PREFIX_ . 'module_shop` ms ON m.`id_module` = ms.`id_module`
-            WHERE m.`id_module` = ' . $id . '
-            AND ms.`id_shop` IN (' . implode(',', $id_shops) . ')');
-
-        return !empty($result);
     }
 }

--- a/tests/Integration/Adapter/Module/ModuleDataProviderTest.php
+++ b/tests/Integration/Adapter/Module/ModuleDataProviderTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Module;
+
+use Db;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * getInstalled() used to ask the database whether each module was active, one query per module, which
+ * is the N+1 @kpodemski pointed at on #38950. The active flag comes from the join the query already had.
+ */
+class ModuleDataProviderTest extends KernelTestCase
+{
+    /**
+     * @var ModuleDataProvider
+     */
+    private $moduleDataProvider;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        global $kernel;
+        $kernel = self::$kernel;
+
+        $this->moduleDataProvider = self::$kernel->getContainer()->get(ModuleDataProvider::class);
+    }
+
+    public function testGetInstalledDoesNotQueryOncePerModule(): void
+    {
+        // warm anything the first call would lazily initialise, so only getInstalled is measured
+        $this->moduleDataProvider->getInstalled();
+
+        $before = $this->queriesRun();
+        $modules = $this->moduleDataProvider->getInstalled();
+        $after = $this->queriesRun();
+
+        $this->assertGreaterThan(
+            1,
+            count($modules),
+            'the shop must have several modules installed, or a per module query would be invisible here'
+        );
+
+        // one for the counter itself
+        $this->assertSame(1, $after - $before - 1, 'getInstalled() must answer with a single query');
+    }
+
+    public function testGetInstalledStillReportsWhichModulesAreActive(): void
+    {
+        $modules = $this->moduleDataProvider->getInstalled();
+
+        $this->assertNotEmpty($modules);
+
+        foreach ($modules as $name => $module) {
+            $this->assertIsBool($module['active'], sprintf('module %s', $name));
+            $this->assertTrue($module['installed']);
+            $this->assertSame($module['active'], $this->isAttachedToAShopOfTheContext((int) $module['id']));
+        }
+
+        $this->assertContains(true, array_column($modules, 'active'), 'no module is active, so the flag proves nothing');
+    }
+
+    private function isAttachedToAShopOfTheContext(int $moduleId): bool
+    {
+        $shopIds = (new \PrestaShop\PrestaShop\Adapter\Shop\Context())->getContextListShopID();
+
+        if (0 === count($shopIds)) {
+            return false;
+        }
+
+        $rows = Db::getInstance()->executeS(
+            'SELECT 1 FROM `' . _DB_PREFIX_ . 'module_shop`'
+            . ' WHERE `id_module` = ' . $moduleId
+            . ' AND `id_shop` IN (' . implode(',', array_map('intval', $shopIds)) . ')'
+        );
+
+        return !empty($rows);
+    }
+
+    private function queriesRun(): int
+    {
+        $rows = Db::getInstance()->executeS("SHOW SESSION STATUS LIKE 'Questions'");
+
+        return (int) $rows[0]['Value'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `ModuleDataProvider::getInstalled()` already `LEFT JOIN`s `module_shop` against the context shops, then throws the join away and asks `isModuleActive()` the same question again for every row - one query per installed module. This is the N+1 @kpodemski identified on #38950. Measured on a shop with 67 modules: **68 queries before, 1 after**, and the returned array is byte identical - same 67 modules, same 64 active, same fingerprint. It matters on that issue because the post install step reaches it: `Install::postInstall()` calls `ModuleManagerBuilder::getInstance()->buildRepository()->getInstalledModules()`, which is `ModuleRepository::getList()`, which calls `getModuleDatabaseAttributes()`, which calls `getInstalled()`.
| Type?                      | improvement
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | With profiling on, load **Modules > Module Manager** or run an install, and count the executions of `SELECT m.active, ms.id_module as shop_active ... WHERE m.id_module = ?`. There is one per installed module before this change and none after. The module list, and which modules show as active, are unchanged. Automated coverage: `tests/Integration/Adapter/Module/ModuleDataProviderTest.php`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Part of #38950
| Related PRs                |
| Sponsor company            |

## The semantics are preserved exactly

`isModuleActive()` selected `m.active` and `ms.id_module`, then returned `!empty($result)`. Because the shop filter sat in the `WHERE` rather than the `ON`, the `LEFT JOIN` behaved as an inner join, so the method answered one question: **is there a `module_shop` row for one of the context shops**. `m.active` was selected and never read.

`MAX(ms.id_module IS NOT NULL)` over the join in `getInstalled()` answers exactly that, and `MAX` is what makes it correct when the context spans several shops and the join returns one row per shop. That is also why the `GROUP BY` is needed; it names `m.id_module, m.name, m.version` rather than relying on functional dependency detection, which MariaDB and MySQL do not treat identically.

When the context has no shops there is no join, and the flag is `false` - which is what the old code effectively produced, since `IN ()` is not valid SQL.

`isModuleActive()` is private and `getInstalled()` was its only caller, so it is removed rather than left unused.

## Scope

kpodemski listed three things on that issue: this N+1, the general slowness of the step, and PHP-Parser being on a version that does not support PHP 8. This is the first only. The other two are untouched and the issue should stay open for them.