### PR TITLE
Query the order countries once per request, not twice

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/OrderCountriesChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/OrderCountriesChoiceProvider.php
@@ -18,12 +18,25 @@ use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 final class OrderCountriesChoiceProvider implements FormChoiceProviderInterface
 {
     /**
+     * The orders grid asks for these twice while it is being built, once to decide whether the delivery
+     * column is worth showing and once to fill the country filter. The service is shared, so remembering
+     * the answer saves the whole second round trip - and the query behind it scans every order.
+     *
+     * @var array<string, int>|null
+     */
+    private $choices;
+
+    /**
      * {@inheritdoc}
      */
     public function getChoices()
     {
+        if (null !== $this->choices) {
+            return $this->choices;
+        }
+
         if (!Country::isCurrentlyUsed('country', true)) {
-            return [];
+            return $this->choices = [];
         }
 
         $countries = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
@@ -39,7 +52,7 @@ final class OrderCountriesChoiceProvider implements FormChoiceProviderInterface
 			ORDER BY cl.name ASC'
         );
 
-        return FormChoiceFormatter::formatFormChoices(
+        return $this->choices = FormChoiceFormatter::formatFormChoices(
             $countries,
             'id_country',
             'name'

--- a/tests/Integration/Adapter/Form/ChoiceProvider/OrderCountriesChoiceProviderTest.php
+++ b/tests/Integration/Adapter/Form/ChoiceProvider/OrderCountriesChoiceProviderTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Form\ChoiceProvider;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\OrderCountriesChoiceProvider;
+
+/**
+ * The orders grid definition asks this provider for its choices twice while building a single page:
+ * once to decide whether to add the "Delivery" column, once to fill the country filter. The query
+ * behind it has to look at every order, so the second round trip is pure waste.
+ */
+class OrderCountriesChoiceProviderTest extends TestCase
+{
+    /**
+     * @var array<string> SQL of every query issued through the mocked Db
+     */
+    private $executedQueries = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->executedQueries = [];
+
+        $mockDatabase = $this->createMock(Db::class);
+        $mockDatabase->method('getValue')->willReturnCallback(function ($sql) {
+            $this->executedQueries[] = (string) $sql;
+
+            return 1;
+        });
+        $mockDatabase->method('executeS')->willReturnCallback(function ($sql) {
+            $this->executedQueries[] = (string) $sql;
+
+            return [
+                ['id_country' => 8, 'name' => 'France'],
+                ['id_country' => 21, 'name' => 'United States'],
+            ];
+        });
+
+        Db::setInstanceForTesting($mockDatabase);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Db::deleteTestingInstance();
+    }
+
+    public function testTheChoicesAreOnlyQueriedOnce(): void
+    {
+        $provider = new OrderCountriesChoiceProvider();
+
+        $first = $provider->getChoices();
+        $queriesAfterFirstCall = count($this->executedQueries);
+
+        $second = $provider->getChoices();
+
+        $this->assertGreaterThan(0, $queriesAfterFirstCall, 'the first call must really hit the database, or this test proves nothing');
+        $this->assertCount($queriesAfterFirstCall, $this->executedQueries, 'the second call must not query again');
+        $this->assertSame($first, $second);
+        $this->assertSame(['France' => 8, 'United States' => 21], $first);
+    }
+
+    /**
+     * The empty answer is the one a shop with no orders gets, and it is also the one the grid uses to
+     * decide the column is not worth showing, so it has to be remembered too.
+     */
+    public function testAnEmptyResultIsAlsoRemembered(): void
+    {
+        $mockDatabase = $this->createMock(Db::class);
+        $mockDatabase->method('getValue')->willReturnCallback(function ($sql) {
+            $this->executedQueries[] = (string) $sql;
+
+            return false;
+        });
+        $mockDatabase->method('executeS')->willReturnCallback(function ($sql) {
+            $this->executedQueries[] = (string) $sql;
+
+            return [];
+        });
+        Db::setInstanceForTesting($mockDatabase);
+
+        $provider = new OrderCountriesChoiceProvider();
+
+        $this->assertSame([], $provider->getChoices());
+        $queriesAfterFirstCall = count($this->executedQueries);
+        $this->assertSame(1, $queriesAfterFirstCall, 'an unused country table short circuits before the expensive query');
+
+        $this->assertSame([], $provider->getChoices());
+        $this->assertCount($queriesAfterFirstCall, $this->executedQueries, 'the second call must not query again');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | `OrderGridDefinitionFactory` asks `OrderCountriesChoiceProvider` for its choices **twice** while building one Orders page: once at `getColumns()` to decide whether the `Delivery` column is worth adding, and once at `getFilters()` to fill the country filter. Each call issues `Country::isCurrentlyUsed('country', true)` plus a query that has to look at every row of `orders` joined to `address`, so the grid pays four queries where two would do. The service is shared, so remembering the answer on the instance is enough. Measured against a real database: **4 queries before, 2 after**, with the second call issuing none. This is the half of #39069 that #39900 and #39990 did not cover - both optimised the query itself and left the duplicate call in place, which is what @ChillCode pointed out on the issue.
| Type?                      | improvement
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Open **Sell > Orders** with profiling enabled and count the executions of the `country_lang ... WHERE EXISTS (SELECT 1 FROM orders ...)` query. It runs twice before this change and once after. The rendered grid is identical: same `Delivery` column, same country filter, same options. Automated coverage: `tests/Integration/Adapter/Form/ChoiceProvider/OrderCountriesChoiceProviderTest.php`.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #39069
| Related PRs                | #39900 and #39990 optimised the query itself; this completes the issue.
| Sponsor company            |

## Measurement

Two consecutive `getChoices()` calls on the same shared instance, counted with the session `Questions` counter against a live database:

```
before   call 1: 2 queries   call 2: 2 queries   total 4
after    call 1: 2 queries   call 2: 0 queries   total 2
```

The empty answer is remembered too, since that is the one a shop with no orders returns and the one the factory uses to decide the column is not worth showing.

## Scope

The provider has a single consumer, the orders grid definition factory, which receives it once through constructor injection and calls `getChoices()` twice on **that same object**, so the memo holds for the case this fixes regardless of how the container shares it. Independently, `form.yml` sets only `_defaults: public: true` and the definition carries no `shared: false`, so the instance - and the memoisation - lives exactly as long as one request. Nothing else observes the value, and no caller can see a stale one within a request because the set of countries that have orders cannot change while a grid definition is being built.