### PR TITLE
Keep vouchers out of the free shipping threshold

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3877,6 +3877,8 @@ class CartCore extends ObjectModel
          * If the order total WITHOUT discounts is greater than or equal to the free shipping price, we return 0.
          *
          * Watch out, this is different from the other calculations which use the order total WITH discounts.
+         * The back office states the same contract next to the setting: "Coupons are not taken into account
+         * when calculating free shipping."
          */
         // Get the configuration value and convert it to the current currency
         $shippingFreePrice = (float) Configuration::get('PS_SHIPPING_FREE_PRICE');
@@ -3890,8 +3892,8 @@ class CartCore extends ObjectModel
          */
         Hook::exec('actionOverrideShippingFreePrice', ['shippingFreePrice' => &$shippingFreePrice, 'id_zone' => $id_zone, 'id_currency' => $this->id_currency]);
 
-        $orderTotalwithDiscounts = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, null, null, false);
-        if ($orderTotalwithDiscounts >= (float) $shippingFreePrice && (float) $shippingFreePrice > 0) {
+        $orderTotalWithoutDiscounts = $this->getOrderTotal(true, Cart::ONLY_PRODUCTS, null, null, false);
+        if ($orderTotalWithoutDiscounts >= (float) $shippingFreePrice && (float) $shippingFreePrice > 0) {
             // Allow module to override the shipping cost and return their custom value
             $shipping_cost = $this->getPackageShippingCostFromModule($carrier, $shipping_cost, $products);
 

--- a/tests/Integration/Classes/Cart/FreeShippingThresholdTest.php
+++ b/tests/Integration/Classes/Cart/FreeShippingThresholdTest.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Cart;
+
+use Address;
+use Carrier;
+use Cart;
+use CartRule;
+use Configuration;
+use Context;
+use Currency;
+use DateTime;
+use Db;
+use Group;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\OutOfRangeBehavior;
+use Product;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Shipping preferences carry the sentence "Coupons are not taken into account when calculating free
+ * shipping" next to the free shipping threshold, and Cart::getPackageShippingCostValue() repeats it in a
+ * comment. Until 1.7.5.2 the code agreed: Cart::BOTH_WITHOUT_SHIPPING fell through to ONLY_PRODUCTS and
+ * returned the row total. From 1.7.6.0 it applies cart rules, so a voucher started pushing carts back below
+ * the threshold.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/38274
+ */
+class FreeShippingThresholdTest extends KernelTestCase
+{
+    /** @var int */
+    private static $idAddress;
+
+    /** @var float */
+    private const FREE_SHIPPING_FROM = 50.0;
+
+    /** @var float what the carrier charges when free shipping does NOT apply */
+    private const SHIPPING_COST = 7.0;
+
+    /** @var int|null */
+    private static $idCarrier;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+        global $kernel;
+        $kernel = self::$kernel;
+
+        Configuration::loadConfiguration();
+        Context::getContext()->currency = Currency::getDefaultCurrency();
+        Group::clearCachedValues();
+
+        Configuration::updateValue('PS_TAX_ADDRESS_TYPE', 'id_address_invoice');
+        Configuration::updateValue('PS_ORDER_OUT_OF_STOCK', true);
+        Configuration::set('PS_CART_RULE_FEATURE_ACTIVE', true);
+        Configuration::set('PS_ATCP_SHIPWRAP', false);
+        Configuration::updateValue('PS_SHIPPING_FREE_PRICE', self::FREE_SHIPPING_FROM);
+        Configuration::updateValue('PS_SHIPPING_FREE_WEIGHT', 0);
+
+        // Pre-existing cart rules would change the totals under the test
+        Db::getInstance()->execute('UPDATE ' . _DB_PREFIX_ . 'cart_rule SET active = 0');
+
+        if (null === self::$idAddress) {
+            self::$idAddress = $this->makeAddress()->id;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        Configuration::updateValue('PS_SHIPPING_FREE_PRICE', 0);
+        parent::tearDown();
+    }
+
+    /**
+     * Control. A cart BELOW the threshold pays the carrier. Without this the other two assertions are
+     * vacuous: getPackageShippingCostValue() also returns 0 when no carrier can be resolved, so "0" alone
+     * does not prove that free shipping was applied.
+     */
+    public function testACartBelowTheThresholdPaysTheCarrier(): void
+    {
+        $cart = $this->makeCartWithProduct(self::FREE_SHIPPING_FROM - 10);
+
+        $this->assertEquals(
+            self::SHIPPING_COST,
+            (float) $cart->getPackageShippingCost(self::idCarrier(), false),
+            'the carrier must charge, or a 0 below means "no carrier" rather than "free shipping"'
+        );
+    }
+
+    /**
+     * Control. Above the threshold, the same carrier ships free.
+     */
+    public function testACartAboveTheThresholdShipsFree(): void
+    {
+        $cart = $this->makeCartWithProduct(self::FREE_SHIPPING_FROM + 50);
+
+        $this->assertEquals(0.0, (float) $cart->getPackageShippingCost(self::idCarrier(), false));
+    }
+
+    /**
+     * The reported case: a voucher drags the discounted total under the threshold. Free shipping must not
+     * be withdrawn, because the setting is documented as ignoring coupons.
+     */
+    public function testAVoucherDoesNotWithdrawFreeShipping(): void
+    {
+        $price = self::FREE_SHIPPING_FROM + 50;
+        $cart = $this->makeCartWithProduct($price);
+
+        $cartRule = $this->makeCartRule($price - 1);
+        $cart->addCartRule((int) $cartRule->id);
+        $cart = new Cart((int) $cart->id);
+        Context::getContext()->cart = $cart;
+
+        // the voucher really does take the discounted total below the threshold
+        $this->assertLessThan(
+            self::FREE_SHIPPING_FROM,
+            $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING),
+            'the voucher must take the discounted total below the threshold, or nothing is being tested'
+        );
+        // while the products total, which the threshold is documented to use, stays above it
+        $this->assertGreaterThanOrEqual(
+            self::FREE_SHIPPING_FROM,
+            $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS)
+        );
+
+        $this->assertEquals(0.0, (float) $cart->getPackageShippingCost(self::idCarrier(), false));
+    }
+
+    private static function idCarrier(): int
+    {
+        if (null !== self::$idCarrier) {
+            return self::$idCarrier;
+        }
+
+        $carrier = new Carrier(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $carrier->name = 'free shipping threshold carrier';
+        $carrier->delay = 'whenever';
+        $carrier->range_behavior = (bool) OutOfRangeBehavior::USE_HIGHEST_RANGE;
+        $carrier->shipping_method = Carrier::SHIPPING_METHOD_PRICE;
+        $carrier->shipping_handling = false;
+        self::assertTrue($carrier->save());
+
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'range_price (id_carrier, delimiter1, delimiter2)
+             VALUES (' . (int) $carrier->id . ', 0, 100000)'
+        );
+        $idRangePrice = (int) Db::getInstance()->Insert_ID();
+        self::assertGreaterThan(0, $idRangePrice);
+
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'delivery (id_carrier, id_range_price, id_range_weight, id_zone, price)
+             SELECT ' . (int) $carrier->id . ', ' . $idRangePrice . ', 0, id_zone, ' . self::SHIPPING_COST . '
+             FROM ' . _DB_PREFIX_ . 'zone'
+        );
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'carrier_zone (id_carrier, id_zone)
+             SELECT ' . (int) $carrier->id . ', id_zone FROM ' . _DB_PREFIX_ . 'zone'
+        );
+
+        return self::$idCarrier = (int) $carrier->id;
+    }
+
+    private function makeCartWithProduct(float $price): Cart
+    {
+        $product = new Product();
+        $product->name = ['1' => 'Free shipping threshold product'];
+        $product->link_rewrite = ['1' => 'free-shipping-threshold-product'];
+        $product->price = $price;
+        $product->id_tax_rules_group = 0;
+        $product->quantity = 100;
+        $product->add();
+
+        $cart = new Cart(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $cart->id_currency = Currency::getDefaultCurrencyId();
+        $cart->id_address_invoice = self::$idAddress;
+        $cart->id_address_delivery = self::$idAddress;
+        $this->assertTrue($cart->save());
+        Context::getContext()->cart = $cart;
+
+        $cart->updateQty(1, (int) $product->id);
+
+        $cart = new Cart((int) $cart->id);
+        Context::getContext()->cart = $cart;
+
+        return $cart;
+    }
+
+    private function makeCartRule(float $amount): CartRule
+    {
+        $from = new DateTime();
+        $to = new DateTime();
+        $from->modify('-2 days');
+        $to->modify('+2 days');
+
+        $cartRule = new CartRule(null, (int) Configuration::get('PS_LANG_DEFAULT'));
+        $cartRule->name = 'Free shipping threshold voucher';
+        $cartRule->date_from = $from->format('Y-m-d H:i:s');
+        $cartRule->date_to = $to->format('Y-m-d H:i:s');
+        $cartRule->quantity = 1;
+        $cartRule->quantity_per_user = 1;
+        $cartRule->reduction_amount = $amount;
+        $cartRule->reduction_tax = true;
+        $cartRule->reduction_currency = Currency::getDefaultCurrencyId();
+        $cartRule->active = true;
+        $this->assertTrue($cartRule->add());
+
+        return $cartRule;
+    }
+
+    private function makeAddress(): Address
+    {
+        $address = new Address();
+        $address->id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $address->id_state = 0;
+        $address->firstname = 'Free';
+        $address->lastname = 'Shipping';
+        $address->address1 = '1 threshold street';
+        $address->city = 'Paris';
+        $address->postcode = '75001';
+        $address->alias = 'free-shipping-threshold';
+        $address->add();
+
+        return $address;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Shipping preferences state, next to the setting: *"Coupons are not taken into account when calculating free shipping."* The comment above the check in `Cart::getPackageShippingCostValue()` says the same. Until **1.7.5.2** the code agreed - `Cart::BOTH_WITHOUT_SHIPPING` fell through to `ONLY_PRODUCTS` and returned the row total with no cart rules applied. Commit `6ed1dfcccf7` in **1.7.6.0** added `BOTH_WITHOUT_SHIPPING` to the types that load cart rules and gave it a body calling `calculateCartRulesWithoutFreeShipping()`, so the threshold started being compared against the **discounted** total and a voucher has withdrawn free shipping ever since. The threshold now uses `Cart::ONLY_PRODUCTS`, the value the pre-1.7.6.0 fall-through produced.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shipping > Preferences: set free shipping from 50. Put a 100 product in a cart with a carrier that charges - shipping is free. Add a voucher of -99. Before this change the shipping charge comes back; after it, shipping stays free, which is what the setting's own help text promises.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38274
| Related PRs       |
| Sponsor company   |

### It is a regression, and the reporter named the right commit

`case Cart::BOTH_WITHOUT_SHIPPING` per release:

```
1.7.5.2   ONLY_PRODUCTS getRowTotal          <- falls through, no cart rules
1.7.6.0   calculateCartRulesWithoutFreeShipping getTotal(
1.7.7.0 / 1.7.8.0 / 8.0.0 / 8.1.0 / 8.2.0 / 9.2.x   same as 1.7.6.0
```

and the diff of `6ed1dfcccf7` ("fix virtual cart rule calculation on virtual cart"):

```diff
-        if (in_array($type, [Cart::BOTH, Cart::ONLY_DISCOUNTS])) {
+        if (in_array($type, [Cart::BOTH, Cart::BOTH_WITHOUT_SHIPPING, Cart::ONLY_DISCOUNTS])) {
             $cartRules = $this->getCartRules();
...
              case Cart::BOTH_WITHOUT_SHIPPING:
+                $calculator->calculateRows();
+                $calculator->calculateCartRules();
+                $amount = $calculator->getTotal(true);
+                break;
```

The commit was about virtual carts; the free shipping threshold was collateral. The tooltip has carried the
same sentence since at least 1.7.5.2, so it was correct when written and the code drifted away from it.

### Verification

`tests/Integration/Classes/Cart/FreeShippingThresholdTest.php`, 3 tests / 12 assertions, green.

**The first version of this test passed on the unfixed code**, because `getPackageShippingCostValue()`
returns 0 both for "free shipping" and for "no carrier could be resolved" - the same fallthrough noted on
#38523. A test asserting `0 === cost` therefore proves nothing on its own. It now builds a carrier that
charges 7 and asserts that a cart **below** the threshold really is charged, so a later 0 means free
shipping was applied.

**Mutation check** - restoring the original line:

```
1) testAVoucherDoesNotWithdrawFreeShipping
   Failed asserting that 7.0 matches expected 0.0.
```

The two controls stay green under the mutation, which is what makes the failure specific. The revert was
verified byte-identical and the suite re-run green. `php -l` clean, `php-cs-fixer --dry-run` 0 of 2.

### Scope, and the alternative I rejected

Only the free-shipping comparison moves. `BOTH_WITHOUT_SHIPPING` is untouched, so the carrier price-range
lookup at `Cart.php:3705` - which feeds `getDeliveryPriceByPrice()` - keeps the total it has today.

The alternative is to leave the behaviour and **change the help text** to "Coupons are taken into account",
which the reporter offered himself once QA disagreed with him. I did not take it: the sentence describes what
the setting did for its whole life before an unrelated 1.7.6.0 commit, and a merchant who sets "free shipping
from 50" is stating a rule about their catalogue price, not about what remains after someone spends a coupon.
If the maintainers prefer the documentation change instead, say so and I will rework it - the diff is two
lines either way.
