### PR TITLE
Find the admin folder on disk when the installer was handed a renamed one

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -7,6 +7,7 @@
 namespace PrestaShopBundle\Install;
 
 use Contact;
+use DirectoryIterator;
 use Exception;
 use FileLogger as LegacyFileLogger;
 use Language as LanguageLegacy;
@@ -1215,6 +1216,30 @@ class Install extends AbstractInstall
         return true;
     }
 
+    /**
+     * Finds the admin folder by its contents, whatever it has been renamed to.
+     *
+     * `bootstrap.php` next to `init.php` is unique to the admin directory: of every directory in the
+     * shop root only the admin one carries both, and the root itself has no `bootstrap.php`.
+     *
+     * @return string|null the folder name, or null when no directory in the root looks like the admin one
+     */
+    protected static function findAdminFolderName(string $rootDir): ?string
+    {
+        foreach (new DirectoryIterator($rootDir) as $entry) {
+            if (!$entry->isDir() || $entry->isDot()) {
+                continue;
+            }
+
+            $path = $entry->getPathname();
+            if (is_file($path . '/bootstrap.php') && is_file($path . '/init.php')) {
+                return $entry->getFilename();
+            }
+        }
+
+        return null;
+    }
+
     public function finalize(?string $randomizedAdminFolderName = null): bool
     {
         $adminFolder = 'admin-dev';
@@ -1237,6 +1262,17 @@ class Install extends AbstractInstall
                 $this->setError($this->translator->trans('The admin folder could not be renamed into %folderName%', ['%folderName%' => $randomizedAdminFolderName], 'Install'));
 
                 return false;
+            }
+        }
+
+        // An automated environment may rename the admin folder BEFORE the installer runs - the official
+        // Docker image does exactly that with PS_FOLDER_ADMIN. Then /admin/ is gone, so the branch above
+        // is skipped, and the admin-dev default does not exist either. The CLI installer has no folder
+        // name to pass in, so look the folder up on disk rather than failing on the assumption.
+        if (!is_dir(_PS_ROOT_DIR_ . '/' . trim($adminFolder, '/'))) {
+            $existingAdminFolder = static::findAdminFolderName(_PS_ROOT_DIR_);
+            if (null !== $existingAdminFolder) {
+                $adminFolder = $existingAdminFolder;
             }
         }
 

