### PR TITLE
Let a theme register assets for a module page

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -994,7 +994,7 @@ class FrontControllerCore extends Controller
         $this->registerJavascript('theme-main', '/assets/js/theme.js', ['position' => 'bottom', 'priority' => 50]);
         $this->registerJavascript('theme-custom', '/assets/js/custom.js', ['position' => 'bottom', 'priority' => 1000]);
 
-        $assets = $this->context->shop->theme->getPageSpecificAssets($this->php_self);
+        $assets = $this->context->shop->theme->getPageSpecificAssets($this->getThemePageIdentifier());
         if (!empty($assets)) {
             foreach ($assets['css'] as $css) {
                 $this->registerStylesheet($css['id'], $css['path'], $css);
@@ -1408,6 +1408,21 @@ class FrontControllerCore extends Controller
     }
 
     /**
+     * The identifier a theme addresses this page by, in theme.yml's `layouts` and `assets` keys.
+     *
+     * WHY: php_self is the primary identifier, but a module front controller never sets it - it
+     * identifies itself through page_name, 'module-<module>-<controller>'. getLayout() has always
+     * fallen back to that, while setMedia() asked for php_self alone, so a theme could pick a layout
+     * for a module page but never register a stylesheet or a script for one.
+     *
+     * @return string
+     */
+    protected function getThemePageIdentifier()
+    {
+        return !empty($this->php_self) ? $this->php_self : $this->getPageName();
+    }
+
+    /**
      * Returns the layout's full path corresponding to the current page by using the override system
      * Ex:
      * On the url: http://localhost/index.php?id_product=1&controller=product, this method will
@@ -1420,12 +1435,7 @@ class FrontControllerCore extends Controller
      */
     public function getLayout()
     {
-        // Primary identifier to search for a template is php_self property,
-        // For modules, we will use page_name
-        $entity = $this->php_self;
-        if (empty($entity)) {
-            $entity = $this->getPageName();
-        }
+        $entity = $this->getThemePageIdentifier();
 
         // Get layout set in prestashop configuration
         $layout = $this->context->shop->theme->getLayoutNameForPage($entity);

--- a/tests/Unit/Classes/controller/FrontControllerTest.php
+++ b/tests/Unit/Classes/controller/FrontControllerTest.php
@@ -88,6 +88,28 @@ class FrontControllerTest extends TestCase
         yield 'external back' => ['https://external.example.test/order'];
     }
 
+    public function testThePageIdentifierIsPhpSelfWhenTheControllerSetsOne(): void
+    {
+        $controller = new TestFrontController(new Context());
+        $controller->php_self = 'category';
+        $controller->page_name = 'category';
+
+        $this->assertSame('category', $controller->getThemePageIdentifier());
+    }
+
+    /**
+     * A module front controller never assigns php_self; ModuleFrontController's constructor gives it a
+     * page_name of 'module-<module>-<controller>' instead. Without the fallback, theme.yml's assets key
+     * is looked up under an empty identifier and can never match such a page.
+     */
+    public function testThePageIdentifierFallsBackToPageNameForAModuleController(): void
+    {
+        $controller = new TestFrontController(new Context());
+        $controller->page_name = 'module-ps_emailsubscription-verification';
+
+        $this->assertSame('module-ps_emailsubscription-verification', $controller->getThemePageIdentifier());
+    }
+
     private function getController(string $expectedPageName, ?array $expectedRequest, string $expectedPageLink): TestFrontController
     {
         $context = new Context();
@@ -122,5 +144,10 @@ class TestFrontController extends FrontControllerCore
     public function getPageLinkForTemplate(string $pageName): string
     {
         return parent::getPageLinkForTemplate($pageName);
+    }
+
+    public function getThemePageIdentifier()
+    {
+        return parent::getThemePageIdentifier();
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `theme.yml`'s `assets` key is documented as being keyed on a controller's `php_self`, and `FrontController::setMedia()` looked the page up under exactly that. A module front controller never assigns `php_self` - `ModuleFrontController::__construct()` gives it a `page_name` of `module-<module>-<controller>` instead - so the lookup ran against an empty identifier and no theme could register a stylesheet or a script for a module page. `getLayout()` has always resolved the same question with a fallback to `page_name`; both now go through one method.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37489
| Related PRs       |
| Sponsor company   |

### Measured

On `9.2.x`, with this appended to the active theme's `config/theme.yml` and a real
`assets/css/qa-probe.css` in the theme:

```yaml
assets:
  css:
    category:
      - id: qa-core-page
        path: assets/css/qa-probe.css
    module-ps_emailsubscription-verification:
      - id: qa-module-page
        path: assets/css/qa-probe.css
```

| page | references to `qa-probe.css` before | after |
| --- | --- | --- |
| `/3-clothes` (core `category`, sets `php_self`) | 1 | 1 |
| `/module/ps_emailsubscription/verification` | **0** | **1** |

The core page is the control: the feature already worked wherever `php_self` is set, and it still
behaves identically. Only the module page changes.

### Why page_name rather than the class name

The report suggests keying on the class name. `page_name` is the better identifier because the project
already uses it for exactly this question: `getLayout()` reads `php_self` and falls back to
`getPageName()` when it is empty, which is how `theme.yml`'s `layouts` key can already target a module
page today. Keying assets the same way makes the two halves of the same configuration file agree, and
needs no new vocabulary in `theme.yml`. Themes that address core pages by `php_self` are unaffected -
for those controllers `php_self` is non-empty and the fallback never runs.

The six core front controllers that do not set `php_self` - `AttachmentController`,
`ChangeCurrencyController`, `GetFileController`, `StatisticsController`, `UploadController` and the
`index.php` guard - serve downloads, redirects or nothing, so they render no assets either way.

### Test

`tests/Unit/Classes/controller/FrontControllerTest.php` gains two cases on the extracted
`getThemePageIdentifier()`: `php_self` wins when set, and a controller with only a
`module-<module>-<controller>` page name resolves to that.

```
vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Classes/controller/FrontControllerTest.php
```

9 tests / 16 assertions green. Mutation check on the behaviour rather than on the method's existence:
keeping `getThemePageIdentifier()` but returning `(string) $this->php_self` fails exactly the module
case with `Failed asserting that two strings are identical`, and leaves the other eight green.

`$entity` is still passed to the `overrideLayoutTemplate` hook in `getLayout()`, so listeners keep
receiving the value they always did - PHPStan caught its removal in a first draft of this change.
