### PR TITLE
Find the most specific combination when combinations are asymmetric

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7372,33 +7372,20 @@ class ProductCore extends ObjectModel
         );
 
         if ($idProductAttribute === false && $findBest) {
-            // find the best possible combination
-            // first we order $idAttributes by the group position
-            $orderred = [];
-            $result = Db::getInstance()->executeS(
-                'SELECT a.`id_attribute`
-                FROM `' . _DB_PREFIX_ . 'attribute` a
-                INNER JOIN `' . _DB_PREFIX_ . 'attribute_group` g ON a.`id_attribute_group` = g.`id_attribute_group`
-                WHERE a.`id_attribute` IN (' . $idAttributesImploded . ')
-                ORDER BY g.`position` ASC'
+            // No combination uses exactly the requested attributes, which happens when the combinations of
+            // a product do not all use the same attribute groups. Fall back to the most specific combination
+            // whose attributes are all part of the request, so nothing the visitor did not ask for is added.
+            // Discarding attributes by group position instead would only ever recover combinations that omit
+            // a late group, and would silently answer with an unrelated combination otherwise.
+            $idProductAttribute = Db::getInstance()->getValue(
+                'SELECT pac.`id_product_attribute`
+                FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac
+                INNER JOIN `' . _DB_PREFIX_ . 'product_attribute` pa ON pa.id_product_attribute = pac.id_product_attribute
+                WHERE pa.id_product = ' . $idProduct . '
+                GROUP BY pac.`id_product_attribute`
+                HAVING SUM(pac.`id_attribute` NOT IN (' . $idAttributesImploded . ')) = 0
+                ORDER BY COUNT(*) DESC, pac.`id_product_attribute` ASC'
             );
-
-            foreach ($result as $row) {
-                $orderred[] = $row['id_attribute'];
-            }
-
-            while ($idProductAttribute === false && count($orderred) > 1) {
-                array_pop($orderred);
-                $idProductAttribute = Db::getInstance()->getValue(
-                    'SELECT pac.`id_product_attribute`
-                    FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac
-                    INNER JOIN `' . _DB_PREFIX_ . 'product_attribute` pa ON pa.id_product_attribute = pac.id_product_attribute
-                    WHERE pa.id_product = ' . (int) $idProduct . '
-                    AND pac.id_attribute IN (' . implode(',', array_map('intval', $orderred)) . ')
-                    GROUP BY pac.id_product_attribute
-                    HAVING COUNT(pa.id_product) = ' . count($orderred)
-                );
-            }
         }
 
         if (empty($idProductAttribute)) {

--- a/tests/Integration/Classes/ProductTest.php
+++ b/tests/Integration/Classes/ProductTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Classes;
 
+use Combination;
 use PHPUnit\Framework\TestCase;
 use Product;
 use Tests\Integration\Utility\ContextMockerTrait;
@@ -29,5 +30,62 @@ class ProductTest extends TestCase
         $product->price = 42.42;
         $product->link_rewrite = 'a-product';
         $this->assertTrue($product->save());
+    }
+
+    /**
+     * When the combinations of a product do not all use the same attribute groups, no combination matches
+     * the requested attributes exactly and getIdProductAttributeByIdAttributes falls back to a best guess.
+     * That fallback used to drop attributes by group position, so it could only recover a combination that
+     * omits a late group and otherwise answered with an unrelated combination.
+     *
+     * @dataProvider provideAsymmetricCombinations
+     *
+     * @param int[] $requestedAttributes
+     */
+    public function testItFindsTheMostSpecificCombinationWithinTheRequestedAttributes(
+        array $combinations,
+        array $requestedAttributes,
+        int $expectedIndex
+    ): void {
+        $product = new Product(null, false, 1);
+        $product->name = 'Asymmetric combinations';
+        $product->price = 100.0;
+        $product->link_rewrite = 'asymmetric-combinations';
+        $product->save();
+
+        $combinationIds = [];
+        foreach ($combinations as $attributeIds) {
+            $combination = new Combination();
+            $combination->id_product = (int) $product->id;
+            $combination->add();
+            $combination->setAttributes($attributeIds);
+            $combinationIds[] = (int) $combination->id;
+        }
+
+        self::assertSame(
+            $combinationIds[$expectedIndex],
+            Product::getIdProductAttributeByIdAttributes((int) $product->id, $requestedAttributes, true)
+        );
+
+        $product->delete();
+    }
+
+    /**
+     * Attribute ids come from the default install: 1 = S and 2 = M in Size, 10 = Red and 14 = Blue in
+     * Color, 19 = 40x60cm and 20 = 60x90cm in Dimension. Size sorts before Color, which sorts before
+     * Dimension, which is what the old positional fallback depended on.
+     */
+    public function provideAsymmetricCombinations(): iterable
+    {
+        // two groups
+        yield 'exact match still wins' => [[[1, 14], [2, 14], [3]], [1, 14], 0];
+        yield 'combination omitting the last group' => [[[1, 14], [2, 14], [3]], [3, 14], 2];
+        yield 'combination omitting the first group' => [[[1, 14], [2, 14], [10]], [1, 10], 2];
+
+        // three groups: a combination can omit the middle group too, which two groups cannot express
+        $threeGroups = [[1, 14, 19], [2, 14], [10, 19], [20], [1, 19]];
+        yield 'three groups, exact match' => [$threeGroups, [1, 14, 19], 0];
+        yield 'three groups, only the last group matches' => [$threeGroups, [1, 14, 20], 3];
+        yield 'three groups, two candidates, the widest wins' => [$threeGroups, [2, 14, 20], 1];
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When a product's combinations do not all use the same attribute groups, no combination matches the requested attributes exactly and `Product::getIdProductAttributeByIdAttributes()` falls back to a best guess. That fallback discarded attributes by attribute group position, so it could only ever recover a combination that omits a late group. A combination omitting an earlier group was unreachable from the front office, and the visitor silently got an unrelated combination at the wrong price. The fallback now returns the combination with the most attributes whose attributes are all part of the request.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a product, create combinations Size=S/Color=Blue, Size=M/Color=Blue and a third one with Color=Red only. In the FO pick Red. Before: the page shows the S/Blue combination and its price. After: it shows the Red combination and its price. The same product with a third combination of Size=L only worked before and still works.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #22661
| Related PRs       |
| Sponsor company   |

### This is the blocker @marionf named when closing #22639

She closed it with "an unwanted behavior depending on the attribute group position is still a problem" and
"Feel free to open another one if you can fix the whole issue". That behaviour is
`getIdProductAttributeByIdAttributes()`'s fallback loop: it sorts the requested attributes by
`attribute_group.position` and `array_pop()`s from the end, so it can only drop late groups.

### Measured on 9.2.x

Product with combinations `{S,Blue}`=55, `{M,Blue}`=56, `{L}`=57, `{Red}`=58, read through the front office:

```
selection      before            after
S + Blue       100.00  (55)      100.00  (55)
L + Blue       110.00  (57)      110.00  (57)   already worked, L omits the LATE group
S + Red        100.00  (55)      125.00  (58)   was showing the Blue combination
```

### Validated at three attribute groups, not only two

Two groups cannot express a combination that omits a *middle* group, so a rule can look correct at two and
be wrong at three. With groups Size / Color / Dimension and combinations
`A{S,Blue,40x60} B{M,Blue} C{Red,40x60} D{60x90} E{S,40x60}`:

```
selection            old        new
S+Blue+40x60         A          A
M+Blue+40x60         B          B
S+Blue+60x90         A  wrong   D
S+40x60              A          A     unchanged, see below
S+Red+40x60          A  wrong   C
M+Blue+60x90         B          B
```

Two corrected, four unchanged, no regressions.

### Deliberately left alone

`S+40x60` returns `A{S,Blue,40x60}` both before and after. That comes from the *exact match* query at the
top of the method, which requires the combination to carry the requested attributes but not that it carries
only those, so a three attribute combination can answer a two attribute request. Tightening it would change
what a partial `group` request returns for ordinary symmetric products too, which is a separate decision
with its own callers (`CartController`), and the front office never produces such a request because it
submits one value per rendered group. Left as is so this PR stays confined to the fallback.

### Test

`tests/Integration/Classes/ProductTest.php`, 6 data sets covering exact match, a combination omitting the
last group, one omitting the first, and the three group cases. Verified RED on `upstream/9.2.x` - exactly
two data sets fail, "combination omitting the first group" and "three groups, only the last group matches"  - 
and GREEN with the change. The other four pass on both sides, so the test is not vacuous.

php-cs-fixer 0 of 2 fixable, PHPStan OK.
