### PR TITLE
Qualify a webservice sort with the main table alias

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1258,7 +1258,10 @@ class WebserviceRequestCore
                     if ($assoc !== false && $assoc['type'] == 'shop' && ($object->isMultiShopField($this->resourceConfiguration['fields'][$fieldName]['sqlId']) || $fieldName == 'id')) {
                         $table_alias = 'multi_shop_' . $this->resourceConfiguration['retrieveData']['table'];
                     } else {
-                        $table_alias = '';
+                        // WHY: getWebserviceObjectList() aliases the resource table `main`, and the joins
+                        // built above reference it as such. An empty alias emits ``.`field`, which MySQL
+                        // rejects as ambiguous as soon as a joined table carries a column of that name.
+                        $table_alias = 'main';
                     }
                     $sql_sort .= (isset($this->resourceConfiguration['retrieveData']['tableAlias']) ? '`' . bqSQL($this->resourceConfiguration['retrieveData']['tableAlias']) . '`.' : '`' . bqSQL($table_alias) . '`.') . '`' . pSQL($this->resourceConfiguration['fields'][$fieldName]['sqlId']) . '` ' . $direction . ', '; // ORDER BY `field` ASC|DESC
                 }

--- a/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
@@ -31,6 +31,14 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @When /^I use Webservice with key "(.*)" to sort "(.+)" by "(.+)"$/
+     */
+    public function whenRequestSortedList(string $webserviceKey, string $endpoint, string $sort): void
+    {
+        $this->lastOutput = $this->requestWebserviceXML($webserviceKey, 'GET', $endpoint, '', ['sort' => $sort]);
+    }
+
+    /**
      * @When /^I use Webservice with key "(.*)" to fast view "(.+)"$/
      */
     public function whenRequestHead(string $webserviceKey, string $endpoint): void
@@ -179,9 +187,10 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
         string $wsKey,
         string $requestMethod,
         string $url,
-        string $postFields = ''
+        string $postFields = '',
+        array $queryParameters = []
     ): Crawler {
-        $output = $this->requestWebservice('XML', $wsKey, $requestMethod, $url, $postFields);
+        $output = $this->requestWebservice('XML', $wsKey, $requestMethod, $url, $postFields, $queryParameters);
 
         $crawler = new Crawler();
         $crawler->addXmlContent($output);
@@ -198,6 +207,7 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
      * @param string $requestMethod
      * @param string $url
      * @param string $postFields
+     * @param array $queryParameters
      *
      * @return string
      */
@@ -206,7 +216,8 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
         string $wsKey,
         string $requestMethod,
         string $url,
-        string $postFields
+        string $postFields,
+        array $queryParameters = []
     ): string {
         // Define mandatory values directly used in webservice/dispatcher.php
         $_SERVER['REQUEST_METHOD'] = $requestMethod;
@@ -215,6 +226,9 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
         $_GET['ws_key'] = $wsKey;
         $_GET['url'] = $url;
         $_GET['output_format'] = $output;
+        foreach ($queryParameters as $name => $value) {
+            $_GET[$name] = $value;
+        }
 
         if ($requestMethod == 'PUT' || $requestMethod == 'POST') {
             StreamWrapperPHP::register();
@@ -238,6 +252,9 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
             $_GET['url'],
             $_GET['output_format']
         );
+        foreach (array_keys($queryParameters) as $name) {
+            unset($_GET[$name]);
+        }
 
         StreamWrapperPHP::unregister();
 

--- a/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/order_states.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/order_states.feature
@@ -1,0 +1,30 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s webservice --tags webservice-endpoints-order-states
+@restore-all-tables-before-feature
+@webservice-endpoints-order-states
+Feature: Webservice order states endpoint
+  PrestaShop allows API users to list order states
+  As an API user
+  I must be able to sort a list on a translatable and on a non translatable field at once
+
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    And I restore tables "webservice_account,webservice_account_shop,webservice_permission"
+    And shop configuration for "PS_WEBSERVICE" is set to 1
+    And I add a new webservice key with specified properties:
+      | key              | ENABLEDENABLEDENABLEDENABLEDENAB |
+      | description      | Enabled key                      |
+      | is_enabled       | 1                                |
+      | shop_association | shop1                            |
+    And I edit webservice key "ENABLEDENABLEDENABLEDENABLEDENAB" with specified properties:
+      | description    | Enabled key with Permissions |
+      | permission_GET | order_states                 |
+
+  Scenario: Sort on a non translatable field listed before a translatable one
+    When I use Webservice with key "ENABLEDENABLEDENABLEDENABLEDENAB" to sort "order_states" by "[id_ASC,name_ASC]"
+    Then I should get 0 errors
+    And I should get 13 items of type "order_state"
+
+  Scenario: Sort on a non translatable field listed after a translatable one
+    When I use Webservice with key "ENABLEDENABLEDENABLEDENABLEDENAB" to sort "order_states" by "[name_ASC,id_ASC]"
+    Then I should get 0 errors
+    And I should get 13 items of type "order_state"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `WebserviceRequest::manageFilters()` builds the ORDER BY with an empty table alias for any field that is not shop-scoped, emitting an empty backtick-quoted qualifier before the column name. MySQL accepts that on a single table but rejects it as `Column 'x' in order clause is ambiguous` the moment the query carries a join that repeats the column name. `ObjectModel::getWebserviceObjectList()` always aliases the resource table `main`, and every join the method builds above already references it as `main.`, so `main` is the correct qualifier and the empty one is never right.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `GET /api/order_states?sort=[id_ASC,name_ASC]` and `GET /api/order_states?sort=[name_ASC,id_ASC]`. Before the change both return an empty list (the SQL error is swallowed by `Db::executeS()` outside debug mode); after it both return the 13 order states. Covered by the two scenarios added in `tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/order_states.feature`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37835
| Related PRs       | Supersedes #37836 and #41228, both closed for base-branch reasons only.
| Sponsor company   |

### Why not the diff that was already approved

#37836 (base 9.0.x, approved by kpodemski and boherm) and #41228 (base 9.1.x, closed when that branch
was deleted) carry the same four lines:

