### PR TITLE
Report the debug mode that is actually in effect

### DIFF
--- a/src/Adapter/Debug/DebugMode.php
+++ b/src/Adapter/Debug/DebugMode.php
@@ -27,7 +27,29 @@ class DebugMode
      */
     public function isDebugModeEnabled()
     {
+        // The constant actually in effect is the ground truth. Reading it back out of the defines files
+        // cannot tell that a define() is guarded: config/defines_custom.inc.php is an supported override
+        // and the official Docker image writes it as
+        //     if ((bool) getenv('PS_DEV_MODE')) { define('_PS_MODE_DEV_', (bool) getenv('PS_DEV_MODE')); }
+        // The parser matches that define wherever it sits and compares the expression text against the
+        // literal 'false', so with PS_DEV_MODE unset an inactive define was reported as ENABLED and
+        // SwitchDebugModeHandler::handle() then had nothing to do when asked to turn debug mode on.
+        $runtimeDebugMode = $this->getRuntimeDebugMode();
+        if (null !== $runtimeDebugMode) {
+            return $runtimeDebugMode;
+        }
+
         return 'false' !== Tools::strtolower($this->getCurrentDebugMode());
+    }
+
+    /**
+     * The value of _PS_MODE_DEV_ as the running process sees it.
+     *
+     * @return bool|null null when the constant is not defined, which happens outside a booted shop
+     */
+    protected function getRuntimeDebugMode(): ?bool
+    {
+        return defined('_PS_MODE_DEV_') ? (bool) _PS_MODE_DEV_ : null;
     }
 
     /**

--- a/tests/Unit/Adapter/Debug/DebugModeTest.php
+++ b/tests/Unit/Adapter/Debug/DebugModeTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Debug;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Debug\DebugMode;
+
+/**
+ * isDebugModeEnabled() used to compare the text of the define() it found in the defines files against the
+ * literal 'false'. config/defines_custom.inc.php is a supported override and the official Docker image
+ * guards its define with `if ((bool) getenv('PS_DEV_MODE'))`, so with the variable unset an inactive define
+ * was still reported as enabled - and SwitchDebugModeHandler then had nothing to do when asked to enable
+ * debug mode.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/38771
+ */
+class DebugModeTest extends TestCase
+{
+    private function debugMode(?bool $runtime, string $parsed): DebugMode
+    {
+        return new class($runtime, $parsed) extends DebugMode {
+            /** @var bool|null */
+            private $runtime;
+            /** @var string */
+            private $parsed;
+
+            public function __construct(?bool $runtime, string $parsed)
+            {
+                $this->runtime = $runtime;
+                $this->parsed = $parsed;
+            }
+
+            protected function getRuntimeDebugMode(): ?bool
+            {
+                return $this->runtime;
+            }
+
+            public function getCurrentDebugMode()
+            {
+                return $this->parsed;
+            }
+        };
+    }
+
+    public function testItReportsTheConstantInEffectRatherThanTheFileText(): void
+    {
+        // exactly what the Docker image's defines_custom.inc.php parses to, with PS_DEV_MODE unset
+        $debugMode = $this->debugMode(false, "(bool) getenv('PS_DEV_MODE')");
+
+        $this->assertFalse($debugMode->isDebugModeEnabled());
+    }
+
+    public function testItReportsEnabledWhenTheConstantIsTrue(): void
+    {
+        $debugMode = $this->debugMode(true, "(bool) getenv('PS_DEV_MODE')");
+
+        $this->assertTrue($debugMode->isDebugModeEnabled());
+    }
+
+    /**
+     * Outside a booted shop the constant is missing and the previous behaviour has to stand.
+     */
+    public function testItFallsBackToTheParsedValueWhenTheConstantIsNotDefined(): void
+    {
+        $this->assertFalse($this->debugMode(null, 'false')->isDebugModeEnabled());
+        $this->assertTrue($this->debugMode(null, 'true')->isDebugModeEnabled());
+        $this->assertTrue($this->debugMode(null, "isset(\$_COOKIE['debug'])")->isDebugModeEnabled());
+    }
+
+    /**
+     * A literal false in the file must not be read as enabled just because the constant says so - the
+     * constant wins, and that is the point.
+     */
+    public function testTheConstantWinsOverTheFileText(): void
+    {
+        $this->assertTrue($this->debugMode(true, 'false')->isDebugModeEnabled());
+        $this->assertFalse($this->debugMode(false, 'true')->isDebugModeEnabled());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `DebugMode::isDebugModeEnabled()` compared the **text** of the `define()` it found in the defines files against the literal `'false'`. `config/defines_custom.inc.php` is a supported override - `config/config.inc.php:11` includes it - and the official Docker image writes it as `if ((bool) getenv('PS_DEV_MODE')) { define('_PS_MODE_DEV_', (bool) getenv('PS_DEV_MODE')); }`. The parser matches that define wherever it sits, so with `PS_DEV_MODE` unset an **inactive** define was reported as enabled. `SwitchDebugModeHandler::handle()` only acts when the reported state differs from the requested one, so asking to turn debug mode on did nothing. The constant in effect is now used when it is defined.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the official Docker image **without** `PS_DEV_MODE` set, so `config/defines_custom.inc.php` exists but its `define()` never executes. Advanced Parameters > Performance: before this change the Debug mode switch shows as already on and turning it on changes nothing; after it, the switch reflects the real state and enabling it works. A shop with no custom defines file behaves exactly as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38771
| Related PRs       |
| Sponsor company   |

### Why nothing happened when the switch was flipped

```
DebugMode::isDebugModeEnabled()          'false' !== strtolower("(bool) getenv('PS_DEV_MODE')")  -> true
SwitchDebugModeHandler::handle():41      if (!$isDebugModeEnabled && $command->enableDebugMode())  -> skipped
                        :47              if ($isDebugModeEnabled && !$command->enableDebugMode())  -> skipped
```

Both branches are guarded on the reported state, so a wrong "already enabled" makes the handler a no-op.
That is the whole of "impossible to enable debug mode", and it is why editing the file by hand was the only
way out.

The custom file itself is legitimate: `config/config.inc.php:11-13` includes `defines_custom.inc.php` when
present, and `DebugMode` already reads and writes it deliberately (lines 41, 122, 173). What it cannot do is
see that a `define()` is **guarded** - a regex has no idea about the surrounding `if`.

### Verification

`tests/Unit/Adapter/Debug/DebugModeTest.php`, 4 tests / 7 assertions, green on PHP 8.1.33. The first case is
the Docker one exactly: runtime constant `false`, parsed text `(bool) getenv('PS_DEV_MODE')`.

**Mutation check** - restoring the original method:

```
1) testItReportsTheConstantInEffectRatherThanTheFileText   Failed asserting that true is false.
2) testTheConstantWinsOverTheFileText                      Failed asserting that false is true.
```

so the tests do hold the behaviour, and failure (1) is literally the reported bug. The revert was verified
byte-identical before committing and the suite re-run green. `php -l` clean, `php-cs-fixer --dry-run` reports
0 of 2 files fixable.

### Scope

`getCurrentDebugMode()` is deliberately untouched - `DebugModeConfiguration::updateDebugMode()` compares its
expression text to decide whether a write is needed, and the form needs it to show the cookie name and value.
Only the boolean answer moves to the constant.

**Not included, and stated so a maintainer can weigh it:** when the custom file's define is guarded, a write
from the back office still lands inside that guard and can be inert, so the two files can disagree. Making
`changePsModeDevValue()` update the main file as well would close that, but it changes what the back office
writes, and it is not needed for the reported symptom.
