### PR TITLE
Send the category tree's AJAX calls to the admin dispatcher

### DIFF
--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -3,6 +3,18 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
+/**
+ * The tree's AJAX calls used a bare 'index.php', which the browser resolves against the CURRENT path.
+ * That is the admin dispatcher only on a legacy page; from a Symfony route such as
+ * /<admin>/improve/modules/manage/action/configure/ it resolves to
+ * /<admin>/improve/modules/manage/action/configure/index.php, which does not exist.
+ * baseAdminDir is published by both back office layouts - AdminController::setMedia() for the legacy one
+ * and the HeadTag Twig component for the Symfony one - and already ends with a slash.
+ */
+function adminDispatcherUrl() {
+  return (typeof window.baseAdminDir !== 'undefined' ? window.baseAdminDir : '') + 'index.php';
+}
+
 window.Tree = function (element, options) {
   this.$element = $(element);
   this.options = $.extend({}, $.fn.tree.defaults, options);
@@ -47,7 +59,7 @@ Tree.prototype = {
             const useCheckBox = inputType === 'checkbox' ? 1 : 0;
 
             $.get(
-              'index.php',
+              adminDispatcherUrl(),
               {
                 ajax: 1,
                 controller: 'AdminProducts',
@@ -174,7 +186,7 @@ Tree.prototype = {
       }
 
       $.get(
-        'index.php',
+        adminDispatcherUrl(),
         data,
         (content) => {
           targetTree.html(content);

--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -12,7 +12,7 @@
  * and the HeadTag Twig component for the Symfony one - and already ends with a slash.
  */
 function adminDispatcherUrl() {
-  return (typeof window.baseAdminDir !== 'undefined' ? window.baseAdminDir : '') + 'index.php';
+  return `${typeof window.baseAdminDir !== 'undefined' ? window.baseAdminDir : ''}index.php`;
 }
 
 window.Tree = function (element, options) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Both `$.get()` calls in `admin-dev/themes/default/js/tree.js` (lines 50 and 177) used a bare `'index.php'`. A browser resolves that against the **current** path, which is the admin dispatcher only on a legacy page. Opened from a Symfony route - a module's configuration page is `/<admin>/improve/modules/manage/action/configure/` - it resolves to `/<admin>/improve/modules/manage/action/configure/index.php`, which does not exist, so **Show all** answers with an error instead of expanding the tree. The calls now go through `baseAdminDir`, which both back office layouts publish and which already ends with a slash.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Render a category tree from a module configuration page - `(new Helper())->renderCategoryTree()` in `getContent()`, as the reporter describes - and click **Show all**. Before this change the request goes to `.../action/configure/index.php` and fails; after it, it goes to `<admin>/index.php` and the tree expands. A tree on a legacy controller page is unaffected: the URL it produced before was already the dispatcher, and it still is.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39108
| Related PRs       |
| Sponsor company   |

### The global is published by both layouts, checked through to the template

```
classes/controller/AdminController.php:2740   Media::addJsDef(['baseAdminDir' => __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/'])
src/PrestaShopBundle/Twig/Component/HeadTag.php:78   'baseAdminDir' => $this->shopContext->getBaseURI() . basename(_PS_ADMIN_DIR_) . '/'
src/.../Admin/Component/Layout/head_tag.html.twig:59-62   {% for k, def in this.jsDef %} var {{ k }} = {{ def|json_encode|raw }};
```

The Twig line matters: a getter on the component is not automatically on the page, and reading the template
rather than assuming is what confirms `var baseAdminDir = "..."` is actually emitted on the Symfony pages
where this bug happens. Both values already end with `/`, so `baseAdminDir + 'index.php'` is a correct
absolute path, and it stays correct for a shop installed in a subdirectory.

### Why not the workaround posted on the issue

`gusdleon` traced the same two lines and proposed
`window.location.origin + '/' + window.location.pathname.split('/')[1] + '/index.php'`. That assumes the
admin folder is the first path segment, so it breaks for any shop installed under a subdirectory.
`baseAdminDir` is what the codebase already publishes for exactly this purpose - `js/admin/tinymce.inc.js`
uses it for the file manager path.

### Not the same as the two tickets it was linked to

`#37441` / merged `#38006` are the customer-group category discounts problem, and that PR changed
`ProductController` and a routing file, not `tree.js`. `#37991` is a multistore "page not found". Neither
touches these two lines, and the reporter said as much on the thread when the duplicate was suggested.

### Verification limit

`node --check` passes, and `admin-dev/themes/default/` has no eslint configuration in this repository. The
resolution rule is standard browser behaviour for a relative URL, and the producers of `baseAdminDir` are
traced above. I have **not** clicked Show all in a browser: that needs a back office session, which I do not
open. Two independent reporters describe the failing URL, and it matches the relative-resolution rule exactly.
