### PR TITLE
Clear carrier ranges and their prices when the shipping method changes

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
@@ -64,9 +64,23 @@ export default class CarrierFormManager {
       this.refreshFreeShipping();
       this.onChangeZones();
     });
-    this.$shippingMethodInput.on('change', () => this.refreshCurrentShippingSymbol());
+    this.$shippingMethodInput.on('change', () => this.onChangeShippingMethod());
     $(CarrierFormMap.zonesContainer).on('click', CarrierFormMap.deleteZoneButton, (e:Event) => this.onDeleteZone(e));
     this.eventEmitter.on(CarrierFormEventMap.rangesUpdated, (ranges: Range[]) => this.onChangeRanges(ranges));
+  }
+
+  private onChangeShippingMethod(): void {
+    // WHY: the ranges and their prices are expressed in the unit of the shipping method that was
+    // selected when they were entered, so switching the method makes them meaningless - a 2kg to 6kg
+    // range is otherwise silently relabelled as a currency range holding the same numbers.
+    // Emitting rangesUpdated with no range reuses the single path that owns the ranges: the hidden
+    // data input is rewritten and every zone's rows, prices included, are rebuilt empty.
+    this.eventEmitter.emit(CarrierFormEventMap.rangesUpdated, []);
+
+    // WHY: this clearing belongs to the change listener and NOT to refreshCurrentShippingSymbol(),
+    // which also runs from initForm() on every page load - clearing there would wipe the ranges of
+    // the carrier being edited before the merchant touched anything.
+    this.refreshCurrentShippingSymbol();
   }
 
   private refreshFreeShipping(): void {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A carrier's ranges are expressed in the unit of the shipping method they were entered under, so switching between the order's total price and its total weight leaves them meaningless. Worse than being kept, they were silently reinterpreted: `refreshCurrentShippingSymbol()` rewrites every range label with the new symbol, so a 2kg to 6kg range becomes `2EUR - 6EUR` with the same numbers and the same zone prices. The change event now resets the ranges, which rebuilds every zone's rows, prices included, empty.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | BO > Shipping > Carriers > Add a new carrier > Shipping locations and costs. Select a zone, `Manage ranges`, set 2 to 6, Apply, then set a price for that zone. Switch `Shipping costs` to the other option. Before: the range row stays, relabelled into the new unit, and the price is still there. After: the ranges and their price fields are gone. Then edit an existing carrier and just open the page - its ranges must still be there, untouched.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37174
| Related PRs       | #42317, #42318
| Sponsor company   |

### The design question was settled on the issue

@florine2623 asked whether keeping the ranges might be deliberate. @ibahloul-ps replied that legacy
erases them and suggested warning the merchant first. @MateoChateau (PM) answered both: switching the
unit means the ranges have to be redone anyway ("it would not make sense to go from a range 0k-1k to
0EUR-1EUR"), and a warning is unnecessary because leaving without saving already restores the stored
configuration. @ibahloul-ps agreed. So: erase, no confirmation modal. This PR implements exactly that
and adds no dialog.

### Implementation

One event, no new clearing code. `rangesUpdated` is already the single path that owns the ranges -
`carrier-range-modal.ts` writes the hidden `ranges_data` input from it and `CarrierFormManager`
rebuilds every zone's rows from it. Emitting it with an empty array does both.

The clearing sits in the change listener and deliberately **not** in `refreshCurrentShippingSymbol()`,
which `initForm()` also calls on every page load - clearing there would wipe the ranges of the carrier
being edited before the merchant touched anything. That hazard is the reason for the second `WHY`
comment and for the second assertion in the measurement below.

### Measured

Driven through the real `CarrierFormManager` in a jsdom document with jQuery, an existing range
`[{"from":2,"to":6}]` and a price of 8 on it:

```
                                          base 9.2.x        with this change
switch shipping method -> ranges_data     [{"from":2,"to":6}]      []
                       -> range rows      1                        0
                       -> price inputs    1                        0
page load (initForm)   -> ranges_data     [{"from":2,"to":6}]      [{"from":2,"to":6}]
                       -> range rows      1                        1
```

RED->GREEN verified by reverting only `carrier-form-manager.ts` to `upstream/9.2.x` with the harness
in place: `expected '[{"from":2,"to":6}]' to equal '[]'`. The page-load row passes on **both** sides,
which is what makes the first row mean something - the fix does not work by clearing unconditionally.

### Why that harness is not in the diff

It cannot run in CI as it stands, and a test that silently fails there is worse than none:

- `jsdom` is not a declared dependency of `new-theme`; it is only present transitively through
  `webpack-font-preload-plugin`. Depending on npm hoisting of an indirect dependency is not a test.
- `carrier-form-manager.ts` does not compile under the theme's own `tsconfig.json`
  (`strict`, `noImplicitAny`): ts-node reports four pre-existing `TS7006` errors on the jQuery `.each`
  callbacks at lines 106, 127, 210 and 213, none of them touched here. The probe needs
  `TS_NODE_TRANSPILE_ONLY`, which `npm run test` does not set. The build never catches these because
  `.webpack/common.js:222` compiles TypeScript with `esbuild-loader`, which transpiles without
  typechecking.

Adding a dev dependency and unblocking the type errors is a larger, separate change than this fix.

### Checks

`eslint` clean on the touched file. A full `webpack --mode=development` build of `new-theme` exits 0
at the same 134 pre-existing warnings. Merges clean against my two other open PRs on this page,
verified with a real `git merge --no-commit --no-ff`, not by comparing hunk ranges.
