### PR TITLE
Let a module observe actionSubmitAccountBefore without refusing the account

### DIFF
--- a/classes/checkout/CheckoutPersonalInformationStep.php
+++ b/classes/checkout/CheckoutPersonalInformationStep.php
@@ -50,11 +50,13 @@ class CheckoutPersonalInformationStepCore extends AbstractCheckoutStep
 
         if (isset($requestParameters['submitCreate'])) {
             $this->registerForm->fillWith($requestParameters);
-            $hookResult = array_reduce(
+            // WHY: only an explicit false is a veto. Modules registered on this hook are observers
+            // as often as they are gatekeepers, and a hook method that returns nothing yields null
+            // in the results array - which the previous `$carry && $item` reduction read as a
+            // refusal, silently blocking account creation with no message (issue #37103).
+            $hookResult = !in_array(
+                false,
                 Hook::exec('actionSubmitAccountBefore', [], null, true),
-                function ($carry, $item) {
-                    return $carry && $item;
-                },
                 true
             );
             if ($hookResult && $this->registerForm->submit()) {

--- a/controllers/front/RegistrationController.php
+++ b/controllers/front/RegistrationController.php
@@ -44,11 +44,13 @@ class RegistrationControllerCore extends FrontController
 
         // If registration form was submitted
         if (Tools::isSubmit('submitCreate')) {
-            $hookResult = array_reduce(
+            // WHY: only an explicit false is a veto. Modules registered on this hook are observers
+            // as often as they are gatekeepers, and a hook method that returns nothing yields null
+            // in the results array - which the previous `$carry && $item` reduction read as a
+            // refusal, silently blocking account creation with no message (issue #37103).
+            $hookResult = !in_array(
+                false,
                 Hook::exec('actionSubmitAccountBefore', [], null, true),
-                function ($carry, $item) {
-                    return $carry && $item;
-                },
                 true
             );
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -50,6 +50,11 @@ parameters:
     - message: "#^Dead catch \\- Symfony\\\\Component\\\\HttpFoundation\\\\File\\\\Exception\\\\FileNotFoundException is never thrown in the try block\\.$#"
       count: 1
       path: src/PrestaShopBundle/Controller/Admin/SecuredFileReaderController.php
+    ## A fixture module driven by a test. tests/Resources is excluded above, so the module class the
+    ## test controls is not in PHPStan's symbol table even though it exists and is loaded at runtime.
+    -
+      message: '#^Access to static property \$hookReturnValue on an unknown class SubmitAccountHookTest\.$#'
+      path: tests/Integration/Classes/Checkout/CheckoutPersonalInformationStepHookTest.php
     ## Smarty functions
     - '#^Function smartyRegisterFunction not found\.$#'
     ## CQRS API Platform operations

--- a/tests/Integration/Classes/Checkout/CheckoutPersonalInformationStepHookTest.php
+++ b/tests/Integration/Classes/Checkout/CheckoutPersonalInformationStepHookTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Checkout;
+
+use Cache;
+use CheckoutPersonalInformationStep;
+use CheckoutProcess;
+use CheckoutSession;
+use Context;
+use Customer;
+use CustomerForm;
+use CustomerLoginForm;
+use Db;
+use Hook;
+use Module;
+use PHPUnit\Framework\MockObject\MockObject;
+use SubmitAccountHookTest;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * actionSubmitAccountBefore lets a module refuse an account creation, but a module that only
+ * observes the hook returns nothing, which arrives as null in the results array. Such a module must
+ * not block the checkout.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/37103
+ */
+class CheckoutPersonalInformationStepHookTest extends KernelTestCase
+{
+    private const MODULE = 'submitaccounthooktest';
+
+    /**
+     * @var int
+     */
+    private $moduleId = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+
+        $db = Db::getInstance();
+        $idHook = (int) $db->getValue('SELECT id_hook FROM ' . _DB_PREFIX_ . "hook WHERE name = 'actionSubmitAccountBefore'");
+        $this->assertGreaterThan(0, $idHook, 'the actionSubmitAccountBefore hook is not registered in this shop');
+
+        // The fixture module is registered directly: Module::install() needs a translator that this
+        // test case does not boot, and the hook execution path only reads these three tables.
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . "module (name, active, version) VALUES ('" . self::MODULE . "', 1, '1.0.0')");
+        $this->moduleId = (int) $db->Insert_ID();
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . 'module_shop (id_module, id_shop, enable_device) VALUES (' . $this->moduleId . ', 1, 7)');
+        $db->execute('INSERT INTO ' . _DB_PREFIX_ . 'hook_module (id_module, id_shop, id_hook, position) VALUES (' . $this->moduleId . ', 1, ' . $idHook . ', 1)');
+
+        // The module class is only included when PrestaShop instantiates it, and the tests below
+        // drive its return value through a static property.
+        $this->assertNotFalse(Module::getInstanceByName(self::MODULE), 'the fixture module could not be loaded');
+
+        Cache::clean('*');
+        Hook::resetStaticCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $db = Db::getInstance();
+        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'hook_module WHERE id_module = ' . $this->moduleId);
+        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'module_shop WHERE id_module = ' . $this->moduleId);
+        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'module WHERE id_module = ' . $this->moduleId);
+        SubmitAccountHookTest::$hookReturnValue = null;
+
+        Cache::clean('*');
+        Hook::resetStaticCache();
+        parent::tearDown();
+    }
+
+    /**
+     * Control for the two tests below: without it, a module that never runs would make both of them
+     * pass for the wrong reason.
+     */
+    public function testTheFixtureModuleIsActuallyCalled(): void
+    {
+        SubmitAccountHookTest::$hookReturnValue = 'called';
+
+        $this->assertSame(
+            [self::MODULE => 'called'],
+            Hook::exec('actionSubmitAccountBefore', [], null, true)
+        );
+    }
+
+    public function testAModuleThatReturnsNothingDoesNotBlockTheAccountCreation(): void
+    {
+        SubmitAccountHookTest::$hookReturnValue = null;
+
+        $registerForm = $this->registerForm();
+        $registerForm->expects($this->once())->method('submit')->willReturn(true);
+
+        $step = $this->step($registerForm);
+        $step->handleRequest(['submitCreate' => 1]);
+
+        $this->assertTrue($step->isComplete());
+    }
+
+    public function testAModuleThatReturnsFalseStillBlocksTheAccountCreation(): void
+    {
+        SubmitAccountHookTest::$hookReturnValue = false;
+
+        $registerForm = $this->registerForm();
+        $registerForm->expects($this->never())->method('submit');
+
+        $step = $this->step($registerForm);
+        $step->handleRequest(['submitCreate' => 1]);
+
+        $this->assertFalse($step->isComplete());
+    }
+
+    /**
+     * @return CustomerForm&MockObject
+     */
+    private function registerForm()
+    {
+        $registerForm = $this->createMock(CustomerForm::class);
+        $registerForm->method('fillWith')->willReturnSelf();
+        $registerForm->method('fillFromCustomer')->willReturnSelf();
+
+        return $registerForm;
+    }
+
+    /**
+     * @param CustomerForm&MockObject $registerForm
+     */
+    private function step($registerForm): CheckoutPersonalInformationStep
+    {
+        $session = $this->createMock(CheckoutSession::class);
+        $session->method('getCustomer')->willReturn(new Customer());
+
+        $process = $this->createMock(CheckoutProcess::class);
+        $process->method('getCheckoutSession')->willReturn($session);
+        $process->method('setHasErrors')->willReturnSelf();
+        // setNextStepAsCurrent() walks the sibling steps; this step is the only one under test.
+        $process->method('getSteps')->willReturn([]);
+
+        $step = new CheckoutPersonalInformationStep(
+            Context::getContext(),
+            self::getContainer()->get(TranslatorInterface::class),
+            $this->createMock(CustomerLoginForm::class),
+            $registerForm
+        );
+        $step->setCheckoutProcess($process);
+
+        return $step;
+    }
+}

