### PR TITLE
Report a failed in-transit notification without failing the webservice save

### DIFF
--- a/classes/order/OrderCarrier.php
+++ b/classes/order/OrderCarrier.php
@@ -169,7 +169,18 @@ class OrderCarrierCore extends ObjectModel
             }
 
             if (!$this->sendInTransitEmail($order)) {
-                return false;
+                // WHY: parent::update() has already committed the row above. Returning false here
+                // makes WebserviceRequest answer "Unable to save resource" (error 46) for a
+                // resource that was saved, so the caller sees a failed write that did happen.
+                // The notification failure is reported through the log instead; Mail::Send()
+                // additionally logs its own transport errors, so nothing is swallowed.
+                PrestaShopLogger::addLog(
+                    sprintf('Order #%d: the "in transit" e-mail could not be sent.', (int) $this->id_order),
+                    3,
+                    null,
+                    'Order',
+                    (int) $this->id_order
+                );
             }
         }
 

--- a/tests/Integration/Classes/Order/OrderCarrierUpdateWsTest.php
+++ b/tests/Integration/Classes/Order/OrderCarrierUpdateWsTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Carrier;
+use Configuration;
+use Context;
+use Currency;
+use Order;
+use OrderCarrier;
+use PHPUnit\Framework\TestCase;
+use Tests\Resources\DatabaseDump;
+use Validate;
+
+/**
+ * OrderCarrier::updateWs() is reachable only through the webservice ($definition
+ * objectMethods). It commits the row with parent::update() before sending the "in transit"
+ * notification, so a failed notification must not be reported back as a failed save:
+ * WebserviceRequest turns a false return into "Unable to save resource" (error 46).
+ */
+class OrderCarrierUpdateWsTest extends TestCase
+{
+    private const ORDER_CARRIER_ID = 1;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private $mailConfigurationBackup = [];
+
+    /**
+     * @var string
+     */
+    private $carrierUrlBackup = '';
+
+    /**
+     * @var int
+     */
+    private $carrierId = 0;
+
+    /**
+     * @var Currency|null
+     */
+    private $contextCurrencyBackup;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['order_carrier', 'carrier']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['order_carrier', 'carrier']);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (['PS_MAIL_METHOD', 'PS_MAIL_SERVER', 'PS_MAIL_SMTP_PORT', 'PS_MAIL_SMTP_ENCRYPTION'] as $key) {
+            $this->mailConfigurationBackup[$key] = Configuration::get($key);
+        }
+
+        // WHY: the send has to fail in Mail::send()'s transport catch. sendInTransitEmail()
+        // calls Mail::send() with $die = true, so any failure routed through Tools::dieOrLog()
+        // would terminate the process instead of returning false.
+        Configuration::updateValue('PS_MAIL_METHOD', 2);
+        Configuration::updateValue('PS_MAIL_SERVER', 'smtp.invalid.test');
+        Configuration::updateValue('PS_MAIL_SMTP_PORT', 25);
+        Configuration::updateValue('PS_MAIL_SMTP_ENCRYPTION', 'off');
+
+        // WHY: sendInTransitEmail() walks the order products, which needs the computing
+        // precision of a loaded context currency. This bare TestCase does not boot a kernel.
+        $context = Context::getContext();
+        $this->contextCurrencyBackup = $context->currency;
+        if (!Validate::isLoadedObject($context->currency)) {
+            $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        }
+
+        $order = new Order((int) (new OrderCarrier(self::ORDER_CARRIER_ID))->id_order);
+        $this->carrierId = (int) $order->id_carrier;
+        $carrier = new Carrier($this->carrierId);
+        $this->carrierUrlBackup = (string) $carrier->url;
+
+        // WHY: sendInTransitEmail() returns true without sending anything when the carrier has
+        // no tracking url, which would make every assertion below vacuous.
+        $carrier->url = 'http://tracking.invalid.test/@';
+        $carrier->save();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_GET['sendemail'], $_POST['sendemail']);
+
+        $carrier = new Carrier($this->carrierId);
+        $carrier->url = $this->carrierUrlBackup;
+        $carrier->save();
+
+        foreach ($this->mailConfigurationBackup as $key => $value) {
+            Configuration::updateValue($key, $value);
+        }
+
+        Context::getContext()->currency = $this->contextCurrencyBackup;
+
+        parent::tearDown();
+    }
+
+    /**
+     * Control: without this, a passing updateWs() test would prove nothing, because the
+     * notification branch would never be entered.
+     */
+    public function testTheNotificationFailsWithThisFixture(): void
+    {
+        $orderCarrier = new OrderCarrier(self::ORDER_CARRIER_ID);
+        $order = new Order((int) $orderCarrier->id_order);
+
+        $this->assertFalse($orderCarrier->sendInTransitEmail($order));
+    }
+
+    public function testUpdateWsReportsSuccessWhenTheNotificationFails(): void
+    {
+        $_GET['sendemail'] = 1;
+
+        $orderCarrier = new OrderCarrier(self::ORDER_CARRIER_ID);
+        $orderCarrier->tracking_number = 'TRACK-37249';
+
+        $this->assertTrue($orderCarrier->updateWs());
+
+        $persisted = new OrderCarrier(self::ORDER_CARRIER_ID);
+        $this->assertSame('TRACK-37249', $persisted->tracking_number);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `OrderCarrier::updateWs()` commits the row with `parent::update()` and then returns `false` when `sendInTransitEmail()` fails. `WebserviceRequest` maps that `false` to `Unable to save resource` (error 46, HTTP 500), so a `PUT /api/order_carriers/<id>?sendemail=1` that saved correctly is reported to the caller as a failed write whenever the mail cannot be sent. The send failure is not lost by decoupling the two: `Mail::send()` logs its own transport errors (`Mailer Error: ...`, severity 3), and this change adds an explicit order-scoped log line as well.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Give the order's carrier a tracking URL, make the configured SMTP server unreachable, then `PUT /api/order_carriers/<id>?sendemail=1` with a new `tracking_number`. Before the change the call answers HTTP 500 `(Code 46) Unable to save resource` while `ps_order_carrier.tracking_number` already holds the new value; after it the call succeeds and the failed notification appears in the BO log. `tests/Integration/Classes/Order/OrderCarrierUpdateWsTest.php` automates this.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/37249
| Related PRs       | https://github.com/PrestaShop/PrestaShop-webservice-lib/pull/102
| Sponsor company   |

### Scope note

This does not fix issue #37249 itself. That report is a client-library bug and is fixed by
PrestaShop-webservice-lib#102 (open, mergeable, unreviewed since 2024-10); measurement posted there.
This branch is the separate core defect found while measuring it, so the issue is linked as the
discussion, not with a closing keyword.

### Measured

`PUT /api/order_carriers/1?sendemail=1` against a 9.2.x shop, library patched with #102:

```
SMTP up      ->  call succeeds, tracking_number written, "Package in transit" delivered
SMTP down    ->  HTTP 500 (Code 46) Unable to save resource, tracking_number WRITTEN anyway
```

`ps_log` for the failing run carries `Mailer Error: Connection could not be established with host ...`
at severity 3, from `Mail::send()`'s own transport catch (`classes/Mail.php:683`). So the failure was
already recorded; only the save result was wrong.

### Test

`tests/Integration/Classes/Order/OrderCarrierUpdateWsTest.php`, 2 tests / 3 assertions.

RED->GREEN verified by reverting only `classes/order/OrderCarrier.php` to `upstream/9.2.x` with the test
in place: `testUpdateWsReportsSuccessWhenTheNotificationFails` fails with "Failed asserting that false is
true", and the control still passes.

The first test is that control, and it is not decorative. `sendInTransitEmail()` returns `true` without
sending anything when the carrier has no tracking URL, and the test DB's carrier 2 has an empty `url` -
so without setting one the notification branch is never entered and the second test would pass on the
unfixed code too.

Two fixture details the test has to handle:
- `sendInTransitEmail()` calls `Mail::send()` with `$die = true`, and `Tools::dieOrLog()` calls `die()`
  whenever `_PS_MODE_DEV_` is on. The failure therefore has to be a transport failure, which is caught
  at `Mail.php:682` and never reaches `dieOrLog()`. An invalid recipient or a missing template would
  kill the test process instead of returning `false`.
- the bare `TestCase` boots no kernel, so `Context::getContext()->currency` can be unloaded and
  `getComputingPrecision()` fatals on a null precision while walking the order's products. Set and
  restore it.
