### PR TITLE
Fill in the category WebP acceptance checks

### DIFF
--- a/tests/UI/campaigns/functional/BO/08_design/06_imageSettings/14_checkCategoryImageFormat.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/06_imageSettings/14_checkCategoryImageFormat.ts
@@ -229,17 +229,14 @@ describe('BO - Design - Image Settings : Check category image format', async () 
           const imageTypeCoverJPG = await utilsFile.getFileType(pathImageCoverJPG);
           expect(imageTypeCoverJPG).to.be.eq(arg.extImageType);
 
-          // @todo : https://github.com/PrestaShop/PrestaShop/issues/32404
-          /*
-          // Check the WebP file
-          const pathImageWEBP: string = `${utilsFile.getRootPath()}/img/c/${idCategory}-large_default.webp`;
+          // Check the cover image file category_default WebP thumbnail is generated
+          const pathImageCoverWEBP: string = `${utilsFile.getRootPath()}/img/c/${idCategory}-category_default.webp`;
 
-          const fileExistsWEBP = await utilsFile.doesFileExist(pathImageWEBP);
-          expect(fileExistsWEBP, `The file ${pathImageWEBP} doesn't exist!`).to.eq(true);
+          const fileExistsCoverWEBP = await utilsFile.doesFileExist(pathImageCoverWEBP);
+          expect(fileExistsCoverWEBP, `The file ${pathImageCoverWEBP} doesn't exist!`).to.eq(true);
 
-          const imageTypeWEBP = await utilsFile.getFileType(pathImageWEBP);
-          expect(imageTypeWEBP).to.be.eq('webp');
-          */
+          const imageTypeCoverWEBP = await utilsFile.getFileType(pathImageCoverWEBP);
+          expect(imageTypeCoverWEBP).to.be.eq('webp');
 
           // Check the cover image file small_default jpg thumbnail is generated in proper format
           const pathImageMetaJPG: string = `${utilsFile.getRootPath()}/img/c/${idCategory}-small_default.jpg`;
@@ -250,17 +247,14 @@ describe('BO - Design - Image Settings : Check category image format', async () 
           const imageTypeMetaJPG = await utilsFile.getFileType(pathImageMetaJPG);
           expect(imageTypeMetaJPG).to.be.eq(arg.extImageType);
 
-          // @todo : https://github.com/PrestaShop/PrestaShop/issues/32404
-          /*
-          // Check the WebP file
-          const pathImageWEBP: string = `${utilsFile.getRootPath()}/img/c/${idCategory}-large_default.webp`;
+          // Check the cover image file small_default WebP thumbnail is generated
+          const pathImageMetaWEBP: string = `${utilsFile.getRootPath()}/img/c/${idCategory}-small_default.webp`;
 
-          const fileExistsWEBP = await utilsFile.doesFileExist(pathImageWEBP);
-          expect(fileExistsWEBP, `The file ${pathImageWEBP} doesn't exist!`).to.eq(true);
+          const fileExistsMetaWEBP = await utilsFile.doesFileExist(pathImageMetaWEBP);
+          expect(fileExistsMetaWEBP, `The file ${pathImageMetaWEBP} doesn't exist!`).to.eq(true);
 
-          const imageTypeWEBP = await utilsFile.getFileType(pathImageWEBP);
-          expect(imageTypeWEBP).to.be.eq('webp');
-          */
+          const imageTypeMetaWEBP = await utilsFile.getFileType(pathImageMetaWEBP);
+          expect(imageTypeMetaWEBP).to.be.eq('webp');
         });
 
         it('should go to FO page', async function () {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The two WebP assertions in `14_checkCategoryImageFormat.ts` were commented out behind a `@todo` pointing at #32404, and they checked `large_default.webp`, which is not a category image type. They now check `{id}-category_default.webp` and `{id}-small_default.webp`, matching the JPG assertions they sit beside, and are enabled. Both files are generated on 9.2.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the campaign `functional/BO/08_design/06_imageSettings/14_checkCategoryImageFormat.ts` with WebP enabled in Image Settings.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #32404
| Related PRs       | #32458 removed the menu thumbnails that point 5 of the issue refers to
| Sponsor company   |  - 

## Files

- `tests/UI/campaigns/functional/BO/08_design/06_imageSettings/14_checkCategoryImageFormat.ts`  -  +12/-18

## Verification

- `eslint`  -  clean, exit 0
- `tsc --noEmit -p tsconfig.json`  -  0 errors mentioning this file
- No `@todo`/#32404 references left in the file
- Generation measured directly through both uploaders, table above

## Not done

The campaign itself was not executed: the UI-test dispatch queue is stopped, and this needs a browser plus a
shop with WebP enabled. The evidence that the assertions will hold is the generation measurement above, taken
through the same uploaders the BO calls, rather than a campaign run.