--- a/tests/Integration/Classes/Checkout/CheckoutPersonalInformationStepHookTest.php
+++ b/tests/Integration/Classes/Checkout/CheckoutPersonalInformationStepHookTest.php
@@ -50,6 +50,11 @@ class CheckoutPersonalInformationStepHookTest extends KernelTestCase
         $idHook = (int) $db->getValue('SELECT id_hook FROM ' . _DB_PREFIX_ . "hook WHERE name = 'actionSubmitAccountBefore'");
         $this->assertGreaterThan(0, $idHook, 'the actionSubmitAccountBefore hook is not registered in this shop');
 
+        // A run that died between setUp and tearDown leaves the fixture row behind, and the INSERT
+        // below then fails on ps_module.name_UNIQUE for every remaining test of the class. Clearing
+        // it first makes setUp idempotent instead of letting one aborted run poison the rest.
+        self::removeFixtureModule();
+
         // The fixture module is registered directly: Module::install() needs a translator that this
         // test case does not boot, and the hook execution path only reads these three tables.
         $db->execute('INSERT INTO ' . _DB_PREFIX_ . "module (name, active, version) VALUES ('" . self::MODULE . "', 1, '1.0.0')");
@@ -67,15 +72,27 @@ class CheckoutPersonalInformationStepHookTest extends KernelTestCase
 
     protected function tearDown(): void
     {
-        $db = Db::getInstance();
-        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'hook_module WHERE id_module = ' . $this->moduleId);
-        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'module_shop WHERE id_module = ' . $this->moduleId);
-        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'module WHERE id_module = ' . $this->moduleId);
+        // Deleting by NAME rather than by $this->moduleId: when setUp itself fails the id is still 0
+        // and a delete on it removes nothing, which is what makes a single failure cascade.
+        self::removeFixtureModule();
         SubmitAccountHookTest::$hookReturnValue = null;
 
         Cache::clean('*');
         Hook::resetStaticCache();
         parent::tearDown();
