### PR TITLE
Refuse to render the configuration page of a module that is switched off

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -106,17 +106,34 @@ class ModuleController extends ModuleAbstractController
         // Get accessed module object
         /** @var ModuleAdapter $module */
         $module = $this->getModuleRepository()->getModule($module_name);
+
+        // Nothing below can run without an instance: getContent() is read off it a few lines down, and
+        // method_exists() rejects null, so falling through here ends in a TypeError rather than the message.
         if (!$module->getInstance()) {
             $this->addFlash('error', $this->trans(
                 'The module "%modulename%" cannot be found',
                 ['%modulename%' => $module_name],
                 'Admin.Modules.Notification'
             ));
-            $layoutSubTitle = null;
-        } else {
-            $this->saveModuleHistory($module);
-            $layoutSubTitle = $module->getInstance()->displayName;
+
+            return $this->redirectToRoute('admin_module_manage');
         }
+
+        // A disabled module still hooks nothing and runs nothing, so its configuration page would be showing
+        // and saving settings for something that is not running. The module list still offers the action, so
+        // say why rather than rendering it.
+        if (!$module->isActive()) {
+            $this->addFlash('error', $this->trans(
+                'You cannot configure the module "%modulename%" while it is disabled. Enable it first.',
+                ['%modulename%' => $module_name],
+                'Admin.Modules.Notification'
+            ));
+
+            return $this->redirectToRoute('admin_module_manage');
+        }
+
+        $this->saveModuleHistory($module);
+        $layoutSubTitle = $module->getInstance()->displayName;
 
         // This controller is not purely migrated, in the sense that it still relies on the legacy layout because module implementing
         // getContent need the default theme to be working as expected


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ModuleController::configureModuleAction()` never checked whether the module is enabled, so the configuration page of a switched-off module rendered and saved settings for something that is not running. It now redirects to the module manager with a message. The "module cannot be found" branch above it needed the same: it added a flash and then fell through into `method_exists(null, ...)`, which is a `TypeError` on PHP 8.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Disable a configurable module in the module manager, then open its Configure action (the button is still offered). Before: the configuration page renders. After: you are returned to the module list with "You cannot configure the module "x" while it is disabled. Enable it first."
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #32211
| Related PRs       |  - 
| Sponsor company   |  - 

### Why the action is still reachable

`AdminModuleDataProvider::setActionUrls()` drops the `configure` URL only here:

```php
if (!$module->isConfigurable()) {
    unset($urls['configure']);
}
```

Never for an inactive module, while `enable`/`disable`/`install`/`delete` are filtered on state just above.
So the button stays on screen for a disabled module and the controller is what has to answer.

Deliberately not changed: hiding the button would contradict the requested behaviour, which is a redirect
*with a message*. If the button were gone there would be nothing to redirect from.

### The second guard

```php
if (!$module->getInstance()) {
    $this->addFlash('error', ...);   // and then fell through
}
...
if (method_exists($module->getInstance(), 'getContent')) {
```

Measured on PHP 8.1: `method_exists(null, 'getContent')` raises
`TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given`.
So the branch written to report the problem politely ended in a fatal. It now returns.

## Not tested automatically, and exactly why

I wrote a functional test against `WebTestCase` + `LoginTrait`, disabling a module and asserting the redirect,
and could not make it meaningful. `ModuleRepository` caches each module twice  -  through
`@doctrine.cache.provider` and through an in-memory `$installedModules` list filled once per request in
`getModuleDatabaseAttributes()`  -  so flipping `ps_module.active` in the test is not visible to the controller.
`clearCache()` resets both but builds its key through the language context, which a functional client does not
have, and `$this->client->request()` boots a fresh kernel anyway, so resetting the container the test holds
does not reach the one the controller uses. Rather than commit a test that passes for the wrong reason or
fails for an unrelated one, there is none, and the evidence is the reading above plus the measured `TypeError`.

Worth knowing from that attempt: because module state is cached per request, the guard relies on the cache
being current. In the back office it is  -  toggling a module goes through the module manager, which clears it,
and the Configure click is a later request.

## Verification

- `php -l` clean; `php-cs-fixer --dry-run`  -  `Found 0 of 1 files that can be fixed`; `phpstan`  -  `[OK] No errors`
- `bin/console debug:router admin_module_manage` resolves, with both path parameters optional
- Existing `ModuleControllerTest`: `testImportModuleAction` passes; `testModuleAction` errors with
  `assertArrayHasKey(): Argument #2 ($array) must be of type ArrayAccess|array, null given` at line 95  - 
  **pre-existing**, confirmed by running it against pristine `upstream/9.2.x` with this change reverted
- `method_exists(null, ...)` TypeError confirmed on PHP 8.1
