### PR TITLE
Answer 404 on a missing back office page

### DIFF
--- a/controllers/admin/AdminNotFoundController.php
+++ b/controllers/admin/AdminNotFoundController.php
@@ -28,6 +28,10 @@ class AdminNotFoundControllerCore extends AdminController
      */
     public function initContent()
     {
+        // WHY: without this the page is served with 200, so a client or a crawler cannot tell a missing
+        // back office page from a real one. The front office does the same in PageNotFoundController.
+        http_response_code(404);
+
         $this->errors[] = $this->trans('Page not found', [], 'Admin.Notifications.Error');
         $tpl_vars['controller'] = Tools::getValue('controllerUri', Tools::getValue('controller'));
         $this->context->smarty->assign($tpl_vars);

--- a/tests/Integration/Classes/controller/AdminControllerTest.php
+++ b/tests/Integration/Classes/controller/AdminControllerTest.php
@@ -6,6 +6,7 @@
 
 namespace Tests\Integration\Classes\controller;
 
+use AdminNotFoundController;
 use Context;
 use Controller;
 use Cookie;
@@ -121,6 +122,33 @@ class AdminControllerTest extends TestCase
         }
 
         $this->assertNull($testedController->run());
+    }
+
+    /**
+     * A missing back office page has to answer 404, otherwise nothing downstream - a browser, a crawler,
+     * an uptime check - can tell it apart from a page that exists.
+     */
+    public function testAdminNotFoundControllerAnswersWithA404Status(): void
+    {
+        $testedController = new AdminNotFoundController();
+        $refController = new ReflectionObject($testedController);
+        $refProperty = $refController->getProperty('container');
+        $refProperty->setAccessible(true);
+        $refProperty->setValue($testedController, $this->getMockContainerBuilder());
+
+        if (!defined('_PS_BASE_URL_')) {
+            define('_PS_BASE_URL_', '');
+            define('__PS_BASE_URI__', '');
+            define('_PS_BASE_URL_SSL_', '');
+        }
+
+        if (!defined('PS_INSTALLATION_IN_PROGRESS')) {
+            define('PS_INSTALLATION_IN_PROGRESS', true);
+        }
+
+        $testedController->run();
+
+        $this->assertSame(404, http_response_code());
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `AdminNotFoundController::initContent()` renders its "Page not found" screen with the default 200 status, so a browser, a crawler or an uptime check cannot tell a missing back office page from a real one. The front office already sets the status in `PageNotFoundController`. This revives the one line approved on #39851, which was closed unmerged when the `9.0.x` branch it targeted was retired - the original change is Matt75's - and adds the regression test it did not have.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a non-existent back office URL, e.g. `/admin-dev/index.php?controller=UnknownController`, and read the status in the network tab. Before this change it is 200, after it 404, with the same page rendered. Automated coverage: `tests/Integration/Classes/controller/AdminControllerTest::testAdminNotFoundControllerAnswersWithA404Status`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39850
| Related PRs       | Revives the approved and closed #39851
| Sponsor company   |

### Measured

`controllers/admin/AdminNotFoundController.php` on `upstream/9.2.x` sets no status anywhere - the whole class is a constructor, two access overrides and an `initContent()` that assigns template variables. So the response carries whatever PHP defaults to.

The new test runs the controller and reads the status back. Without the fix:

```
FAIL Admin not found controller answers with a 404 status
  Failed asserting that false is identical to 404.
```

`false` is what `http_response_code()` returns when nothing has set a code. With the fix the class is green: **29 tests, 43 assertions**.

`http_response_code()` behaves under the CLI SAPI, which is what makes the assertion possible - checked directly: `false` initially, `true` on set, `404` on read back.

### Provenance

#39851 was **approved** by a maintainer and then closed on 2026-04-07, not on its merits: it targeted `9.0.x`, and the retirement notice asked contributors to rebase onto `9.1.x` before the branch was deleted. The one line is reproduced here unchanged, on `9.2.x`, with the test added. If Matt75 would rather reopen and rebase it themselves, that is obviously preferable - the point of this branch is that the fix should not be lost to a branch retirement.

### Note on the test's placement

It lives in the existing `AdminControllerTest`, which shares context state across its cases; run on its own with `--filter` it errors on a missing currency in the mocked context, exactly as the class's other cases would. It passes when the file is run as a whole, which is how the suite executes it.
