### PR TITLE
Survive a memcached server that answers nothing

### DIFF
--- a/classes/cache/CacheMemcached.php
+++ b/classes/cache/CacheMemcached.php
@@ -59,7 +59,12 @@ class CacheMemcachedCore extends Cache
             $this->memcached->addServer($server['ip'], $server['port'], (int) $server['weight']);
         }
 
-        $this->is_connected = in_array('255.255.255', $this->memcached->getVersion(), true) === false;
+        // getVersion() answers false when no server could be reached - a memcached being restarted, for
+        // instance - and in_array() then raises a TypeError that takes the whole page down. A cache that
+        // cannot be reached is simply not connected.
+        $version = $this->memcached->getVersion();
+
+        $this->is_connected = is_array($version) && in_array('255.255.255', $version, true) === false;
     }
 
     /**

--- a/src/Adapter/Cache/MemcacheServerManager.php
+++ b/src/Adapter/Cache/MemcacheServerManager.php
@@ -72,6 +72,12 @@ class MemcacheServerManager
             return is_array($version) && false === in_array('255.255.255', $version, true);
         }
 
+        // Neither extension is a supported configuration, but reaching for the class anyway turns
+        // "this server does not work" into a fatal Error on the page that exists to report it.
+        if (!extension_loaded('memcache')) {
+            return false;
+        }
+
         $memcache = new Memcache();
 
         return true === $memcache->connect($serverIp, (int) $serverPort);

--- a/tests/Unit/Adapter/Cache/MemcacheServerManagerTest.php
+++ b/tests/Unit/Adapter/Cache/MemcacheServerManagerTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Cache;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Cache\MemcacheServerManager;
+
+/**
+ * testConfiguration() falls back to `new Memcache()` when the memcached extension is absent. With neither
+ * extension installed that is an Error, on the very page whose job is to report that a server does not
+ * work.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/38149
+ */
+class MemcacheServerManagerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (extension_loaded('memcache') || extension_loaded('memcached')) {
+            $this->markTestSkipped('This case only exists when neither memcache extension is installed');
+        }
+    }
+
+    public function testItReportsAFailureRatherThanRaisingWhenNoExtensionIsInstalled(): void
+    {
+        $manager = new MemcacheServerManager(
+            $this->createMock(\Doctrine\DBAL\Connection::class),
+            _DB_PREFIX_
+        );
+
+        $this->assertFalse($manager->testConfiguration('127.0.0.1', 11211));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Memcached::getVersion()` returns **false** when no server could be reached - one being restarted, for instance - and `CacheMemcached::connect()` passed that straight into `in_array()`, so the page died with `in_array(): Argument #2 ($haystack) must be of type array, bool given`. A cache that cannot be reached is simply not connected. `MemcacheServerManager::testConfiguration()` has the same shape one level up: with the memcached extension absent it falls back to `new Memcache()`, an `Error` when that extension is missing too - on the page whose job is to report that a server does not work.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Configure a memcached server in Advanced Parameters > Performance, then stop it and load any page. Before this change the shop returns a fatal `TypeError` from `CacheMemcached.php`; after it, the page renders with the cache reported as not connected. Separately, on a host with neither `memcached` nor `memcache` installed, testing a server on that same page answers "not working" instead of `Class "Memcache" not found`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38149
| Related PRs       |
| Sponsor company   |

### Measured, on the project's own PHP 8.1.33

Every outcome `getVersion()` can produce, old expression against new:

```
getVersion()                       old                                new
false (no server reachable)        TypeError: Argument #2 must be array   is_connected = false
['host:11211' => '1.6.21']         true                               true
['host:11211' => '255.255.255']    false                              false
```

so only the crashing case changes; a reachable server and the sentinel `255.255.255` behave exactly as
before. The container this was measured in has **neither** extension loaded
(`extension_loaded('memcached')` and `('memcache')` both false), which is what makes the second half
testable at all.

### Verification

`tests/Unit/Adapter/Cache/MemcacheServerManagerTest.php`, 1 test, green, and it skips itself on a host that
does have an extension, so it can never give a false pass.

**Mutation check** - removing the `extension_loaded('memcache')` guard:

```
Error: Class "Memcache" not found
```

which is the production failure, reproduced. The revert was verified byte-identical and the test re-run
green. `php -l` clean on all three files, `php-cs-fixer --dry-run` 0 of 3.

**No test for the `CacheMemcached` half**, and that is deliberate rather than an oversight: `connect()`
constructs `Memcached` directly with no seam, so a test would need the extension installed **and** a server
that is reachable at `addServer()` time and gone by `getVersion()`. The expression itself is measured above
across all three outcomes.

### Recreated from an approved PR

**#40041** (ChillCode) proposed both guards, was **APPROVED by kpodemski and Codencode**, and was closed
**by its author** on 2025-12-04 against `9.0.x`, a branch that no longer exists upstream. Nothing was
objected to on its merits - SiraDIOP's review comment was about which HTTP status the BO returns while
testing, which ChillCode answered. The reporter of #38149 had independently proposed the same
`is_array($version) &&` guard in the issue body.

Note that `MemcacheServerManager.php:72` **already** carries an `is_array($version)` guard for the
memcached branch; the missing one was in `classes/cache/CacheMemcached.php`, which is the file the reporter
pointed at.
