### PR TITLE
Reference order exception messages so they can be translated

### DIFF
--- a/classes/lang/KeysReference/OrderExceptionLang.php
+++ b/classes/lang/KeysReference/OrderExceptionLang.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+// OrderException and InvoiceException carry their wording in the message itself, and
+// OrderController::getErrorMessages() renders it with $this->trans($e->getMessage()), so the parser
+// never sees the literal at the call site and the merchant always reads these in English.
+// Referencing them here is what makes them extractable. Domain: Admin.Orderscustomers.Notification.
+trans('An error occurred during payment.', 'Admin.Orderscustomers.Notification');
+trans('An error occurred during the CartRule creation', 'Admin.Orderscustomers.Notification');
+trans('An error occurred when trying to get info for order processing', 'Admin.Orderscustomers.Notification');
+trans('An error occurred while adding CartRule to cart', 'Admin.Orderscustomers.Notification');
+trans('An error occurred while editing the product line.', 'Admin.Orderscustomers.Notification');
+trans('Can\'t load Currency object', 'Admin.Orderscustomers.Notification');
+trans('Can\'t load Order Invoice object', 'Admin.Orderscustomers.Notification');
+trans('Cannot add product to shipped order.', 'Admin.Orderscustomers.Notification');
+trans('Cart linked to the order cannot be found.', 'Admin.Orderscustomers.Notification');
+trans('Could not delete customization from database.', 'Admin.Orderscustomers.Notification');
+trans('Could not delete order cart rule from database.', 'Admin.Orderscustomers.Notification');
+trans('Could not find the product in cart, meaning Order and Cart are out of sync', 'Admin.Orderscustomers.Notification');
+trans('Could not update order invoice in database.', 'Admin.Orderscustomers.Notification');
+trans('Delivered order cannot be modified.', 'Admin.Orderscustomers.Notification');
+trans('Failed to add order.', 'Admin.Orderscustomers.Notification');
+trans('Invalid cart provided.', 'Admin.Orderscustomers.Notification');
+trans('Invalid order cart rule provided.', 'Admin.Orderscustomers.Notification');
+trans('Invalid order invoice id supplied.', 'Admin.Orderscustomers.Notification');
+trans('Invalid price', 'Admin.Orderscustomers.Notification');
+trans('Invalid quantity', 'Admin.Orderscustomers.Notification');
+trans('Invoice management has been disabled.', 'Admin.Orderscustomers.Notification');
+trans('New delivery address is not valid', 'Admin.Orderscustomers.Notification');
+trans('New invoice address is not valid', 'Admin.Orderscustomers.Notification');
+trans('Order detail could not be found.', 'Admin.Orderscustomers.Notification');
+trans('Order detail does not belong to order.', 'Admin.Orderscustomers.Notification');
+trans('Product combination not found.', 'Admin.Orderscustomers.Notification');
+trans('The Order Detail object could not be loaded.', 'Admin.Orderscustomers.Notification');
+trans('The invoice is invalid.', 'Admin.Orderscustomers.Notification');
+trans('The invoice note was not saved.', 'Admin.Orderscustomers.Notification');
+trans('The invoice object cannot be loaded.', 'Admin.Orderscustomers.Notification');
+trans('The order carrier ID is invalid.', 'Admin.Orderscustomers.Notification');
+trans('The order carrier cannot be updated.', 'Admin.Orderscustomers.Notification');
+trans('The order has already been assigned this status.', 'Admin.Orderscustomers.Notification');
+trans('The order object cannot be loaded.', 'Admin.Orderscustomers.Notification');
+trans('The selected currency is invalid.', 'Admin.Orderscustomers.Notification');
+trans('The tracking number is incorrect.', 'Admin.Orderscustomers.Notification');
+trans('This order already has an invoice.', 'Admin.Orderscustomers.Notification');
+trans('You cannot change the currency.', 'Admin.Orderscustomers.Notification');
+trans('You cannot edit the order detail for this order.', 'Admin.Orderscustomers.Notification');
+trans('You cannot generate a partial credit slip.', 'Admin.Orderscustomers.Notification');
+trans('You cannot generate a voucher.', 'Admin.Orderscustomers.Notification');
+trans('You cannot use this invoice for the order', 'Admin.Orderscustomers.Notification');