```php
elseif (preg_match('#main\.#', $sql_join)) {
    $table_alias = 'main';
}
```

That guard reads `$sql_join` **inside** the `foreach ($sorts as $sort)` loop, and the i18n join is
appended by a later iteration of that same loop. So it depends on the order the sort fields are listed
in. Measured on `9.2.x` with the two scenarios in this PR:

```
                                          sort=[id_ASC,name_ASC]   sort=[name_ASC,id_ASC]
9.2.x, unchanged                                    0 items                 0 items
9.2.x + the preg_match guard                        0 items                13 items
9.2.x + this change                                13 items                13 items
```

Rejected alternative: keeping the guard and additionally moving the i18n join out of the sorts loop.
That is a larger change to the same method for no behavioural gain, since `main` is the correct alias
whether or not a join is present.

### The defect is reachable without `linked_tables`

No core resource declares `linked_tables`, so the reported symptom needs a custom resource. The i18n
join at the same place reaches the identical defect with stock resources: `order_state` has a `_lang`
table and no shop association, so `Shop::getAssoTable()` returns false, the sort falls into the empty
alias branch, and `ps_order_state_lang` supplies a second `id_order_state`.

```
SELECT DISTINCT main.`id_order_state` FROM `ps_order_state` AS main
LEFT JOIN `ps_order_state_lang` AS main_i18n ON (main.`id_order_state` = main_i18n.`id_order_state`)
WHERE 1 AND main_i18n.`id_lang` = 1 ORDER BY ``.`id_order_state` ASC
ERROR 1052 (23000): Column 'id_order_state' in order clause is ambiguous
```

### Non-regression on the shop-scoped path

The branch this change touches is also taken by shop-associated resources sorting a field that is
neither `id` nor `isMultiShopField()`. Item counts before and after, through the webservice dispatcher:

```
products      sort=[id_ASC]              85 -> 85
products      sort=[reference_ASC]       85 -> 85
products      sort=[name_ASC,id_ASC]     85 -> 85
products      sort=[id_ASC,name_ASC]     85 -> 85
customers     sort=[id_ASC]               2 ->  2
customers     sort=[email_ASC]            2 ->  2
orders        sort=[id_ASC]           60039 -> 60039
orders        sort=[reference_ASC]    60039 -> 60039
manufacturers sort=[id_ASC,name_ASC]      2 ->  2
```

Only `order_states` changes, 0 to 13.

### Test

`WebserviceEndpointFeatureContext` could only reach the dispatcher with `url`, `ws_key` and
`output_format`, so `sort` was unreachable. It now takes an optional query-parameter map, set and
unset around the dispatch like the existing ones, behind one new step. Reverting only
`classes/webservice/WebserviceRequest.php` to `9.2.x` fails both scenarios.
