### PR TITLE
Give the installer's back office link its trailing slash

### DIFF
--- a/install-dev/theme/views/process.php
+++ b/install-dev/theme/views/process.php
@@ -72,7 +72,7 @@
         </h3>
 
         <div class="fo-bo-container">
-          <div id="boBlock" class="blockInfoEnd clearfix" onclick="window.open('<?php echo '../' . $this->session->adminFolderName; ?>')">
+          <div id="boBlock" class="blockInfoEnd clearfix" onclick="window.open('<?php echo '../' . rtrim($this->session->adminFolderName, '/') . '/'; ?>')">
               <img src="theme/img/visu_boBlock.png" alt="" />
               <div class="bo-infos">
                 <h3><?php echo $this->translator->trans('Back Office', [], 'Install'); ?></h3>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The last installer screen links to the back office as `'../' . $this->session->adminFolderName`. That name is set two ways in `install-dev/controllers/http/configure.php`: a randomized `sprintf('admin%03d%s/', ...)`, which **ends in a slash**, and the literal `'admin-dev'` used when the shop is a git checkout, which does not. A checkout install therefore links to a directory with no trailing slash and depends on the web server redirecting to add one. The front office link in the same view is already `'../'`, and `Install::finalize()` logs the back office URL with a trailing slash as well, so this is the one place that did not agree.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install from a git checkout, so the admin folder stays `admin-dev`, and look at the Back Office block on the final screen. Before this change it opens `../admin-dev`; after it, `../admin-dev/`. A package install, where the folder is randomized, is unchanged - that name already carried the slash.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39316
| Related PRs       |
| Sponsor company   |

### Measured

The emitted href for each of the two branches, before and after:

```
session value "admin-dev"                   before ../admin-dev                    after ../admin-dev/
session value "admin123abcdefghijklmnop/"   before ../admin123abcdefghijklmnop/    after ../admin123abcdefghijklmnop/
```

Only the checkout case changes. The randomized one is byte-identical, which is what `rtrim(..., '/') . '/'`
is for.

The asymmetry is in one function:

```php
if (file_exists(_PS_ROOT_DIR_ . '/admin-dev')) {
    $this->session->adminFolderName = 'admin-dev';            // no slash
} else {
    $this->session->adminFolderName = sprintf('admin%03d%s/', ...);   // slash
}
```

### Why this is the likely cause, and what is not proven

The reporter states **"How you installed PrestaShop: github"**, which is exactly the branch that omits the
slash, and suspects the web server. QA could not reproduce; a package install takes the other branch and
would not show it. That consistency is the strongest evidence available - the reporter has not answered
since 2025-08-06.

What is **not** established: which server configuration turns the missing slash into a 404. Apache's
`mod_dir` issues a `DirectorySlash` redirect, so it is invisible there; PrestaShop ships no nginx
configuration, so a site's own rules decide whether `/admin-dev` reaches the directory or falls through to
the front controller. The fix does not depend on knowing which: a link to a directory should carry its own
slash rather than rely on a redirect, which is the position the randomized branch, the front office link and
`finalize()` already take.

### Not included

`Install::finalize()` builds `$adminUrl = rtrim(getAdminBaseLink(), '/') . '/' . $adminFolder . '/'`, so
when `$adminFolder` is the randomized name it already ends in a slash and the logged URL gets a doubled one.
It is cosmetic, it is in a log line, and it sits inside a method another prepared branch already changes, so
it is deliberately left out of this one.
