### PR TITLE
Make the product category filter's "Clear filter" button translatable

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
@@ -110,7 +110,7 @@
   </div>
   {% if form.vars.data is not empty %}
   <button class="btn btn-link category_tree_filter_reset" type="button">
-    <i class="material-icons">clear</i> Clear filter
+    <i class="material-icons">clear</i> {{ 'Clear filter'|trans({}, 'Admin.Actions') }}
   </button>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The "Clear filter" button in the product form's category tree was written as plain text instead of going through the translator, so the string never reached the translation catalogue and stayed in English whatever the employee's language. The button directly above it in the same block already uses `\|trans`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set the employee language to anything but English, open a product, and look at the category tree filter. Before: the button reads "Clear filter" in English and the string cannot be found in the translation catalogue. After: it is translatable. `php bin/console debug:translation en --domain=Admin.Actions` lists a `Clear filter` key only with this change applied.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #32976
| Related PRs       |  - 
| Sponsor company   |  - 

### The change

`src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig:113`

```diff
-    <i class="material-icons">clear</i> Clear filter
+    <i class="material-icons">clear</i> {{ 'Clear filter'|trans({}, 'Admin.Actions') }}
```

`Admin.Actions` is the domain the same wording already uses in
`Product/Combination/paginated_list_header.html.twig:90`, but only as the pluralised
`Clear filter|Clear {filtersNb} filters`, which is fed to JS with a count. A plain button has no count, so a
plain key is added rather than bending the pluralised one.

The default catalogue under `translations/default/` is regenerated in bulk by the project's own
"Update default catalog" commits, not by feature PRs, so no `.xlf` is touched here.

## Verification

- `bin/console lint:twig`  -  `[OK] All 1 Twig files contain valid syntax`
- **Mutation check on the actual symptom.** `bin/console debug:translation en --domain=Admin.Actions`:
  - without the change, the only match is `Clear filter|Clear {filtersNb} filters`
  - with it, a plain `Clear filter` key appears

  That is the defect the issue reports  -  the string being absent from the catalogue  -  measured directly
  rather than by reading the template.
