### PR TITLE
Report install step fatals instead of a blank HTTP 500

### DIFF
--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -99,7 +99,12 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
             } elseif (Tools::getValue('finalize') && !empty($this->session->process_validated['postInstall'])) {
                 $this->processFinalize();
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // WHY: Throwable, not Exception. An install step fails with a PHP Error - a TypeError, a
+            // call on null, a class that will not load - as readily as with an Exception, and catching
+            // only Exception let those escape as an uncaught fatal. The step then answered HTTP 500
+            // with no body, so the wizard had nothing to show but the status code. The console entry
+            // point, index_cli.php, already catches Throwable for the same reason.
             if (_PS_MODE_DEV_) {
                 // display stack trace
                 $message = (string) $e;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | An installation step that fails with a PHP `Error` rather than an `Exception` produced an uncaught fatal, so the AJAX step answered HTTP 500 with no body and the wizard could only report the status code. `install-dev/controllers/http/process.php` now catches `\Throwable`, which is what `install-dev/index_cli.php` already does.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | #37657
| Related PRs       | #42642 - the other half of the installer diagnostics, on the same files
| Sponsor company   |

`InstallControllerHttpProcess::process()` wrapped every install step in `catch (\Exception $e)`, and
that block is the only thing that turns a failed step into the wizard's JSON error channel. A PHP
`Error` - a `TypeError`, a call on null, a class that will not load - is a `Throwable` but not an
`Exception`, so it walked straight past it. `install-dev/index.php` catches only
`PrestashopInstallerException`, so nothing further up caught it either and the request died as an
uncaught fatal.

The wizard has no way to recover from that. `install-dev/theme/js/process.js:78` builds its message
as `'HTTP ' + jqXHR.status + ' - ' + textStatus + ' - ' + jqXHR.responseText`, so with an empty body
the user is shown the status code and nothing else.

`install-dev/index_cli.php` already catches `Throwable` next to `PrestashopInstallerException`. The
HTTP entry point never grew the same arm.

### Measured

`9.2.x` at 7365d50, PHP 8.1, with a `throw new \Error('...')` as the first statement of
`processInstallDefaultData()` and the wizard driven to the process step:

| `process()` catches | HTTP | response body |
| --- | --- | --- |
| `\Exception` (before) | 500 | Symfony's generic `An Error Occurred: Internal Server Error` page, no message, no trace |
| `\Throwable` (after) | 200 | `{"success":false,"message":"Error: ... in ...:169\nStack trace: ...","warning":""}` |

`_PS_MODE_DEV_` was `true` for both rows, so debug mode does not compensate for the missing catch -
which matches what the reporter described.

With `_PS_MODE_DEV_` set to `false` the same run answers HTTP 200 and
`{"success":false,"message":"<the exception message>","warning":""}`. The existing branch in the
catch keeps the stack trace out of the browser outside debug mode, so nothing new is disclosed.

### How to test

1. On a shop that is not yet installed, add `throw new \Error('probe');` as the first statement of
   any `process*()` method in `install-dev/controllers/http/process.php` - for example
   `processInstallDefaultData()`.
2. Run the installer through to the installation step.
3. Before this change the progress bar stops and the error panel shows `HTTP 500 - error - ` with
   nothing after it. After it, the panel shows the message from the `Error`.

### Not in this change

`install-dev/index.php` still catches only `PrestashopInstallerException`. Mirroring
`index_cli.php`'s `echo (string) $e;` there would print a stack trace with absolute server paths to
anyone who can reach the installer, so that entry point needs a different treatment and is left
alone here. The AJAX steps are where an installation actually fails partway through, and they are
covered by this change.

`install-dev/` has no PHPUnit or Behat coverage in this repository - CI exercises it only by running
a real install through `index_cli.php` - and these controllers depend on installer globals and an
`InstallSession` that cannot be bootstrapped from a unit test, so this change comes with the
reproduction above rather than an automated test.

