### PR TITLE
Tell the merchant what went wrong when a module upload fails

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -692,7 +692,18 @@ class AdminModuleController {
   displayOnUploadError(message) {
     const self = this;
     self.animateEndUpload(() => {
-      $(self.moduleImportFailureMsgDetailsSelector).html(message);
+      // A request that never reached the JSON contract - a 500, a timeout - hands us the raw response
+      // body. Injecting an HTML error page as markup renders nothing readable, which is how this modal
+      // came to say "Oops... Upload failed." with an empty "What happened?".
+      const details = typeof message === 'string' ? message.trim() : '';
+      const looksLikeMarkup = /^\s*(<!doctype|<html|<\?xml)/i.test(details);
+
+      if (details === '' || looksLikeMarkup) {
+        $(self.moduleImportFailureMsgDetailsSelector).text(window.moduleTranslations.uploadUnexpectedError);
+      } else {
+        $(self.moduleImportFailureMsgDetailsSelector).text(details);
+      }
+
       $(self.moduleImportFailureSelector).fadeIn();
     });
   }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Throwable;
 use Twig\Environment;
 
 /**
@@ -429,10 +430,15 @@ class ModuleController extends ModuleAbstractController
                 ],
                 'Admin.Modules.Notification',
             );
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
+            // Throwable, not Exception: a broken module already sitting in modules/ raises an Error while
+            // the list is rebuilt, which escaped this catch and left the request to die as a 500. The
+            // uploader can only render the JSON contract, so an HTML error page reaches it as an
+            // unreadable blob - which is what "Oops... Upload failed." with nothing behind
+            // "What happened?" actually is.
             try {
                 $moduleManager->disable($moduleName);
-            } catch (Exception) {
+            } catch (Throwable) {
             }
             $installationResponse['status'] = false;
             $installationResponse['msg'] = $this->trans(

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -22,6 +22,7 @@
       'moduleModalUpdateUpgrade': '{{ 'Upgrade'|trans({}, 'Admin.Actions') }}',
       'upgradeAnywayButtonText': '{{ 'Update anyway'|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateConfirmMessage': '{{ 'We strongly advise you to update the modules on maintenance mode to avoid any cache issues.'|trans({}, 'Admin.Modules.Notification') }}',
+      'uploadUnexpectedError': '{{ 'Unexpected error occurred when uploading the module. Check error logs for more information.'|trans({}, 'Admin.Modules.Notification')|e('js') }}',
     };
 
     // Need to come from the backend


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `importModuleAction()` caught `Exception`. A broken module **already sitting in `modules/`** raises an `Error` while the module list is rebuilt, which escaped that catch and let the request die as a 500. The uploader can only render the JSON contract, so an HTML error page reaches it as an unreadable blob - which is exactly what "Oops... Upload failed." with nothing behind "What happened?" is. Catching `Throwable` keeps the contract and puts the real message in front of the merchant. A 500 can still arrive from outside the controller, so `displayOnUploadError()` no longer injects the raw response as markup: an empty body, a non-string or an HTML document now shows the wording the report proposed.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow the report: extract the broken `pscleaner` into `modules/` by hand, then upload any module through the back office. Before this change the modal says "Oops... Upload failed." and "What happened?" reveals nothing; after it, the failure names the module and the error. Separately, forcing any non-JSON response now shows "Unexpected error occurred when uploading the module. Check error logs for more information." instead of an empty panel.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38109
| Related PRs       |
| Sponsor company   |

### The two halves, and why both

```
src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php   catch (Exception $e)  -> catch (Throwable $e)
admin-dev/themes/new-theme/js/pages/module/controller.js             .html(message)        -> guarded .text()
src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig   + uploadUnexpectedError
```

The server half is the root cause and restores real information. The client half is the safety net the
reporter actually asked for, because a 500 from a memory limit or a fatal in an unrelated listener never
reaches the controller's catch at all.

`catch (Throwable)` is not a new habit here: `src/Adapter/Module/CommandHandler/UploadModuleHandler.php:31`
does the same for the same feature, and there are 49 files under `src/` using it.

### Measured

The client-side decision, replayed for every shape Dropzone can hand `displayOnUploadError()`:

```
a 500 HTML error page    -> FALLBACK MESSAGE
an empty body            -> FALLBACK MESSAGE
whitespace only          -> FALLBACK MESSAGE
a real JSON message      -> shows: Installation of module pscleaner failed. Class n...
a non-string (object)    -> FALLBACK MESSAGE
```

so a usable message is still shown; only unusable input changes. It is now inserted with `.text()`, which
also stops a server response being rendered as markup in the back office.

`php -l` clean, `php-cs-fixer` clean on the controller (it placed the `Throwable` import itself),
`npx eslint js/pages/module/controller.js` exits 0.

### Verification limit

There is **no test**, and no seam for a proportionate one: `importModuleAction()` is a controller action
whose failure mode requires a module that raises an `Error` during list rebuilding, and the JS half runs in
Dropzone's callback. The decision logic is measured above and the `Throwable` change is a one-word widening
of an existing catch. I have **not** reproduced the modal in a browser - that needs a back office session,
which I do not open.

### Note on the label

The ticket carries `Needs Specs`, but the spec is in the report itself and it is from a core maintainer:
*"it would be good not to show 'What happened?' text. Or show something like 'Unexpected error occurred when
uploading the module. Check error logs for more information.'"* That exact sentence is the fallback string.
The first option - hiding the link - is not taken: the link is still right when there is a real message,
which after the server half is the common case.
