### PR TITLE
Keep the dependent translation field visible after a browser Back

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.ts
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.ts
@@ -55,7 +55,17 @@ export default class FormFieldToggle {
       this.toggleEmailFields.bind(this),
     );
 
-    $(window).on('load', this.toggleFields.bind(this));
+    // Coming back to this page through browser history restores the selected translation type after
+    // load has already fired, so a handler bound to load reads the value the server rendered and leaves
+    // the dependent field hidden. pageshow runs after that restoration.
+    $(window).on('pageshow', this.toggleFields.bind(this));
+
+    // On that same history restore the page can already be complete by the time this runs, which means
+    // pageshow has fired and the listener above missed it. The selected value is final at that point,
+    // so read it once straight away.
+    if (document.readyState === 'complete') {
+      this.toggleFields();
+    }
   }
 
   /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The translation type select and its dependent field (theme, module or email) are toggled by `FormFieldToggle`, bound to `window load`. Coming back to the page through browser history without the back/forward cache, the browser restores the selected value *after* `load` has fired, so the toggle reads what the server rendered and leaves the dependent field hidden while the type reads "Installed modules". Bound to `pageshow` instead, plus a direct call when the document is already `complete` at construction, which is the case on that same restore.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to International > Translations, pick "Installed modules", choose a module, submit, then navigate away and press Back. Before this change the type still says "Installed modules" while the module select is hidden, and picking another type is the only way to get it back. It only reproduces when the page is re-parsed rather than served from the back/forward cache, which is why it was not reproducible for everyone.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33204
| Related PRs       |
| Sponsor company   |

## This also answers the `Waiting for QA` question that has blocked the issue since 2023

@florine2623 could not reproduce it, @Hlavtox could. Both were right:

**It reproduces only when the page is re-parsed on Back.** If the browser serves it from the
back/forward cache, the DOM comes back exactly as it was left  -  classes and all  -  and nothing is wrong.
Measured both ways with the shipped `translation_settings.bundle.js`:

| Restore | `pageshow.persisted` | Result |
|---|---|---|
| back/forward cache | `true` | correct, field still visible |
| page re-parsed | `false` | **field hidden while the type still says "modules"** |

That is the whole disagreement, and it is why the reproduction depended on who tried it.

## Mechanism

`ModifyTranslationsType` renders the theme, module and email rows with `d-none`
(`'class' => 'js-module-form-group d-none'`), and `FormFieldToggle` removes it for whichever the chosen
translation type needs. That ran on `window load`.

On a re-parsed history restore the browser restores the select **after** `load`. Measured ordering:

```
setTimeout(0)        select=back      modulesHidden=true
DOMContentLoaded     select=back      modulesHidden=true
window load          select=back      modulesHidden=true   <- toggleFields() ran here
pageshow             select=modules   modulesHidden=true   <- value restored, nothing re-ran
final                select=modules   modulesHidden=true
```

So the type reads "Installed modules" while the module select stays hidden  -  the reporter's "the 2nd field
disappears". Picking another type fixes it because that fires `change`, which they also noted.

## Why moving to `pageshow` alone is not enough  -  measured, not assumed

The obvious fix is to bind `pageshow` instead of `load`. **It does not work**, and the branch does not stop
there. Built that version, ran the same sequence: the field was still hidden. Dispatching `pageshow` by hand
on the restored page *did* reveal it, and `jQuery._data(window, 'events')` showed only `pageshow` bound  -  so
the handler was correct and simply had not been bound when the real event fired. `index.ts` constructs the
class inside `$(() => ...)`, and on that restore the page was already complete by then.

Hence the second half: when `document.readyState === 'complete'` at construction, the selected value is
already final, so read it once immediately.

## Verified against the real bundle, both directions

Built `translation_settings.bundle.js` from the patched source and drove a harness that loads the **shipped
bundle** and the real markup, using genuine history navigation:

| | before | after |
|---|---|---|
| fresh load, type "back" | field hidden | unchanged |
| user picks "modules" | field shown | unchanged |
| **Back, page re-parsed** | **field hidden, type says modules** | **field shown** |
| Back, back/forward cache (type "mails") | email row shown | unchanged |

## Files

- `admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.ts`  -  the only file

`admin-dev/themes/new-theme/public/*` is gitignored (`.gitignore:126`), so the built bundle is not part of the
diff  -  same shape as #32318, which fixed a neighbouring problem in this file and touched only `.ts`.

## Verification

- `eslint -c .eslintrc.js --ext .ts` on the changed file  -  clean
- `tsc --noEmit -p tsconfig.json`  -  0 errors mentioning `FormFieldToggle`
- `npm run build`  -  exit 0
- Behaviour measured in Chrome through real Back navigation, before and after, on both restore paths
- The locally built bundle was reverted to the shipped one afterwards, so the dev shop is unchanged

## Not covered

No automated test. The behaviour depends on the browser restoring form state between `load` and `pageshow`,
which is not reproducible in jsdom or in the theme's mocha setup. A UI test could cover it if the campaign
queue reopens; the measurements above are the evidence for now.
