### PR TITLE
Release reserved stock when an order is refunded

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -795,7 +795,8 @@ abstract class PaymentModuleCore extends Module
                 (int) Configuration::get('PS_OS_ERROR'),
                 (int) Configuration::get('PS_OS_CANCELED'),
                 null,
-                (int) $order->id
+                (int) $order->id,
+                (int) Configuration::get('PS_OS_REFUND')
             );
         } // End foreach $order_detail_list
 

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -328,7 +328,8 @@ class OrderHistoryCore extends ObjectModel
             (int) Configuration::get('PS_OS_ERROR'),
             (int) Configuration::get('PS_OS_CANCELED'),
             null,
-            (int) $order->id
+            (int) $order->id,
+            (int) Configuration::get('PS_OS_REFUND')
         );
 
         ShopUrl::resetMainDomainCache();

--- a/src/Adapter/Order/CommandHandler/AbstractOrderCommandHandler.php
+++ b/src/Adapter/Order/CommandHandler/AbstractOrderCommandHandler.php
@@ -59,7 +59,8 @@ abstract class AbstractOrderCommandHandler extends AbstractOrderHandler
             (int) Configuration::get('PS_OS_ERROR'),
             (int) Configuration::get('PS_OS_CANCELED'),
             null,
-            (int) $orderDetail->id_order
+            (int) $orderDetail->id_order,
+            (int) Configuration::get('PS_OS_REFUND')
         );
 
         if ($delete) {

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -390,7 +390,8 @@ class OrderProductQuantityUpdater
             (int) Configuration::get('PS_OS_ERROR'),
             (int) Configuration::get('PS_OS_CANCELED'),
             null,
-            (int) $orderDetail->id_order
+            (int) $orderDetail->id_order,
+            (int) Configuration::get('PS_OS_REFUND')
         );
 
         if ($delete) {

--- a/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
@@ -129,7 +129,8 @@ class CombinationStockUpdater
             $this->stockAvailableRepository->updatePhysicalProductQuantity(
                 new StockId((int) $stockAvailable->id),
                 new OrderStateId((int) $this->configuration->get('PS_OS_ERROR', null, $shopConstraint)),
-                new OrderStateId((int) $this->configuration->get('PS_OS_CANCELED', null, $shopConstraint))
+                new OrderStateId((int) $this->configuration->get('PS_OS_CANCELED', null, $shopConstraint)),
+                new OrderStateId((int) $this->configuration->get('PS_OS_REFUND', null, $shopConstraint))
             );
         }
     }

--- a/src/Adapter/Product/Stock/Repository/StockAvailableRepository.php
+++ b/src/Adapter/Product/Stock/Repository/StockAvailableRepository.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Stock\Repository;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
@@ -312,10 +313,11 @@ class StockAvailableRepository extends AbstractMultiShopObjectModelRepository
      * @param StockId $stockId
      * @param OrderStateId $errorStateId
      * @param OrderStateId $canceledStateId
+     * @param OrderStateId|null $refundedStateId
      */
-    public function updatePhysicalProductQuantity(StockId $stockId, OrderStateId $errorStateId, OrderStateId $canceledStateId): void
+    public function updatePhysicalProductQuantity(StockId $stockId, OrderStateId $errorStateId, OrderStateId $canceledStateId, ?OrderStateId $refundedStateId = null): void
     {
-        $this->updateReservedProductQuantity($stockId, $errorStateId, $canceledStateId);
+        $this->updateReservedProductQuantity($stockId, $errorStateId, $canceledStateId, $refundedStateId);
 
         // Now update the physical_quantity
         $updateQb = $this->connection->createQueryBuilder();
@@ -328,8 +330,14 @@ class StockAvailableRepository extends AbstractMultiShopObjectModelRepository
         $updateQb->executeStatement();
     }
 
