### PR TITLE
Name a delivery option after every carrier it covers

### DIFF
--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -61,6 +61,8 @@ class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
 
         if (isset($delivery_option_list[$this->context->cart->id_address_delivery])) {
             foreach ($delivery_option_list[$this->context->cart->id_address_delivery] as $id_carriers_list => $carriers_list) {
+                $option_carrier_names = [];
+                $option_carrier_delays = [];
                 foreach ($carriers_list as $carriers) {
                     if (is_array($carriers)) {
                         foreach ($carriers as $carrier) {
@@ -111,9 +113,22 @@ class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
                                 }
                             }
 
+                            $option_carrier_names[] = $carrier['name'];
+                            $option_carrier_delays[] = $carrier['delay'];
+
                             $carriers_available[$id_carriers_list] = $carrier;
                         }
                     }
+                }
+
+                // A delivery option covers one package per carrier and is priced for all of them, while
+                // the entry kept above is only the last carrier of the loop. Name it after every carrier
+                // it covers, so the name agrees with the price shown next to it. A single logo cannot
+                // stand for several carriers, so it is dropped rather than picked arbitrarily.
+                if (count($option_carrier_names) > 1 && isset($carriers_available[$id_carriers_list])) {
+                    $carriers_available[$id_carriers_list]['name'] = implode(', ', array_unique($option_carrier_names));
+                    $carriers_available[$id_carriers_list]['delay'] = implode(', ', array_unique($option_carrier_delays));
+                    $carriers_available[$id_carriers_list]['logo'] = false;
                 }
             }
         }

--- a/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
@@ -6,15 +6,68 @@
 
 namespace Tests\Integration\Behaviour\Features\Context;
 
+use Behat\Gherkin\Node\TableNode;
 use Cart;
 use Context;
