### PR TITLE
Apply cart rules in the same order with and without shipping

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2465,6 +2465,24 @@ class CartCore extends ObjectModel
                     $cartRules[] = $cartRuleCandidate;
                 }
             }
+
+            // WHY: the Calculator applies these rules in the order it receives them and a percentage
+            // reduction is computed against the running total, so the order decides the amount. Merging
+            // a reduction query with a gift query puts every reduction ahead of every gift, while the
+            // branch above hands over one FILTER_ACTION_ALL result in priority order - so BOTH and
+            // BOTH_WITHOUT_SHIPPING disagreed on a cart holding both kinds, even with free shipping.
+            // getOrderedCartRulesIds() answers "in what order does this cart apply its rules" and
+            // computes no contextual value, so reordering against it cannot re-enter the
+            // getCartRules() -> getOrderTotal() -> getCartRules() loop that asking FILTER_ACTION_ALL
+            // for the values here would.
+            $canonicalOrder = array_flip(array_column(
+                $this->getOrderedCartRulesIds(CartRule::FILTER_ACTION_ALL),
+                'id_cart_rule'
+            ));
+            usort($cartRules, static function (array $a, array $b) use ($canonicalOrder): int {
+                return ($canonicalOrder[$a['id_cart_rule']] ?? PHP_INT_MAX)
+                    <=> ($canonicalOrder[$b['id_cart_rule']] ?? PHP_INT_MAX);
+            });
         }
 
         return $cartRules;

--- a/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
@@ -119,6 +119,23 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
         $this->expectsTotal($expectedTotal, false, !empty($precisely));
     }
 
