### PR TITLE
Drop the unused supplier join from the product search

### DIFF
--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -910,7 +910,6 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->join('p', $this->dbPrefix . 'product_shop', 'ps', 'ps.id_product = p.id_product AND ps.id_shop = :shopId')
             ->leftJoin('p', $this->dbPrefix . 'product_lang', 'pl', 'pl.id_product = p.id_product AND pl.id_lang = :languageId')
             ->leftJoin('p', $this->dbPrefix . 'image_shop', 'i', 'i.id_product = p.id_product AND i.id_shop = :shopId AND i.cover = 1')
-            ->leftJoin('p', $this->dbPrefix . 'product_supplier', 'psu', 'psu.id_product = p.id_product')
             ->leftJoin('p', $this->dbPrefix . 'product_attribute', 'pa', 'pa.id_product = p.id_product')
             ->setParameter('shopId', $shopId->getValue())
             ->setParameter('languageId', $languageId->getValue())

--- a/tests/Integration/Behaviour/Features/Scenario/Product/search_products_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/search_products_for_association.feature
@@ -215,3 +215,37 @@ Feature: Search products to associate them in the BO
       | product  | name            | reference | image url                                             |
       | product6 | can of coke     |           | http://myshop.com/img/p/{image2}-home_default.jpg     |
       | product5 | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+
+  Scenario: A product associated with several suppliers is returned once
+    Given shop "shop1" with name "test_shop" exists
+    And I add new supplier supplier1 with the following properties:
+      | name                    | first supplier   |
+      | address                 | Donelaicio st. 1 |
+      | city                    | Kaunas           |
+      | country                 | Lithuania        |
+      | enabled                 | true             |
+      | description[en-US]      | just a supplier  |
+      | meta title[en-US]       | first supplier   |
+      | meta description[en-US] |                  |
+      | shops                   | [shop1]          |
+    And I add new supplier supplier2 with the following properties:
+      | name                    | second supplier  |
+      | address                 | Donelaicio st. 2 |
+      | city                    | Kaunas           |
+      | country                 | Lithuania        |
+      | enabled                 | true             |
+      | description[en-US]      | another supplier |
+      | meta title[en-US]       | second supplier  |
+      | meta description[en-US] |                  |
+      | shops                   | [shop1]          |
+    When I add product "product7" with following information:
+      | name[en-US] | jar of honey |
+      | name[fr-FR] | pot de miel  |
+      | type        | standard     |
+    And I associate suppliers to product "product7"
+      | supplier  | product_supplier   |
+      | supplier1 | product7_supplier1 |
+      | supplier2 | product7_supplier2 |
+    Then I search for products with locale "english" matching "honey" I should get following results:
+      | product  | name         | reference | image url                                             |
+      | product7 | jar of honey |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ProductRepository::getSearchQueryBuilder()` joins `product_supplier` as `psu`, and no caller reads it: the alias appears nowhere in the SELECT, the WHERE, the ORDER BY or the GROUP BY of any of the three methods built on it, and `psu` occurs exactly once in the whole `src/` tree. The join is not free - it multiplies every candidate row by that product's supplier count before `GROUP BY p.id_product` collapses it again, on top of the multiplication the `product_attribute` join already causes. Removing it leaves the emitted rows byte-identical.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a product, tab SEO, choose a permanent redirection to a product and type in the search box, on a catalogue that has several suppliers per product. The autocomplete returns the same products, faster. Automated: `vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags search-products`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37767
| Related PRs       |
| Sponsor company   |

### Measured

Reproduced the reporter's row counts exactly - 1252 products, 14926 `product_supplier` rows, 13680
combinations, 4218 `image_shop` rows - in a scratch schema whose tables are `CREATE TABLE ... LIKE`
copies of the real ones, so the indexes and the query plan are the shipped ones. The statement is the
one `searchProducts()` emits, `p.product_type` and the `p.id_product` tiebreaker included. MySQL 8.4,
three runs each, `ONLY_FULL_GROUP_BY` disabled the way the Doctrine connection does it:

```
search phrase   rows returned   with the join   without it
"Product"            1252         0.15-0.17 s    0.01-0.02 s
"number 5"            111         0.14-0.15 s    0.01 s
"REF12"                64         0.14-0.15 s    0.02 s
```

The two result sets are identical, not merely equal in count: both hash to the same digest for every
phrase, over all 1252 rows in the first case.

All three methods built on the shared builder were then A/B'd through the repository itself, on the
demo catalogue, against `9.2.x`:

```
phrase        searchProducts   searchProductsForFreeGift   searchCombinations
mug              5 rows                 5 rows                   5 rows
Hummingbird      5 rows                 5 rows
demo            19 rows                19 rows
a               20 rows                20 rows
```

Every one of them serialises to the same md5 before and after, so no caller of the shared builder
changes what it returns.

### The test

`search_products_for_association.feature` gains a scenario where one product carries two suppliers and
has to come back from the search exactly once. The four existing scenarios already cover names,
references and combination references, and all five pass with the join removed. The other two callers
have their own suites, run for the same reason: `--tags search-combinations` 6 scenarios and
`--tags search-product-combinations` 4 scenarios, all green.

The scenario is not vacuous: with the supplier join present and every `addGroupBy('p.id_product')`
removed - the state in which supplier rows reach the caller - it fails, together with the existing
combination-reference scenario. Reverting only the join leaves it green, which is expected: the join
is dead, so its removal is behaviour-neutral by construction and the scenario guards the opposite
direction, that a supplier association never duplicates a search result.

### The alternative I did not take

`product_supplier.product_supplier_reference` is not searched today; the WHERE matches
`p.supplier_reference`, the product's own column. Wiring the join into the search instead of removing
it would widen what the autocomplete matches on every existing shop, so it is a separate decision -
say so and I will open it as its own change.