+use DeliveryOptionsFinder;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use RuntimeException;
 
 class CartFeatureContext extends AbstractPrestaShopFeatureContext
 {
     use CartAwareTrait;
+
+    /**
+     * The checkout presents one entry per delivery option, and an option can span several packages when
+     * the cart holds products restricted to different carriers. Its price then covers every package, so
+     * the name shown beside that price has to cover them too.
+     *
+     * @Then the delivery options for cart :cartReference should be named:
+     *
+     * @param string $cartReference
+     * @param TableNode $table
+     */
+    public function checkDeliveryOptionNames(string $cartReference, TableNode $table): void
+    {
+        $cart = new Cart((int) SharedStorage::getStorage()->get($cartReference));
+        $context = Context::getContext();
+        $previousCart = $context->cart;
+        $context->cart = $cart;
+
+        try {
+            $finder = new DeliveryOptionsFinder(
+                $context,
+                CommonFeatureContext::getContainer()->get('translator'),
+                new ObjectPresenter(),
+                new PriceFormatter()
+            );
+            $options = $finder->getDeliveryOptions();
+        } finally {
+            $context->cart = $previousCart;
+        }
+
+        $expected = array_column($table->getColumnsHash(), 'name');
+        $actual = array_values(array_map(static function (array $option): string {
+            return (string) $option['name'];
+        }, $options));
+
+        sort($expected);
+        sort($actual);
+
+        Assert::assertSame(
+            $expected,
+            $actual,
+            sprintf(
+                'Delivery option names for cart %s: expected [%s], got [%s]',
+                $cartReference,
+                implode(' | ', $expected),
+                implode(' | ', $actual)
+            )
+        );
+    }
 
     /**
      * @Then there is no delivery options available for my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/delivery_option_naming.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/delivery_option_naming.feature
@@ -1,0 +1,74 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shipment --tags delivery-option-naming
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@delivery-option-naming
+Feature: Naming of a delivery option that covers several carriers
+  As a customer
+  I want the carrier named beside a shipping price to be the carrier that price pays for
+  So that I can tell what I am choosing when my cart ships in several packages
+
+  Background:
+    Given the current currency is "USD"
+    And country "US" is enabled
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And there is a zone "north_america" named "North America"
+    And I identify tax rules group named "US-FL Rate (6%)" as "us-fl-tax-rate"
+    When I create carrier "beer_carrier" with specified properties:
+      | name           | Beer carrier  |
+      | active         | true          |
+      | shippingMethod | price         |
+      | zones          | north_america |
+      | shippingHandling | false       |
+    Then I set ranges for carrier "beer_carrier" with specified properties for all shops:
+      | id_zone       | range_from | range_to | range_price |
+      | north_america | 0          | 1000     | 5           |
+    When I set tax rule "us-fl-tax-rate" for carrier "beer_carrier"
+    When I create carrier "saucisson_carrier" with specified properties:
+      | name           | Saucisson carrier |
+      | active         | true              |
+      | shippingMethod | price             |
+      | zones          | north_america     |
+      | shippingHandling | false           |
+    Then I set ranges for carrier "saucisson_carrier" with specified properties for all shops:
+      | id_zone       | range_from | range_to | range_price |
+      | north_america | 0          | 1000     | 10          |
+    When I set tax rule "us-fl-tax-rate" for carrier "saucisson_carrier"
+    When I add product "bottle_of_beer" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    When I update product "bottle_of_beer" stock with following information:
+      | delta_quantity | 51  |
+      | location       | dtc |
+    And I assign product bottle_of_beer with following carriers:
+      | beer_carrier |
+    And I enable product "bottle_of_beer"
+    When I add product "saucisson" with following information:
+      | name[en-US] | saucisson |
+      | type        | standard  |
+    When I update product "saucisson" stock with following information:
+      | delta_quantity | 42  |
+      | location       | dtc |
+    And I assign product saucisson with following carriers:
+      | saucisson_carrier |
+    And I enable product "saucisson"
+
+  Scenario: An option covering two carriers is named after both
+    Given I create an empty cart "naming_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "naming_cart"
+    And I add 1 products "bottle of beer" to the cart "naming_cart"
+    And I add 1 products "saucisson" to the cart "naming_cart"
+    # The two products ship with different carriers, so this option covers two packages and is priced for
+    # both. Before the fix only the last carrier of the loop survived, so the checkout showed one carrier's
+    # name against the price of two.
+    Then the delivery options for cart "naming_cart" should be named:
+      | name                            |
+      | Beer carrier, Saucisson carrier |
+
+  Scenario: An option covering a single carrier keeps that carrier's name
+    Given I create an empty cart "single_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "single_cart"
+    And I add 1 products "bottle of beer" to the cart "single_cart"
+    Then the delivery options for cart "single_cart" should be named:
+      | name         |
+      | Beer carrier |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When a cart holds products restricted to different carriers it ships in several packages, and one delivery option then covers a carrier per package and is priced for all of them. The checkout showed only the last of those carriers, so a customer read one carrier's name against the price of several. The option is now named after every carrier it covers.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Refs #9998
| Related PRs       | None
| Sponsor company   |

### Why

`DeliveryOptionsFinder::getDeliveryOptions()` walks the carriers of a delivery option and stores each one
under the same key:

```php
foreach ($carriers as $carrier) {                       // one entry per package
    ...
    $carrier['price'] = $this->priceFormatter->format($carriers_list['total_price_with_tax']);  // all packages
    ...
    $carriers_available[$id_carriers_list] = $carrier;  // overwrites; only the last survives
}
```

So `name`, `logo` and `delay` end up describing the last package's carrier while `price` is the sum over
every package. That is the report in #9998: two products restricted to different carriers gave "the name
of carrier C with the price of A+C".

There is a guard two lines up - `if (count($carriers) > 1) { $carrier['label'] = $carrier['price']; }`  - 
but it does not reach what the customer reads: `classic-theme` renders the fields separately, `name` at
`templates/checkout/_partials/steps/shipping.tpl:61` and `price` at `:69`, with `name` also used as the
logo's alt text at `:57`.

### What it does

Names the option after every carrier it covers, joins their delays, and drops the logo when there is more
than one, since a single logo cannot stand for several carriers. An option covering one carrier is
untouched, and the per-option data shape the themes consume is unchanged.

### How to test

1. Two carriers with different prices, two products each restricted to a different one.
2. Put both products in a cart and open the shipping step.
3. Before: one carrier's name against the price of both. After: both carriers are named.

```
vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shipment --tags delivery-option-naming
```

### Coverage

`tests/Integration/Behaviour/Features/Scenario/Shipment/delivery_option_naming.feature` - two scenarios:
an option covering two carriers is named after both, and an option covering one keeps that carrier's name.
Reverting the change fails the first with `expected [Beer carrier, Saucisson carrier], got
[Saucisson carrier]` while the second still passes, so the test separates the multi-carrier case from the
ordinary one.

The feature is deliberately its own file rather than a scenario added to
`products_with_different_carriers.feature`: that one restores tables once per FEATURE, so its scenarios are
order-coupled - adding to the end made the assertion read a product reassigned to a pickup carrier by the
scenario before it, and adding to the front consumed stock the scenario after it expects.

### Scope

This does not address the multi-carrier shipping feature the thread later turned to, which is why the row
says Refs. #9998 carries `Needs Specs` and that half is a specification decision.
