### PR TITLE
Name the KPI chart function the same way it is called

### DIFF
--- a/admin-dev/themes/default/template/helpers/kpi/kpi.tpl
+++ b/admin-dev/themes/default/template/helpers/kpi/kpi.tpl
@@ -57,7 +57,7 @@
 
 {if $chart}
 <script>
-	function set_d3_{$id|str_replace:'-':'_'|addslashes}(jsonObject)
+	function set_d3_{$id|replace:'-':'_'|addslashes}(jsonObject)
 	{
 		var data = new Array;
 		$.each(jsonObject, function (index, value) {

--- a/admin-dev/themes/new-theme/template/helpers/kpi/kpi.tpl
+++ b/admin-dev/themes/new-theme/template/helpers/kpi/kpi.tpl
@@ -39,7 +39,7 @@
 
 {if $chart}
   <script>
-    function set_d3_{$id|str_replace:'-':'_'|addslashes}(jsonObject)
+    function set_d3_{$id|replace:'-':'_'|addslashes}(jsonObject)
     {
       var data = new Array;
       $.each(jsonObject, function (index, value) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The function that receives a KPI's chart data is declared with the Smarty modifier `str_replace`, while all three call sites in the same two templates use `replace`. A Smarty modifier passes the variable as the **first** argument, so `str_replace($id, '-', '_')` searches for the id inside the literal `'_'` and returns `'_'` - the declaration is always `set_d3__` whatever the KPI id is, while the calls are `set_d3_<id>`. So no `HelperKpi` chart could ever run, and several KPIs on one page would all declare that same function. `replace` is what the rest of both templates already uses.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In any back office controller return a `HelperKpi` with `chart = true` and `data = json_encode([10,20,30], JSON_NUMERIC_CHECK)`. Before this change the browser console reports `set_d3_<id> is not defined` and the KPI renders without its chart. After it, the chart draws. Both admin themes are affected and both are fixed.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39355
| Related PRs       |
| Sponsor company   |

### Measured

The two lines changed are the declarations; every other `set_d3_` occurrence in the same files already
used `replace`:

```
new-theme/template/helpers/kpi/kpi.tpl   32 call   replace
                                         42 DECL   str_replace   <- changed
                                         69 call   replace
default/template/helpers/kpi/kpi.tpl     50 call   replace
                                         60 DECL   str_replace   <- changed
                                         87 call   replace
```

What each line actually produced, run on PHP 8.1.33 with the argument order Smarty uses for a modifier:

```
id = "box-kpi"    declaration -> set_d3__          calls -> set_d3_box_kpi
id = "kpi"        declaration -> set_d3__          calls -> set_d3_kpi
```

The declaration does not depend on the id at all, so this is not limited to ids containing a dash as the
report supposed - it has never matched for any id. Smarty is `smarty/smarty v4.5.7`, where a PHP function
is still accepted as a modifier, so the template compiles and the breakage is silent.

### Why no test

These are `.tpl` files with no rendering harness in core, and the change is a modifier name. The check that
matters is the argument-order measurement above plus the internal precedent: five sibling lines in the same
two files already spell it `replace`. Adding a Smarty bootstrap to assert two characters would be more
fragile than the thing it guards.

### Two dead PRs on this, both the reporter's

**#39356** and **#39357** (luigimassa, opened 10 minutes after the issue) made the same change but each
carried **hundreds of unrelated files** - workflows, discount pages, SCSS - so neither could be reviewed.
Both were closed 2026-04-07 against `9.0.x`, a branch that no longer exists upstream. The issue is labelled
`Ready`, and Touxten confirmed the cause with the Smarty documentation, so nothing here is in doubt.
