### PR TITLE
Keep the back office up when the preload asset was never built

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -65,9 +65,14 @@
 {/if}
 {$admin_path = "{__PS_BASE_URI__}{basename(_PS_ADMIN_DIR_)}/themes/default/public/"}
 
-{$preloadFilePath = "../public/preload.tpl"}
+{* preload.tpl is written by webpack into the gitignored public/ directory, so an install whose
+   admin assets were never built does not have it. The preload hints are an optimisation - without this
+   guard their absence takes the whole back office down with "Unable to load template". *}
+{$preloadFilePath = _PS_ADMIN_DIR_|cat:"/themes/default/public/preload.tpl"}
 
-{include file=$preloadFilePath admin_dir=$admin_path}
+{if file_exists($preloadFilePath)}
+	{include file=$preloadFilePath admin_dir=$admin_path}
+{/if}
 
 {if isset($css_files)}
 {foreach from=$css_files key=css_uri item=media}

--- a/admin-dev/themes/new-theme/template/header.tpl
+++ b/admin-dev/themes/new-theme/template/header.tpl
@@ -56,9 +56,14 @@
 
 {$admin_path = "{__PS_BASE_URI__}{basename(_PS_ADMIN_DIR_)}/themes/new-theme/public/"}
 
-{$preloadFilePath = "../public/preload.tpl"}
+{* preload.tpl is written by webpack into the gitignored public/ directory, so an install whose
+   admin assets were never built does not have it. The preload hints are an optimisation - without this
+   guard their absence takes the whole back office down with "Unable to load template". *}
+{$preloadFilePath = _PS_ADMIN_DIR_|cat:"/themes/new-theme/public/preload.tpl"}
 
-{include file=$preloadFilePath admin_dir=$admin_path}
+{if file_exists($preloadFilePath)}
+  {include file=$preloadFilePath admin_dir=$admin_path}
+{/if}
 
 {if isset($css_files)}
   {foreach from=$css_files key=css_uri item=media}

