### PR TITLE
Remove a theme's cached configuration when it is uninstalled

### DIFF
--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -114,6 +114,12 @@ class ThemeManager implements AddonManagerInterface
 
         $this->filesystem->remove($theme->getDirectory());
 
+        // The parsed configuration is cached per shop outside the theme directory, and the repository
+        // reads it in preference to config/theme.yml. Removing only the theme leaves that cache behind,
+        // so installing the theme again - which is how a theme is upgraded, since installing over an
+        // existing directory is refused - serves the previous version's data.
+        $this->filesystem->remove($this->configuration->get('_PS_CONFIG_DIR_') . 'themes/' . $name);
+
         return true;
     }
 

--- a/tests/Unit/Core/Addon/Theme/ThemeManagerUninstallTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeManagerUninstallTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Addon\Theme;
+
+use Employee;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeValidator;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Image\ImageTypeRepository;
+use PrestaShop\PrestaShop\Core\Module\HookConfigurator;
+use Shop;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The parsed theme configuration is cached per shop under config/themes/<name>, outside the theme
+ * directory, and the repository prefers it over config/theme.yml. Uninstalling has to take it with the
+ * theme, or a later install of the same theme serves the previous version's data. See #39792.
+ */
+class ThemeManagerUninstallTest extends TestCase
+{
+    public function testUninstallAlsoRemovesTheCachedThemeConfiguration(): void
+    {
+        $themeDirectory = '/var/www/html/themes/hummingbird';
+        $configDirectory = '/var/www/html/config/';
+
+        $employee = $this->createMock(Employee::class);
+        $employee->method('can')->willReturn(true);
+
+        $configuration = $this->createMock(ConfigurationInterface::class);
+        $configuration->method('get')->willReturnCallback(
+            static fn (string $key) => '_PS_CONFIG_DIR_' === $key ? $configDirectory : null
+        );
+
+        $theme = $this->createMock(Theme::class);
+        $theme->method('getDirectory')->willReturn($themeDirectory);
+
+        $themeRepository = $this->createMock(ThemeRepository::class);
+        $themeRepository->method('getInstanceByName')->willReturn($theme);
+
+        $removed = [];
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('remove')->willReturnCallback(function ($path) use (&$removed): void {
+            $removed[] = (string) $path;
+        });
+
+        $manager = new ThemeManager(
+            $this->createMock(Shop::class),
+            $configuration,
+            $this->createMock(ThemeValidator::class),
+            $this->createMock(TranslatorInterface::class),
+            $employee,
+            $filesystem,
+            $this->createMock(Finder::class),
+            $this->createMock(HookConfigurator::class),
+            $themeRepository,
+            $this->createMock(ImageTypeRepository::class)
+        );
+
+        self::assertTrue($manager->uninstall('hummingbird'));
+
+        self::assertContains($themeDirectory, $removed, 'the theme directory is removed');
+        self::assertContains(
+            $configDirectory . 'themes/hummingbird',
+            $removed,
+            'the cached per-shop configuration is removed with it'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?                    | 9.2.x
| Description?               | Uninstalling a theme left its cached configuration behind under config/themes, and the repository reads that cache in preference to the theme's own config. Installing the theme again then showed the previous version's data, which is what the Theme & Logo page displays.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | See below.
| UI Tests                   | Not run. A campaign can be launched on request.
| Fixed issue or discussion? | Fixes #39792
| Related PRs                |
| Sponsor company            |

### Why

`ThemeRepository::getInstanceByName()` prefers the cached configuration when it exists:

```php
$jsonConf = $confDir . '/shop' . $this->shop->id . '.json';
if ($this->filesystem->exists($jsonConf)) {
    $data = $this->getConfigFromFile($jsonConf);
}
```

That cache lives under `config/themes/<name>/`, outside the theme directory. `ThemeManager::uninstall()`
removed the theme itself and nothing else:

```php
$this->filesystem->remove($theme->getDirectory());
```

so the cache survived. `enable()` and `disable()` each unlink it, but uninstall did not.

This surfaces on an upgrade because `installFromZip()` refuses to install over an existing theme
directory — "There is already a theme named X in your themes/ folder" — so replacing a theme means
uninstalling it and installing the new zip. The new files land, the stale cache is read, and the Theme &
Logo page reports the old version. It also explains the workaround in the report: deleting the theme
**and** `config/themes/hummingbird/shop1.json` by hand makes the new version appear.

### What it does

Removes `config/themes/<name>` along with the theme in `uninstall()`.

### How to test

1. Install a theme, note its version on Design > Theme & Logo.
2. Uninstall it, then install a zip of the same theme at a newer version.
3. Before: the old version is shown. After: the new one.

```
php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/Addon/Theme/ThemeManagerUninstallTest.php
```

The test asserts both removals against a mocked filesystem. Reverting the change fails it with
`Failed asserting that an array contains '/var/www/html/config/themes/hummingbird'`.