### PR TITLE
Leave a tax that does not exist out of the order detail calculator

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -350,7 +350,17 @@ class OrderDetailCore extends ObjectModel
         $taxes = [];
         if ($results = Db::getInstance()->executeS($sql)) {
             foreach ($results as $result) {
-                $taxes[] = new Tax((int) $result['id_tax']);
+                $tax = new Tax((int) $result['id_tax']);
+                // WHY: order_detail_tax can carry an id_tax that resolves to nothing - a tax-free line
+                // stores 0, and a tax deleted since the order was placed leaves its id behind. new Tax()
+                // then returns an unloaded object whose rate is null, and TaxCalculator's abs($tax->rate)
+                // is deprecated on PHP 8 and a TypeError on PHP 9. Such a row also carries no rate to
+                // apply, so leaving it out changes no amount: getTaxesAmount() simply stops returning an
+                // entry keyed by the empty string, which Order::getProductTaxesDetails() would otherwise
+                // write straight back as another id_tax = 0 row.
+                if (Validate::isLoadedObject($tax)) {
+                    $taxes[] = $tax;
+                }
                 $computation_method = $result['tax_computation_method'];
             }
         }

--- a/tests/Integration/Classes/Order/OrderDetailTaxCalculatorTest.php
+++ b/tests/Integration/Classes/Order/OrderDetailTaxCalculatorTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Db;
+use OrderDetail;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `order_detail_tax` can hold an `id_tax` that resolves to nothing: a tax-free line stores 0, and a tax
+ * deleted after the order was placed leaves its id behind. `getTaxCalculatorStatic()` handed those to
+ * `TaxCalculator` as unloaded `Tax` objects whose `rate` is null, so `abs($tax->rate)` raised
+ * "Passing null to parameter #1 ($num) of type int|float is deprecated" on PHP 8 - a TypeError on PHP 9 -
+ * and `getTaxesAmount()` returned an entry keyed by the empty string, which
+ * `Order::getProductTaxesDetails()` writes back as another `id_tax = 0` row.
+ */
+class OrderDetailTaxCalculatorTest extends TestCase
+{
+    /**
+     * @var int
+     */
+    private $orderDetailId;
+
+    /**
+     * @var array<int, array<string, string>>
+     */
+    private $originalRows = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->orderDetailId = (int) Db::getInstance()->getValue(
+            'SELECT id_order_detail FROM ' . _DB_PREFIX_ . 'order_detail ORDER BY id_order_detail'
+        );
+        if (!$this->orderDetailId) {
+            $this->markTestSkipped('the fixture holds no order detail to attach a tax row to');
+        }
+
+        $this->originalRows = (array) Db::getInstance()->executeS(
+            'SELECT * FROM ' . _DB_PREFIX_ . 'order_detail_tax WHERE id_order_detail = ' . $this->orderDetailId
+        );
+        $this->deleteRows();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteRows();
+        foreach ($this->originalRows as $row) {
+            $this->insertRow((int) $row['id_tax'], (float) $row['unit_amount'], (float) $row['total_amount']);
+        }
+        $this->originalRows = [];
+
+        parent::tearDown();
+    }
+
+    public function testATaxThatDoesNotExistIsLeftOutOfTheCalculator(): void
+    {
+        $this->insertRow(0, 0.0, 0.0);
+
+        $calculator = OrderDetail::getTaxCalculatorStatic($this->orderDetailId);
+
+        $this->assertSame([], $calculator->taxes, 'an id_tax that loads nothing must not reach the calculator');
+        $this->assertSame(0.0, (float) $calculator->getTotalRate());
+        $this->assertSame(
+            [],
+            $calculator->getTaxesAmount(100.0),
+            'a tax with no rate must not produce an amount keyed by the empty string'
+        );
+    }
+
+    public function testAnExistingTaxStillReachesTheCalculator(): void
+    {
+        $idTax = (int) Db::getInstance()->getValue(
+            'SELECT id_tax FROM ' . _DB_PREFIX_ . 'tax WHERE active = 1 AND rate > 0 ORDER BY id_tax'
+        );
+        if (!$idTax) {
+            $this->markTestSkipped('the fixture holds no active tax with a rate');
+        }
+        $this->insertRow($idTax, 1.0, 1.0);
+
+        $calculator = OrderDetail::getTaxCalculatorStatic($this->orderDetailId);
+
+        $this->assertCount(1, $calculator->taxes);
+        $this->assertGreaterThan(0, $calculator->getTotalRate(), 'the control must exercise a real rate');
+        $this->assertArrayHasKey($idTax, $calculator->getTaxesAmount(100.0));
+    }
+
+    private function insertRow(int $idTax, float $unitAmount, float $totalAmount): void
+    {
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'order_detail_tax (id_order_detail, id_tax, unit_amount, total_amount)'
+            . ' VALUES (' . $this->orderDetailId . ', ' . $idTax . ', ' . $unitAmount . ', ' . $totalAmount . ')'
+        );
+    }
+
+    private function deleteRows(): void
+    {
+        Db::getInstance()->execute(
+            'DELETE FROM ' . _DB_PREFIX_ . 'order_detail_tax WHERE id_order_detail = ' . $this->orderDetailId
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `OrderDetail::getTaxCalculatorStatic()` built a `Tax` object for every `order_detail_tax` row, including rows whose `id_tax` resolves to nothing. `new Tax(0)` is an unloaded ObjectModel with a null `rate`, so `TaxCalculator`'s `abs($tax->rate)` raised a deprecation on PHP 8 - a TypeError on PHP 9 - and `getTaxesAmount()` returned an entry keyed by the empty string. Such rows now stay out of the calculator, which changes no amount and stops the empty key being written back as another `id_tax = 0` row.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37409
| Related PRs       |
| Sponsor company   |

### Where the null comes from

@Hlavtox asked the right question on the issue - a tax should never hand back a null rate. It does not:
the `Tax` object was never loaded. `getTaxCalculatorStatic()` runs
`$taxes[] = new Tax((int) $result['id_tax'])` over every `order_detail_tax` row
(`classes/order/OrderDetail.php:353`), and `new Tax(0)` returns an object with `id` and `rate` both null.

The row is also written by PrestaShop itself, which is why it persists. `Order::getProductTaxesDetails()`
iterates `$tax_calculator->getTaxesAmount(...)` **keyed by the tax id**
(`classes/order/Order.php:2493`) and copies that key into `'id_tax' => $id_tax`. For an unloaded tax the
key is `''`, and `Order::updateOrderDetailTax()` inserts it as `(int) '' = 0`
(`classes/order/Order.php:2578`). So one such row keeps regenerating itself on every recalculation, which
matches the `id_tax` of zero in the reporter's screenshots.

### Measured

On `9.2.x`, with an `id_tax = 0` row attached to an existing order detail, calling
`OrderDetail::getTaxCalculatorStatic()` and then the two methods the report names:

| | taxes in the calculator | `getTotalRate()` | `getTaxesAmount(100)` | deprecations raised |
| --- | --- | --- | --- | --- |
| before | 1 | `0.0` | `{"": 0}` | **2** - `abs(): Passing null to parameter #1 ($num) of type int|float is deprecated` |
| after | 0 | `0.0` | `[]` | **0** |

The rate is `0.0` either way, so no amount moves - what disappears is the deprecation and the entry keyed
by the empty string.

### Why here rather than `abs($tax->rate ?? 0)`

The report proposes coalescing at the four `abs()` call sites in `classes/tax/TaxCalculator.php`. That
silences the notice but keeps handing `TaxCalculator` an object that is not a tax, keeps the empty-string
key, and keeps `getProductTaxesDetails()` writing the `id_tax = 0` row back. Filtering where the objects
are built fixes all three, and it is the only one of the three callers of `getTaxCalculatorStatic()` that
can introduce them.

### Test

`tests/Integration/Classes/Order/OrderDetailTaxCalculatorTest.php`: attaches an `id_tax = 0` row to an
existing order detail and asserts the calculator holds no taxes, a total rate of `0.0`, and no
empty-string key; a second case attaches a real active tax and asserts it still arrives, with a rate above
zero, so the first is not passing vacuously. Both restore the detail's original rows in `tearDown()`.

```
vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/Order/OrderDetailTaxCalculatorTest.php
```

2 tests / 6 assertions green. Reverting `classes/order/OrderDetail.php` alone fails only the first case,
`Failed asserting that two arrays are identical`. `tests/Integration/Classes/tax`,
`tests/Integration/Adapter/Tax` and `tests/Unit/Classes/Tax` stay green (41 and 3 tests).
