### PR TITLE
Embed only the glyphs an invoice uses instead of the whole font

### DIFF
--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -143,10 +143,17 @@ class PDFGeneratorCore extends TCPDF
             $this->font = self::DEFAULT_FONT;
         }
 
-        $this->setHeaderFont([$this->font, '', PDF_FONT_SIZE_MAIN, '', false]);
-        $this->setFooterFont([$this->font, '', PDF_FONT_SIZE_MAIN, '', false]);
+        // Embed only the glyphs the document actually uses. Embedding the whole face made an invoice
+        // 462 KB in a language mapped to dejavusans and 1.9 MB in one mapped to freeserif, while a
+        // language falling back to helvetica stayed at 7 KB because a core font is never embedded at all.
+        // Subsetting is TCPDF's own default, which this call was overriding; it does not change which
+        // characters render, and TCPDF disables it by itself in PDF/A mode.
+        // Note TCPDF reads only the first three entries of the header and footer font arrays, so the flag
+        // is inert there and kept only so the three calls say the same thing.
+        $this->setHeaderFont([$this->font, '', PDF_FONT_SIZE_MAIN, '', true]);
+        $this->setFooterFont([$this->font, '', PDF_FONT_SIZE_MAIN, '', true]);
 
-        $this->setFont($this->font, '', PDF_FONT_SIZE_MAIN, '', false);
+        $this->setFont($this->font, '', PDF_FONT_SIZE_MAIN, '', true);
     }
 
     /**

--- a/tests/Integration/Classes/PdfGeneratorFontSubsettingTest.php
+++ b/tests/Integration/Classes/PdfGeneratorFontSubsettingTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use PDFGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Invoices used to embed the whole font face, which made them 462 KB in a language mapped to dejavusans and
+ * 1.9 MB in one mapped to freeserif, while a language falling back to helvetica stayed at 7 KB because a core
+ * font is never embedded. Only the glyphs actually used are embedded now.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/32913
+ */
+class PdfGeneratorFontSubsettingTest extends TestCase
+{
+    private const BODY = '<h1>Invoice</h1><p>Order reference ABCDEFG, total 42.00 EUR.</p>';
+
+    /**
+     * The font programs TCPDF embeds live next to their definitions. A document that embeds a whole face is
+     * necessarily bigger than the face itself, so comparing against the file on disk keeps this honest
+     * without pinning a byte count that a font update would invalidate.
+     *
+     * @dataProvider provideEmbeddedFontLanguages
+     */
+    public function testOnlyTheUsedGlyphsAreEmbedded(string $isoCode, string $expectedFont): void
+    {
+        $fontProgram = _PS_ROOT_DIR_ . '/vendor/tecnickcom/tcpdf/fonts/' . $expectedFont . '.z';
+        $this->assertFileExists($fontProgram, 'The font this language maps to is expected to be embeddable.');
+
+        $pdf = new PDFGenerator(false, 'P');
+        $pdf->setFontForLang($isoCode);
+        $pdf->AddPage();
+        $pdf->writeHTML(self::BODY);
+        $size = strlen($pdf->Output('test.pdf', 'S'));
+
+        $this->assertLessThan(
+            filesize($fontProgram),
+            $size,
+            sprintf(
+                'A one-line %s document came out at %d bytes, which is bigger than the %s font program itself'
+                . ' (%d bytes) — the whole face is being embedded instead of the glyphs in use.',
+                $isoCode,
+                $size,
+                $expectedFont,
+                filesize($fontProgram)
+            )
+        );
+    }
+
+    public function provideEmbeddedFontLanguages(): array
+    {
+        return [
+            'dejavusans' => ['en', 'dejavusans'],
+            'freeserif' => ['el', 'freeserif'],
+        ];
+    }
+
+    /**
+     * A language with no entry in the map falls back to a TCPDF core font, which is never embedded. That is
+     * unchanged, and it is the baseline the two cases above are measured against.
+     */
+    public function testACoreFontLanguageEmbedsNothing(): void
+    {
+        $pdf = new PDFGenerator(false, 'P');
+        $pdf->setFontForLang('de');
+        $pdf->AddPage();
+        $pdf->writeHTML(self::BODY);
+
+        $this->assertLessThan(50000, strlen($pdf->Output('test.pdf', 'S')));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PDFGenerator::setFontForLang()` passed `false` as TCPDF's `$subset` argument, so every generated PDF embedded the complete font face. One line of invoice content came to 462 KB in a language mapped to dejavusans and 1.9 MB in one mapped to freeserif, while a language with no entry in the map stayed at 7 KB because it falls back to a core font that is never embedded. Embedding only the glyphs in use brings those to 103 KB and 114 KB and leaves the core-font case untouched.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Generate an invoice PDF from the back office with the employee language set to English, then to Greek or Russian, and compare file sizes against the same invoices before the change. The text must be identical in both.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #32913
| Related PRs       | #40697, closed unrebased after 9.0.x was deleted; this keeps its subsetting idea and leaves the `Footer()` change out
| Sponsor company   |  - 

### Measured, through `setFontForLang()` itself

Same one-line document, before and after:

| language | font | before | after | saving |
|---|---|---|---|---|
| en, pl | dejavusans | 462,726 | 103,274 | 77.7% |
| el, ru | freeserif | 1,930,250 | 113,874 | 94.1% |
| de, fr | helvetica (core font) | 6,949 | 6,949 | unchanged |

The spread between the largest and smallest language drops from **278x** to **16x**, which is the
inconsistency the report is about. It also lands where the reporter said it should: they had patched their own
install to subset and measured 109 KB, against 103 KB here.

### Answering the character-support question

Text extracted with `pdftotext -enc UTF-8` from documents generated with and without subsetting:

```
dejavusans, full font     Zażółć gęślą jaźń  -  ĄĆĘŁŃÓŚŹŻ  -  Příliš žluťoučký kůň
dejavusans, subset        Zażółć gęślą jaźń  -  ĄĆĘŁŃÓŚŹŻ  -  Příliš žluťoučký kůň
freeserif, full font      Ελληνικά: Καλημέρα κόσμε  -  Русский: Здравствуй мир
freeserif, subset         Ελληνικά: Καλημέρα κόσμε  -  Русский: Здравствуй мир
```

Identical. Subsetting embeds the glyphs the document uses, so it cannot change what renders  -  it changes only
how much of the face travels with the file. Also verified through `setFontForLang()` for en, de, el and ru.

Two more points that answer the obvious review questions:

- **Subsetting is TCPDF's own default.** `$font_subsetting = true` at `vendor/tecnickcom/tcpdf/tcpdf.php:1523`;
  this call was overriding it.
- **PDF/A is safe.** `AddFont()` forces `$subset = false` when `pdfa_mode` is on, where a full embed is
  required, so nothing is needed here for that case.
- Generation time is unaffected: 9-31 ms either way in the same measurements, sometimes faster with subsetting
  because less data is written.

### Note on the header and footer calls

TCPDF reads only the first three entries of the arrays given to `setHeaderFont()` / `setFooterFont()`
(`tcpdf.php:3623`), so the flag is inert there. It is set to `true` anyway so the three calls say the same
thing rather than leaving a misleading `false` behind.

## Deliberately not addressed

The reporter also asks for a *consistent* font across languages and a single font family. That means changing
which font a language maps to  -  for instance putting `de` on dejavusans would take German invoices from 7 KB
to about 103 KB, and helvetica cannot render Greek or Cyrillic at all. That is a design decision about
rendering, separate from the size defect, and is raised in the issue comment rather than decided here.

## Files

- `classes/pdf/PDFGenerator.php`  -  +10/-3
- `tests/Integration/Classes/PdfGeneratorFontSubsettingTest.php`  -  new, 3 tests

## Verification

- `php -l` clean; `php-cs-fixer --dry-run`  -  `Found 0 of 2 files that can be fixed`; `phpstan`  -  `[OK] No errors`
- The test compares each PDF against the font program on disk rather than a pinned byte count, so a font
  update cannot invalidate it: a document embedding a whole face is necessarily larger than the face itself.
- Test: 3 tests, 5 assertions, green, exit code `0`
- **Mutation check:** with `PDFGenerator.php` reverted to `upstream/9.2.x` (revert verified by grep), both
  embedded-font cases fail with `462726 bytes, which is bigger than the dejavusans font program itself
  (375806 bytes)` and the freeserif equivalent, while the core-font case still passes
