### PR TITLE
Remove the obsolete PS_DISABLE_NON_NATIVE_MODULE handling from Hook::exec()

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -47,6 +47,11 @@ class HookCore extends ObjectModel
      */
     public static $executed_hooks = [];
 
+    /**
+     * @deprecated since 8.0.0 - the PS_DISABLE_NON_NATIVE_MODULE setting this served was replaced by the
+     *             bulk "disable non-native modules" action in Advanced Parameters > Performance, and its
+     *             back-office switch was removed in the same change. Nothing populates this any more.
+     */
     public static $native_module;
 
     protected static $disabledHookModules = [];
@@ -918,14 +923,6 @@ class HookCore extends ObjectModel
             $array_return = false;
         }
 
-        // Check if we should execute non native modules
-        static $disable_non_native_modules = null;
-        if ($disable_non_native_modules === null) {
-            $disable_non_native_modules = (bool) Configuration::get(
-                'PS_DISABLE_NON_NATIVE_MODULE'
-            );
-        }
-
         // Check arguments validity
         if (
             ($id_module && !is_numeric($id_module))
@@ -961,12 +958,6 @@ class HookCore extends ObjectModel
         $altern = 0;
         $output = $array_return ? [] : '';
 
-        // If non native modules are disabled, we must get the list of native ones
-        // that came bundled with the store.
-        if ($disable_non_native_modules && !isset(Hook::$native_module)) {
-            Hook::$native_module = Module::getNativeModuleList();
-        }
-
         $different_shop = false;
         if (
             $id_shop !== null
@@ -987,16 +978,6 @@ class HookCore extends ObjectModel
             // If the caller provided a specific module ID for which ONLY this hook
             // should be executed, we check if it matches.
             if ($id_module && $id_module != $hookRegistration['id_module']) {
-                continue;
-            }
-
-            // If non native modules are disabled and this module is not a native one.
-            if (
-                (bool) $disable_non_native_modules
-                && Hook::$native_module
-                && count(Hook::$native_module)
-                && !in_array($hookRegistration['module'], Hook::$native_module)
-            ) {
                 continue;
             }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PS_DISABLE_NON_NATIVE_MODULE` lost its back office switch in **8.0.0**: commit `47d2daba6e1` replaced it with the bulk "disable non-native modules" action in Advanced Parameters > Performance, dropping the field from `DebugModeConfiguration` and `DebugModeType`. The enforcement in `Hook::exec()` was left behind. A shop upgraded from 1.7.x carries the value forward, and every non-native module's hooks are then skipped with nothing in the interface able to clear it - the merchant has to edit `ps_configuration` by hand. The sibling `PS_DISABLE_OVERRIDES` kept its switch, which is what makes this a leftover rather than a deprecation. The three blocks are removed and `Hook::$native_module`, which nothing else populates or reads, is marked deprecated.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with a module that did not ship in `composer.lock`, set `PS_DISABLE_NON_NATIVE_MODULE` to 1 in `ps_configuration`. Before this change that module's hooks stop rendering and no back office page can turn it back on. After it, the value has no effect and the bulk action in Advanced Parameters > Performance remains the supported way to disable non-native modules.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39616
| Related PRs       |
| Sponsor company   |

### Measured

**When the control disappeared** - occurrences of the key per release tag, `*.php`/`*.tpl`/`*.twig`, vendor excluded:

```
1.7.8.11   2 files   classes/Hook.php  +  src/Adapter/Debug/DebugModeConfiguration.php
8.0.0      1 file    classes/Hook.php
8.1.0      1 file    classes/Hook.php
8.2.0      1 file    classes/Hook.php
9.2.x      1 file    classes/Hook.php
```

On 1.7.8.11 `DebugModeConfiguration` both read it (`getConfiguration()`) and wrote it (`updateConfiguration()`),
and `DebugModeType` rendered it as a `SwitchType`. Commit `47d2daba6e1` removed all three and added
`BulkToggleModuleStatusCommand` / `BulkToggleModuleStatusHandler` plus the button in `performance.html.twig`.
That commit's subject says "Add a button...", so a `-S` search reads as an addition; the diff for these two
files is entirely deletions.

**That the enforcement is still live on 9.2.x**, not dead code: `classes/Hook.php` reads the key at line 924
and uses it at 966 and 995.

**What "non-native" means**: `ModuleRepository::getNativeModules()` derives the list from `composer.lock`
packages of type `prestashop-module`, plus `autoupgrade`. On a stock 9.2 install that is 68 names, so every
module a merchant installed from Addons or by hand is suppressed:

```
paypal      native=0        ps_facetedsearch  native=1
klaviyo     native=0        autoupgrade       native=1 (via ADDITIONAL_ALLOWED_MODULES)
mailchimp   native=0
```

**After the change** `PS_DISABLE_NON_NATIVE_MODULE` has **zero readers** in core, and `Hook::$native_module`
is referenced nowhere outside its own declaration. `Module::getNativeModuleList()` is kept - it is public API.

### This is a recreation of an approved PR that its author withdrew

**#39936** (ChillCode) made the same removal, was **APPROVED by Hlavtox**, and carried a UI-tests run. It was
closed by its own author on 2025-12-26, deleting the head branch, with **zero review objections**. Its base was
`9.0.x`, which no longer exists upstream - `git ls-remote --heads upstream` returns only `9.2.x` and `develop`.
So the fix did not die on merit. This targets `9.2.x` and adds the version boundary and the mechanism that the
original did not state.

### Answering the maintainer's question on the issue

Quetzacoalt91 asked whether the value was removed from the back office pages in v9. It was not - it went in
**8.0.0**, and 8.2.x has no switch either, so this is not a v9 regression. It is a 1.7.x value that survives an
upgrade into a version with no way to clear it.

### Verification limit

What is measured is the code path across five release tags, the composer-derived native list, and the review
state of the withdrawn PR. I have **not** watched a hook stop firing in a browser: every one of the 67 modules
installed on the local 9.2 shop is composer-shipped, so the suppression branch cannot fire there without
installing a non-composer module first.