+    }
+
+    private static function removeFixtureModule(): void
+    {
+        $db = Db::getInstance();
+        $idModule = (int) $db->getValue('SELECT id_module FROM ' . _DB_PREFIX_ . "module WHERE name = '" . self::MODULE . "'");
+        if ($idModule <= 0) {
+            return;
+        }
+
+        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'hook_module WHERE id_module = ' . $idModule);
+        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'module_shop WHERE id_module = ' . $idModule);
+        $db->execute('DELETE FROM ' . _DB_PREFIX_ . 'module WHERE id_module = ' . $idModule);
     }
 
     /**

--- a/tests/Resources/modules/submitaccounthooktest/config.xml
+++ b/tests/Resources/modules/submitaccounthooktest/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<module>
+    <name>submitaccounthooktest</name>
+    <displayName><![CDATA[Submit account hook test]]></displayName>
+    <version><![CDATA[1.0.0]]></version>
+    <description><![CDATA[Test fixture returning a configurable value from actionSubmitAccountBefore.]]></description>
+    <author><![CDATA[PrestaShop]]></author>
+    <is_configurable>0</is_configurable>
+    <need_instance>0</need_instance>
+    <limited_countries></limited_countries>
+</module>

--- a/tests/Resources/modules/submitaccounthooktest/submitaccounthooktest.php
+++ b/tests/Resources/modules/submitaccounthooktest/submitaccounthooktest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Test fixture for the actionSubmitAccountBefore hook.
+ *
+ * The value the hook method returns is what distinguishes a module that merely observes the hook
+ * from one that vetoes the account creation, so the test drives it through a static property.
+ */
+class SubmitAccountHookTest extends Module
+{
+    /**
+     * Returned by the hook. null stands for the very common module that observes without returning
+     * anything at all; false is an explicit veto.
+     *
+     * @var mixed
+     */
+    public static $hookReturnValue = null;
+
+    public function __construct()
+    {
+        $this->name = 'submitaccounthooktest';
+        $this->tab = 'front_office_features';
+        $this->version = '1.0.0';
+        $this->author = 'PrestaShop';
+        $this->need_instance = 0;
+        $this->bootstrap = true;
+
+        parent::__construct();
+
+        $this->displayName = 'Submit account hook test';
+        $this->description = 'Test fixture returning a configurable value from actionSubmitAccountBefore.';
+    }
+
+    public function install()
+    {
+        return parent::install() && $this->registerHook('actionSubmitAccountBefore');
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return mixed
+     */
+    public function hookActionSubmitAccountBefore($params)
+    {
+        return self::$hookReturnValue;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `actionSubmitAccountBefore` lets a module refuse an account creation, but both call sites reduced its results with `$carry && $item` over `Hook::exec(..., $array_return = true)`. A module that only observes the hook returns nothing, which arrives in that array as `null`, so the reduction produced `false` and the account creation was refused - on the registration page and in the checkout alike, with no message explaining why. Only an explicit `false` is a refusal now. The hook is described as "Triggers after submitting registration form, before the registration process itself. Allows to modify result of this action", which is a veto, not a mandatory acknowledgement.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a module registering `actionSubmitAccountBefore` with a `hookActionSubmitAccountBefore($params)` method that does not return anything - the exact shape posted on issue #37103. Create an account from the registration page and from the checkout's personal information step. Before: both are silently refused, the form redisplays with no error. After: both succeed. A module that returns `false` still blocks both, which is what the second and third test assert.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/37103
| Related PRs       | #34133, #37448
| Sponsor company   |

### Scope note

This does not fix issue #37103 as filed - that report is "the hook does not fire in the checkout", and
it was fixed by merged **#37448** (Touxten, 8.2.x, 2024-11-26), which is present on 9.2.x and develop.
The issue is simply still open. What #37448 did was copy the reduction that **#34133** had already
introduced in `RegistrationController` in 2023, so both call sites now carry the same defect, which is
why both are changed here rather than one.

The trap lands squarely on the reporter of #37103: the example module in that issue is
`hookActionSubmitAccountBefore($params) { @dump($this); }`, with no return.

### Measured

A fixture module registered on the hook, returning nothing:

```
Hook::exec('actionSubmitAccountBefore', [], null, true)  =  ['<module>' => NULL]
array_reduce($carry && $item, true)                      =  false
=> registerForm->submit() SKIPPED, account creation silently refused
```

The hook method did run (a marker file was written), so this is not the hook failing to fire - it is
the result being read as a refusal.

### Why `in_array(false, ..., true)` and not a truthiness test

A strict search keeps the rule readable in one line at each call site and says exactly what the hook
contract is: a module refuses by returning `false`, anything else is not a refusal. `0`, `''` and
`null` therefore stop blocking, which is the behaviour change. A module that deliberately relied on
returning a falsy non-`false` value to block was relying on an accident of the reduction rather than on
anything documented, and the cost of the current behaviour - a checkout that silently refuses to create
an account - is much higher than that.

No shared helper was extracted for the two call sites. `classes/Hook.php` already carries three open
PRs of mine (#42540, #42557, #42640), and a one-line rule duplicated twice is cheaper than a new public
API on that class. Verified this branch merges clean against all three with a real
`git merge --no-commit --no-ff`.

### Test

`tests/Integration/Classes/Checkout/CheckoutPersonalInformationStepHookTest.php`, 3 tests /
11 assertions, with the fixture module `tests/Resources/modules/submitaccounthooktest`. The module
returns a value driven by a static property, so one fixture covers the observer and the gatekeeper.

- `testTheFixtureModuleIsActuallyCalled` - the control. Without it the other two would pass for the
  wrong reason if the module were never reached.
- `testAModuleThatReturnsNothingDoesNotBlockTheAccountCreation` - `submit()` is expected once.
- `testAModuleThatReturnsFalseStillBlocksTheAccountCreation` - `submit()` is expected never.

RED->GREEN verified by reverting **only** `classes/checkout/CheckoutPersonalInformationStep.php` to
`upstream/9.2.x` with the tests in place: exactly one failure, the middle test, "Failed asserting that
false is true", while the control and the veto test still pass.

`Module::install()` is not used to register the fixture - it needs a translator this test case does not
boot - so the three rows the hook execution path reads (`module`, `module_shop`, `hook_module`) are
inserted directly and removed in `tearDown`.

### Checks

`php-cs-fixer` and `phpstan` clean on all four files.
