### PR TITLE
Serve virtual product downloads with fread and support byte ranges

### DIFF
--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -263,10 +263,33 @@ class GetFileControllerCore extends FrontController
             ob_end_clean();
         }
 
+        $fileSize = (int) filesize($file);
+        $start = 0;
+        $end = $fileSize - 1;
+
+        /*
+         * A download of several hundred megabytes is regularly interrupted, and without range support the
+         * customer has to start again from the beginning, which also spends another slot of their download
+         * quota's worth of traffic. Announcing ranges lets the client ask for the remaining bytes instead.
+         */
+        $range = $this->parseRangeHeader($_SERVER['HTTP_RANGE'] ?? null, $fileSize);
+        if ($range === false) {
+            header('HTTP/1.1 416 Range Not Satisfiable');
+            header('Content-Range: bytes */' . $fileSize);
+
+            exit;
+        }
+        if ($range !== null) {
+            [$start, $end] = $range;
+            header('HTTP/1.1 206 Partial Content');
+            header('Content-Range: bytes ' . $start . '-' . $end . '/' . $fileSize);
+        }
+
         /* Set headers for download */
         header('Content-Transfer-Encoding: binary');
         header('Content-Type: ' . $this->getMimeType($file, $filename));
-        header('Content-Length: ' . filesize($file));
+        header('Accept-Ranges: bytes');
+        header('Content-Length: ' . ($end - $start + 1));
         if ($forceDownload) {
             header('Content-Disposition: attachment; filename="' . $filename . '"');
         }
@@ -275,12 +298,75 @@ class GetFileControllerCore extends FrontController
         $fp = fopen($file, 'rb');
 
         if ($fp && is_resource($fp)) {
-            while (!feof($fp)) {
-                echo fgets($fp, 16384);
+            if ($start > 0) {
+                fseek($fp, $start);
             }
+            /*
+             * fread is used rather than fgets: fgets stops at the first line break, and binary content
+             * contains those at random, so it returned chunks far smaller than the requested length and
+             * looped a lot more than needed for the same bytes.
+             */
+            $remaining = $end - $start + 1;
+            while ($remaining > 0 && !feof($fp)) {
+                $chunk = fread($fp, (int) min(16384, $remaining));
+                if ($chunk === false || $chunk === '') {
+                    break;
+                }
+                echo $chunk;
+                $remaining -= strlen($chunk);
+            }
+            fclose($fp);
         }
 
         exit;
+    }
+
+    /**
+     * Reads a single byte range out of a Range header.
+     *
+     * Only one range is honoured; a request for several is answered with the whole file, which the
+     * specification allows, rather than building a multipart response.
+     *
+     * @param string|null $rangeHeader
+     * @param int $fileSize
+     *
+     * @return array{0: int, 1: int}|false|null the range to serve, null to serve the whole file,
+     *                                          false when the range cannot be satisfied
+     */
+    private function parseRangeHeader(?string $rangeHeader, int $fileSize)
+    {
+        if ($fileSize <= 0 || !is_string($rangeHeader)) {
+            return null;
+        }
+
+        if (!preg_match('/^bytes=(\d*)-(\d*)$/', trim($rangeHeader), $matches)) {
+            return null;
+        }
+
+        [, $firstByte, $lastByte] = $matches;
+
+        if ($firstByte === '' && $lastByte === '') {
+            return null;
+        }
+
+        if ($firstByte === '') {
+            // "bytes=-500" asks for the last 500 bytes
+            $length = (int) $lastByte;
+            if ($length <= 0) {
+                return false;
+            }
+            $start = max(0, $fileSize - $length);
+            $end = $fileSize - 1;
+        } else {
+            $start = (int) $firstByte;
+            $end = $lastByte === '' ? $fileSize - 1 : (int) $lastByte;
+        }
+
+        if ($start > $end || $start >= $fileSize) {
+            return false;
+        }
+
+        return [$start, min($end, $fileSize - 1)];
     }
 
     private function getMimeType(string $file, string $filename): string

