### PR TITLE
Keep fragment-only url() intact when building the CSS cache

### DIFF
--- a/classes/assets/CssMinifier.php
+++ b/classes/assets/CssMinifier.php
@@ -16,12 +16,38 @@ class CssMinifierCore
      */
     public static function minify(array $files, $destination)
     {
-        $minifier = new CSS();
+        $minifier = self::getMinifier();
 
         foreach ($files as $file) {
             $minifier->add($file);
         }
 
         return $minifier->minify($destination);
+    }
+
+    /**
+     * The minifier rewrites every relative url() so that it still resolves from the cache directory the
+     * combined file is written to. It decides what is relative in canImportByPath(), which only excludes
+     * data:, http(s): and root-relative paths — so a fragment-only url(#gooey) is taken for a file name and
+     * becomes url(../css/#gooey), which resolves to nothing.
+     *
+     * Those fragments are how a filter, clip-path or mask points at an SVG that is inlined in the page, and
+     * they are valid CSS. Excluding them here leaves them untouched; url(file.svg#fragment) still carries a
+     * real path and is still rewritten.
+     *
+     * @return CSS
+     */
+    private static function getMinifier()
+    {
+        return new class() extends CSS {
+            protected function canImportByPath($path)
+            {
+                if (isset($path[0]) && '#' === $path[0]) {
+                    return false;
+                }
+
+                return parent::canImportByPath($path);
+            }
+        };
     }
 }

