### PR TITLE
Prefer the translations directory over the module root for module wordings

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -93,16 +93,20 @@ class TranslateCore
         }
 
         if (!isset($translationsMerged[$name][$iso])) {
-            $filesByPriority = [
-                // PrestaShop 1.5 translations
-                _PS_MODULE_DIR_ . $name . '/translations/' . $iso . '.php',
+            // Ordered from lowest to highest priority: every file found is merged over the previous
+            // ones, so the last one that exists wins. The 1.5 location comes after the 1.4 one because
+            // it is the only place the back office translation pages read from and write to, and a
+            // module shipping both files would otherwise ignore anything translated from the back office.
+            $filesByAscendingPriority = [
                 // PrestaShop 1.4 translations
                 _PS_MODULE_DIR_ . $name . '/' . $iso . '.php',
+                // PrestaShop 1.5 translations
+                _PS_MODULE_DIR_ . $name . '/translations/' . $iso . '.php',
                 // Translations in theme
-                _PS_THEME_DIR_ . 'modules/' . $name . '/translations/' . $iso . '.php',
                 _PS_THEME_DIR_ . 'modules/' . $name . '/' . $iso . '.php',
+                _PS_THEME_DIR_ . 'modules/' . $name . '/translations/' . $iso . '.php',
             ];
-            foreach ($filesByPriority as $file) {
+            foreach ($filesByAscendingPriority as $file) {
                 if (file_exists($file)) {
                     include_once $file;
                     $_MODULES = !empty($_MODULES) ? array_merge($_MODULES, $_MODULE) : $_MODULE;

--- a/tests/Integration/Classes/TranslateTest.php
+++ b/tests/Integration/Classes/TranslateTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\Utility\ContextMockerTrait;
+use Translate;
+
+class TranslateTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    private const LOCALE = 'en-US';
+    private const ISO = 'en';
+    private const WORDING = 'Hello';
+
+    /**
+     * @var string[] module directories created by a test
+     */
+    private array $createdModuleDirs = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdModuleDirs as $dir) {
+            foreach (['/translations/' . self::ISO . '.php', '/' . self::ISO . '.php'] as $file) {
+                if (file_exists($dir . $file)) {
+                    unlink($dir . $file);
+                }
+            }
+            if (is_dir($dir . '/translations')) {
+                rmdir($dir . '/translations');
+            }
+            if (is_dir($dir)) {
+                rmdir($dir);
+            }
+        }
+        $this->createdModuleDirs = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * The back office translation pages only read and write modules/<module>/translations/<iso>.php, so
+     * when a module also ships the 1.4 style modules/<module>/<iso>.php the front office has to prefer the
+     * former, otherwise nothing translated from the back office is ever displayed.
+     */
+    public function testItPrefersTheTranslationsDirectoryOverTheModuleRoot(): void
+    {
+        // A distinct module name per case is required: getModuleTranslation() keeps a static per module
+        // and iso cache of the merged files, so reusing a name would assert against the first merge.
+        $module = $this->createModule('qatranslatepriority', 'from-root', 'from-translations-dir');
+
+        self::assertSame(
+            'from-translations-dir',
+            Translate::getModuleTranslation($module, self::WORDING, $module, null, false, self::LOCALE)
+        );
+    }
+
+    public function testItStillUsesTheModuleRootWhenItIsTheOnlyFile(): void
+    {
+        $module = $this->createModule('qatranslaterootonly', 'from-root', null);
+
+        self::assertSame(
+            'from-root',
+            Translate::getModuleTranslation($module, self::WORDING, $module, null, false, self::LOCALE)
+        );
+    }
+
+    public function testItUsesTheTranslationsDirectoryWhenItIsTheOnlyFile(): void
+    {
+        $module = $this->createModule('qatranslatedironly', null, 'from-translations-dir');
+
+        self::assertSame(
+            'from-translations-dir',
+            Translate::getModuleTranslation($module, self::WORDING, $module, null, false, self::LOCALE)
+        );
+    }
+
+    /**
+     * @param string $module module name, must be unique per test
+     * @param string|null $rootValue wording stored in modules/<module>/<iso>.php, null to skip the file
+     * @param string|null $translationsValue wording stored in modules/<module>/translations/<iso>.php
+     *
+     * @return string the module name
+     */
+    private function createModule(string $module, ?string $rootValue, ?string $translationsValue): string
+    {
+        $dir = _PS_MODULE_DIR_ . $module;
+        @mkdir($dir . '/translations', 0777, true);
+        $this->createdModuleDirs[] = $dir;
+
+        $key = strtolower('<{' . $module . '}prestashop>' . $module) . '_' . md5(self::WORDING);
+
+        if (null !== $rootValue) {
+            file_put_contents($dir . '/' . self::ISO . '.php', $this->buildFile($key, $rootValue));
+        }
+        if (null !== $translationsValue) {
+            file_put_contents($dir . '/translations/' . self::ISO . '.php', $this->buildFile($key, $translationsValue));
+        }
+
+        return $module;
+    }
+
+    private function buildFile(string $key, string $value): string
+    {
+        return sprintf("<?php\nglobal \$_MODULE;\n\$_MODULE = [];\n\$_MODULE['%s'] = '%s';\n", $key, $value);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A module can ship legacy translations as `modules/<module>/<iso>.php` (the 1.4 location) or `modules/<module>/translations/<iso>.php` (the 1.5 one). `Translate::getModuleTranslation()` merges every file that exists over the previous ones, so the last entry of the list wins, and the 1.4 file was listed after the 1.5 one. The back office translation pages only read from and write to the 1.5 location, so for a module shipping both files nothing translated from the back office was ever displayed. The two are swapped, in the module and in the theme.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a module that ships both `<module>/en.php` and `<module>/translations/en.php` with different values for the same wording. Before: the front office shows the root file's value while the back office translation page shows and edits the other one. After: both show the `translations/` value.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #22571
| Related PRs       |
| Sponsor company   |

### Measured on 9.2.x

A throwaway module with both files, same wording key, different values:

```
                                                    before                     after
Translate::getModuleTranslation()                   FROM-ROOT-en.php           FROM-translations-en.php
back office (ExternalModuleLegacySystemProvider)    translations/en.php        translations/en.php
```

The two halves are now the same file, which is what the issue asks for: "The same file should be considered
both in Translations menu and in front."

### Where each side looks

- Front office: `Translate::getModuleTranslation()` builds a list of candidate files and `include_once`
  each one that exists, doing `$_MODULES = array_merge($_MODULES, $_MODULE)` after each. Later files
  therefore overwrite earlier ones, so the **last** existing file wins - the opposite of what the old
  variable name `$filesByPriority` suggests. Renamed to `$filesByAscendingPriority` and commented.
- Back office: `ExternalModuleLegacySystemProvider::getDefaultResourceDirectory()` returns
  `<resourceDirectory>/<module>/translations/` and `LegacyFileReader::load()` appends `<locale>.php`.
  There is no code path that reads the module root, so the back office can only ever edit the 1.5 file.

Theme entries keep winning over module ones; only the relative order of the 1.4 and 1.5 locations changes,
in both the module and the theme pair.

### Why this direction rather than the other

The mismatch could in principle be closed by making the back office read the module root instead. That does
not work: the back office also *writes* to `translations/`, so it would read one file and write another,
and making it write the 1.4 format would revive a format deprecated since 1.5. Preferring the newer location
is the only direction where reading and writing agree.

### Test

`tests/Integration/Classes/TranslateTest.php`, three cases: both files present (the fix), root only, and
`translations/` only. Each case uses a **different module name** on purpose -
`getModuleTranslation()` keeps a `static $translationsMerged` cache per module and iso, so reusing a name
would make the later assertions test the first merge instead of their own fixture.
Verified RED on `upstream/9.2.x` - one failure, `from-root` where `from-translations-dir` was expected -
and GREEN with the change; the two single file cases pass on both sides.

php-cs-fixer 0 of 2 fixable, PHPStan OK.
