### PR TITLE
Publish Serbian with a country code that still exists

### DIFF
--- a/app/Resources/all_languages.json
+++ b/app/Resources/all_languages.json
@@ -564,7 +564,7 @@
     "date_format_lite": "d. m. Y.",
     "date_format_full": "d. m. Y. H:i:s",
     "is_rtl": "0",
-    "language_code": "sr-cs",
+    "language_code": "sr-rs",
     "locale": "sr-CS"
   },
   "sv": {

--- a/tests/Unit/Core/Language/AllLanguagesCatalogTest.php
+++ b/tests/Unit/Core/Language/AllLanguagesCatalogTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\Core\Language;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The catalogue shipped in app/Resources/all_languages.json is copied field by field into ps_lang by
+ * Language::checkAndAddLanguage(), so every value has to survive that table and its validators.
+ */
+class AllLanguagesCatalogTest extends TestCase
+{
+    /**
+     * Withdrawn ISO 3166-1 alpha-2 codes. A language tag built on one of these is deprecated in the
+     * IANA registry, and it reaches the browser through <html lang> and the hreflang alternates.
+     */
+    private const WITHDRAWN_REGION_CODES = ['AN', 'BU', 'CS', 'DD', 'FX', 'NT', 'SU', 'TP', 'YU', 'ZR'];
+
+    /**
+     * @return array<string, array{string, array<string, string>}>
+     */
+    public static function provideLanguages(): array
+    {
+        $catalog = json_decode(
+            file_get_contents(__DIR__ . '/../../../../app/Resources/all_languages.json'),
+            true
+        );
+
+        $cases = [];
+        foreach ($catalog as $key => $language) {
+            $cases[$key] = [$key, $language];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideLanguages
+     *
+     * @param array<string, string> $language
+     */
+    public function testItFitsTheLangTableAndItsValidators(string $key, array $language): void
+    {
+        // ps_lang.iso_code is varchar(2), language_code and locale are varchar(5)
+        $this->assertLessThanOrEqual(2, strlen($language['iso_code']), $key . ': iso_code');
+        $this->assertLessThanOrEqual(5, strlen($language['language_code']), $key . ': language_code');
+        $this->assertLessThanOrEqual(5, strlen($language['locale']), $key . ': locale');
+
+        // Validate::isLanguageCode()
+        $this->assertMatchesRegularExpression(
+            '/^[a-zA-Z]{2}(-[a-zA-Z]{2})?$/',
+            $language['language_code'],
+            $key . ': language_code has to pass Validate::isLanguageCode()'
+        );
+    }
+
+    /**
+     * @dataProvider provideLanguages
+     *
+     * @param array<string, string> $language
+     */
+    public function testItsPublishedLanguageTagIsNotDeprecated(string $key, array $language): void
+    {
+        $region = explode('-', $language['language_code'])[1] ?? null;
+
+        $this->assertNotContains(
+            strtoupper((string) $region),
+            self::WITHDRAWN_REGION_CODES,
+            $key . ': language_code is published as hreflang, so its region has to be a current ISO 3166-1 code'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Serbian is catalogued as `sr-CS` in `app/Resources/all_languages.json`. CS was the ISO 3166-1 code for Serbia and Montenegro, withdrawn in 2006; the IANA subtag registry marks it deprecated with preferred value RS. Of the 78 entries in that file it is the only one built on a withdrawn region code, and `language_code` is what `FrontController::getAlternativeLangsUrl()` publishes as `hreflang`, so every multi-language shop offering Serbian advertises a deprecated tag to search engines. This changes `language_code` to `sr-rs` and adds a unit test over the whole catalogue. `locale` is deliberately left at `sr-CS`: it is also the language-pack key on i18n.prestashop-project.org, which publishes Serbian under that name, so moving it here would break installing the language.
| Type?             | bug fix
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install Serbian on a shop with at least two languages and open any front-office page. The `link rel="alternate"` for Serbian carries `hreflang="sr-rs"` instead of `sr-cs`. Existing shops keep their stored value; the catalogue is read when a language is added. Automated: `vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/Language/AllLanguagesCatalogTest.php`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | #37804 - referenced, not closed: this fixes the `hreflang` half only, see below
| Related PRs       |
| Sponsor company   |

### Rendered, not traced

`Language::checkAndAddLanguage('sr')` on a shop running this branch stores
`iso_code=sr language_code=sr-rs locale=sr-CS`, and the front office home page then emits:

```
before   <link rel="alternate" href=".../sr/" hreflang="sr-cs">
after    <link rel="alternate" href=".../sr/" hreflang="sr-rs">
```

`<html lang>` renders `{$language.locale}`, so it stays `sr-CS` until the pack moves - which is why
#37804 should stay open after this lands rather than being closed by it.

`Language::getIdByLocale()` matches `locale = LOWER(:locale) OR language_code = LOWER(:locale)`;
`ps_lang` collates `utf8mb4_0900_ai_ci`, so `sr-CS` still resolves through the first condition and
`sr-RS` now resolves through the second. `getLanguageCodeByIso()` and the browser-preference lookup
compare `LEFT(language_code, 2)`, so a Serbian shop keeps resolving through `locale`.

The one behaviour change is `ModuleTabRegister::getTabNames()`: it tries `locale`, then
`language_code`, then `iso_code`, and the `language_code` step is `array_key_exists()` - an exact
PHP array lookup with no collation behind it. A module that keys its tab names by the literal string
`sr-cs` stops matching on that step and falls through to `iso_code`, then to the first available
name. No module in the tree keys names that way (grep for `sr-cs` under `modules/` returns nothing),
and the fallback is a different label, not a failure.

### What the rest of the report cannot have

The issue asks for `iso_code: "rs"` and `locale: "sr-Latn-RS"`. Measured on `9.2.x`, neither is available:

- `ps_lang.iso_code` is `varchar(2)` and holds the **language**, not the country - `rs` is Serbia's
  ISO 3166-1 code. It is also the front-office URL segment, so changing it breaks every indexed
  `/sr/...` URL on existing shops.
- `ps_lang.locale` and `ps_lang.language_code` are both `varchar(5)`, and
  `Validate::isLanguageCode()` is `/^[a-zA-Z]{2}(-[a-zA-Z]{2})?$/`, so a script subtag is rejected
  before it reaches the column. All 78 catalogue locales are 5 characters or fewer.
- `Language::SF_LANGUAGE_PACK_URL` is keyed on `%locale%`, and the translation service answers only
  for the old name:

  ```
  available_languages.json     ->  "sr-CS": "Serbian (Serbia)"
  .../9.0.0/sr-CS/sr-CS.zip        200
  .../9.0.0/sr-RS/sr-RS.zip        404
  .../9.0.0/sr-Latn-RS/...zip      404
  ```

### CLDR is not affected

`localization/CLDR/core/common/main/` ships `sr.xml`, `sr_Latn.xml`, `sr_Latn_RS.xml`,
`sr_Cyrl_RS.xml` and five more, and no `sr_CS.xml` - the reader already resolves `sr-CS` along
`root -> sr`. Number symbols come out identical for `sr-CS`, `sr` and `sr-Latn-RS` (`latn` decimal
`,`, group `.`), so nothing about formatting changes either way.

### The test

156 cases, two per catalogue entry: every value fits the `ps_lang` column it is copied into and passes
`Validate::isLanguageCode()`, and no published `language_code` is built on a withdrawn ISO 3166-1
region code. Reverting only `all_languages.json` fails exactly one of them, the `sr` data set.