--- a/tests/Unit/Classes/assets/CssMinifierTest.php
+++ b/tests/Unit/Classes/assets/CssMinifierTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\assets;
+
+use CssMinifier;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The combined stylesheet is written to a different directory than the sources, so every relative url() is
+ * rewritten to keep resolving. A fragment-only url(#gooey) is not a path — it points at an SVG filter, clip
+ * path or mask inlined in the page — and rewriting it breaks the rule.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/33329
+ */
+class CssMinifierTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->workDir = sys_get_temp_dir() . '/ps-css-minifier-' . uniqid();
+        mkdir($this->workDir . '/src', 0777, true);
+        mkdir($this->workDir . '/cache', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDir . '/*/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->workDir . '/src');
+        @rmdir($this->workDir . '/cache');
+        @rmdir($this->workDir);
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider provideUrls
+     */
+    public function testUrlsSurviveMinificationAsExpected(string $rule, string $expected, string $because): void
+    {
+        $this->assertStringContainsString($expected, $this->minify($rule), $because);
+    }
+
+    public function provideUrls(): array
+    {
+        return [
+            'fragment-only filter is left alone' => [
+                '#heading{filter:url("#gooey")}',
+                'url("#gooey")',
+                'A fragment points at an SVG inlined in the page, not at a file.',
+            ],
+            'unquoted fragment-only filter is left alone' => [
+                '.b{filter:url(#svg-blur)}',
+                'url(#svg-blur)',
+                'Quoting must not change whether the fragment is treated as a path.',
+            ],
+            'fragment-only clip-path is left alone' => [
+                '.c{clip-path:url(#clipper)}',
+                'url(#clipper)',
+                'clip-path takes the same fragment references as filter.',
+            ],
+            'fragment-only mask is left alone' => [
+                '.m{mask:url(#masker)}',
+                'url(#masker)',
+                'mask takes the same fragment references as filter.',
+            ],
+            'a file with a fragment is still rewritten' => [
+                '.f{filter:url(my-file.svg#svg-blur)}',
+                'url(../src/my-file.svg#svg-blur)',
+                'This one carries a real path, so it must keep resolving from the cache directory.',
+            ],
+            'an ordinary relative url is still rewritten' => [
+                '.bg{background:url(../img/logo.png)}',
+                'url(../img/logo.png)',
+                'Ordinary relative paths must keep being rewritten.',
+            ],
+            'a root-relative url is left alone' => [
+                '.a{background:url(/img/abs.png)}',
+                'url(/img/abs.png)',
+                'Root-relative paths already resolve.',
+            ],
+            'a remote url is left alone' => [
+                '.r{background:url(https://example.com/x.png)}',
+                'url(https://example.com/x.png)',
+                'Remote paths already resolve.',
+            ],
+        ];
+    }
+
+    private function minify(string $css): string
+    {
+        $source = $this->workDir . '/src/theme.css';
+        $destination = $this->workDir . '/cache/theme-ccc.css';
+        file_put_contents($source, $css);
+
+        CssMinifier::minify([$source], $destination);
+
+        return (string) file_get_contents($destination);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | With CSS smart cache on, `filter: url(#gooey)` is rewritten to `filter: url(../css/#gooey)` and stops working. The combined stylesheet is written to a different directory than its sources, so the minifier rewrites relative `url()` values to keep them resolving; it decides what is relative in `canImportByPath()`, which excludes `data:`, `http(s):` and root-relative paths but not fragments. A fragment-only URL is not a path  -  it is how `filter`, `clip-path` and `mask` reference an SVG inlined in the page  -  so it is now excluded too. `url(file.svg#fragment)` still carries a real path and is still rewritten.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add `#heading{filter:url("#gooey")}` to a theme stylesheet, enable CSS smart cache in Advanced Parameters > Performance, clear the cache, then open the generated `themes/<theme>/assets/cache/theme-*.css` and search for `gooey`. Before: `url("../css/#gooey")`. After: `url("#gooey")`. The unit test covers this plus seven neighbouring URL shapes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33329
| Related PRs       |  - 
| Sponsor company   |  - 

### This works around a bug in a dependency, deliberately

The rewrite happens in `matthiasmullie/minify` (`src/CSS.php`), not in PrestaShop:

```php
protected function canImportByPath($path)
{
    return preg_match('/^(data:|https?:|\\/)/', $path) === 0;
}
```

That is **still the code on the library's `master`** (checked this run), so bumping the dependency does not
help and the `~1.3.0` constraint has nothing newer to offer. Overriding one protected method in an anonymous
subclass keeps the workaround in one place and makes it trivial to drop if the library ever fixes it. The
codebase already uses this pattern for a vendor class in
`src/PrestaShopBundle/Doctrine/Middleware/SetSessionTimeZoneMiddleware.php:33`.

### Why overriding `canImportByPath()` is safe

It has exactly two call sites in the library:

- `move()` (line 441)  -  the URL rewriter. This is the bug; returning `false` leaves the value alone.
- `combineImports()` (line 211)  -  inlines `@import` **statements**, guarded by
  `!canImportByPath(...) || !canImportFile(...)`. For a fragment, `dirname($source) . '/#gooey'` never exists,
  so `canImportFile()` already sends it down the same `continue`. The override only short-circuits earlier.

`importFiles()` (base64 inlining) does not call it at all  -  it has its own regex and extension gate.

### Measured, before -> after

| CSS | Before | After |
|---|---|---|
| `filter:url("#gooey")` | `url("../src/#gooey")` | `url("#gooey")` |
| `filter:url(#svg-blur)` | `url(../src/#svg-blur)` | `url(#svg-blur)` |
| `clip-path:url(#clipper)` | `url(../src/#clipper)` | `url(#clipper)` |
| `mask:url(#masker)` | `url(../src/#masker)` | `url(#masker)` |
| `filter:url(my-file.svg#svg-blur)` | `url(../src/my-file.svg#svg-blur)` | unchanged |
| `background:url(../img/logo.png)` | rewritten | unchanged |
| `background:url(/img/abs.png)` | left alone | unchanged |
| `background:url(https://example.com/x.png)` | left alone | unchanged |

The report only mentioned `filter`; `clip-path` and `mask` take the same references and were equally broken.

## Files

- `classes/assets/CssMinifier.php`
- `tests/Unit/Classes/assets/CssMinifierTest.php`  -  new, 8 data sets

## Verification

- `php -l` clean; `php-cs-fixer --dry-run`  -  `Found 0 of 2 files that can be fixed`; `phpstan -c phpstan.neon.dist`  -  `[OK] No errors`
- Test: `Tests: 8, Assertions: 8` green, process exit code `0`
- **Mutation check:** with `classes/assets/CssMinifier.php` reverted to `upstream/9.2.x` (revert verified by grep), exactly the four fragment cases go red and the four control cases stay green  -  so the test discriminates and the fix does not over-reach
- Reproduced through `CssMinifier::minify()`, the real entry point `CccReducer::reduceCss()` calls, not the library directly

## Needs the user's approval before acting

The same defect is present in `matthiasmullie/minify` upstream. Reporting it on that third-party repo is an
outward-facing post and is **not** covered by the standing instructions, so it has not been done. Worth
offering to the user as a follow-up.