--- a/tests/Unit/PrestaShopBundle/Install/InstallAdminFolderDiscoveryTest.php
+++ b/tests/Unit/PrestaShopBundle/Install/InstallAdminFolderDiscoveryTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Install;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Install\Install;
+use ReflectionMethod;
+
+/**
+ * Install::finalize() used to hand the hardcoded 'admin-dev' to assets:install whenever /admin/ was
+ * absent. An environment that renames the admin folder BEFORE the installer runs - the official Docker
+ * image does this with PS_FOLDER_ADMIN - then failed with "The target directory ... does not exist".
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/39414
+ * @see https://github.com/PrestaShop/PrestaShop/issues/40348
+ */
+class InstallAdminFolderDiscoveryTest extends TestCase
+{
+    /** @var string */
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/ps-admin-discovery-' . bin2hex(random_bytes(6));
+        mkdir($this->root);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->root)) {
+            exec('rm -rf ' . escapeshellarg($this->root));
+        }
+    }
+
+    private function findAdminFolderName(): ?string
+    {
+        $method = new ReflectionMethod(Install::class, 'findAdminFolderName');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $this->root);
+    }
+
+    private function makeDir(string $name, array $files): void
+    {
+        mkdir($this->root . '/' . $name);
+        foreach ($files as $file) {
+            file_put_contents($this->root . '/' . $name . '/' . $file, '<?php');
+        }
+    }
+
+    public function testItFindsAnAdminFolderThatWasRenamedBeforeTheInstallerRan(): void
+    {
+        $this->makeDir('admin1234', ['bootstrap.php', 'init.php', 'index.php']);
+
+        $this->assertSame('admin1234', $this->findAdminFolderName());
+    }
+
+    public function testItFindsTheDefaultAdminDevFolder(): void
+    {
+        $this->makeDir('admin-dev', ['bootstrap.php', 'init.php']);
+
+        $this->assertSame('admin-dev', $this->findAdminFolderName());
+    }
+
+    /**
+     * The marker has to be both files. The shop root itself ships init.php, and so do other directories,
+     * so init.php alone would match the wrong place.
+     */
+    public function testItIgnoresDirectoriesCarryingOnlyOneOfTheTwoMarkers(): void
+    {
+        $this->makeDir('classes', ['init.php']);
+        $this->makeDir('app', ['bootstrap.php']);
+        $this->makeDir('install-dev', ['index.php', 'init.php']);
+
+        $this->assertNull($this->findAdminFolderName());
+    }
+
+    /**
+     * Nothing found must stay null rather than guessing, so finalize() keeps its existing value and the
+     * original error still surfaces instead of a silently wrong folder.
+     */
+    public function testItReturnsNullWhenNoDirectoryLooksLikeTheAdminOne(): void
+    {
+        $this->makeDir('img', []);
+        $this->makeDir('var', []);
+
+        $this->assertNull($this->findAdminFolderName());
+    }
+
+    public function testItIgnoresFilesThatShareTheName(): void
+    {
+        file_put_contents($this->root . '/admin-dev', 'not a directory');
+
+        $this->assertNull($this->findAdminFolderName());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Install::finalize()` could only ever use two folder names: the hardcoded `'admin-dev'`, or a fresh random name generated inside the `if (file_exists(_PS_ROOT_DIR_ . '/admin/'))` branch. An environment that renames the admin folder **before** the installer runs leaves neither on disk - `/admin/` is gone so the branch is skipped, and `admin-dev` does not exist either - so `assets:install` is handed a directory that is not there and the install dies with `The target directory "/var/www/html/admin-dev" does not exist`. The official Docker image does exactly this with `PS_FOLDER_ADMIN`. The CLI installer cannot pass a name (`install-dev/controllers/console/process.php` calls `finalize()` with no argument), so the folder is now looked up by its contents, and the previous value is kept when nothing matches so the existing error still surfaces instead of a silently wrong folder.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `docker run` the official image with `PS_FOLDER_ADMIN=admin1234` and auto-install enabled. Before this change the install aborts at `assets:install admin-dev`. After it, the assets are installed into `admin1234` and the shop finishes installing. An install where the folder is still named `admin`, and a git checkout where it is `admin-dev`, both behave exactly as before - neither reaches the new lookup.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39414, Fixes #40348
| Related PRs       |
| Sponsor company   |

### The mechanism

```php
public function finalize(?string $randomizedAdminFolderName = null): bool
{
    $adminFolder = 'admin-dev';                         // (1) the only default

    if (file_exists(_PS_ROOT_DIR_ . '/admin/')) {       // (2) skipped when already renamed
        ... $adminFolder = $randomizedAdminFolderName;
    }

    ...->installAssets($adminFolder);                   // (3) fatal when (1) does not exist
}
```

Three entry paths, and only the third breaks:

```
admin folder named  admin       -> branch (2) renames it, works
admin folder named  admin-dev   -> branch (2) skipped, the default is real, works
renamed before the installer    -> branch (2) skipped, the default is absent, FATAL
```

The HTTP installer never hits it because it passes `$session->adminFolderName` into `finalize()`.
This also explains every workaround reported on the two issues: setting `PS_FOLDER_ADMIN=admin-dev`
works because it makes the hardcoded name true, and "keep the folder named `admin` during install"
works because it takes branch (2).

### Why `bootstrap.php` + `init.php` identifies the folder

Measured over the shop root on `9.2.x` - of every directory there, exactly one carries both, and the
root itself has no `bootstrap.php`, so it cannot be confused either:

```
root subdirectories checked   29
carrying bootstrap.php AND init.php    admin-dev   (1 match)
```

One marker would not do. `init.php` alone also matches the root and `install-dev`; the mutation check
below shows what that costs.

### Verification

`tests/Unit/PrestaShopBundle/Install/InstallAdminFolderDiscoveryTest.php`, 5 tests, all green on
PHP 8.1.33. Cases: a folder renamed before the installer ran, the plain `admin-dev` default, a root
where several directories carry only one of the two markers, a root where nothing matches (must return
null, not a guess), and a plain **file** named `admin-dev` (must not match).

**Mutation check** - relaxing the rule from `&&` to `||` in the production file:

```
1) testItIgnoresDirectoriesCarryingOnlyOneOfTheTwoMarkers
   Failed asserting that 'install-dev' is null.
```

so the test does hold the behaviour, and the weaker rule would have pointed the installer at
`install-dev`. The revert was confirmed byte-identical before committing, and the suite re-run green.

`php -l` clean, `php-cs-fixer --dry-run` reports nothing fixable on either file.

### Scope

`finalize()` only. The Docker image's own choice to rename before installing is left alone: the shipped
installer should cope with the folder it is given, and changing the image would not help the shops that
already run it, nor the non-Docker reports on #40348 (`franckysolo`, `bvrignaud`).
