### PR TITLE
Report a failure when an imported image is not a decodable image

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -844,7 +844,14 @@ class ImageManagerCore
             $tgt_width = $tgt_height = 0;
             $src_width = $src_height = 0;
             $error = 0;
-            ImageManager::resize($tmpfile, $path . '.jpg', null, null, 'jpg', false, $error, $tgt_width, $tgt_height, 5, $src_width, $src_height);
+            // A download can succeed and still not be an image: an HTTP error page, a redirect to a login
+            // form, or a rewrite rule that answers with HTML. Nothing is written in that case, so report
+            // the failure instead of letting the caller record an image that has no file behind it.
+            if (!ImageManager::resize($tmpfile, $path . '.jpg', null, null, 'jpg', false, $error, $tgt_width, $tgt_height, 5, $src_width, $src_height)) {
+                @unlink($orig_tmpfile);
+
+                return false;
+            }
             $images_types = ImageType::getImagesTypes($entity, true);
 
             if ($regenerate) {

--- a/src/Adapter/Import/ImageCopier.php
+++ b/src/Adapter/Import/ImageCopier.php
@@ -134,7 +134,10 @@ final class ImageCopier
             $targetWidth = $targetHeight = 0;
             $sourceWidth = $sourceHeight = 0;
             $error = 0;
-            ImageManager::resize(
+            // A download can succeed and still not be an image: an HTTP error page, a redirect to a login
+            // form, or a rewrite rule that answers with HTML. Nothing is written in that case, so report
+            // the failure instead of letting the caller record an image that has no file behind it.
+            if (!ImageManager::resize(
                 $tmpFile,
                 $path . '.jpg',
                 null,
@@ -147,7 +150,11 @@ final class ImageCopier
                 5,
                 $sourceWidth,
                 $sourceHeight
-            );
+            )) {
+                @unlink($origTmpfile);
+
+                return false;
+            }
             $imagesTypes = ImageType::getImagesTypes($entity, true);
 
             if ($regenerate) {

--- a/tests/Integration/Classes/ImportImageCopyReportsFailureTest.php
+++ b/tests/Integration/Classes/ImportImageCopyReportsFailureTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use ImageManager;
+use PrestaShop\PrestaShop\Adapter\Import\ImageCopier;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A download that succeeds without yielding a decodable image must be reported as a failure.
+ *
+ * The import fetches image URLs from a CSV. When the answer is an HTTP error page, a login form or
+ * anything else that is not an image, the bytes are written to the temporary file and the download
+ * itself is a success, so the only signal left is the resize step. Both copy implementations used to
+ * discard it and answer true, which made the caller keep an image row with no file behind it and skip
+ * its "Error copying image" warning.
+ */
+class ImportImageCopyReportsFailureTest extends KernelTestCase
+{
+    /**
+     * High enough not to collide with a real category's image.
+     */
+    private const CATEGORY_ID = 999123;
+
+    private static string $notAnImage;
+    private static string $realImage;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::bootKernel();
+
+        // What a 404 page, a redirect to a login form or an index.php rewrite leaves in the temp file.
+        self::$notAnImage = _PS_TMP_IMG_DIR_ . 'copyimg_not_an_image.jpg';
+        file_put_contents(self::$notAnImage, '404: Not Found');
+
+        self::$realImage = _PS_TMP_IMG_DIR_ . 'copyimg_real_image.jpg';
+        $image = imagecreatetruecolor(80, 60);
+        imagejpeg($image, self::$realImage);
+        imagedestroy($image);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        @unlink(self::$notAnImage);
+        @unlink(self::$realImage);
+        parent::tearDownAfterClass();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob(_PS_CAT_IMG_DIR_ . self::CATEGORY_ID . '*.jpg') ?: [] as $generated) {
+            @unlink($generated);
+        }
+        parent::tearDown();
+    }
+
+    public function testLegacyCopyImgReportsFailureWhenTheSourceIsNotAnImage(): void
+    {
+        $copied = ImageManager::copyImg(self::CATEGORY_ID, null, self::$notAnImage, 'categories', false);
+
+        $this->assertFalse($copied, 'copyImg() must not report success when nothing could be written.');
+        $this->assertFileDoesNotExist($this->destination());
+    }
+
+    public function testLegacyCopyImgStillSucceedsForARealImage(): void
+    {
+        $copied = ImageManager::copyImg(self::CATEGORY_ID, null, self::$realImage, 'categories', false);
+
+        $this->assertTrue($copied);
+        $this->assertFileExists($this->destination());
+    }
+
+    public function testImportCopyImgReportsFailureWhenTheSourceIsNotAnImage(): void
+    {
+        $copied = $this->imageCopier()->copyImg(self::CATEGORY_ID, null, self::$notAnImage, 'categories', false);
+
+        $this->assertFalse($copied, 'ImageCopier::copyImg() must not report success when nothing could be written.');
+        $this->assertFileDoesNotExist($this->destination());
+    }
+
+    public function testImportCopyImgStillSucceedsForARealImage(): void
+    {
+        $copied = $this->imageCopier()->copyImg(self::CATEGORY_ID, null, self::$realImage, 'categories', false);
+
+        $this->assertTrue($copied);
+        $this->assertFileExists($this->destination());
+    }
+
+    /**
+     * The back office passes the negation of the "skip thumbnail regeneration" box, so an unchecked box
+     * — the common case — reaches copyImg() as true. That is the path where a regression would bite, and
+     * none of the cases above cover it.
+     */
+    public function testImportCopyImgStillRegeneratesThumbnailsForARealImage(): void
+    {
+        $copied = $this->imageCopier()->copyImg(self::CATEGORY_ID, null, self::$realImage, 'categories', true);
+
+        $this->assertTrue($copied);
+        $this->assertFileExists($this->destination());
+
+        $thumbnails = glob(_PS_CAT_IMG_DIR_ . self::CATEGORY_ID . '-*.jpg') ?: [];
+        $this->assertNotEmpty($thumbnails, 'Thumbnails must still be generated for a valid image.');
+    }
+
+    private function imageCopier(): ImageCopier
+    {
+        return self::getContainer()->get('prestashop.adapter.import.image_copier');
+    }
+
+    private function destination(): string
+    {
+        return _PS_CAT_IMG_DIR_ . self::CATEGORY_ID . '.jpg';
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ImageManager::copyImg()` and `ImageCopier::copyImg()` discarded the return value of the primary `ImageManager::resize()` call, so a download that succeeded without yielding a decodable image still answered `true`. The caller then kept the `ps_image` row and skipped its `Error copying image: %url%` warning, leaving a record with no file behind it. This happens whenever an image URL answers with something that is not an image: an HTTP error page, a redirect to a login form, or a rewrite rule that sends the request to `index.php`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Import a products or categories CSV whose image URL column points at a URL that answers with HTML rather than an image  -  a 404 on a public host is enough. Before: the import finishes with no warning and the product carries an image that never displays. After: the import reports `Error copying image: <url>` and no orphan image row is created. The included integration test covers both copy implementations in both directions, plus thumbnail regeneration.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33460
| Related PRs       |  - 
| Sponsor company   |  - 

### Why the return value matters

`ImageManager::resize()` has exactly four returns. Three are explicit failures  -  `ERROR_FILE_NOT_EXIST`,
`ERROR_FILE_WIDTH`, `ERROR_MEMORY_LIMIT`  -  and all three precede the write; the fourth is the write result
itself. So `resize() === false` always means nothing was written, and propagating it cannot turn a
successful copy into a reported failure.

### Measured chain (9.2.x, before the fix)

```
download body                 = 14 bytes, "404: Not Found"    <- curl does not treat HTTP 404 as an error
copyFromUntrustedSource       = true                          <- the 14 bytes were written to the temp file
checkImageMemoryLimit(...)    = true                          <- returns true for a non-image, it only guards memory
resize(...)                   = false, $error = 2 (ERROR_FILE_WIDTH), nothing written
copyImg(...)                  = true                          <- the bool above was discarded
```

Five URL shapes through `copyImg()`, before -> after:

| Shape | Before | After |
|---|---|---|
| local path that exists (real jpg) | `true`, file written | unchanged |
| local path that does not exist | `false` | unchanged |
| http URL to a real image | `true`, file written | unchanged |
| **http URL that 404s (HTML body)** | **`true`, no file written** | **`false`** |
| shop-local http URL (private IP, SSRF guard) | `false` | unchanged |

Only the silent-failure row moves.

## Files

- `classes/ImageManager.php`  -  legacy `copyImg()`, used by `AdminImportController` (suppliers, manufacturers, stores)
- `src/Adapter/Import/ImageCopier.php`  -  modern `copyImg()`, used by `ProductImportHandler` and `CategoryImportHandler`, i.e. what the 9.2 BO import actually runs for products and categories
- `tests/Integration/Classes/ImportImageCopyReportsFailureTest.php`  -  new, 5 tests

The two copy methods are copy-pasted siblings carrying the identical defect, so both are fixed.

## Verification

- `php -l`  -  clean on all three files
- `php-cs-fixer --config=.php-cs-fixer.dist.php --dry-run`  -  `Found 0 of 3 files that can be fixed`
- `phpstan -c phpstan.neon.dist`  -  `[OK] No errors`
- New test: `Tests: 5, Assertions: 11` green, process exit code `0` (the run prints "OK, but there were issues!" for 120 pre-existing PHPUnit deprecations; `tests/Integration/phpunit.xml` sets no `failOn*`, so this does not fail CI)
- **Mutation check:** with both source files reverted to `upstream/9.2.x` (revert verified by grep, not assumed), the two failure tests go red  -  one per implementation  -  while the two success tests stay green
- Covers `regenerate = true` (the back-office default, since the box is a *skip* flag) and asserts thumbnails are still generated
- Regression: `tests/Unit/Classes/ImageManagerTest.php` 18/18 green
- `CQRSOpenApiFactoryTest::testPathTags` fails **5/5 on pristine `upstream/9.2.x`**  -  pre-existing and unrelated, confirmed by a base-rate control

## Which case on the thread this fixes

`Fixes #33460` is correct  -  the issue is "the images are not imported", and the silent failure reported on
that thread is fixed here  -  but the thread holds two different cases and only one of them is this bug:

- **The attached CSV is not it.** Its image column holds a filesystem path
  (`/var/www/html/prestashop/imagens/...`). Schemeless paths still work via `@copy()`, and when the file is
  absent `copyImg()` already returns `false` and the import already prints `Error copying image:`  -  which is
  what florine2623 screenshotted. That path is behaving correctly.
- **f1rollo's case is it.** Their `RewriteRule ^upload/.+$ ... index.php` turns an image URL into the shop's
  HTML, and that is exactly the payload that returned `true` with no file written.

Say this plainly in the PR description so a reviewer testing with the attached CSV does not conclude the fix
does nothing.

## Behavioural delta a reviewer will ask about

On the failure path with `regenerate = true`, `Hook::exec('actionWatermark', ...)` used to fire and now does
not, because the early return precedes it. That is intended: there is no file to watermark, and the product
callers delete the image row immediately afterwards. Worth one line in the PR description to pre-empt the
question.
