### PR TITLE
Key the presented product row on the shop it was presented for

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5486,7 +5486,14 @@ class ProductCore extends ObjectModel
         // Tax
         $usetax = Configuration::get('PS_TAX');
 
-        $cache_key = $row['id_product'] . '-' . $id_product_attribute . '-' . $id_lang . '-' . (int) $usetax;
+        /*
+         * The shop belongs in the key: the presented row carries per-shop values - price first of all -
+         * so without it a request that presents the same product for two shops, which is what a
+         * cross-shop listing or a loop over Shop::getContextListShopID() does, serves the first shop's
+         * row to every later one.
+         */
+        $cache_key = $row['id_product'] . '-' . $id_product_attribute . '-' . $id_lang . '-' . (int) $usetax
+            . '-' . (int) $context->shop->id;
         if (isset($row['id_product_pack'])) {
             $cache_key .= '-pack' . $row['id_product_pack'];
         }

--- a/tests/Integration/Classes/Product/ProductPropertiesCachePerShopTest.php
+++ b/tests/Integration/Classes/Product/ProductPropertiesCachePerShopTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Configuration;
+use Context;
+use Currency;
+use Db;
+use Product;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Product::getProductProperties() memoises the presented row, and that row carries per-shop values.
+ * The key left the shop out, so presenting the same product for a second shop in one request returned
+ * the first shop's row.
+ */
+class ProductPropertiesCachePerShopTest extends KernelTestCase
+{
+    private const PRODUCT_ID = 6;
+    private const FIRST_SHOP_PRICE = 11.90;
+    private const SECOND_SHOP_PRICE = 99.90;
+
+    private int $secondShop = 0;
+
+    private string $previousPrice = '';
+
+    private string $previousCategory = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $context = Context::getContext();
+        $context->container = self::getContainer();
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->currentLocale = self::getContainer()
+            ->get('prestashop.core.localization.locale.repository')
+            ->getLocale($context->language->getLocale());
+
+        $this->previousPrice = (string) Db::getInstance()->getValue(
+            'SELECT price FROM ' . _DB_PREFIX_ . 'product_shop WHERE id_product = ' . self::PRODUCT_ID . ' AND id_shop = 1',
+            false
+        );
+        $this->previousCategory = (string) Db::getInstance()->getValue(
+            'SELECT id_category_default FROM ' . _DB_PREFIX_ . 'product_shop WHERE id_product = ' . self::PRODUCT_ID . ' AND id_shop = 1',
+            false
+        );
+
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'configuration (name, value, date_add, date_upd)
+             VALUES ("PS_MULTISHOP_FEATURE_ACTIVE", 1, NOW(), NOW())
+             ON DUPLICATE KEY UPDATE value = 1'
+        );
+        Shop::resetStaticCache();
+
+        $shop = new Shop();
+        $shop->active = true;
+        $shop->id_shop_group = 1;
+        $shop->id_category = 2;
+        $shop->theme_name = _THEME_NAME_;
+        $shop->name = 'product properties cache test shop';
+        $shop->color = 'red';
+        $shop->add();
+        $this->secondShop = (int) $shop->id;
+        Shop::resetStaticCache();
+
+        Db::getInstance()->execute(
+            'INSERT IGNORE INTO ' . _DB_PREFIX_ . 'product_shop
+                (id_product, id_shop, id_category_default, price, active, visibility, id_tax_rules_group, indexed, date_add, date_upd)
+             SELECT id_product, ' . $this->secondShop . ', id_category_default, price, active, visibility, id_tax_rules_group, indexed, date_add, date_upd
+             FROM ' . _DB_PREFIX_ . 'product_shop WHERE id_product = ' . self::PRODUCT_ID . ' AND id_shop = 1'
+        );
+        $this->setShopPrice(1, self::FIRST_SHOP_PRICE);
+        $this->setShopPrice($this->secondShop, self::SECOND_SHOP_PRICE);
+    }
+
+    protected function tearDown(): void
+    {
+        Shop::setContext(Shop::CONTEXT_ALL);
+        Db::getInstance()->delete('stock_available', 'id_shop = ' . $this->secondShop);
+        Db::getInstance()->delete('product_shop', 'id_shop = ' . $this->secondShop);
+        Db::getInstance()->delete('shop_url', 'id_shop = ' . $this->secondShop);
+        Db::getInstance()->delete('shop', 'id_shop = ' . $this->secondShop);
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'configuration WHERE id_shop = ' . $this->secondShop);
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'configuration WHERE name = "PS_MULTISHOP_FEATURE_ACTIVE"');
+        Db::getInstance()->update(
+            'product_shop',
+            ['price' => $this->previousPrice, 'id_category_default' => $this->previousCategory],
+            'id_product = ' . self::PRODUCT_ID . ' AND id_shop = 1'
+        );
+        Shop::resetStaticCache();
+        Product::resetStaticCache();
+
+        parent::tearDown();
+    }
+
+    public function testEachShopGetsItsOwnPresentedRow(): void
+    {
+        $this->assertSame(self::FIRST_SHOP_PRICE, $this->presentedPrice(1));
+        $this->assertSame(self::SECOND_SHOP_PRICE, $this->presentedPrice($this->secondShop));
+    }
+
+    /**
+     * And in the other order, so the assertion cannot pass just because the first shop happened to be
+     * asked first.
+     */
+    public function testTheOrderOfTheShopsDoesNotMatter(): void
+    {
+        $this->assertSame(self::SECOND_SHOP_PRICE, $this->presentedPrice($this->secondShop));
+        $this->assertSame(self::FIRST_SHOP_PRICE, $this->presentedPrice(1));
+    }
+
+    /**
+     * A column that comes straight out of product_shop and is never recomputed, so it isolates the
+     * static array from the separate cache getPriceStatic() keeps.
+     */
+    public function testAPlainPerShopColumnIsNotSharedEither(): void
+    {
+        Db::getInstance()->update('product_shop', ['id_category_default' => 3], 'id_product = ' . self::PRODUCT_ID . ' AND id_shop = 1');
+        Db::getInstance()->update('product_shop', ['id_category_default' => 4], 'id_product = ' . self::PRODUCT_ID . ' AND id_shop = ' . $this->secondShop);
+
+        $this->assertSame(3, $this->presentedField(1, 'id_category_default'));
+        $this->assertSame(4, $this->presentedField($this->secondShop, 'id_category_default'));
+    }
+
+    /**
+     * Documents which shop the presentation follows, because that is what the key has to match:
+     * every per-shop read inside it goes through the context object - priceCalculation() at
+     * Product.php:3515, computeUnitPriceRatio() at :5754, the tax-rules-group warmup at :5462 - and not
+     * through Shop::getContextShopID(). Moving the shop context alone therefore changes nothing, and
+     * the key must not pretend otherwise.
+     */
+    public function testThePresentationFollowsTheContextObjectNotTheShopContext(): void
+    {
+        $context = Context::getContext();
+        $context->shop = new Shop(1);
+        Shop::setContext(Shop::CONTEXT_SHOP, $this->secondShop);
+        Product::resetStaticCache();
+
+        $row = $this->rowFor(1);
+
+        $this->assertSame(
+            self::FIRST_SHOP_PRICE,
+            (float) Product::getProductProperties((int) Configuration::get('PS_LANG_DEFAULT'), $row, $context)['price']
+        );
+    }
+
+    private function setShopPrice(int $idShop, float $price): void
+    {
+        Db::getInstance()->update('product_shop', ['price' => $price], 'id_product = ' . self::PRODUCT_ID . ' AND id_shop = ' . $idShop);
+    }
+
+    private function presentedPrice(int $idShop): float
+    {
+        return (float) $this->present($idShop)['price'];
+    }
+
+    private function presentedField(int $idShop, string $field): int
+    {
+        return (int) $this->present($idShop)[$field];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function present(int $idShop): array
+    {
+        $context = Context::getContext();
+        Shop::setContext(Shop::CONTEXT_SHOP, $idShop);
+        $context->shop = new Shop($idShop);
+
+        return Product::getProductProperties(
+            (int) Configuration::get('PS_LANG_DEFAULT'),
+            $this->rowFor($idShop),
+            $context
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function rowFor(int $idShop): array
+    {
+        return Db::getInstance()->getRow(
+            'SELECT p.*, ps.* FROM ' . _DB_PREFIX_ . 'product p
+             JOIN ' . _DB_PREFIX_ . 'product_shop ps ON ps.id_product = p.id_product AND ps.id_shop = ' . $idShop . '
+             WHERE p.id_product = ' . self::PRODUCT_ID
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Product::getProductProperties()` memoises the presented row without the shop in its key, so presenting the same product for a second shop in one request returns the first shop's row - its price included. The row carries every per-shop value `product_shop` holds, so the first shop to present a product wins for the rest of the request.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Refs #20156
| Related PRs       |
| Sponsor company   |

### The bug

```php
$cache_key = $row['id_product'] . '-' . $id_product_attribute . '-' . $id_lang . '-' . (int) $usetax;
```

The memoised value is the **whole presented row**, and that row carries per-shop values - `price`,
`unit_price`, `id_category_default`, `active`, everything `product_shop` holds. The key has no shop in
it, so the first shop to present a product wins for the rest of the request.

Measured on 9.2.x with two shops holding the same product at different prices:

```
shop 1 asked first          price = 11.90   (its own)
shop 2, same process        price = 11.90   (should be 99.90)
after Product::resetStaticCache()  price = 99.90
```

Note the second line is not a stale-database problem: `Cache::clean('*')` does not change it, because this
is the class's own static array, not the query cache.

Anything that presents one product for more than one shop in a single request hits it - a cross-shop
listing, a back-office grid spanning shops, or any loop over `Shop::getContextListShopID()`.

### The fix

Add `(int) $context->shop->id` to the key.

**Why that value and not `Shop::getContextShopID()`.** The key has to name whatever the computation
depends on, and every per-shop read inside this presentation goes through the context object:
`getPriceStatic()` passes `$context->shop->id` to `priceCalculation()` (`Product.php:3515`),
`computeUnitPriceRatio()` selects `product_shop ... id_shop = $context->shop->id` (`:5754`), and the
tax-rules-group warmup keys on it too (`:5462`). Keying on `Shop::getContextShopID()` instead would name
a value the computation never reads, so the key could change while the result did not, or the reverse.
A test documents that contract, so the choice is not left implicit.

**Effect on the cache.** On a single-shop install the key gains a constant suffix and the hit rate is
unchanged. On multishop, presentations that used to collide now each compute once - strictly more work
than before, and correct; the memoisation still works exactly as it did within one shop.

### How to test

Two shops, the same product priced differently in each, presented one after the other in the same request:
each now reports its own price.

### Verification

- `tests/Integration/Classes/Product/ProductPropertiesCachePerShopTest.php` - 4 cases. The test builds
  the second shop for its own duration and removes it in `tearDown()`.
  - each shop reports its own price;
  - the same, asking the shops in the opposite order, so the result cannot come from whichever was asked
    first;
  - the same for `id_category_default` - a column that comes straight out of `product_shop` and is never
    recomputed, which isolates this static array from the separate cache `getPriceStatic()` keeps;
  - which shop the presentation follows, pinning the contract the key is built on.

  Reverting `classes/Product.php` to `upstream/9.2.x` fails the first **three**
  (*"Failed asserting that 11.9 is identical to 99.9"* and its mirror, and the same for the category);
  the fourth documents the contract and passes on both sides.
- `tests/Integration/Classes` - 185 tests OK.
- Behat `-s cart` - **242 scenarios, 3538 steps, all passed**.
- Behat `-s product` - 414 scenarios, 413 passed; the single failure,
  `unit_price_with_specific_price.feature:10`, fails identically on `upstream/9.2.x` when run on its own.
- php-cs-fixer `Found 0 of 2`, PHPStan `[OK] No errors`.
