### PR TITLE
Make a failed installer step report what actually went wrong

### DIFF
--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -25,6 +25,11 @@ class InstallControllerHttp
     protected static $instances = [];
 
     /**
+     * @var bool whether an AJAX step has already written its JSON answer
+     */
+    private static $answerSent = false;
+
+    /**
      * @var string Current step
      */
     public $step;
@@ -371,11 +376,64 @@ class InstallControllerHttp
             );
         }
 
+        self::$answerSent = true;
+
         die(json_encode([
             'success' => (bool) $success,
             'message' => $message,
             'warning' => $warning,
         ]));
+    }
+
+    /**
+     * A step that dies fatally - the container build running out of memory is the usual one - never
+     * reaches ajaxJsonAnswer(), so the browser receives an empty body with status 200 and reports
+     * "HTTP 200 - parsererror -", which says nothing about what happened. Emit the answer the step
+     * would have emitted, so the reason reaches the screen.
+     */
+    public static function registerFatalErrorHandler(): void
+    {
+        register_shutdown_function(static function (): void {
+            $answer = self::buildFatalErrorAnswer();
+
+            if (null === $answer) {
+                return;
+            }
+
+            if (!headers_sent()) {
+                header('Content-Type: application/json');
+            }
+
+            echo $answer;
+        });
+    }
+
+    /**
+     * @return string|null the JSON body to emit, or null when there is nothing to report
+     */
+    public static function buildFatalErrorAnswer(?array $error = null): ?string
+    {
+        if (self::$answerSent || !self::isXmlHttpRequest()) {
+            return null;
+        }
+
+        $message = self::getLastFatalError($error);
+
+        if ('' === $message) {
+            return null;
+        }
+
+        return json_encode([
+            'success' => false,
+            'message' => $message,
+            'warning' => '',
+        ]);
+    }
+
+    private static function isXmlHttpRequest(): bool
+    {
+        return !empty($_SERVER['HTTP_X_REQUESTED_WITH'])
+            && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
     }
 
     /**

--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -361,7 +361,14 @@ class InstallControllerHttp
     public function ajaxJsonAnswer(bool $success, $message = '', $warning = ''): void
     {
         if (!$success && empty($message)) {
-            $message = print_r(@error_get_last(), true);
+            $message = self::getLastFatalError();
+        }
+        if (!$success && empty($message)) {
+            $message = $this->translator->trans(
+                'The installation step failed without reporting a reason. Check your server error log for details.',
+                [],
+                'Install'
+            );
         }
 
         die(json_encode([
@@ -369,6 +376,27 @@ class InstallControllerHttp
             'message' => $message,
             'warning' => $warning,
         ]));
+    }
+
+    /**
+     * The last PHP error, but only when it is one that can actually have aborted a step.
+     *
+     * error_get_last() also returns notices, warnings and deprecations, and the container build
+     * that every install triggers emits plenty of those, so using it unfiltered reports whichever
+     * deprecation happened to come last instead of the failure.
+     *
+     * @param array|null $error defaults to the last error raised
+     */
+    public static function getLastFatalError(?array $error = null): string
+    {
+        $error ??= @error_get_last();
+        $fatalTypes = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR];
+
+        if (null === $error || !isset($error['type']) || !in_array($error['type'], $fatalTypes, true)) {
+            return '';
+        }
+
+        return print_r($error, true);
     }
 
     /**

--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -394,6 +394,10 @@ class InstallControllerHttp
     public static function registerFatalErrorHandler(): void
     {
         register_shutdown_function(static function (): void {
+            // The fatal being reported is often the memory limit itself, and the handler has to be able
+            // to allocate to report it. Raising the limit here costs nothing: the request is over.
+            @ini_set('memory_limit', '-1');
+
             $answer = self::buildFatalErrorAnswer();
 
             if (null === $answer) {

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -140,8 +140,8 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
             $this->session->database_engine
         );
 
-        if (!$success) {
-            $this->ajaxJsonAnswer(false);
+        if (!$success || $this->model_install->getErrors()) {
+            $this->ajaxJsonAnswer(false, $this->model_install->getErrors());
         }
         $this->session->process_validated = array_merge($this->session->process_validated, ['generateSettingsFile' => true]);
         $this->ajaxJsonAnswer(true);

--- a/install-dev/index.php
+++ b/install-dev/index.php
@@ -33,6 +33,7 @@ try {
 
     require_once _PS_INSTALL_PATH_.'classes'.DIRECTORY_SEPARATOR.'controllerHttp.php';
     require_once _PS_INSTALL_PATH_.'classes'.DIRECTORY_SEPARATOR.'HttpConfigureInterface.php';
+    InstallControllerHttp::registerFatalErrorHandler();
     InstallControllerHttp::execute();
 } catch (PrestashopInstallerException $e) {
     $e->displayMessage();

--- a/tests/Unit/Install/InstallControllerHttpTest.php
+++ b/tests/Unit/Install/InstallControllerHttpTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Install;
+
+use InstallControllerHttp;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The installer reports the last PHP error when a step fails without a message of its own.
+ * Building the Symfony container, which every install does, raises deprecations, so that fallback
+ * must not mistake one of them for the cause of the failure.
+ */
+class InstallControllerHttpTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/../../../install-dev/classes/controllerHttp.php';
+    }
+
+    /**
+     * This is the reported case: PrestaShop's own service definitions reference the deprecated
+     * "prestashop.adapter.cache.clearer.symfony_cache_clearer" alias, so a real install has an
+     * E_USER_DEPRECATED sitting in error_get_last() by the time any step can fail.
+     */
+    public function testADeprecationIsNotReportedAsTheCauseOfAFailure(): void
+    {
+        $last = $this->raiseThroughPhpsOwnErrorHandler(
+            'Since PrestaShop\PrestaShop 9: The "prestashop.adapter.cache.clearer.symfony_cache_clearer" service alias is deprecated.',
+            E_USER_DEPRECATED
+        );
+
+        $this->assertSame(E_USER_DEPRECATED, $last['type'], 'the deprecation must really be the last error, or this test proves nothing');
+
+        $this->assertSame('', InstallControllerHttp::getLastFatalError());
+    }
+
+    public function testAWarningIsNotReportedAsTheCauseOfAFailure(): void
+    {
+        $last = $this->raiseThroughPhpsOwnErrorHandler('some warning', E_USER_WARNING);
+
+        $this->assertSame(E_USER_WARNING, $last['type'], 'the warning must really be the last error, or this test proves nothing');
+
+        $this->assertSame('', InstallControllerHttp::getLastFatalError());
+    }
+
+    /**
+     * PHPUnit installs its own error handler, and a userland handler that swallows an error leaves
+     * error_get_last() untouched, so raising one here would test nothing. Dropping to PHP's own
+     * handler for the call is what makes this the same code path a real install takes.
+     *
+     * @return array the recorded last error
+     */
+    private function raiseThroughPhpsOwnErrorHandler(string $message, int $type): array
+    {
+        set_error_handler(null);
+
+        try {
+            @trigger_error($message, $type);
+
+            return error_get_last();
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * @dataProvider provideNonFatalErrorTypes
+     */
+    public function testNonFatalErrorTypesAreDiscarded(int $type): void
+    {
+        $this->assertSame('', InstallControllerHttp::getLastFatalError(['type' => $type, 'message' => 'x', 'file' => 'f', 'line' => 1]));
+    }
+
+    public static function provideNonFatalErrorTypes(): iterable
+    {
+        yield 'deprecated' => [E_DEPRECATED];
+        yield 'user deprecated' => [E_USER_DEPRECATED];
+        yield 'notice' => [E_NOTICE];
+        yield 'user notice' => [E_USER_NOTICE];
+        yield 'warning' => [E_WARNING];
+        yield 'user warning' => [E_USER_WARNING];
+    }
+
+    /**
+     * @dataProvider provideFatalErrorTypes
+     */
+    public function testFatalErrorTypesAreReported(int $type): void
+    {
+        $message = InstallControllerHttp::getLastFatalError([
+            'type' => $type,
+            'message' => 'Allowed memory size exhausted',
+            'file' => '/var/www/html/install-dev/index.php',
+            'line' => 42,
+        ]);
+
+        $this->assertStringContainsString('Allowed memory size exhausted', $message);
+        $this->assertStringContainsString('/var/www/html/install-dev/index.php', $message);
+    }
+
+    public static function provideFatalErrorTypes(): iterable
+    {
+        yield 'error' => [E_ERROR];
+        yield 'parse' => [E_PARSE];
+        yield 'core error' => [E_CORE_ERROR];
+        yield 'compile error' => [E_COMPILE_ERROR];
+        yield 'user error' => [E_USER_ERROR];
+        yield 'recoverable error' => [E_RECOVERABLE_ERROR];
+    }
+
+    public function testNoErrorAtAllYieldsNoMessage(): void
+    {
+        $this->assertSame('', InstallControllerHttp::getLastFatalError([]));
+    }
+}

--- a/tests/Unit/Install/InstallControllerHttpTest.php
+++ b/tests/Unit/Install/InstallControllerHttpTest.php
@@ -117,4 +117,61 @@ class InstallControllerHttpTest extends TestCase
     {
         $this->assertSame('', InstallControllerHttp::getLastFatalError([]));
     }
+
+    /**
+     * A step that dies fatally never reaches ajaxJsonAnswer(), so the browser gets an empty body with
+     * status 200 and shows "HTTP 200 - parsererror -", which names nothing. The shutdown handler emits
+     * the answer the step could not.
+     */
+    public function testAFatalDuringAnAjaxStepStillProducesAJsonAnswer(): void
+    {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+        $answer = InstallControllerHttp::buildFatalErrorAnswer([
+            'type' => E_ERROR,
+            'message' => 'Allowed memory size of 134217728 bytes exhausted',
+            'file' => '/var/www/html/install-dev/index.php',
+            'line' => 1,
+        ]);
+
+        $this->assertNotNull($answer);
+        $decoded = json_decode((string) $answer, true);
+        $this->assertIsArray($decoded, 'the browser parses this with dataType json, so it must decode');
+        $this->assertFalse($decoded['success']);
+        $this->assertStringContainsString('Allowed memory size', $decoded['message']);
+    }
+
+    public function testADeprecationDuringAnAjaxStepProducesNoAnswer(): void
+    {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+        $this->assertNull(InstallControllerHttp::buildFatalErrorAnswer([
+            'type' => E_USER_DEPRECATED,
+            'message' => 'some deprecation',
+            'file' => 'f',
+            'line' => 1,
+        ]));
+    }
+
+    /**
+     * A normal page load renders HTML. Appending a JSON envelope to it would corrupt the page instead
+     * of reporting anything.
+     */
+    public function testAFatalOutsideAnAjaxStepProducesNoAnswer(): void
+    {
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+
+        $this->assertNull(InstallControllerHttp::buildFatalErrorAnswer([
+            'type' => E_ERROR,
+            'message' => 'Allowed memory size of 134217728 bytes exhausted',
+            'file' => 'f',
+            'line' => 1,
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+        parent::tearDown();
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A failed browser install shows a PHP deprecation instead of the reason the step failed, which makes the failure undiagnosable. The screenshot on #40379 is `[type] => 16384` (`E_USER_DEPRECATED`) about the `prestashop.adapter.cache.clearer.symfony_cache_clearer` alias, which has nothing to do with installing. Two causes, both here. First, `processGenerateSettingsFile()` answers `ajaxJsonAnswer(false)` without its error list, alone among the ten failure paths in that controller - the other nine all pass `$this->model_install->getErrors()`. The message the user sees therefore comes from the `print_r(@error_get_last(), true)` fallback in `ajaxJsonAnswer()`. Second, that fallback accepts any error type. Every install builds the Symfony container, and the container build raises `E_USER_DEPRECATED` because PrestaShop's own service definitions reference that deprecated alias (four references: `cache_clearer_chain`, `currency_form_data_handler`, `module.repository.eventsubscriber`, `adapter.caching.configuration`), so `error_get_last()` is primed with a deprecation before any step can fail. The real message for this step, `%file% file is not writable (check permissions)`, was being discarded - which is why the CLI install works and the browser one does not on the same tree: the console controller reports the model's errors.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Two failures, two symptoms. **(a)** Make `app/config/parameters.php` (or `app/config/`) unwritable by the web server user, which is the usual Docker case where the CLI runs as root and PHP-FPM as www-data, then run the browser installer. Before this change the "Create file parameters" step fails showing an unrelated deprecation about `prestashop.adapter.cache.clearer.symfony_cache_clearer`; after it, the step shows `app/config/parameters.php file is not writable (check permissions)`. **(b)** For #38962, lower `memory_limit` far enough that the container build cannot complete and run the browser installer with `display_errors` off. Before this change the step returns status 200 with an empty body and the screen shows `1: HTTP 200 - parsererror -` with nothing after the last dash; after it the screen shows the fatal. Automated coverage: `tests/Unit/Install/InstallControllerHttpTest.php`, 18 tests.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #40379, Fixes #38962
| Related PRs       | #42625 - the other half of the installer diagnostics, on the same files
| Sponsor company   |

## The second symptom, #38962

`1: HTTP 200 - parsererror -` is jQuery's `error` callback printing `'HTTP ' + status + ' - ' + textStatus + ' - ' + responseText`, and in every report of #38962 the text ends at that last dash: **the response body is empty**. That is a step dying fatally, most often the container build exhausting memory on a small host. `ajaxJsonAnswer()` is never reached, PHP ends the request with status 200 and no output, and `dataType: 'json'` turns that into `parsererror`. Nothing on the screen names the step's problem or the fatal.

A shutdown handler now emits the answer the step could not, for XHR requests only and only for error types that can abort a step. Measured with a genuine out-of-memory fatal and `display_errors` off:

```
before   response body: 0 bytes
after    {"success":false,"message":"Array\n(\n    [type] => 1\n    [message] => Allowed memory size of
         33554432 bytes exhausted (tried to allocate 1052672 bytes)\n ...","warning":""}
```

Three allocation patterns were tried, because the handler has to be able to allocate in order to report an out-of-memory fatal: 1MB chunks, 1KB chunks and 8-byte strings. The tightest of them died with roughly 20KB free and the answer still came out, but the handler raises `memory_limit` first anyway - a build that dies with less would fail to report the very error the handler exists for, which is the empty body again.

**What this does not cover.** A step that emits output *before* `die(json_encode(...))` - a PHP warning printed on a host with `display_errors` on - also produces `parsererror`, but with a **non-empty** `responseText`. That is a different failure and this change does not address it; every report on #38962 shows the empty form.

The two halves are one method's failure path, which is why they are one PR: without the first, a step that fails cleanly reports the wrong thing; without the second, a step that dies reports nothing at all.

Coverage boundary, stated so it is not mistaken for a gap: the fatal error types are asserted by passing the error array in, while the live `error_get_last()` read is exercised only for the non-fatal types, which are the ones this change is about. Priming a real fatal in-process is not possible - `trigger_error()` only raises `E_USER_*`, and `E_USER_ERROR` terminates - and a subprocess harness is not worth it for a fallback branch.

The four service definitions that still reference the deprecated alias, and the two `->get()` calls on it in `classes/Tools.php` and `classes/module/Module.php`, are left alone here. Removing them would silence this particular deprecation, but not the problem: the container build records 358 deprecations in total, so the fallback would simply report a different one. The fix has to be that a deprecation is never mistaken for a failure.

