### PR TITLE
Read the PDF logo from the filesystem instead of over HTTP

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -128,7 +128,12 @@ abstract class HTMLTemplateCore
         }
 
         $this->smarty->assign([
-            'logo_path' => Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_ . $logo,
+            // The PDF is rendered by the server, so the logo is read straight off the filesystem instead of
+            // being fetched over HTTP from the shop's own public URL. That request often cannot succeed from
+            // the server itself: a container published on another port, a firewall, or split horizon DNS all
+            // break it, and the invoice then carries no logo at all. HTMLTemplateSupplyOrderForm already
+            // passes a filesystem path here.
+            'logo_path' => !empty($logo) ? _PS_IMG_DIR_ . $logo : '',
             'img_ps_dir' => Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_,
             'img_update_time' => Configuration::get('PS_IMG_UPDATE_TIME'),
             'date' => $this->date,

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/11_checkInvoice.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/11_checkInvoice.ts
@@ -404,11 +404,8 @@ describe('BO - Orders - View and edit order: Check invoice', async () => {
     describe('Check the invoice', async () => {
       // Check: Header, Delivery address, Billing address, Invoice number, Invoice date, Order reference and date
       describe('Check Header', async () => {
-        // @todo : https://github.com/PrestaShop/PrestaShop/issues/22581
         it('should check the header of the invoice', async function () {
           await testContext.addContextItem(this, 'testIdentifier', 'checkHeaderInvoice1', baseContext);
-
-          this.skip();
 
           const imageNumber = await utilsFile.getImageNumberInPDF(filePath);
           expect(imageNumber, 'Logo is not visible!').to.be.equal(1);
@@ -640,11 +637,8 @@ describe('BO - Orders - View and edit order: Check invoice', async () => {
     describe('Check the invoice', async () => {
       // Check: Header, Delivery address, Billing address, Invoice number, Invoice date, Order reference and date
       describe('Check Header', async () => {
-        // @todo : https://github.com/PrestaShop/PrestaShop/issues/22581
         it('should check the header of the invoice', async function () {
           await testContext.addContextItem(this, 'testIdentifier', 'checkHeaderInvoice2', baseContext);
-
-          this.skip();
 
           const imageNumber = await utilsFile.getImageNumberInPDF(filePath);
           expect(imageNumber, 'Logo is not visible!').to.be.equal(1);
@@ -838,11 +832,8 @@ describe('BO - Orders - View and edit order: Check invoice', async () => {
     describe('Check the invoice', async () => {
       // Check: Header, Delivery address, Billing address, Invoice number, Invoice date, Order reference and date
       describe('Check Header', async () => {
-        // @todo : https://github.com/PrestaShop/PrestaShop/issues/22581
         it('should check the header of the invoice', async function () {
           await testContext.addContextItem(this, 'testIdentifier', 'checkHeaderInvoice3', baseContext);
-
-          this.skip();
 
           const imageNumber = await utilsFile.getImageNumberInPDF(filePath);
           expect(imageNumber, 'Logo is not visible!').to.be.equal(1);
@@ -1081,11 +1072,8 @@ describe('BO - Orders - View and edit order: Check invoice', async () => {
     describe('Check the invoice', async () => {
       // Check: Header, Delivery address, Billing address, Invoice number, Invoice date, Order reference and date
       describe('Check Header', async () => {
-        // @todo : https://github.com/PrestaShop/PrestaShop/issues/22581
         it('should check the header of the invoice', async function () {
           await testContext.addContextItem(this, 'testIdentifier', 'checkHeaderInvoice4', baseContext);
-
-          this.skip();
 
           const imageNumber = await utilsFile.getImageNumberInPDF(filePath);
           expect(imageNumber, 'Logo is not visible!').to.be.equal(1);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The PDF header built the logo `src` as an absolute URL on the shop's own domain, so rendering an invoice made the server fetch a file from its own public address. That request frequently cannot succeed from the server itself - a container published on a different port, a firewall, or split horizon DNS all break it - and the document is produced with no logo. The file is already read from disk one line above to measure it, so the same path is now used as the image source.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the shop behind a port that the server itself cannot reach, which is the default for a Docker install published on 8001. Place an order, set it to Payment accepted and open the invoice PDF. Before: no logo. After: the logo is there. Same for the delivery slip, the order return and the shipment delivery slip.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #22581, Fixes #24546
| Related PRs       |
| Sponsor company   |

### Measured on 9.2.x

Rendering invoice 30 on a shop whose configured domain is not resolvable from inside the app container, counting embedded
image objects in the produced PDF:

```
                 img src                              pdf bytes   images
before   http://<shop-domain>/img/logo.png             465866       0
after    /var/www/html/img/logo.png                     469493       2
```

Two objects is one painted image plus its PNG soft mask; the UI helper counts `paintImageXObject`
operations, so it sees 1, which is what the parked assertions expect.

The reason it fails is not that the port is dropped. It is that the renderer asks the server to fetch its
own public URL: a host side port mapping does not exist inside the container.
Setting the domain to something unreachable on purpose (`example.invalid`) still produces the logo after
the change, since the domain no longer takes part.

Also checked that the server path does not end up in the document: `/var/www` appears **0** times in the
generated PDF, because TCPDF embeds the image and discards the path.

### Scope

`assignCommonHeaderData()` is used by `HTMLTemplateInvoice`, `HTMLTemplateDeliverySlip`,
`HTMLTemplateOrderReturn` and `HTMLTemplateShipmentDeliverySlip`, so all four documents are fixed.
`HTMLTemplateSupplyOrderForm` does not call it - it already passes a filesystem path to the same
`logo_path` variable, which is the in-tree precedent for this change.

`img_ps_dir` is left as it is: it is assigned next to `logo_path` but no core PDF template uses it.

### Why not the earlier attempt

#24496 stripped the host in `pdf/header.tpl` with a `regex_replace`. @PululuK requested changes because
that belongs in the controller rather than the template, and it was then closed as stale. This puts it in
`assignCommonHeaderData()`, and uses the path that is already being read on the previous line rather than
rewriting a URL.

### Acceptance test

The issue lists four assertions to unskip in
`tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/11_checkInvoice.ts`; they were
parked by #38198 ("Functional Tests : Enable after #22581", merged). All four are unskipped here.
**They were not executed** - the UI campaign queue is stopped - so they are enabled on the strength of the
PDF measurement above and of the helper counting painted images, not of a green run. eslint passes on the
file.

php-cs-fixer 0 of 1 fixable, PHPStan OK.

## Update 2026-09-21: integration test, and #24546

#24546 reports the same defect from the other side (the PDF renderer fetching the logo over HTTP), so this PR
closes it too. Added `tests/Integration/Classes/Pdf/HTMLTemplateLogoPathTest.php`: the logo reaches the renderer
as a readable filesystem path, never an `http(s)` URL, and as an empty string when no logo is configured.
Against the base `HTMLTemplate.php` both tests fail (`'http://localhost/img/...' does not match "#^https?://#"`);
with this PR, 2 tests / 5 assertions pass.
