### PR TITLE
Let a shop silence the deprecated hook alias notice it asked to silence

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1011,15 +1011,21 @@ class HookCore extends ObjectModel
                 );
 
                 // We throw an error - aliases are deprecated.
-                trigger_error(
-                    sprintf(
-                        'The hook "%s" is deprecated, please use "%s" instead in module "%s".',
-                        $registeredHookName,
-                        $hook_name,
-                        $hookRegistration['module']
-                    ),
-                    E_USER_DEPRECATED
-                );
+                // A module sitting on a legacy alias is a compatibility warning, so a shop that has turned
+                // those off with _PS_DISPLAY_COMPATIBILITY_WARNING_ should not get it. Tools::throwDeprecated()
+                // already honours that constant; this call did not, and it fires once per registered module
+                // per hook execution, so it can fill an error log on a shop that asked for silence.
+                if (_PS_DISPLAY_COMPATIBILITY_WARNING_) {
+                    trigger_error(
+                        sprintf(
+                            'The hook "%s" is deprecated, please use "%s" instead in module "%s".',
+                            $registeredHookName,
+                            $hook_name,
+                            $hookRegistration['module']
+                        ),
+                        E_USER_DEPRECATED
+                    );
+                }
             }
 
             // Check conditions to execute the module


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `_PS_DISPLAY_COMPATIBILITY_WARNING_` exists so a shop can turn compatibility warnings off, and `Tools::throwDeprecated()` honours it. The notice raised when a module is registered on a legacy hook alias called `trigger_error()` directly and ignored the constant, so setting it silenced one kind of deprecation and not the other. That notice fires once per registered module per hook execution, so a shop with modules still on aliases keeps filling its error log with a message it already asked not to receive.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with a module registered to a legacy hook alias, set `define('_PS_DISPLAY_COMPATIBILITY_WARNING_', false);` in `config/defines.inc.php` and load a page that runs that hook. Before: `The hook "X" is deprecated, please use "Y" instead in module "Z".` still lands in the error log. After: it does not. Leaving the constant at its default keeps the notice.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #32513
| Related PRs       |  - 
| Sponsor company   |  - 

### Measured, both directions

Driving `Hook::exec('displayAdminStatsGraphEngine')` on an install where `graphnvd3` is registered to the
legacy alias `GraphEngine`, counting `E_USER_DEPRECATED` through a scoped error handler:

| `_PS_DISPLAY_COMPATIBILITY_WARNING_` | `Tools::displayAsDeprecated()` | hook alias path (before) | hook alias path (after) |
|---|---|---|---|
| `false`  -  the merchant silenced them | 0 | **1** | **0** |
| `true`  -  the default | 1 | 1 | 1 |

The message raised is exactly the one in the report:

```
The hook "GraphEngine" is deprecated, please use "displayAdminStatsGraphEngine" instead in module "graphnvd3".
```

### Why this constant and not error_reporting

`config/defines.inc.php` only adjusts `error_reporting` inside `if (_PS_MODE_DEV_ === true)`. On a production
shop  -  which is where a 150 MB daily error log hurts  -  the constant does nothing to `error_reporting`, and
`Tools::throwDeprecated()` is the only thing that consults it. So a merchant who sets it, as the reporter did,
has every reason to expect silence and gets it for one code path only.

### Scope

Core raises `E_USER_DEPRECATED` from 44 places, and this changes one of them. That is deliberate rather than
arbitrary: a module sitting on a legacy hook alias is a *compatibility* warning, which is what the constant is
named for, and it is the only one of the 44 that fires per module per hook execution rather than once per
deprecated call. The others in `Cart`, `Context`, `Feature` and elsewhere are API deprecations aimed at
developers and are left alone.

## Not tested automatically, and why

`_PS_DISPLAY_COMPATIBILITY_WARNING_` is a `define()` resolved during bootstrap, so a single PHPUnit process
sees one value for its whole run and cannot exercise both branches. The suite has no mechanism for running a
case under a second bootstrap. A test that only asserted the guard exists would restate the code rather than
check behaviour, so the evidence here is the measured table above rather than a hollow test.

`tests/Integration/Classes/HookTest.php` still passes (3 tests).

## Verification

- `php -l` clean; `php-cs-fixer --dry-run`  -  `Found 0 of 1 files that can be fixed`; `phpstan`  -  `[OK] No errors`
- `HookTest`  -  3 tests, green
- Before/after measured in both constant states, table above
