### PR TITLE
Apply the country tax rule to visitors with no postcode

### DIFF
--- a/classes/tax/TaxRulesTaxManager.php
+++ b/classes/tax/TaxRulesTaxManager.php
@@ -86,6 +86,10 @@ class TaxRulesTaxManagerCore implements TaxManagerInterface
 					OR (tr.`zipcode_to` = 0 AND tr.`zipcode_from` IN(0, \'' . pSQL($postcode) . '\')))
 				ORDER BY tr.`zipcode_from` DESC, tr.`zipcode_to` DESC, tr.`id_state` DESC, tr.`id_country` DESC');
 
+            if (empty($rows) && empty($postcode)) {
+                $rows = $this->getCountryRuleWithoutZipcodeRestriction();
+            }
+
             $behavior = 0;
             $first_row = true;
 
@@ -111,5 +115,34 @@ class TaxRulesTaxManagerCore implements TaxManagerInterface
         }
 
         return Cache::retrieve($cache_id);
+    }
+
+    /**
+     * A visitor with no address has no postcode, and the postcode predicate above is a string
+     * comparison, so it excludes every zipcode restricted rule - even one written as 00000 to 99999,
+     * because '0' does not sort between them. A shop whose rules are all zipcode restricted therefore
+     * showed untaxed prices to everyone who was not logged in.
+     *
+     * Only one row is taken. The ranges of a country are usually disjoint, so matching them all would
+     * stack unrelated taxes on top of each other whenever the rules are set to be combined.
+     *
+     * The state restriction is deliberately left in place: a country that splits its rate by state
+     * genuinely has no applicable rate until the state is known, whereas a country that splits its
+     * single rate into postcode ranges does.
+     *
+     * @return array at most one tax rule row
+     */
+    protected function getCountryRuleWithoutZipcodeRestriction(): array
+    {
+        return Db::getInstance()->executeS('
+			SELECT tr.*
+			FROM `' . _DB_PREFIX_ . 'tax_rule` tr
+			JOIN `' . _DB_PREFIX_ . 'tax_rules_group` trg ON (tr.`id_tax_rules_group` = trg.`id_tax_rules_group`)
+			WHERE trg.`active` = 1
+			AND tr.`id_country` = ' . (int) $this->address->id_country . '
+			AND tr.`id_tax_rules_group` = ' . (int) $this->type . '
+			AND tr.`id_state` IN (0, ' . (int) $this->address->id_state . ')
+			ORDER BY tr.`zipcode_from` DESC, tr.`zipcode_to` DESC, tr.`id_state` DESC, tr.`id_country` DESC
+			LIMIT 1') ?: [];
     }
 }

--- a/tests/Integration/Classes/tax/TaxRulesTaxManagerTest.php
+++ b/tests/Integration/Classes/tax/TaxRulesTaxManagerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Classes\tax;
 
 use Address;
+use Cache;
 use Db;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\EntityMapper;
@@ -47,9 +48,19 @@ class TaxRulesTaxManagerTest extends TestCase
      */
     private $savedContainer;
 
+    /**
+     * @var array<string> SQL of every query issued through the mocked Db
+     */
+    private $executedQueries = [];
+
     public function setUp(): void
     {
         parent::setUp();
+
+        // Every address in this class resolves to the same TaxRulesTaxManager cache id, so without this
+        // the first test to run answers for all the others and their queries are never issued.
+        Cache::clean('*');
+        $this->executedQueries = [];
 
         $this->configuration = $this->createMock(ConfigurationInterface::class);
         $this->configuration->method('get')->willReturn(1);
@@ -105,5 +116,76 @@ class TaxRulesTaxManagerTest extends TestCase
             $this->assertEquals($this->tax_rows[$key]['id_tax'], $tax->id);
             $this->assertEquals($this->tax_rows[$key]['rate'], $tax->rate);
         }