--- a/tests/Unit/Controllers/Front/GetFileControllerTest.php
+++ b/tests/Unit/Controllers/Front/GetFileControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Controllers\Front;
+
+use GetFileControllerCore;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class GetFileControllerTest extends TestCase
+{
+    private const FILE_SIZE = 1000;
+
+    /**
+     * @dataProvider provideRangeHeaders
+     *
+     * @param array{0: int, 1: int}|false|null $expected
+     */
+    public function testItReadsASingleByteRange(?string $header, $expected): void
+    {
+        self::assertSame($expected, $this->parseRange($header, self::FILE_SIZE));
+    }
+
+    public function provideRangeHeaders(): iterable
+    {
+        // null means "serve the whole file", false means the range cannot be satisfied
+        yield 'no header' => [null, null];
+        yield 'not a byte range' => ['items=0-10', null];
+        yield 'malformed' => ['bytes=abc', null];
+        yield 'open ended on both sides' => ['bytes=-', null];
+        // Several ranges at once are answered with the whole file rather than a multipart response
+        yield 'several ranges' => ['bytes=0-10,20-30', null];
+
+        yield 'first hundred bytes' => ['bytes=0-99', [0, 99]];
+        yield 'from an offset to the end' => ['bytes=100-', [100, 999]];
+        yield 'a suffix' => ['bytes=-500', [500, 999]];
+        yield 'a suffix longer than the file' => ['bytes=-5000', [0, 999]];
+        yield 'end past the file is clamped' => ['bytes=0-99999', [0, 999]];
+        yield 'the very last byte' => ['bytes=999-999', [999, 999]];
+        yield 'surrounding spaces are tolerated' => [' bytes=10-20 ', [10, 20]];
+
+        yield 'start past the end' => ['bytes=1000-1100', false];
+        yield 'start after end' => ['bytes=50-10', false];
+        yield 'empty suffix' => ['bytes=-0', false];
+    }
+
+    public function testAnEmptyFileIsAlwaysServedWhole(): void
+    {
+        self::assertNull($this->parseRange('bytes=0-10', 0));
+    }
+
+    /**
+     * @return array{0: int, 1: int}|false|null
+     */
+    private function parseRange(?string $header, int $fileSize)
+    {
+        $reflection = new ReflectionClass(GetFileControllerCore::class);
+        $controller = $reflection->newInstanceWithoutConstructor();
+        $method = $reflection->getMethod('parseRangeHeader');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $header, $fileSize);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Virtual product downloads are sent with `echo fgets($fp, 16384)`. `fgets` stops at the first line break, and binary content contains those at random, so it returns chunks far smaller than the requested length. The controller also does not support byte ranges, so a download interrupted at 400 MB has to start again from zero. It now reads with `fread`, announces `Accept-Ranges`, answers a single byte range with 206 and a `Content-Range`, and replies 416 when the range cannot be satisfied.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Attach a large file to a virtual product and order it. `curl -I` on the download link now reports `Accept-Ranges: bytes`; `curl -r 0-99` returns 206 with `Content-Range: bytes 0-99/<size>` and exactly 100 bytes; an out of range request returns 416. Downloading the whole file returns the same bytes as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #20371
| Related PRs       |
| Sponsor company   |

### Measured, on 4 MB of random bytes

```
fgets   16335 iterations   avg chunk    256 bytes   4194304 bytes total
fread     257 iterations   avg chunk  16320 bytes   4194304 bytes total
ideal at 16 kB chunks: 256 iterations
```

`fgets` was doing 64 times the loop for the same content, because a byte stream hits `0x0A` roughly every
256 bytes. Both read the identical number of bytes, so nothing about the delivered file changes.

### Nothing here has moved since the report

Per release, `controllers/front/GetFileController.php`:

```
                 set_time_limit   fgets   any Range handling
1.7.6.4                yes         yes           no
1.7.8.11 / 8.0.0       yes         yes           no
9.0.0 / 9.2.x          yes         yes           no
```

`@set_time_limit(0)` was already there in the reported version, so the timeout @PierreRambaud mentioned is
handled; ranges never were.

### Direction

@digitalhuman, @davidglezz and @PierreRambaud converged on resumable downloads through `Content-Range` in
2020, and @PierreRambaud wrote "I like the idea of continuous download". That is what this implements. The
access checks stay exactly where they are, in PHP, so nothing about who may download what changes; only how
the bytes are handed over.

Range parsing follows the HTTP semantics rather than inventing any: `bytes=0-99`, `bytes=100-`,
`bytes=-500`, an end past the file is clamped, `start >= size` or `start > end` is 416. A request for
several ranges is answered with the whole file, which the specification permits, instead of building a
multipart/byteranges response.

### Test

`tests/Unit/Controllers/Front/GetFileControllerTest.php`, 16 cases over the parser, reached with
reflection so no production visibility changes. Verified RED on `upstream/9.2.x` (the method does not exist
there) and GREEN with the change.

### What is not proven here

The reporter measured 45 kB/s on a 600 MB file. The iteration count above is measured, and byte identity is
measured, but I have not measured end to end throughput over a network, and I would not claim this alone
explains 45 kB/s - that figure is as likely to come from the FPM and proxy buffering the reporter quoted.
What this changes with certainty is the loop count and the ability to resume, which is what makes a failed
600 MB download recoverable instead of a restart.

php-cs-fixer clean, PHPStan OK.
