### PR TITLE
Mark disabled carriers in the product Shipping tab carrier list

### DIFF
--- a/src/Core/Form/ChoiceProvider/CarrierByReferenceChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CarrierByReferenceChoiceProvider.php
@@ -9,6 +9,7 @@ namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 use PrestaShop\PrestaShop\Adapter\Carrier\CarrierDataProvider;
 use PrestaShop\PrestaShop\Adapter\Entity\Carrier;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CarrierByReferenceChoiceProvider is responsible for providing carrier choices with value reference.
@@ -26,13 +27,20 @@ final class CarrierByReferenceChoiceProvider implements FormChoiceProviderInterf
     private $langId;
 
     /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
      * @param CarrierDataProvider $carrierDataProvider
      * @param int $langId
+     * @param TranslatorInterface $translator
      */
-    public function __construct(CarrierDataProvider $carrierDataProvider, $langId)
+    public function __construct(CarrierDataProvider $carrierDataProvider, $langId, TranslatorInterface $translator)
     {
         $this->carrierDataProvider = $carrierDataProvider;
         $this->langId = $langId;
+        $this->translator = $translator;
     }
 
     /**
@@ -55,6 +63,12 @@ final class CarrierByReferenceChoiceProvider implements FormChoiceProviderInterf
             $choiceId = $carrier['id_carrier'] . ' - ' . $carrier['name'];
             if (!empty($carrier['delay'])) {
                 $choiceId .= ' (' . $carrier['delay'] . ')';
+            }
+            // Disabled carriers stay selectable on purpose: a carrier is often assigned to products
+            // before it is turned on, and disabling one temporarily must not silently detach it from
+            // every product. They are labelled instead of hidden so the merchant can tell them apart.
+            if (!$carrier['active']) {
+                $choiceId .= ' - ' . $this->translator->trans('Disabled', [], 'Admin.Global');
             }
 
             $choices[$choiceId] = $carrier['id_reference'];

--- a/tests/Unit/Core/Form/ChoiceProvider/CarrierByReferenceChoiceProviderTest.php
+++ b/tests/Unit/Core/Form/ChoiceProvider/CarrierByReferenceChoiceProviderTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Adapter\Carrier\CarrierDataProvider;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CarrierByReferenceChoiceProvider;
+
+class CarrierByReferenceChoiceProviderTest extends ChoiceProviderTestCase
+{
+    private const LANG_ID = 1;
+
+    public function testItLabelsDisabledCarriersWithoutRemovingThem(): void
+    {
+        $choices = $this->buildProvider([
+            ['id_carrier' => 1, 'id_reference' => 1, 'name' => 'Click and collect', 'delay' => 'Pick up in-store', 'active' => '1'],
+            ['id_carrier' => 3, 'id_reference' => 3, 'name' => 'My cheap carrier', 'delay' => 'Buy more to pay less!', 'active' => '0'],
+        ])->getChoices();
+
+        self::assertSame([
+            '1 - Click and collect (Pick up in-store)' => 1,
+            '3 - My cheap carrier (Buy more to pay less!) - Disabled' => 3,
+        ], $choices);
+    }
+
+    /**
+     * A disabled carrier must stay selectable: carriers are commonly assigned to products before
+     * being turned on, and disabling one temporarily must not detach it from every product.
+     */
+    public function testDisabledCarriersAreStillOffered(): void
+    {
+        $choices = $this->buildProvider([
+            ['id_carrier' => 3, 'id_reference' => 3, 'name' => 'Disabled one', 'delay' => '', 'active' => '0'],
+            ['id_carrier' => 4, 'id_reference' => 4, 'name' => 'Another disabled', 'delay' => '', 'active' => '0'],
+        ])->getChoices();
+
+        self::assertCount(2, $choices);
+        self::assertSame([3, 4], array_values($choices));
+    }
+
+    public function testItLeavesActiveCarrierLabelsUntouched(): void
+    {
+        $choices = $this->buildProvider([
+            ['id_carrier' => 2, 'id_reference' => 2, 'name' => 'My carrier', 'delay' => 'Delivery next day!', 'active' => '1'],
+            ['id_carrier' => 5, 'id_reference' => 5, 'name' => 'No delay carrier', 'delay' => '', 'active' => '1'],
+        ])->getChoices();
+
+        self::assertSame([
+            '2 - My carrier (Delivery next day!)' => 2,
+            '5 - No delay carrier' => 5,
+        ], $choices);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $carriers
+     */
+    private function buildProvider(array $carriers): CarrierByReferenceChoiceProvider
+    {
+        $dataProvider = $this->createMock(CarrierDataProvider::class);
+        $dataProvider
+            ->method('getCarriers')
+            ->willReturn($carriers);
+
+        return new CarrierByReferenceChoiceProvider($dataProvider, self::LANG_ID, $this->mockTranslator());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The "Available carriers" list on a product's Shipping tab shows every carrier with no indication of its status, so a disabled carrier is indistinguishable from an active one. Disabled carriers are now labelled. They deliberately stay selectable: a carrier is commonly assigned to products before it is turned on, and disabling one temporarily must not silently detach it from every product.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shipping > Carriers on a fresh install has 2 active and 2 disabled carriers. Open any non-virtual product > Shipping tab. Before: the four carriers are listed identically. After: "My cheap carrier" and "My light carrier" are suffixed with "Disabled", the two active ones are unchanged, and all four are still checkable.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #24497
| Related PRs       |
| Sponsor company   |

`CarrierByReferenceChoiceProvider::__construct()` gains a third parameter, a `TranslatorInterface`. The
class is `final` and is consumed as an autowired service, so no service configuration changes; flagging it
in case a reviewer counts a constructor signature change against the BC promise.

### The design question this was parked on was already answered in the thread

The issue carries `Waiting for PM` for @arouiadib's question: grey the disabled carriers out, or hide them.
@Hlavtox answered it on #25161 - disabled carriers must stay checkable, because you assign a carrier to
products before enabling it, and disabling one for a week would otherwise strip it from every product you
touch meanwhile. @arouiadib agreed and restated the target: "show all carriers, enabled ones and disabled
ones, but with some indication on the difference." That is what this implements.

Both earlier PRs died of inactivity rather than review. #25161 changed `false` to `true` on the
`$active` argument, i.e. it hid disabled carriers - the option that discussion had just rejected - and
@PierreRambaud closed it with "Feel free to reopen or open another one if you think it's still relevant".
#24487 was closed the same way.

### Measured on 9.2.x

The provider was called through the container against a fresh install (2 active, 2 disabled carriers):

```
before                                              after
1 - Click and collect (Pick up in-store)            1 - Click and collect (Pick up in-store)
2 - My carrier (Delivery next day!)                 2 - My carrier (Delivery next day!)
3 - My cheap carrier (Buy more to pay less!)        3 - My cheap carrier (Buy more to pay less!) - Disabled
4 - My light carrier (The lighter the cheaper!)     4 - My light carrier (The lighter the cheaper!) - Disabled
```

### Notes

- `Disabled` already exists as a source string in `Admin.Global`, so nothing new needs translating.
- The issue title says "product v1 and v2". v1 is gone in 9.x - `src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php`
  no longer exists - so only the v2 provider is left to fix.
- `tests/Unit/.../CarrierByReferenceChoiceProviderTest.php` covers the label, the untouched active labels,
  and that disabled carriers are still offered - the last one guards against a future "fix" that filters
  them out. Verified RED on `upstream/9.2.x` (1 failure on the label assertion) and GREEN with the change.
- php-cs-fixer and PHPStan both clean on the two files. The 1 PHPUnit deprecation is pre-existing suite
  noise: `ProductImagesChoiceProviderTest`, untouched by this branch, emits 2.