-    protected function updateReservedProductQuantity(StockId $stockId, OrderStateId $errorStateId, OrderStateId $canceledStateId): void
+    protected function updateReservedProductQuantity(StockId $stockId, OrderStateId $errorStateId, OrderStateId $canceledStateId, ?OrderStateId $refundedStateId = null): void
     {
+        $nonReservingStates = [$errorStateId->getValue(), $canceledStateId->getValue()];
+
+        if (null !== $refundedStateId) {
+            $nonReservingStates[] = $refundedStateId->getValue();
+        }
+
         $qb = $this->connection->createQueryBuilder();
         $qb
             ->addSelect('SUM(od.product_quantity - od.product_quantity_refunded) AS reserved_quantity')
@@ -345,19 +353,15 @@ class StockAvailableRepository extends AbstractMultiShopObjectModelRepository
                 $qb->expr()->neq('os.shipped', 1),
                 $qb->expr()->or(
                     $qb->expr()->eq('o.valid', 1),
-                    $qb->expr()->and(
-                        $qb->expr()->neq('os.id_order_state', ':errorStateId'),
-                        $qb->expr()->neq('os.id_order_state', ':canceledStateId')
-                    )
+                    $qb->expr()->notIn('os.id_order_state', ':nonReservingStates')
                 ),
                 $qb->expr()->eq('sa.id_stock_available', ':stockId')
             ))
             ->groupBy('od.product_id', 'od.product_attribute_id')
             ->setParameters([
                 'stockId' => $stockId->getValue(),
-                'errorStateId' => $errorStateId->getValue(),
-                'canceledStateId' => $canceledStateId->getValue(),
             ])
+            ->setParameter('nonReservingStates', array_values(array_unique($nonReservingStates)), ArrayParameterType::INTEGER)
         ;
 
         $result = $qb->executeQuery()->fetchAssociative();

--- a/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
+++ b/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
@@ -162,7 +162,8 @@ class ProductStockUpdater
             $this->stockAvailableRepository->updatePhysicalProductQuantity(
                 new StockId((int) $stockAvailable->id),
                 new OrderStateId((int) $this->configuration->get('PS_OS_ERROR', null, $shopConstraint)),
-                new OrderStateId((int) $this->configuration->get('PS_OS_CANCELED', null, $shopConstraint))
+                new OrderStateId((int) $this->configuration->get('PS_OS_CANCELED', null, $shopConstraint)),
+                new OrderStateId((int) $this->configuration->get('PS_OS_REFUND', null, $shopConstraint))
             );
         }
     }
@@ -263,7 +264,8 @@ class ProductStockUpdater
             $this->stockAvailableRepository->updatePhysicalProductQuantity(
                 new StockId((int) $stockAvailable->id),
                 new OrderStateId((int) $this->configuration->get('PS_OS_ERROR', null, $shopConstraint)),
-                new OrderStateId((int) $this->configuration->get('PS_OS_CANCELED', null, $shopConstraint))
+                new OrderStateId((int) $this->configuration->get('PS_OS_CANCELED', null, $shopConstraint)),
+                new OrderStateId((int) $this->configuration->get('PS_OS_REFUND', null, $shopConstraint))
             );
         }
     }

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -86,9 +86,9 @@ class StockManager
      *
      * @return bool
      */
