### PR TITLE
Generate a module's mail templates when it is installed

### DIFF
--- a/src/Adapter/Module/MailTemplate/ModuleMailTemplatesSubscriber.php
+++ b/src/Adapter/Module/MailTemplate/ModuleMailTemplatesSubscriber.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Module\MailTemplate;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+use PrestaShopBundle\Event\ModuleManagementEvent;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Throwable;
+
+/**
+ * Generates the mail templates a freshly installed module needs, in every language of the shop.
+ *
+ * Templates are rendered from the mail theme's layouts, and until now that only happened while
+ * installing or updating a language. A module installed afterwards therefore had no templates in the
+ * languages that already existed, and Mail::send() has no language fallback: it logs "The following
+ * e-mail template is missing" and returns false, so those mails are simply never sent.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/36734
+ */
+class ModuleMailTemplatesSubscriber implements EventSubscriberInterface
+{
+    private const DEFAULT_MAIL_THEME = 'modern';
+
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    /**
+     * @var LangRepository
+     */
+    private $langRepository;
+
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        CommandBusInterface $commandBus,
+        LangRepository $langRepository,
+        ConfigurationInterface $configuration,
+        LoggerInterface $logger
+    ) {
+        $this->commandBus = $commandBus;
+        $this->langRepository = $langRepository;
+        $this->configuration = $configuration;
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ModuleManagementEvent::INSTALL => 'generateMailTemplates',
+            // WHY: an upgrade can add a mail layout the previous version did not have, and it lands in
+            // the same gap as an install does.
+            ModuleManagementEvent::UPGRADE => 'generateMailTemplates',
+        ];
+    }
+
+    public function generateMailTemplates(ModuleManagementEvent $event): void
+    {
+        $mailTheme = (string) $this->configuration->get('PS_MAIL_THEME');
+        if ('' === $mailTheme) {
+            $mailTheme = self::DEFAULT_MAIL_THEME;
+        }
+
+        foreach ($this->langRepository->findAll() as $language) {
+            try {
+                $this->commandBus->handle(new GenerateThemeMailTemplatesCommand(
+                    $mailTheme,
+                    $language->getLocale(),
+                    // WHY: never overwrite. This only fills the gaps left by a module installed after a
+                    // language, so a template the merchant has customised through Design > Email theme
+                    // must survive every later module installation untouched.
+                    false
+                ));
+            } catch (Throwable $e) {
+                // WHY: a template that cannot be rendered must not fail the module installation - the
+                // module itself is already installed by the time this event is dispatched. Report it
+                // instead, which is more than the silent gap this replaces.
+                $this->logger->error(sprintf(
+                    'Could not generate the mail templates of module %s for locale %s: %s',
+                    $event->getModule()->get('name'),
+                    $language->getLocale(),
+                    $e->getMessage()
+                ));
+            }
+        }
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -90,6 +90,15 @@ services:
     tags:
       - { name: kernel.event_subscriber }
 
+  PrestaShop\PrestaShop\Adapter\Module\MailTemplate\ModuleMailTemplatesSubscriber:
+    arguments:
+      - "@PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface"
+      - "@PrestaShopBundle\\Entity\\Repository\\LangRepository"
+      - "@PrestaShop\\PrestaShop\\Adapter\\Configuration"
+      - "@logger"
+    tags:
+      - { name: kernel.event_subscriber }
+
   PrestaShop\PrestaShop\Adapter\Presenter\Module\ModulePresenter:
     public: false
     arguments: [ "@=service('prestashop.adapter.legacy.context').getContext().currency", "@prestashop.adapter.formatter.price" ]

--- a/tests/Unit/Adapter/Module/MailTemplate/ModuleMailTemplatesSubscriberTest.php
+++ b/tests/Unit/Adapter/Module/MailTemplate/ModuleMailTemplatesSubscriberTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Module\MailTemplate;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Module\MailTemplate\ModuleMailTemplatesSubscriber;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
+use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
+use PrestaShopBundle\Entity\Lang;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+use PrestaShopBundle\Event\ModuleManagementEvent;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class ModuleMailTemplatesSubscriberTest extends TestCase
+{
+    public function testItListensToInstallAndUpgrade(): void
+    {
+        $this->assertSame(
+            [
+                ModuleManagementEvent::INSTALL => 'generateMailTemplates',
+                ModuleManagementEvent::UPGRADE => 'generateMailTemplates',
+            ],
+            ModuleMailTemplatesSubscriber::getSubscribedEvents()
+        );
+    }
+
+    public function testItGeneratesTheConfiguredThemeForEveryLanguageWithoutOverwriting(): void
+    {
+        $commands = [];
+        $commandBus = $this->createMock(CommandBusInterface::class);
+        $commandBus->method('handle')->willReturnCallback(function ($command) use (&$commands) {
+            $commands[] = $command;
+
+            return null;
+        });
+
+        $subscriber = $this->createSubscriber($commandBus, ['en-US', 'fr-FR'], 'classic');
+        $subscriber->generateMailTemplates($this->event());
+
+        $this->assertCount(2, $commands);
+        foreach ($commands as $command) {
+            $this->assertInstanceOf(GenerateThemeMailTemplatesCommand::class, $command);
+            $this->assertSame('classic', $command->getThemeName());
+            // The whole point: an existing template, possibly customised by the merchant, is kept.
+            $this->assertFalse($command->overwriteTemplates());
+        }
+        $this->assertSame(
+            ['en-US', 'fr-FR'],
+            array_map(function (GenerateThemeMailTemplatesCommand $command): string {
+                return $command->getLanguage();
+            }, $commands)
+        );
+    }
+
+    public function testItFallsBackToTheModernThemeWhenNoneIsConfigured(): void
+    {
+        $commands = [];
+        $commandBus = $this->createMock(CommandBusInterface::class);
+        $commandBus->method('handle')->willReturnCallback(function ($command) use (&$commands) {
+            $commands[] = $command;
+
+            return null;
+        });
+
+        $subscriber = $this->createSubscriber($commandBus, ['en-US'], null);
+        $subscriber->generateMailTemplates($this->event());
+
+        $this->assertSame('modern', $commands[0]->getThemeName());
+    }
+
+    /**
+     * A module is already installed by the time this event is dispatched, so a template that cannot be
+     * rendered must be reported rather than thrown - and it must not stop the other languages.
+     */
+    public function testAFailureIsLoggedAndTheRemainingLanguagesAreStillGenerated(): void
+    {
+        $handled = 0;
+        $commandBus = $this->createMock(CommandBusInterface::class);
+        $commandBus->method('handle')->willReturnCallback(function (GenerateThemeMailTemplatesCommand $command) use (&$handled) {
+            ++$handled;
+            if ('en-US' === $command->getLanguage()) {
+                throw new RuntimeException('no such layout');
+            }
+
+            return null;
+        });
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with($this->stringContains('no such layout'));
+
+        $subscriber = $this->createSubscriber($commandBus, ['en-US', 'fr-FR'], 'modern', $logger);
+        $subscriber->generateMailTemplates($this->event());
+
+        $this->assertSame(2, $handled);
+    }
+
+    /**
+     * @param string[] $locales
+     */
+    private function createSubscriber(
+        CommandBusInterface $commandBus,
+        array $locales,
+        ?string $mailTheme,
+        ?LoggerInterface $logger = null
+    ): ModuleMailTemplatesSubscriber {
+        $languages = [];
+        foreach ($locales as $locale) {
+            $language = $this->createMock(Lang::class);
+            $language->method('getLocale')->willReturn($locale);
+            $languages[] = $language;
+        }
+
+        $langRepository = $this->createMock(LangRepository::class);
+        $langRepository->method('findAll')->willReturn($languages);
+
+        $configuration = $this->createMock(ConfigurationInterface::class);
+        $configuration->method('get')->with('PS_MAIL_THEME')->willReturn($mailTheme);
+
+        return new ModuleMailTemplatesSubscriber(
+            $commandBus,
+            $langRepository,
+            $configuration,
+            $logger ?? $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    private function event(): ModuleManagementEvent
+    {
+        $module = $this->createMock(ModuleInterface::class);
+        $module->method('get')->with('name')->willReturn('ps_emailalerts');
+
+        return new ModuleManagementEvent($module);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Mail templates are rendered per language from the mail theme's layouts, and that only ever happened while installing or updating a language (`Language::generateEmailsLanguagePack()`). A module installed after a language therefore has no `mails/<iso>` folder for it, and `Mail::send()` has no language fallback - it logs "The following e-mail template is missing" and returns false, so those mails are silently never sent. A subscriber on the module install and upgrade events now generates the templates for every language of the shop, without overwriting any that already exist.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with two languages, delete `modules/ps_emailalerts/mails/<second iso>`, then uninstall and install the module (`bin/console prestashop:module uninstall ps_emailalerts` then `install`). Before: the folder does not come back and any alert in that language is never sent. After: it is regenerated. Check that `mails/<first iso>` is untouched - same mtimes, same content.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36734
| Related PRs       |
| Sponsor company   |

### Reproduced on 9.2.x, and the diagnosis on the issue was right

@Hlavtox called it in October 2024 - "the mails are generated by the core when updating a language and
other actions. And not when installing a module" - and the reporter's steps hold on 9.2.x. Measured on a
shop with `en` and `fr`:

```
delete modules/ps_emailalerts/mails/fr, then uninstall + install the module

  base 9.2.x     mails/ = en, index.php          -> fr NOT regenerated
  with the fix   mails/ = en, fr, index.php      -> fr regenerated
```

Control, and it is the reason the change is safe: `mails/en` came out of the fixed run
**byte-identical to the pre-install backup, same mtimes**. The command is dispatched with
`overwriteTemplates = false`, so a template a merchant customised through Design > Email theme survives
every later module installation.

The mechanism was confirmed independently first, by running the existing
`bin/console prestashop:mail:generate modern fr-FR` by hand: it recreates the folder and leaves `en`
alone. The subscriber only automates what a merchant currently has to know to run.

### Design

An event subscriber on `ModuleManagementEvent::INSTALL` and `::UPGRADE`, following the
`ModuleTabManagementSubscriber` precedent that already sits in the same service file - the install flow
itself is not touched. `UPGRADE` is included because a module version can add a mail layout the previous
one did not have, which lands in exactly the same gap.

Failures are logged, not thrown: the module is already installed by the time the event is dispatched, so
a layout that cannot be rendered must not fail the installation, and the remaining languages are still
generated. That is still strictly more visible than the silent gap it replaces - which is @Hlavtox's
other point on the issue, that a missing template is currently only logged and never surfaces.

### Test

`tests/Unit/Adapter/Module/MailTemplate/ModuleMailTemplatesSubscriberTest.php`, 4 tests / 12 assertions:
the subscribed events, one command per language carrying the configured theme and `overwriteTemplates()`
false, the `modern` fallback when `PS_MAIL_THEME` is unset, and that a bus failure is logged without
stopping the other languages.

Mutation-checked: flipping the non-overwrite flag to `true` fails exactly
`testItGeneratesTheConfiguredThemeForEveryLanguageWithoutOverwriting` ("Failed asserting that true is
false") while the other three still pass.

### Checks

`php-cs-fixer` and `phpstan` clean. The service resolves in the admin container
(`debug:container` shows it tagged `kernel.event_subscriber`). The service is registered with FQCN
references rather than the deprecated `prestashop.core.admin.lang.repository` alias, matching #42620.