+    /**
+     * @Then /^my cart total without shipping should be (precisely )?(\d+\.\d+) tax (excluded|included)$/
+     */
+    public function totalCartWithoutShippingShouldBe($precisely, $expectedTotal, $taxes)
+    {
+        $cart = $this->getCurrentCart();
+        $total = $cart->getOrderTotal($taxes === 'included', Cart::BOTH_WITHOUT_SHIPPING);
+        if (empty($precisely)) {
+            // here we round values to avoid round issues : rounding modes are tested by specific tests
+            $expectedTotal = round($expectedTotal, 1);
+            $total = round($total, 1);
+        }
+        if ($expectedTotal != $total) {
+            throw new RuntimeException(sprintf('Expects %s, got %s instead', $expectedTotal, $total));
+        }
+    }
+
     protected function expectsTotal($expectedTotal, $withTax = true, $precisely = false)
     {
         $cart = $this->getCurrentCart();

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/gift.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/gift.feature
@@ -151,3 +151,27 @@ Feature: Cart calculation with cart rules giving gift
     When I apply the voucher code "foo12"
     Then I should have 6 products in my cart
     And my cart total should be 126.8692 tax included
+
+  @restore-cart-rules-after-scenario
+  Scenario: a separate gift rule and a separate percentage rule are applied in the same order with and without shipping
+    Given there is a product in the catalog named "product20" with a price of 100.0 and 1000 items in stock
+    And there is a product in the catalog named "product21" with a price of 10.0 and 1000 items in stock
+    And there is a cart rule "cartrule20" with following properties:
+      | name[en-US]   | cartrule20 |
+      | priority      | 1          |
+      | free_shipping | false      |
+      | code          | foo20      |
+      | gift_product  | product21  |
+    And there is a cart rule "cartrule21" with following properties:
+      | name[en-US]         | cartrule21 |
+      | priority            | 1          |
+      | free_shipping       | false      |
+      | code                | foo21      |
+      | discount_percentage | 50         |
+    And I add 1 items of product "product20" in my cart
+    When I apply the voucher code "foo20"
+    And I apply the voucher code "foo21"
+    Then I should have 2 products in my cart
+    # the gift rule sorts before the percentage rule, so the 50% applies to 100.00 and not to 110.00
+    And my cart total without shipping should be 50.0 tax included
+    And my cart total should be 57.0 tax included


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Cart::getTotalCalculationCartRules()` built the without-shipping subset from a reduction query followed by a gift query, so every reduction was applied before every gift. The other branch hands over one `FILTER_ACTION_ALL` result in priority order. Since a percentage reduction is computed against the running total, `BOTH` and `BOTH_WITHOUT_SHIPPING` returned different amounts for a cart carrying both kinds of rule. The subset is now reordered against `Cart::getOrderedCartRulesIds()`.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the scenario added to `gift.feature`, or the steps below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37627
| Related PRs       |
| Sponsor company   |

### The defect

`Cart::getOrderTotal()` hands the Calculator a list of cart rules and the Calculator applies them in
the order it receives them. A percentage reduction is computed against the running total, so the
order decides the amount.

`getTotalCalculationCartRules()` produced that list two different ways:

- `Cart::BOTH` and `Cart::ONLY_DISCOUNTS` take one `getCartRules(FILTER_ACTION_ALL)` result, ordered
  by `priority ASC, gift_product DESC`;
- `Cart::BOTH_WITHOUT_SHIPPING` merged a `FILTER_ACTION_REDUCTION` result with a
  `FILTER_ACTION_GIFT` one, which puts every reduction ahead of every gift whatever their priority.

Measured on `9.2.x`, one 100.00 product in the cart, a gift rule and a 50 percent rule both at
priority 1, shipping free:

| | rule order | total |
| --- | --- | --- |
| `BOTH` | gift, then 50 percent | 50.00 |
| `BOTH_WITHOUT_SHIPPING` | 50 percent, then gift | 45.00 |

Shipping was free (`ONLY_SHIPPING` returned 0.00), so the two must agree.

### Why the subset is not simply taken from FILTER_ACTION_ALL

The obvious fix - fetch `FILTER_ACTION_ALL` and filter out the shipping-only rules - does not
terminate. `getCartRules()` passes its `$filter` down to `CartRule::getContextualValue()`, and with
`FILTER_ACTION_ALL` the free-shipping branch at `classes/CartRule.php:1523` calls
`getOrderTotal(..., Cart::ONLY_SHIPPING)`; the shipping cost is then evaluated against
`getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING)` at `classes/Cart.php:4903`, which comes straight
back into `getTotalCalculationCartRules()`. Measured: with that version, a cart holding a
free-shipping rule did not return within 120 seconds, while the same cart on unmodified code
finished in a few seconds and the same version on a cart with no free-shipping rule returned
normally. The two narrower filters exist precisely so that the shipping value is never computed
here - `classes/Cart.php:2304` already carries the comment "dont process free shipping to avoid
calculation loop".

So the merge stays, and only the order is corrected. `Cart::getOrderedCartRulesIds()` already
answers "in what order does this cart apply its rules", is cached and invalidated alongside
`getCartRules()` (`classes/Cart.php:1453-1456`), and is what `CartRule::getContextualValue()` itself
uses at `classes/CartRule.php:1495`. It computes no contextual value, so reordering against it
cannot re-enter the loop.

### Test

`tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/gift.feature` gains a
scenario with a separate gift rule and a separate percentage rule, plus a
`my cart total without shipping should be ... tax included` step in `CartFeatureContext` - there was
no step asserting `Cart::BOTH_WITHOUT_SHIPPING` before.

```
./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags fo-cart-rule-gift
```

8 scenarios, 117 steps, all passing with the change. Reverting `classes/Cart.php` alone leaves the
new scenario failing with `Expects 50, got 45 instead` and the other seven passing. The whole `cart`
suite (243 scenarios, 3554 steps) passes.

### Not in this change

With the `discount` feature flag enabled the totals still diverge, for a second and independent
reason: `getCartRules()` orders its query by `priority ASC, gift_product DESC` before running
`sortCartRulesByPriority()`, while `getOrderedCartRulesIds()` runs the same sorter over an unordered
query. `DiscountPriority::compareDiscounts()` ends on `strcmp()` of `date_add`, so rules that tie on
type, priority and creation second compare equal, and `usort` - stable since PHP 8 - keeps whatever
order each query happened to return. Measured with the flag on: `BOTH` and `BOTH_WITHOUT_SHIPPING`
report different orders for the same two rules. That belongs to the discount rework rather than to
this fix, so it is reported on #37627 rather than patched here.
