### PR TITLE
Read the live checked state in the back office scripts

### DIFF
--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -602,7 +602,7 @@ $(() => {
       .parent();
     parentZone.find('.status').addClass('hide');
 
-    if ($(this).attr('checked') === 'checked') {
+    if ($(this).prop('checked')) {
       parentZone.find('.enabled').removeClass('hide');
       $('#currency_form #active').val(1);
     } else {
@@ -620,7 +620,7 @@ $(() => {
       .parent();
     parentZone.find('.status').addClass('hide');
 
-    if ($(this).attr('checked') === 'checked') {
+    if ($(this).prop('checked')) {
       enable = 1;
       parentZone.find('.enabled').removeClass('hide');
     } else {

--- a/admin-dev/themes/default/js/calendar.js
+++ b/admin-dev/themes/default/js/calendar.js
@@ -167,7 +167,7 @@ function updatePickerFromInput() {
 
   $('#date-start').trigger('change');
 
-  if ($('#datepicker-compare').attr('checked')) {
+  if ($('#datepicker-compare').prop('checked')) {
     if ($('#compare-options').val() == 1) setPreviousPeriod();
 
     if ($('#compare-options').val() == 2) setPreviousYear();
@@ -396,7 +396,7 @@ $(() => {
     if (this.value === '3') $('#date-start-compare').focus();
   });
 
-  if ($('#datepicker-compare').attr('checked')) {
+  if ($('#datepicker-compare').prop('checked')) {
     if ($('#date-start-compare').val().replace(/^\s+|\s+$/g, '').length === 0) $('#compare-options').trigger('change');
 
     datepickerStart.setStartCompare($('#date-start-compare').val());

--- a/js/admin.js
+++ b/js/admin.js
@@ -237,7 +237,7 @@ function checkPaymentBoxes(name, module)
     function()
     {
       if ($(this).attr('name') == module + '_' + name + '[]')
-        $(this).attr("checked", ((current.val() == 'checked') ? true : false));
+        $(this).prop("checked", ((current.val() == 'checked') ? true : false));
     }
   );
   current.val() == 'checked' ? current.val('unchecked') : current.val('checked');
@@ -253,7 +253,7 @@ function setPaymentBoxes(name, module)
     {
       if ($(this).attr('name') == module + '_' + name + '[]')
       {
-        ($(this).attr("checked") ? checked++ : '');
+        ($(this).prop("checked") ? checked++ : '');
         total++;
       }
     }
@@ -329,11 +329,11 @@ function selectCheckbox(obj)
 
 function toggleShippingCost()
 {
-  generateDiscount = $('#generateDiscount').attr("checked");
-  generateCreditSlip = $('#generateCreditSlip').attr("checked");
-  if (generateDiscount != 'checked' && generateCreditSlip != 'checked')
+  generateDiscount = $('#generateDiscount').prop("checked");
+  generateCreditSlip = $('#generateCreditSlip').prop("checked");
+  if (!generateDiscount && !generateCreditSlip)
   {
-    $('#spanShippingBack input[type=checkbox]').attr("checked", false);
+    $('#spanShippingBack input[type=checkbox]').prop("checked", false);
     $('#spanShippingBack').css('display', 'none');
   }
   else

--- a/js/admin/dashboard.js
+++ b/js/admin/dashboard.js
@@ -198,7 +198,10 @@ function saveDashConfig(widget_name) {
 	configs = '';
 
 	$('#'+widget_name+' form input, #'+widget_name+' form textarea , #'+widget_name+' form select').each( function () {
-		if ($(this).attr('type') === 'radio' && !$(this).attr('checked')) {
+		// WHY: since jQuery 1.6 attr('checked') returns the attribute, i.e. the state the markup was
+		// rendered with, so a radio the merchant just selected still reads as unchecked and its value is
+		// never submitted. prop('checked') reads the live DOM state.
+		if ($(this).attr('type') === 'radio' && !$(this).prop('checked')) {
 			return;
 		}
 		configs += '&configs['+$(this).attr('name')+']='+$(this).val();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Since jQuery 1.6, `attr('checked')` returns the attribute - the state the markup was rendered with - and never changes afterwards, so these reads always see the initial state rather than the merchant's. `saveDashConfig()` submits the radio the widget was rendered with instead of the one just selected, the currency status switcher writes the old value from inside its own `change` handler, and the payment-restriction and refund forms count and clear the wrong boxes. All six reads now use `prop('checked')`, and the two `attr('checked', ...)` writes inside the same functions follow, since a write to the attribute does not move a control the merchant has already touched.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Dashboard: add a radio ("switch") to a dashboard widget's config form, change it, save - before, the previous value comes back; after, the new one sticks. Currency: BO > International > Currencies, toggle a currency's status switch - before, `#currency_form #active` receives the value the row was rendered with. Order refund: tick "generate a voucher" - before, the shipping-cost block does not follow the tick.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36755
| Related PRs       |
| Sponsor company   |

### Measured

The real `saveDashConfig()` from both versions of `js/admin/dashboard.js`, run against a jsdom document
holding a radio group rendered with `advanced` checked, after the merchant selects `simple`:

```
A) the merchant selects "simple"
   base 9.2.x       submitted MY_MODE = advanced
   with the fix     submitted MY_MODE = simple

B) CONTROL - the merchant changes nothing, so both versions must agree
   base 9.2.x       submitted MY_MODE = advanced
   with the fix     submitted MY_MODE = advanced
```

The control is what makes A mean something: without it, "the fix submits a different value" could just be
a change that always picks the first radio. The non-radio field (`MY_LABEL`) is submitted unchanged in
all four runs.

### Scope, and what is deliberately left alone

The reported defect is a **read**. All six live reads of `attr('checked')` were surveyed and all six are
wrong for the same reason:

| Site | What it decides |
|---|---|
| `js/admin/dashboard.js` `saveDashConfig()` | which radio value is submitted |
| `js/admin.js` `setPaymentBoxes()` | how many payment-restriction boxes count as checked |
| `js/admin.js` `toggleShippingCost()` (x2) | whether the shipping-cost block is shown |
| `admin-dev/themes/default/js/calendar.js` (x2) | whether the comparison date range is applied |
| `admin-dev/themes/default/js/admin-theme.js` (x2) | the currency status / cron value written to the form |

The last two are read from inside the element's own `change` handler, so they are guaranteed stale.

Two `attr('checked', ...)` **writes** are changed as well, and only because they sit inside functions
being repaired here: `checkPaymentBoxes()` is the setter half of `setPaymentBoxes()` - fixing only the
read would leave the check-all toggle broken - and `toggleShippingCost()` clears a box in its own body.

The remaining `attr('checked', ...)` writes in `js/admin.js` (permissions matrix, hook toggles) and in
the theme bundles are the same jQuery migration but a separate, larger change with a different blast
radius, so they are not touched here. `js/admin/products.js` has many of them and is dead code -
`AdminProductsController` no longer exists in PS9 and nothing references the file.

### Checks

`node --check` on all four files. `eslint` clean on the two `admin-dev/themes/default` files using that
theme's own config, proven with a positive control (an injected spacing violation was reported, so the
clean run is real). `js/` is not covered by any lint or test target in this repository, and the jsdom
harness above depends on `jsdom` being present only as a transitive dependency of the new-theme build,
so it is not shippable as a test.
