### PR TITLE
Expose product tags to the front office templates

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -34,6 +34,7 @@ use Product;
 use ReflectionException;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Tag;
 use Tools;
 use Validate;
 
@@ -143,6 +144,28 @@ class ProductLazyArray extends AbstractLazyArray
     public function getId()
     {
         return $this->product['id_product'];
+    }
+
+    /**
+     * Tags of the product, for the current language.
+     *
+     * Tags are not part of the product's ObjectModel definition, so ObjectPresenter, which copies the
+     * definition fields only, drops them before the array reaches this class. Reading them here keeps
+     * {$product.tags} working without loading them for products that never ask for them.
+     *
+     * @return string[]
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getTags(): array
+    {
+        $tags = Tag::getProductTags((int) ($this->product['id_product'] ?? 0));
+
+        // getProductTags() returns false when the product carries no tag at all.
+        if (!is_array($tags)) {
+            return [];
+        }
+
+        return $tags[(int) $this->language->id] ?? [];
     }
 
     /**

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -6,6 +6,7 @@
 
 namespace Tests\Integration\Adapter\Presenter\Product;
 
+use Db;
 use Language;
 use Link;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -20,6 +21,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Tag;
 
 class ProductLazyArrayTest extends TestCase
 {
@@ -143,6 +145,56 @@ class ProductLazyArrayTest extends TestCase
                 return $id;
             })
         ;
+    }
+
+    /**
+     * Tags are not part of the product's ObjectModel definition, so ObjectPresenter drops them before the
+     * array reaches the lazy array. They have to be resolved here instead.
+     *
+     * A product id that does not exist is used on purpose: ps_product_tag carries no foreign key, so the
+     * fixture stays out of the real catalogue.
+     */
+    public function testItExposesTagsOfTheCurrentLanguage(): void
+    {
+        $productId = 9999901;
+        Tag::addTags(1, $productId, 'qa-lazy-alpha,qa-lazy-beta');
+
+        try {
+            $productLazyArray = $this->buildLazyArrayForProduct($productId);
+            $tags = $productLazyArray['tags'];
+            sort($tags);
+
+            $this->assertSame(['qa-lazy-alpha', 'qa-lazy-beta'], $tags);
+        } finally {
+            $this->removeTagsOfProduct($productId);
+        }
+    }
+
+    public function testItExposesAnEmptyArrayWhenTheProductHasNoTag(): void
+    {
+        $this->assertSame([], $this->buildLazyArrayForProduct(9999902)['tags']);
+    }
+
+    private function buildLazyArrayForProduct(int $productId): ProductLazyArray
+    {
+        return new ProductLazyArray(
+            $this->mockProductPresentationSettings,
+            array_merge($this->baseProduct, ['id_product' => $productId]),
+            $this->mockLanguage,
+            $this->mockImageRetriever,
+            $this->mockLink,
+            $this->mockPriceFormatter,
+            $this->mockProductColorsRetriever,
+            $this->mockTranslatorInterface,
+            $this->mockHookManager,
+            $this->mockConfiguration
+        );
+    }
+
+    private function removeTagsOfProduct(int $productId): void
+    {
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'product_tag WHERE id_product = ' . $productId);
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . "tag WHERE name LIKE 'qa-lazy-%'");
     }
 
     public function testConstructor(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `{$product.tags}` is always empty on the product page. The array handed to the product presenter is built by `ObjectPresenter::present()`, which copies the fields of the ObjectModel definition only; tags are a dynamic property filled by the `Product` constructor, so they are dropped before the lazy array ever sees them. The lazy array now resolves them itself, which also means they are read only for the products that ask for them.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Give a product some tags in the back office, then output `{$product.tags}` in `catalog/product.tpl`. Before: nothing. After: the tag names for the current language.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #21893
| Related PRs       |
| Sponsor company   |

### Measured on 9.2.x

```
Product object ->tags            {"1":["qa-tag-alpha","qa-tag-beta"]}
ObjectPresenter output           tags absent  (65 keys, none of them "tags")
tags in Product definition       no
```

`ProductController::getTemplateVarProduct()` line 1225 builds the array with
`$this->objectPresenter->present($this->product)`, which is the line @lusimeon linked in 2020. It still
reads the same way.

### Why the lazy array and not the presenter

`ObjectPresenter` is generic: it presents any `ObjectModel` from its definition, and is also used for
country, language, store and supplier. Teaching it about a product-specific dynamic property would push
product knowledge into a shared class. `ProductLazyArray` already resolves other things the definition does
not carry, and it is lazy, so nothing is loaded for products whose template never mentions tags.

### What was deliberately left out

@Hlavtox suggested in November 2025: "Add tags to lazy array, even if not used in FO, can't hurt. Remove
them from product constructor." Only the first half is here, because the second half needs a change he did
not mention. `Product::getTags()` refetches only when the product is **not** fully loaded:

```php
if (!$this->isFullyLoaded && null === $this->tags) {
    $this->tags = Tag::getProductTags($this->id);
}
```

Measured on a fully loaded product with the constructor assignment simulated away:

```
tags from the constructor   getTags(1) = 'qa-tag-alpha, qa-tag-beta'
tags nulled                 getTags(1) = ''            <- silent regression
not fully loaded            getTags(1) = 'qa-tag-alpha, qa-tag-beta'
```

So dropping `$this->tags = Tag::getProductTags(...)` from the constructor also requires
`getTags()` to lose its `!$this->isFullyLoaded` condition, and it is a BC break on a public property
that `AdminImportController` writes to (lines 1940-1959). Worth its own change rather than riding along
with the display fix.

### Test

`tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php`, two cases. The fixture uses a
product id that does not exist, since `ps_product_tag` carries no foreign key, so the real catalogue is
untouched.

Honest note on the second case: `testItExposesTagsOfTheCurrentLanguage` is the guard, it fails on
`upstream/9.2.x` with an empty array where the two tags are expected.
`testItExposesAnEmptyArrayWhenTheProductHasNoTag` passes with **and** without the change, because reading a
missing key already yields an empty array; it documents the no-tag shape rather than guarding the fix.

php-cs-fixer clean (after one fix on the test file), PHPStan OK.