--- a/tests/Unit/Core/Translation/OrderExceptionKeysReferenceTest.php
+++ b/tests/Unit/Core/Translation/OrderExceptionKeysReferenceTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Translation;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * OrderController::getErrorMessages() renders OrderException and InvoiceException with
+ * $this->trans($e->getMessage()), so the wording never appears as a literal in a trans() call and the
+ * extractor cannot see it. classes/lang/KeysReference/OrderExceptionLang.php exists to reference those
+ * literals; this test keeps it in step with the code that throws them.
+ */
+class OrderExceptionKeysReferenceTest extends TestCase
+{
+    private const EXCEPTIONS = ['OrderException', 'InvoiceException'];
+
+    private const KEYS_REFERENCE = 'classes/lang/KeysReference/OrderExceptionLang.php';
+
+    private const SCANNED_DIRECTORIES = ['src', 'classes'];
+
+    public function testEveryThrownLiteralIsReferencedForTranslation(): void
+    {
+        $referenced = $this->referencedKeys();
+        $thrown = $this->thrownLiterals();
+
+        $this->assertNotEmpty($thrown, 'No literal exception message was found, the scanner is broken.');
+
+        foreach ($thrown as $message => $origins) {
+            $this->assertContains(
+                $message,
+                $referenced,
+                sprintf(
+                    '"%s" is thrown at %s but is not referenced in %s, so it cannot be translated.',
+                    $message,
+                    implode(', ', $origins),
+                    self::KEYS_REFERENCE
+                )
+            );
+        }
+    }
+
+    public function testNoKeyIsReferencedForAMessageThatIsNoLongerThrown(): void
+    {
+        $thrown = array_keys($this->thrownLiterals());
+
+        foreach ($this->referencedKeys() as $key) {
+            $this->assertContains(
+                $key,
+                $thrown,
+                sprintf('"%s" is referenced in %s but no longer thrown.', $key, self::KEYS_REFERENCE)
+            );
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function referencedKeys(): array
+    {
+        $keys = [];
+        foreach ($this->stringCalls(file_get_contents($this->rootDir() . '/' . self::KEYS_REFERENCE), 'trans') as $call) {
+            $keys[] = $call;
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Messages thrown with a single literal as the first constructor argument. An interpolated message
+     * (sprintf, concatenation) is deliberately skipped: the placeholder is already substituted before
+     * trans() sees it, so referencing it would produce one catalogue key per order.
+     *
+     * @return array<string, string[]> message => files it is thrown from
+     */
+    private function thrownLiterals(): array
+    {
+        $found = [];
+        foreach (self::SCANNED_DIRECTORIES as $directory) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($this->rootDir() . '/' . $directory)
+            );
+            foreach ($iterator as $file) {
+                if (!$file->isFile() || $file->getExtension() !== 'php') {
+                    continue;
+                }
+                $contents = file_get_contents($file->getPathname());
+                foreach (self::EXCEPTIONS as $exception) {
+                    if (!str_contains($contents, 'new ' . $exception . '(')) {
+                        continue;
+                    }
+                    foreach ($this->stringCalls($contents, $exception, 'new') as $message) {
+                        $found[$message][] = $directory . '/' . $file->getFilename();
+                    }
+                }
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * First argument of every `$name(` call whose first argument is a single quoted string.
+     *
+     * @return string[]
+     */
+    private function stringCalls(string $contents, string $name, ?string $precededBy = null): array
+    {
+        $tokens = array_values(array_filter(
+            token_get_all($contents),
+            static fn ($token) => !is_array($token) || !in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)
+        ));
+
+        $messages = [];
+        foreach ($tokens as $i => $token) {
+            if (!is_array($token) || $token[0] !== T_STRING || $token[1] !== $name) {
+                continue;
+            }
+            if ($precededBy !== null && (!isset($tokens[$i - 1]) || !is_array($tokens[$i - 1]) || $tokens[$i - 1][1] !== $precededBy)) {
+                continue;
+            }
+            if (($tokens[$i + 1] ?? null) !== '(') {
+                continue;
+            }
+            $argument = $tokens[$i + 2] ?? null;
+            $after = $tokens[$i + 3] ?? null;
+            if (!is_array($argument) || $argument[0] !== T_CONSTANT_ENCAPSED_STRING) {
+                continue;
+            }
+            if ($after !== ',' && $after !== ')') {
+                continue;
+            }
+            $messages[] = stripslashes(substr($argument[1], 1, -1));
+        }
+
+        return $messages;
+    }
+
+    private function rootDir(): string
+    {
+        return dirname(__DIR__, 4);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `OrderController::getErrorMessages()` renders `OrderException` and `InvoiceException` with `$this->trans($e->getMessage())`, so the wording lives at the `throw` site and the extractor never sees a literal. All 42 distinct messages are absent from `translations/default/AdminOrderscustomersNotification.xlf`, which is why the merchant reads them in English whatever the shop language. This references them in `classes/lang/KeysReference/`, the directory the project already keeps for exactly this - "translation keys that need to be referenced, but not clearly visible in code", per its README - and adds a test that keeps the file in step with the code.
| Type?             | bug fix
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open an order in the back office and set its status to the one it already has. The flash message is "The order has already been assigned this status." - with this branch that string is in the catalogue, so a translated shop shows the translation instead of the English source. Automated: `vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/Translation/OrderExceptionKeysReferenceTest.php`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | #37760 - referenced, not closed: 16 interpolated messages remain, see below
| Related PRs       |
| Sponsor company   |

### The derivation

`throw new OrderException(...)` and `throw new InvoiceException(...)` occur **63** times across `src/`
and `classes/` - the number in the report. Splitting them by what the first constructor argument is:

```
63  throw sites
47  first argument is a single literal   ->  42 distinct messages  ->  all 42 referenced here
16  first argument is built with sprintf() or concatenation
 0  of the 42 already present in translations/default/AdminOrderscustomersNotification.xlf
```

Verified with the real extractor rather than by inspection. Running
`PrestaShop\\TranslationToolsBundle\\Translation\\Extractor\\PhpExtractor` over the three relevant files:

```
classes/lang/KeysReference/OrderExceptionLang.php   42 keys in Admin.Orderscustomers.Notification
classes/lang/KeysReference/FeatureFlagLang.php      keys collected the same way   (positive control)
src/Adapter/Order/CommandHandler/UpdateOrderStatusHandler.php   nothing            (the bug)
```

The extractor's `ExplicitTranslationCall` visitor accepts `trans()` as a plain function call and reads
the domain from the second argument, which is the form every file in that directory already uses.

### The 16 that are not fixed here, and why

Their message is interpolated before the exception is constructed - `sprintf('Order status with id
"%s" was not found.', $orderStatusId)` and similar. By the time `trans()` receives it the placeholder
is gone, so referencing it would add one catalogue key per order id. Making those translatable is a
different change: the exception has to carry the value, either as a dedicated class with a getter or
as a code plus parameters, so the controller can call `trans()` with a literal and a placeholder map -
the shape `InvalidCartRuleDiscountValueException` already uses a few lines below in the same method.
That touches the domain exception taxonomy rather than the translation catalogue, so it is a separate
PR; say the word and I will open it.

The issue is referenced rather than closed for that reason: half of the report is fixed here.

### The test

`OrderExceptionKeysReferenceTest` re-derives the literal messages from the source with
`token_get_all()` and asserts the reference file matches in both directions - every thrown literal is
referenced, and nothing is referenced that is no longer thrown. Interpolated messages are skipped
deliberately, with the reason in the docblock. 85 assertions.

Mutation checked both ways: dropping one key fails the first test naming the throw site, and adding a
key nobody throws fails the second naming the stale entry.
