### PR TITLE
Inject the combination name builder through its interface

### DIFF
--- a/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
+++ b/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
@@ -24,7 +24,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryResult\PackedProductDeta
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
-use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder;
+use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -59,7 +59,7 @@ class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
     protected $attributeRepository;
 
     /**
-     * @var CombinationNameBuilder
+     * @var CombinationNameBuilderInterface
      */
     protected $combinationNameBuilder;
 
@@ -84,7 +84,7 @@ class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
         ProductRepository $productRepository,
         CombinationRepository $combinationRepository,
         AttributeRepository $attributeRepository,
-        CombinationNameBuilder $combinationNameBuilder,
+        CombinationNameBuilderInterface $combinationNameBuilder,
         ProductImageRepository $productImageRepository,
         TranslatorInterface $translator,
         ProductImageProviderInterface $productImageProvider

--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -32,7 +32,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
-use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder;
+use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilderInterface;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopBundle\Form\Admin\Sell\Discount\CartConditionsType;
 use PrestaShopBundle\Form\Admin\Sell\Discount\DeliveryConditionsType;
@@ -50,7 +50,7 @@ class DiscountFormDataProvider implements FormDataProviderInterface
         private readonly CommandBusInterface $queryBus,
         private readonly ProductRepository $productRepository,
         private readonly CombinationRepository $combinationRepository,
-        private readonly CombinationNameBuilder $combinationNameBuilder,
+        private readonly CombinationNameBuilderInterface $combinationNameBuilder,
         private readonly ProductImageProviderInterface $productImageProvider,
         private readonly LanguageContext $languageContext,
         private readonly AttributeRepository $attributeRepository,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -491,7 +491,7 @@ services:
       $productRepository: '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository'
       $attributeRepository: '@PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository'
       $specificPriceCombinationListener: '@PrestaShopBundle\Form\Admin\Sell\Product\EventListener\SpecificPriceCombinationListener'
-      $combinationNameBuilder: '@PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder'
+      $combinationNameBuilder: '@PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilderInterface'
 
   PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPricePriorityType:
     arguments:

--- a/tests/Unit/Core/Product/Combination/NameBuilder/CombinationNameBuilderConsumersTest.php
+++ b/tests/Unit/Core/Product/Combination/NameBuilder/CombinationNameBuilderConsumersTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Product\Combination\NameBuilder;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Product\Pack\QueryHandler\GetPackedProductsHandler;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\DiscountFormDataProvider;
+use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder;
+use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilderInterface;
+use ReflectionClass;
+use ReflectionNamedType;
+
+/**
+ * A consumer that type hints the concrete builder cannot be given another one, so a module aliasing
+ * CombinationNameBuilderInterface to its own implementation is silently ignored there.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/36709
+ */
+class CombinationNameBuilderConsumersTest extends TestCase
+{
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function getConsumers(): array
+    {
+        return [
+            'pack query handler' => [GetPackedProductsHandler::class],
+            'discount form data provider' => [DiscountFormDataProvider::class],
+        ];
+    }
+
+    /**
+     * @dataProvider getConsumers
+     */
+    public function testTheBuilderIsInjectedThroughItsInterface(string $consumerClass): void
+    {
+        $parameter = $this->findBuilderParameter($consumerClass);
+        $this->assertNotNull($parameter, sprintf(
+            '%s does not take a combination name builder any more, drop it from this test.',
+            $consumerClass
+        ));
+
+        $this->assertSame(
+            CombinationNameBuilderInterface::class,
+            $parameter,
+            sprintf('%s must type hint the interface so the builder stays replaceable.', $consumerClass)
+        );
+    }
+
+    /**
+     * Guards the test itself: if the concrete class stopped implementing the interface, every
+     * assertion above would still pass while nothing could be substituted at all.
+     */
+    public function testTheConcreteBuilderImplementsTheInterface(): void
+    {
+        $this->assertTrue(is_subclass_of(CombinationNameBuilder::class, CombinationNameBuilderInterface::class));
+    }
+
+    private function findBuilderParameter(string $consumerClass): ?string
+    {
+        $constructor = (new ReflectionClass($consumerClass))->getConstructor();
+        if (null === $constructor) {
+            return null;
+        }
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            if (!$type instanceof ReflectionNamedType) {
+                continue;
+            }
+
+            $name = $type->getName();
+            if (CombinationNameBuilder::class === $name || CombinationNameBuilderInterface::class === $name) {
+                return $name;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Three consumers reach the concrete `CombinationNameBuilder` instead of `CombinationNameBuilderInterface`, so a module that aliases the interface to its own implementation is silently ignored there while it works everywhere else. Two are type hints (`GetPackedProductsHandler`, `DiscountFormDataProvider`) and the third is a service argument: `SpecificPriceType` already type hints the interface but `form_type.yml` wires the concrete class to it, which defeats the hint. All three now name the interface, which the container already aliases to that same class, so nothing changes for a shop that does not override it.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In a module's `config/services.yml`, alias `PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilderInterface` to your own implementation and clear the cache. Before: `debug:container --show-arguments` shows the three consumers still receiving the core `CombinationNameBuilder`. After: they receive yours.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36709
| Related PRs       |
| Sponsor company   |

### Measured

A throwaway module aliasing the interface to its own builder, with the container recompiled between the
two runs:

```
consumer                    base 9.2.x                          with this change
GetPackedProductsHandler    core CombinationNameBuilder         <module>\MyCombinationNameBuilder
DiscountFormDataProvider    core CombinationNameBuilder         <module>\MyCombinationNameBuilder
SpecificPriceType           core CombinationNameBuilder         <module>\MyCombinationNameBuilder
```

Read off `bin/console --app-id=admin debug:container --show-arguments <id>`, i.e. the resolved
container definition rather than a claim about it. The override is ignored on the base in all three
places and honoured in all three afterwards.

### The third site is not in the report

@majdisa1 named `GetPackedProductsHandler`. Two more turned up when the whole class was surveyed:

- `DiscountFormDataProvider` has the same concrete type hint on a promoted readonly property.
- `SpecificPriceType` already type hints `CombinationNameBuilderInterface`, and would still have ignored
  the override, because `bundle/form/form_type.yml` binds `$combinationNameBuilder` to the concrete
  service by name. A correct type hint is not enough when the argument is wired explicitly.

Every other consumer - `CombinationIdChoiceProvider`, `GetCombinationForEditingHandler`,
`GetEditableCombinationsListHandler`, `SearchCombinationsForAssociationHandler`,
`GetSpecificPriceListHandler`, `SearchProductCombinationsHandler`, `SpecificProductType` - already uses
the interface, which is what makes these three the outliers rather than the convention.

Both methods the consumers call, `buildName()` and `buildFullName()`, are declared on the interface, so
the narrowing loses nothing.

### Test

`tests/Unit/Core/Product/Combination/NameBuilder/CombinationNameBuilderConsumersTest.php`, 3 tests /
5 assertions. It reflects on each consumer's constructor and asserts the combination-name-builder
parameter is typed against the interface, and carries a guard asserting the concrete class still
implements it - without that guard the other assertions would keep passing while nothing was
substitutable at all.

Mutation-checked: restoring the concrete hint on `GetPackedProductsHandler` fails exactly its row with
"must type hint the interface so the builder stays replaceable".

The YAML site is covered by the container measurement above and by review, not by this test: a unit test
asserting a string inside a service definition would pin the file rather than the behaviour.

### Checks

`php-cs-fixer` and `phpstan` clean. The admin container compiles and all three services resolve. Merges
clean against every other open PR and local branch touching these files.