+    }
+
+    /**
+     * A shop whose rules are all restricted to a zipcode range showed untaxed prices to visitors who
+     * were not logged in, because the postcode predicate is a string comparison and an address with no
+     * postcode compares as '0', which does not sort inside any range.
+     */
+    public function testAnAddressWithoutPostcodeFallsBackToTheCountryRule(): void
+    {
+        $this->mockDatabaseWithNoZipcodeRestrictedMatch();
+
+        $tax_calculator = (new TaxRulesTaxManager(new Address(), null, $this->configuration))->getTaxCalculator();
+
+        $this->assertCount(2, $this->executedQueries, 'the fallback query must have been issued');
+        $this->assertStringContainsString('BETWEEN', $this->executedQueries[0]);
+        $this->assertStringNotContainsString('BETWEEN', $this->executedQueries[1]);
+        $this->assertStringContainsString('LIMIT 1', $this->executedQueries[1]);
+
+        $this->assertCount(1, $tax_calculator->taxes);
+        $this->assertEquals(20.6, $tax_calculator->taxes[0]->rate);
+    }
+
+    /**
+     * The fallback is for the address we know nothing about. A real postcode that simply matches no
+     * rule must keep returning no tax, otherwise a customer would be charged a rate for a zone they
+     * are not in.
+     */
+    public function testAnAddressWithAPostcodeDoesNotFallBack(): void
+    {
+        $this->mockDatabaseWithNoZipcodeRestrictedMatch();
+
+        $address = new Address();
+        $address->postcode = '75001';
+
+        $tax_calculator = (new TaxRulesTaxManager($address, null, $this->configuration))->getTaxCalculator();
+
+        $this->assertCount(1, $this->executedQueries, 'no fallback query may be issued for a known postcode');
+        $this->assertEmpty($tax_calculator->taxes);
+    }
+
+    public function testTheFallbackIsSkippedWhenARuleAlreadyMatched(): void
+    {
+        $rows = $this->tax_rows;
+        $mockDatabase = $this->createMock(Db::class);
+        $mockDatabase->method('executeS')->willReturnCallback(function ($sql) use ($rows) {
+            $this->executedQueries[] = (string) $sql;
+
+            return $rows;
+        });
+        Db::setInstanceForTesting($mockDatabase);
+
+        $tax_calculator = (new TaxRulesTaxManager(new Address(), null, $this->configuration))->getTaxCalculator();
+
+        $this->assertCount(1, $this->executedQueries, 'the fallback must not run when the normal query matched');
+        $this->assertCount(2, $tax_calculator->taxes);
+    }
+
+    /**
+     * Mocks the database so the zipcode restricted query matches nothing, which is the situation of a
+     * shop whose rules all carry a zipcode range, and records the SQL actually issued.
+     */
+    private function mockDatabaseWithNoZipcodeRestrictedMatch(): void
+    {
+        $firstRow = [$this->tax_rows[0]];
+        $mockDatabase = $this->createMock(Db::class);
+        $mockDatabase->method('executeS')->willReturnCallback(function ($sql) use ($firstRow) {
+            $this->executedQueries[] = (string) $sql;
+
+            return str_contains((string) $sql, 'BETWEEN') ? [] : $firstRow;
+        });
+        Db::setInstanceForTesting($mockDatabase);
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | A shop whose tax rules all carry a zipcode range shows prices with **no tax at all** to every visitor who is not logged in. `TaxRulesTaxManager::getTaxCalculator()` matches the postcode with a string comparison, and `Address::initialize()` gives an anonymous visitor `postcode = '0'`, which `empty()` turns into `0`. Measured in MySQL: `'0' BETWEEN '00000' AND '99999'` is **false** while `'75001' BETWEEN '00000' AND '99999'` is **true** - so a rule written to cover every postcode of the country matches nobody without an address. The `zipcode_to = 0` escape hatch does not help either, since it only fires for rules that carry no range. This PR falls back to the country's rule when the normal query matched nothing **and** the address has no postcode. Verified against the running app with the production query: for one rule `id_country = 8, id_state = 0, 00000-99999` in an active group, a guest matched **0** rules and a customer with `75001` matched **1**.
| Type?                      | bug fix
| Category?                  | FO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Give a country a tax rule restricted to a zipcode range covering the whole country (for France, `00000` to `99999`) and make sure no unrestricted rule exists in the same group. Browse the front office logged out. Before this change the prices carry no tax; after it they carry the country's rate. Log in with an address inside the range and the price is unchanged in both cases. Automated coverage: `tests/Integration/Classes/tax/TaxRulesTaxManagerTest.php`, three new tests.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #39102
| Related PRs                |
| Sponsor company            |

## Why only one row is taken

Dropping the zipcode predicate outright is not safe. A country's ranges are normally disjoint, and I measured three rules covering `01000-29999`, `30000-59999` and `60000-99999` all matching at once once the predicate is gone. With `behavior = 1` the loop below would then stack all three taxes on a visitor who can be in only one of the zones. The fallback therefore takes a single row, using the ordering the method already relies on to mean "most specific first".

## Why the state restriction is left alone

The same gap exists for rules restricted by state, but the right answer there is different. A country that splits its rate by state genuinely has no applicable rate until the state is known - guessing one would invent a tax for a visitor. A country that splits a single rate into postcode ranges does have an applicable rate, and it is the one this PR now applies. Relaxing the state predicate would change what US style shops charge, so it is deliberately not part of this change.

## Not fixed here

`Address::initialize()` case 3 fires for every visitor on a shop whose store contact address was never filled, because its condition compares `$context->country->id` against `PS_SHOP_COUNTRY_ID` and the installer never writes that key. That makes case 4 - the branch that would supply `PS_SHOP_STATE_ID` and `PS_SHOP_CODE` - unreachable by default. It is a real defect and it is described on #39102, but changing which branch fires shifts country and state resolution for every guest on every shop, including ones with no tax problem, so it needs a maintainer decision rather than being folded in here.