--- a/tests/Integration/Classes/Smarty/AdminHeaderPreloadTest.php
+++ b/tests/Integration/Classes/Smarty/AdminHeaderPreloadTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Smarty;
+
+use Configuration;
+use Context;
+use Currency;
+use Language;
+use Link;
+use PHPUnit\Framework\TestCase;
+use Shop;
+
+/**
+ * `preload.tpl` is written by webpack into the gitignored `public/` directory of each admin theme, so an
+ * install whose admin assets were never built - a plain checkout, or `docker compose up` on one - does
+ * not have it. `header.tpl` included it unconditionally, and Smarty answers a missing include with an
+ * exception, so the whole back office went down over an optional set of preload hints.
+ *
+ * @group non-mysql
+ */
+class AdminHeaderPreloadTest extends TestCase
+{
+    /**
+     * @var array<string, string|null> path => original contents, or null when the file was absent
+     */
+    private $movedAside = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach ($this->preloadPaths() as $path) {
+            $this->movedAside[$path] = file_exists($path) ? (string) file_get_contents($path) : null;
+            if (null !== $this->movedAside[$path]) {
+                unlink($path);
+            }
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->movedAside as $path => $contents) {
+            if (null === $contents) {
+                if (file_exists($path)) {
+                    unlink($path);
+                }
+            } else {
+                file_put_contents($path, $contents);
+            }
+        }
+        $this->movedAside = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider adminThemeProvider
+     */
+    public function testTheHeaderRendersWhenTheBuiltPreloadFileIsMissing(string $theme): void
+    {
+        $header = _PS_ADMIN_DIR_ . '/themes/' . $theme . '/template/header.tpl';
+        $this->assertFileExists($header);
+        $this->assertFileDoesNotExist(_PS_ADMIN_DIR_ . '/themes/' . $theme . '/public/preload.tpl');
+
+        $smarty = $this->prepareContext()->smarty;
+        $smarty->clearCompiledTemplate();
+
+        $output = $smarty->fetch($header);
+
+        $this->assertNotSame('', trim($output), 'the header must still render without the preload hints');
+    }
+
+    /**
+     * @dataProvider adminThemeProvider
+     */
+    public function testTheHeaderStillEmitsThePreloadHintsWhenTheFileIsThere(string $theme): void
+    {
+        $path = _PS_ADMIN_DIR_ . '/themes/' . $theme . '/public/preload.tpl';
+        file_put_contents($path, '<link rel="preload" href="{$admin_dir}marker.woff2" as="font">');
+
+        $smarty = $this->prepareContext()->smarty;
+        $smarty->clearCompiledTemplate();
+
+        $output = $smarty->fetch(_PS_ADMIN_DIR_ . '/themes/' . $theme . '/template/header.tpl');
+
+        $this->assertStringContainsString('marker.woff2', $output, 'the hints must still reach the page');
+        $this->assertStringContainsString(
+            'themes/' . $theme . '/public/',
+            $output,
+            'admin_dir must still be handed to the included template'
+        );
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public function adminThemeProvider(): array
+    {
+        return [['new-theme'], ['default']];
+    }
+
+    private function prepareContext(): Context
+    {
+        $context = Context::getContext();
+        $context->link = new Link();
+        $context->shop = new Shop(1);
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->smarty->assign([
+            'link' => $context->link,
+            'js_def' => [],
+            'js_files' => [],
+            'css_files' => [],
+        ]);
+
+        return $context;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function preloadPaths(): array
+    {
+        return [
+            _PS_ADMIN_DIR_ . '/themes/new-theme/public/preload.tpl',
+            _PS_ADMIN_DIR_ . '/themes/default/public/preload.tpl',
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Both admin themes' `header.tpl` include `public/preload.tpl` unconditionally. That file is written by webpack and `public/` is gitignored, so an install whose admin assets were never built does not have it - and Smarty answers a missing include with an exception, so the whole back office goes down over a set of optional font preload hints. The include is now guarded, and the hints are emitted exactly as before when the file is there.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Delete `admin-dev/themes/new-theme/public/preload.tpl` and open any back office page. Before this change the page is replaced by `Unable to load template 'file:../public/preload.tpl'`; after it, the page renders without the preload links. Covered by the added integration test.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37440
| Related PRs       |
| Sponsor company   |

### Why the file can be missing

`preload.tpl` is generated by `webpack-font-preload-plugin`, configured at
`admin-dev/themes/default/webpack.config.js:97` (`filename: 'preload.tpl'`) and the equivalent in
`admin-dev/themes/new-theme/.webpack/`. Its destination, `admin-dev/themes/*/public/`, is ignored -
`.gitignore:126`. So the file exists only after the admin assets have been built. A checkout that has
not run the asset build - which is what `docker compose up` on the repository gives you - has the
template that includes it and not the file itself.

Nothing about that is specific to Docker or to 8.2.0: the two `header.tpl` files on `9.2.x` still
include it unconditionally, at `admin-dev/themes/new-theme/template/header.tpl:61` and
`admin-dev/themes/default/template/header.tpl:70`.

### Measured

Rendering the real `header.tpl` through the shop's own Smarty, on `9.2.x`:

| `public/preload.tpl` | before | after |
| --- | --- | --- |
| absent | `SmartyException: Unable to load template 'file:../public/preload.tpl' in '.../new-theme/template/header.tpl'` | renders, include skipped |
| present, with a real `<link rel="preload">` in it | hint reaches the output, `{$admin_dir}` interpolated | identical |

The second row is the control and it is not vacuous: the built file on a normal install is **empty**
(the plugin writes nothing when there is nothing to preload), so it was given real content before the
comparison - otherwise "the hints still work" would have been asserted against an empty string.

### Test

`tests/Integration/Classes/Smarty/AdminHeaderPreloadTest.php` moves the built file aside, renders each
admin theme's `header.tpl`, and puts it back in `tearDown()`. Four cases, two per theme: renders with
the file missing, and still emits the hints plus the `admin_dir` value when it is there.

```
vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/Smarty/AdminHeaderPreloadTest.php
```

4 tests / 10 assertions green. Reverting the two templates alone fails exactly the two missing-file
cases, each with the reporter's own message, and leaves the two present-file cases green.
