### PR TITLE
Dispatch displayBackOfficeEmployeeMenu again

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/employee_dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/employee_dropdown.html.twig
@@ -28,7 +28,7 @@
 
         <p class="divider"></p>
 
-        {% for menuItem in displayBackOfficeEmployeeMenu %}
+        {% for menuItem in this.displayBackOfficeEmployeeMenu %}
           {% set menuItemProperties = menuItem.getProperties %}
           <a class="dropdown-item {{ menuItem.getClass }}" href="{{ menuItemProperties.link }}" {% if menuItemProperties.isExternalLink %} target="_blank"{% endif %} rel="noopener noreferrer nofollow">
             {% if menuItemProperties.icon is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/employee_dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/employee_dropdown.html.twig
@@ -20,7 +20,7 @@
       <li class="employee-wrapper-profile"><a class="admin-link" href="{{ path('admin_employees_edit', {employeeId: this.employee.id}) }}"><i class="material-icons">edit</i> {{ 'Your profile'|trans({}, 'Admin.Navigation.Header') }}</a></li>
       <li class="divider"></li>
 
-      {% for menuItem in displayBackOfficeEmployeeMenu %}
+      {% for menuItem in this.displayBackOfficeEmployeeMenu %}
         {% set menuItemProperties = menuItem.getProperties %}
         <li class="{{ menuItem.getClass }}">
           <a class="dropdown-item" href="{{ menuItemProperties.link }}" {% if menuItemProperties.isExternalLink %} target="_blank"{% endif %} rel="noopener noreferrer nofollow">

--- a/src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
+++ b/src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
@@ -17,7 +17,12 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 #[AsTwigComponent(template: '@PrestaShop/Admin/Component/Layout/employee_dropdown.html.twig')]
 class EmployeeDropdown
 {
-    public ?ActionsBarButtonsCollection $displayBackOfficeEmployeeMenu = null;
+    /**
+     * Protected on purpose: a public property is exposed to the component template under its own
+     * name, and a template reading it directly gets this null instead of going through the getter
+     * that dispatches the hook. That is exactly how displayBackOfficeEmployeeMenu stopped firing.
+     */
+    protected ?ActionsBarButtonsCollection $displayBackOfficeEmployeeMenu = null;
 
     public function __construct(
         protected readonly HookDispatcherInterface $hookDispatcher,
@@ -30,7 +35,7 @@ class EmployeeDropdown
         return $this->employeeContext->getEmployee();
     }
 
-    public function getDisplayBackOfficeEmployeeMenu()
+    public function getDisplayBackOfficeEmployeeMenu(): ActionsBarButtonsCollection
     {
         if ($this->displayBackOfficeEmployeeMenu === null) {
             $menuLinksCollections = new ActionsBarButtonsCollection();

--- a/tests/Unit/PrestaShopBundle/Twig/Component/EmployeeDropdownTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Component/EmployeeDropdownTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig\Component;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection;
+use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShopBundle\Twig\Component\EmployeeDropdown;
+
+/**
+ * The employee menu hook stopped firing because both component templates read the bare
+ * `displayBackOfficeEmployeeMenu`, which resolves to the component's own null property, instead of
+ * `this.displayBackOfficeEmployeeMenu`, which goes through the getter that dispatches the hook.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/38359
+ */
+class EmployeeDropdownTest extends TestCase
+{
+    private const TEMPLATES = [
+        'src/PrestaShopBundle/Resources/views/Admin/Component/Layout/employee_dropdown.html.twig',
+        'src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/employee_dropdown.html.twig',
+    ];
+
+    public function testTheGetterDispatchesTheHookAndReturnsTheCollection(): void
+    {
+        $dispatched = [];
+        $hookDispatcher = $this->createMock(HookDispatcherInterface::class);
+        $hookDispatcher
+            ->expects($this->once())
+            ->method('dispatchWithParameters')
+            ->willReturnCallback(function (string $hookName, array $parameters) use (&$dispatched) {
+                $dispatched[] = $hookName;
+                $this->assertInstanceOf(ActionsBarButtonsCollection::class, $parameters['links']);
+            });
+
+        $component = new EmployeeDropdown($hookDispatcher, $this->createMock(EmployeeContext::class));
+
+        $collection = $component->getDisplayBackOfficeEmployeeMenu();
+
+        $this->assertSame(['displayBackOfficeEmployeeMenu'], $dispatched);
+        $this->assertInstanceOf(ActionsBarButtonsCollection::class, $collection);
+    }
+
+    public function testTheHookIsDispatchedOnlyOnce(): void
+    {
+        $hookDispatcher = $this->createMock(HookDispatcherInterface::class);
+        $hookDispatcher->expects($this->once())->method('dispatchWithParameters');
+
+        $component = new EmployeeDropdown($hookDispatcher, $this->createMock(EmployeeContext::class));
+
+        $first = $component->getDisplayBackOfficeEmployeeMenu();
+        $this->assertSame($first, $component->getDisplayBackOfficeEmployeeMenu());
+    }
+
+    /**
+     * The regression that actually happened: a template reading the member without `this.` gets the
+     * property, never the getter, so the hook is never dispatched and the loop renders nothing.
+     */
+    public function testBothTemplatesReachTheMemberThroughTheComponent(): void
+    {
+        foreach (self::TEMPLATES as $template) {
+            $contents = file_get_contents(_PS_ROOT_DIR_ . '/' . $template);
+            $this->assertIsString($contents, $template . ' could not be read');
+
+            $this->assertStringContainsString(
+                'this.displayBackOfficeEmployeeMenu',
+                $contents,
+                $template . ' must read the member through the component, or the hook is never dispatched'
+            );
+            $this->assertDoesNotMatchRegularExpression(
+                '/(?<!this\.)\bdisplayBackOfficeEmployeeMenu\b/',
+                preg_replace('/this\.displayBackOfficeEmployeeMenu/', '', $contents),
+                $template . ' still reads the bare property name'
+            );
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Both employee dropdown templates looped over a **bare** `displayBackOfficeEmployeeMenu`. In a Twig component a public property is exposed to the template under its own name, so that read the component's property - `null` until `getDisplayBackOfficeEmployeeMenu()` runs, and nothing called it. Iterating `null` renders nothing, so the hook was never dispatched at all. Both templates now read `this.displayBackOfficeEmployeeMenu`, which is how they already reach every other member of the same component. The property is `protected` so the getter is the only way in.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a module hooked to `displayBackOfficeEmployeeMenu` - `ps_mbo` as the reporter did - and open any back office page with the profiler on. Before this change the hook does not appear among the dispatched hooks and the menu entry is missing; after it, the hook fires and the entry renders in the employee dropdown.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38359
| Related PRs       |
| Sponsor company   |

### Measured

```
getDisplayBackOfficeEmployeeMenu()   referenced nowhere in the tree except its own declaration
Layout/employee_dropdown.html.twig:31        {% for menuItem in displayBackOfficeEmployeeMenu %}   bare
LegacyLayout/employee_dropdown.html.twig:23  {% for menuItem in displayBackOfficeEmployeeMenu %}   bare
Layout/employee_dropdown.html.twig:14,17,21  this.employee.imageUrl / firstName / id               this.
```

The same file reaches three other component members through `this.` and only this one without it, so the
convention to follow was already in the file. Both call sites render the component with no props -
`default_layout.html.twig:110` and `legacy_layout.html.twig:87` both use `component('...')` with no
arguments - so making the property `protected` takes nothing away.

### Verification

`tests/Unit/PrestaShopBundle/Twig/Component/EmployeeDropdownTest.php`, 3 tests / 12 assertions, green on
PHP 8.1.33: the getter dispatches `displayBackOfficeEmployeeMenu` exactly once with an
`ActionsBarButtonsCollection` in `links`, the result is memoised, and **both templates** reach the member
through the component.

**Mutation check** - putting the bare name back in one template:

```
1) testBothTemplatesReachTheMemberThroughTheComponent
   ...Layout/employee_dropdown.html.twig must read the member through the component, or the hook is never dispatched
```

The revert was verified byte-identical and the suite re-run green. `php -l` clean, `php-cs-fixer --dry-run`
0 of 2 files fixable.

### Recreated from an approved PR

**#40382** (ChillCode) made the same change, was **APPROVED by Codencode**, and was closed **by its own
author** on 2025-12-26 - the same day he withdrew #39936 and `classic-theme#178` - against `9.0.x`, a branch
that no longer exists upstream. Nothing was objected to on its merits. This adds the regression test the
original did not have.

### Scope

Only this hook. ChillCode also listed several other never-called hooks on the issue and kpodemski answered
that most of them belong to the old product page and should be "marked correctly" - that is a separate,
larger question, and worth knowing before anyone tries: `Hook::$deprecated_hooks` (`classes/Hook.php:87`)
is read nowhere in the tree, so adding a name to it changes nothing observable.