-    public function updatePhysicalProductQuantity($shopId, $errorState, $cancellationState, $idProduct = null, $idOrder = null)
+    public function updatePhysicalProductQuantity($shopId, $errorState, $cancellationState, $idProduct = null, $idOrder = null, $refundState = null)
     {
-        $this->updateReservedProductQuantity($shopId, $errorState, $cancellationState, $idProduct, $idOrder);
+        $this->updateReservedProductQuantity($shopId, $errorState, $cancellationState, $idProduct, $idOrder, $refundState);
 
         $updatePhysicalQuantityQuery = 'UPDATE {table_prefix}stock_available sa';
 
@@ -128,7 +128,7 @@ class StockManager
      *
      * @return bool
      */
-    private function updateReservedProductQuantity($shopId, $errorState, $cancellationState, $idProduct = null, $idOrder = null)
+    private function updateReservedProductQuantity($shopId, $errorState, $cancellationState, $idProduct = null, $idOrder = null, $refundState = null)
     {
         $updateReservedQuantityQuery = 'UPDATE {table_prefix}stock_available sa';
 
@@ -158,8 +158,7 @@ class StockManager
                 WHERE ' . $orderScopeCondition . ' AND
                 os.shipped != 1 AND (
                     o.valid = 1 OR (
-                        os.id_order_state != :error_state AND
-                        os.id_order_state != :cancellation_state
+                        os.id_order_state NOT IN (:non_reserving_states)
                     )
                 ) AND sa.id_product = od.product_id AND
                 sa.id_product_attribute = od.product_attribute_id
@@ -174,8 +173,7 @@ class StockManager
             '{table_prefix}' => _DB_PREFIX_,
             ':stock_shop_id' => (int) $stockContext['shopId'],
             ':stock_shop_group_id' => (int) $stockContext['shopGroupId'],
-            ':error_state' => (int) $errorState,
-            ':cancellation_state' => (int) $cancellationState,
+            ':non_reserving_states' => implode(',', $this->getNonReservingStates($errorState, $cancellationState, $refundState)),
         ];
 
         if ($idProduct) {
@@ -261,5 +259,26 @@ class StockManager
     public function outOfStock($productId, $shopId = null)
     {
         return StockAvailable::outOfStock($productId, $shopId);
+    }
+
+    /**
+     * States whose orders must not hold reserved stock. The refund state is optional so that callers
+     * which have not been updated keep the previous behaviour.
+     *
+     * @param int $errorState
+     * @param int $cancellationState
+     * @param int|null $refundState
+     *
+     * @return int[]
+     */
+    private function getNonReservingStates($errorState, $cancellationState, $refundState = null)
+    {
+        $states = [(int) $errorState, (int) $cancellationState];
+
+        if (null !== $refundState) {
+            $states[] = (int) $refundState;
+        }
+
+        return array_values(array_unique($states));
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -16,6 +16,7 @@ use Cart;
 use Configuration;
 use Context;
 use Currency;
+use Db;
 use FrontController;
 use Order;
 use OrderInvoice;
@@ -1655,6 +1656,24 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
      *
      * @return int
      */
+    /**
+     * @Then the reserved stock for product :productName should be :expectedQuantity
+     */
+    public function assertReservedStockForProduct(string $productName, int $expectedQuantity): void
+    {
+        $reservedQuantity = (int) Db::getInstance()->getValue(
+            'SELECT reserved_quantity FROM ' . _DB_PREFIX_ . 'stock_available
+            WHERE id_product = ' . $this->getProductIdByName($productName) . '
+            AND id_product_attribute = 0'
+        );
+
+        Assert::assertSame(
+            $expectedQuantity,
+            $reservedQuantity,
+            sprintf('Expected %d reserved for "%s", got %d', $expectedQuantity, $productName, $reservedQuantity)
+        );
+    }
+
     private function getProductIdByName(string $productName)
     {
         $product = $this->getProductByName($productName);

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_update_status.feature
@@ -80,3 +80,21 @@ Feature: Order from Back Office (BO)
       | Delivered                  |                     |                    |               |
       | Payment accepted           |                     |                    | api_client    |
       | Awaiting bank wire payment |                     |                    |               |
+
+  Scenario: Reserved stock is released when the order is refunded
+    Given I am logged in as "test@prestashop.com" employee
+    And I create an empty cart "refund_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "refund_cart"
+    And I add 2 products "Mug The best is yet to come" to the cart "refund_cart"
+    And I add order "refund_order" with the following details:
+      | cart                | refund_cart      |
+      | message             | test             |
+      | payment module name | dummy_payment    |
+      | status              | Payment accepted |
+    Then the reserved stock for product "Mug The best is yet to come" should be 2
+    # Refunded is a final state, it must release the reservation exactly like Canceled does
+    When I update order "refund_order" status to "Refunded"
+    Then the reserved stock for product "Mug The best is yet to come" should be 0
+    # and returning the order to a live state must reserve it again, the release is not one way
+    When I update order "refund_order" status to "Payment accepted"
+    Then the reserved stock for product "Mug The best is yet to come" should be 2


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Reserved quantity is computed from every order that is neither in the error state nor the cancelled state, so an order moved to Refunded keeps holding stock. Refunded is a final state and carries exactly the same state flags as Canceled, which does release it. The refund state is now passed to the two places that compute reserved quantity. It is an optional argument in both, so any caller that does not supply it keeps the current behaviour.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Catalog > Stock, note the reserved quantity for a product. Place an order for it and set the order to Payment accepted: reserved goes up. Set the order to Refunded. Before: reserved stays. After: reserved drops to 0, and setting the order back to Payment accepted reserves it again. Canceled behaves as it always did.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23013
| Related PRs       |
| Sponsor company   |

Both changed methods gain a trailing optional parameter (`$refundState` / `?OrderStateId $refundedStateId`)
defaulting to null, so no existing caller signature breaks.

### Measured on 9.2.x, with a control

Order 2 of the fixture shop, two lines, moved through states while reading `ps_stock_available`:

```
                              before the fix        after the fix
Payment accepted (2)          reserved 2 / 1        reserved 2 / 1
REFUNDED (7)                  reserved 2 / 1        reserved 0 / 0
back to Payment accepted - reserved 2 / 1
Canceled (6)   [control]      reserved 0 / 0        reserved 0 / 0
```

Canceled is the control: it already released, and still does. The third row matters too - the release is not
one way, returning the order to a live state reserves again.

### Why Refunded cannot simply be derived from the state flags

There is no attribute on `ps_order_state` that means "final". Measured on a fresh install:

```
id  name                        invoice send_email logable delivery hidden shipped paid
1   Awaiting check payment      0       1          0       0        0      0       0
6   Canceled                    0       1          0       0        0      0       0
7   Refunded                    1       1          0       0        0      0       0
8   Payment error               0       1          0       0        0      0       0
10  Awaiting bank wire payment  0       1          0       0        0      0       0
```

Awaiting-check-payment and Canceled are identical on every flag, yet one must reserve and the other must
not. That is why the query names states by id, and it is what @groukx was asking for in this thread with
"maybe add a new flag reserved into the order_states". Adding such a flag is a schema change with an
upgrade script and a BO form change, so this PR keeps the existing id-based approach and only adds the
missing state.

### The rule is implemented twice

- `StockManager::updateReservedProductQuantity()` - legacy path, reached from `OrderHistory`,
  `PaymentModule`, `AbstractOrderCommandHandler` and `OrderProductQuantityUpdater`.
- `StockAvailableRepository::updateReservedProductQuantity()` - the CQRS path, a Doctrine QueryBuilder
  copy whose docblock says "Most of this function logic comes from StockManager::updatePhysicalProductQuantity",
  reached from `ProductStockUpdater` (twice) and `CombinationStockUpdater`.

Both are fixed. #23022 changed only the first, so editing a product's stock in the BO would have restored
the wrong reserved value.

### Test

`tests/Integration/Behaviour/Features/Scenario/Order/order_update_status.feature`, plus a new
`the reserved stock for product :name should be :qty` step on `OrderFeatureContext`.
Verified RED on `upstream/9.2.x` - `Expected 0 reserved for "Mug The best is yet to come", got 2` - and
GREEN with the change. The "should be 2" assertion passes on both sides, so the scenario is not vacuous.
`behat -s order --tags order-update-status`: 3 scenarios, 61 steps, all passing.

php-cs-fixer 0 of 9 fixable, PHPStan OK.

### Separate observation, deliberately NOT in this PR

`StockAvailableRepository::updateReservedProductQuantity()` ends with
`if ($reservedQuantity > 0) { ...update... }`, so a computed value of 0 is never written and a previously
non-zero `reserved_quantity` stays stale on that path. Reading only - not measured, and out of scope here.
Worth its own issue.
