### PR TITLE
Keep a shop's main URL reachable when it is promoted or re-enabled

### DIFF
--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -99,9 +99,13 @@ class ShopUrlCore extends ObjectModel
 
     public function setMain()
     {
+        // A main URL has to be active: AdminShopUrlController::processUpdate() already refuses to save one
+        // that is not, and a shop whose main URL is disabled cannot be reached. Promoting a disabled URL
+        // through this method was the one way around that rule, so enable it as it is promoted.
         $res = Db::getInstance()->update('shop_url', ['main' => 0], 'id_shop = ' . (int) $this->id_shop);
-        $res &= Db::getInstance()->update('shop_url', ['main' => 1], 'id_shop_url = ' . (int) $this->id);
+        $res &= Db::getInstance()->update('shop_url', ['main' => 1, 'active' => 1], 'id_shop_url = ' . (int) $this->id);
         $this->main = true;
+        $this->active = true;
 
         // Reset main URL for all shops to prevent problems
         $sql = 'SELECT s1.id_shop_url FROM ' . _DB_PREFIX_ . 'shop_url s1
@@ -112,7 +116,7 @@ class ShopUrlCore extends ObjectModel
                 ) = 0
                 GROUP BY s1.id_shop';
         foreach (Db::getInstance()->executeS($sql) as $row) {
-            Db::getInstance()->update('shop_url', ['main' => 1], 'id_shop_url = ' . $row['id_shop_url']);
+            Db::getInstance()->update('shop_url', ['main' => 1, 'active' => 1], 'id_shop_url = ' . $row['id_shop_url']);
         }
 
         return $res;

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -409,7 +409,10 @@ class AdminShopUrlControllerCore extends AdminController
             if ($this->access('edit')) {
                 if (Validate::isLoadedObject($object = $this->loadObject())) {
                     /** @var ShopUrl $object */
-                    if ($object->main) {
+                    // Only the disabling direction is forbidden. Refusing the toggle outright left a main
+                    // URL that had been disabled with no way back: it could not be enabled here, and the
+                    // edit form will not save a main URL that is inactive either.
+                    if ($object->main && $object->active) {
                         $this->errors[] = $this->trans('You cannot disable the Main URL.', [], 'Admin.Notifications.Error');
                     } elseif ($object->toggleStatus()) {
                         Tools::redirectAdmin(self::$currentIndex . '&conf=5&token=' . $token);

--- a/tests/Integration/Classes/ShopUrlSetMainTest.php
+++ b/tests/Integration/Classes/ShopUrlSetMainTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use ShopUrl;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * A main shop URL has to be active. AdminShopUrlController::processUpdate() already refuses to save one that
+ * is not, but setMain() used to promote a disabled URL as it was, leaving the shop with a main URL that could
+ * not be reached and that the back office refused to enable again.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/33305
+ */
+class ShopUrlSetMainTest extends TestCase
+{
+    private const TABLES_TO_RESTORE = ['shop_url'];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        // A broken main URL takes every later test down with it, so put the table back whatever happened.
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        parent::tearDownAfterClass();
+    }
+
+    public function testPromotingADisabledUrlEnablesIt(): void
+    {
+        $url = $this->createDisabledUrl();
+
+        $url->setMain();
+
+        $stored = $this->readRow((int) $url->id);
+        $this->assertSame(1, $stored['main']);
+        $this->assertSame(1, $stored['active'], 'A URL promoted to main must not stay disabled.');
+        $this->assertTrue((bool) $url->active, 'The in-memory object must agree with the row.');
+    }
+
+    public function testPromotingADisabledUrlDemotesThePreviousMain(): void
+    {
+        $previousMainId = (int) Db::getInstance()->getValue(
+            'SELECT id_shop_url FROM ' . _DB_PREFIX_ . 'shop_url WHERE id_shop = 1 AND main = 1'
+        );
+        $url = $this->createDisabledUrl();
+
+        $url->setMain();
+
+        $this->assertSame(0, $this->readRow($previousMainId)['main']);
+    }
+
+    public function testAnAlreadyActiveUrlIsUnaffectedApartFromBecomingMain(): void
+    {
+        $url = $this->createDisabledUrl();
+        $url->active = true;
+        $url->update();
+
+        $url->setMain();
+
+        $stored = $this->readRow((int) $url->id);
+        $this->assertSame(1, $stored['main']);
+        $this->assertSame(1, $stored['active']);
+    }
+
+    private function createDisabledUrl(): ShopUrl
+    {
+        $url = new ShopUrl();
+        $url->id_shop = 1;
+        $url->domain = 'set-main-test.localhost';
+        $url->domain_ssl = 'set-main-test.localhost';
+        $url->physical_uri = '/';
+        $url->virtual_uri = 'setmaintest' . uniqid() . '/';
+        $url->main = false;
+        $url->active = false;
+        $url->add();
+
+        $stored = $this->readRow((int) $url->id);
+        $this->assertSame(0, $stored['active'], 'The fixture must start disabled.');
+
+        return $url;
+    }
+
+    private function readRow(int $idShopUrl): array
+    {
+        $row = Db::getInstance()->getRow(
+            'SELECT main, active FROM ' . _DB_PREFIX_ . 'shop_url WHERE id_shop_url = ' . $idShopUrl
+        );
+
+        // The driver hands these back as native ints on some setups and as strings on others.
+        return ['main' => (int) $row['main'], 'active' => (int) $row['active']];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A shop could end up with a main URL that is disabled, and then nothing in the back office would repair it. `ShopUrl::setMain()` promoted a URL without touching its `active` flag, and the status toggle in `AdminShopUrlController` refused *every* change on a main URL  -  so a main URL that had been disabled answered "You cannot disable the Main URL." to a request to **enable** it. `setMain()` now enables the URL it promotes, and the toggle refuses only the disabling direction.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable multistore, add a second URL to a shop, disable it, then use the list's "Is it the main URL?" action to promote it. Before: the shop's main URL is now disabled, the toggle refuses to enable it, and only the Multistore page still works. After: promoting enables it, and a main URL that is somehow disabled can be enabled from the list while disabling one is still refused.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33305
| Related PRs       |  - 
| Sponsor company   |  - 

### The codebase had already decided this rule; one path bypassed it

`AdminShopUrlController::processUpdate()` has carried this guard all along:

```php
if (($object->main || Tools::getValue('main')) && !Tools::getValue('active')) {
    $this->errors[] = $this->trans('You cannot disable the Main URL.', ...);
}
```

So the edit form will not save a main URL that is inactive. `setMain()`  -  reached from the list's quick
action at `AdminShopUrlController:430`  -  wrote `main = 1` with a raw `Db::update` and never looked at
`active`. This change makes that path honour the same rule rather than inventing a new one.

### How the two defects compound

```
step 8   disable the second URL
step 9   promote it with the list action  ->  setMain()  ->  main=1, active=0   (measured)
step 10  try to enable it                 ->  REFUSED, "You cannot disable the Main URL."
```

Measured on 9.2 before the fix:

```
created id=2  main=false active=false
after setMain():  main=1  active=0   <- a main URL that is disabled
toggle attempt  -> REFUSED: 'You cannot disable the Main URL.'  (the URL is currently active=0)
```

After, both directions behave:

```
state: main=1 active=0   ->  toggle ALLOWED, URL enabled
state: main=1 active=1   ->  toggle REFUSED    <- still blocked, as @Hlavtox asked
```

That matches Hlavtox's comment on the issue  -  "it should not be possible to deactivate the main URL"  -  while
making the state recoverable.

### Writers of `shop_url.main`, all checked

- `ShopUrl::setMain()` lines 102/103  -  the promotion, **fixed**
- `ShopUrl::setMain()` line 115  -  the loop that picks a main URL for any shop that has none, **fixed** (it
  could promote an inactive URL for the same reason)
- `src/PrestaShopBundle/Install/Install.php:571-572`  -  already sets `main` and `active` together
- the admin edit form, already guarded by `processUpdate()`

No other path can produce `main = 1, active = 0`.

## Reported but deliberately NOT fixed here

**Step 12, "I can navigate on the FO with a store disabled", is real and is a different defect.**
`shop_url.active` is never consulted when a request is resolved:

```sql
-- Shop::findShopByHost(), classes/Shop.php:1369
SELECT s.id_shop, CONCAT(su.physical_uri, su.virtual_uri) AS uri, su.domain, su.main
FROM ps_shop_url su
LEFT JOIN ps_shop s ON (s.id_shop = su.id_shop)
WHERE (su.domain = '...' OR su.domain_ssl = '...')
    AND s.active = 1        -- the SHOP
    AND s.deleted = 0
```

`s.active` is the shop; `su.active` is never tested, and `Shop::initialize()` only reads `$row['main']`.
Measured: with the resolved URL's `active = 0`, the front office serves the product page normally (200, no
redirect). Adding `AND su.active = 1` would change behaviour for every shop that has inactive URL rows lying
around, and what a disabled URL should actually do (404, redirect to the main URL, maintenance) is exactly
the specification this issue is labelled as needing. Raised in the issue comment for a maintainer decision.

Step 16 ("the product wants to open in the previous main shop") is a cache-staleness report the reporter
themself flagged as such, and is not addressed here.

## Files

- `classes/shop/ShopUrl.php`  -  `setMain()` enables what it promotes, +6/-2
- `controllers/admin/AdminShopUrlController.php`  -  the toggle refuses only disabling, +4/-1
- `tests/Integration/Classes/ShopUrlSetMainTest.php`  -  new, 3 tests

## Verification

- `php -l` clean; `php-cs-fixer --dry-run`  -  `Found 0 of 3 files that can be fixed`; `phpstan`  -  `[OK] No errors`
- `ShopUrlSetMainTest`: 3 tests, 9 assertions green, exit code `0`
- **Mutation check:** with `classes/shop/ShopUrl.php` reverted to `upstream/9.2.x` (revert verified by grep),
  exactly the promotion test fails on "A URL promoted to main must not stay disabled", while the demotion test
  and the already-active control stay green
- The test restores `ps_shop_url` via `DatabaseDump::restoreTables()` in both `setUpBeforeClass` and
  `tearDownAfterClass`; verified afterwards that the table holds only the original row and the front office
  still answers 200. A broken main URL would otherwise take the rest of the suite down with it.
- **The controller branch has no automated test.** It is one condition inside an admin request, and a test
  that reimplements `$object->main && $object->active` would assert nothing. It is covered by the measurement
  above, run in both directions.
