### PR TITLE
Keep the order confirmation working when a product belongs to another shop

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -472,6 +472,20 @@ abstract class PaymentModuleCore extends Module
                 $price = Product::getPriceStatic((int) $product['id_product'], false, $product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null, 6, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
                 $price_wt = Product::getPriceStatic((int) $product['id_product'], true, $product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null, 2, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
 
+                /*
+                 * getPriceStatic() resolves the price in the current shop context and returns null for a
+                 * product belonging to another shop of the group, which happens when the group shares
+                 * orders and the cart was filled across two shops. The order line already holds the amount
+                 * the customer is charged, and the order total was computed from it, so fall back to it
+                 * instead of formatting null further down.
+                 */
+                if (null === $price) {
+                    $price = $product['price'] ?? 0;
+                }
+                if (null === $price_wt) {
+                    $price_wt = $product['price_wt'] ?? 0;
+                }
+
                 $product_price = Product::getTaxCalculationMethod() == PS_TAX_EXC ? Tools::ps_round($price, Context::getContext()->getComputingPrecision()) : $price_wt;
 
                 $carrierName = null;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | In a shop group that shares its orders, a cart can hold products from two shops. The order is created correctly, but the confirmation then recomputes each line price with `Product::getPriceStatic()`, which resolves prices in the current shop context and returns null for a product of the other shop. Formatting that null threw a TypeError **after the order had been created and paid**, leaving the customer on an error page. The order line already carries the amount charged, so it is used when the recomputation yields nothing.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the reproduction below. Before: TypeError on `Locale::formatPrice()`, order created but the customer sees an exception. After: `validateOrder()` returns true and the confirmation is produced.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #21714
| Related PRs       |
| Sponsor company   |

### Measured on 9.2.x

Two shops in one group sharing customers, stock and orders; one product created in each; a cart filled from
both shops; `validateOrder()` run from the second shop:

```
before   TypeError: Locale::formatPrice(): Argument #1 ($number) must be of type string|int|float,
         null given, called in classes/PaymentModule.php on line 499
after    validateOrder() returns true, 1 order created
```

The discriminator, in the shop where the order is placed (shop 18):

```
product created in shop 17   Product::getPriceStatic() -> NULL
product created in shop 18   Product::getPriceStatic() -> 20.0
```

**The order is created before the throw.** In the failing run the order existed with the correct total:
`id_order 65564, id_shop 18, total_paid 40.000000`, and both `order_detail` rows carried
`product_price 20.000000` - including the cross-shop one. So the data is right; only the confirmation's
recomputation fails, which is why the fix falls back to the line the order already stores.

### Reproduction

1. Enable multistore. Create a group sharing customers, available quantities and orders, with two shops in it.
2. Create one product in each shop.
3. Add the first product to the cart while in shop A, then the second while in shop B.
4. Complete the order from shop B.

### No automated test, and why

The fix is verified by the scripted reproduction above, run RED then GREEN against the same script. I did
attempt a Behat scenario: `ShopFeatureContext` is already in the `cart` suite and has the multishop, shop
group and shop steps, and I added `shares its customers` / `shares its orders` to go with the existing
`shares its stock`. The scenario got as far as validating, then stalled on fixture bookkeeping rather than
on the behaviour: `LegacyProductFeatureContext::getProductWithName()` keys products as
`$productName . $idShop`, with the suffix blanked when the context shop equals `PS_SHOP_DEFAULT`, so a
product created under one shop cannot be looked up once the context or that configuration value moves.
Making it work needs changes to that fixture keying, which is a wider job than this fix and would have made
the diff mostly test scaffolding. Backed it out rather than ship half a harness. It can be done separately if
that keying change is wanted.
