### PR TITLE
Write rich text editors back before the carrier wizard serialises a step

### DIFF
--- a/js/admin/carrier_wizard.js
+++ b/js/admin/carrier_wizard.js
@@ -107,9 +107,22 @@ function onShowStepCallback()
 	$('#carrier_logo_block').prependTo($('div.content').filter(function() { return $(this).css('display') != 'none' }).find('.defaultForm').find('fieldset'));
 }
 
+/**
+ * TinyMCE keeps what is typed inside its own editor and only writes it back to the textarea when the
+ * form is submitted natively. Every step of this wizard is sent with serialize() instead, so without
+ * this the textarea still holds its original value and the edit is silently dropped.
+ */
+function syncRichTextEditors()
+{
+	if (typeof tinyMCE !== 'undefined' && typeof tinyMCE.triggerSave === 'function') {
+		tinyMCE.triggerSave();
+	}
+}
+
 function onFinishCallback(obj, context)
 {
 	$('.wizard_error').remove();
+	syncRichTextEditors();
 	$.ajax({
 		type:"POST",
 		url : validate_url,
@@ -271,6 +284,7 @@ function validateSteps(fromStep, toStep)
 	if (is_ok)
 	{
 		form = $('#carrier_wizard #step-'+fromStep+' form');
+		syncRichTextEditors();
 		$.ajax({
 			type:"POST",
 			url : validate_url,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Every step of the carrier wizard is sent with jQuery `serialize()` (`js/admin/carrier_wizard.js:118` and `:279`), never a native form submit. TinyMCE keeps what is typed inside its own editor and writes it back to the underlying `<textarea>` on submit, so a field rendered with `autoload_rte` still held its original value and the edit was dropped with no error shown. Both call sites now call `tinyMCE.triggerSave()` first, guarded so a wizard page without TinyMCE loaded is untouched.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use the override the reporter gives on the issue, which turns the carrier's name field into a `textarea` with `autoload_rte`. Edit a carrier, change the rich text field, click through the step. Before this change the posted value is the one the page was loaded with; after it, the edited value is posted. A wizard with no rich text field behaves identically either way.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39142
| Related PRs       |
| Sponsor company   |

### Measured: the legacy path has no sync at all

There are two TinyMCE initialisers in the back office and only one of them keeps the textarea current:

```
js/admin/tinymce_loader.js       binds triggerSave on change and blur   (2 calls)
                                 referenced outside documentation:      0 times
admin-dev/.../helpers/form/form.tpl:716
                                 tinySetup({editor_selector:'autoload_rte'})  - no setup callback
js/admin/tinymce.inc.js          tinySetup default_config: 'setup' keys: 0
```

So on the legacy `HelperForm` path nothing writes the editor back on change, on blur, or on submit - and the
wizard never submits natively. `triggerSave()` immediately before `serialize()` is the reliable point: blur
and change are heuristics that depend on where the click lands, while this runs on the exact path that reads
the field.

### Scope, measured rather than assumed

Other `serialize()` calls in the legacy back office were checked and are not part of this class:
`js/admin/dashboard.js:56` serialises a date-picker form with no rich text field, `js/admin/dnd.js` serialises
a table order rather than a form, and `admin-dev/themes/default/js/bundle/product/form.js` is referenced
**0** times anywhere in the tree - a dead bundle from the pre-Symfony product page. Both of the wizard's own
`serialize()` sites are fixed, not just the one the reporter hit.

### Honest note on who is affected

`AdminCarrierWizardController` ships **no** textarea and no `autoload_rte` field, which is why the reporter
had to supply an override to demonstrate it. The defect is therefore reachable through an override or a
module that adds a rich text field to the wizard, not on a stock installation. It is still a real hole in a
general mechanism: any field type needing a pre-submit sync is silently dropped by these two calls.

### Verification limit

`node --check` passes, and `js/admin/` is not covered by an eslint configuration in this repository. The
mechanism is read from the code, and the asymmetry between the two initialisers is measured above. I have
**not** driven the wizard in a browser: that needs a back office session, which I do not open.
