### PR TITLE
Select a cache driver only when its adapter can be built

### DIFF
--- a/app/config/set_parameters.php
+++ b/app/config/set_parameters.php
@@ -47,9 +47,14 @@ if (isset($container) && $container instanceof Symfony\Component\DependencyInjec
     }
 
     $driver = 'array';
+    // WHY: the adapter, not the extension, decides whether a driver is usable - Symfony also
+    // requires memcached >= 3.1.6 and apc.enabled=1, and its adapters throw from their
+    // constructor when that is not met. Picking a driver on extension_loaded() alone makes
+    // every Symfony page fail to boot, including the one the merchant would need to turn the
+    // caching system back off.
     $cacheType = [
-        'CacheMemcached' => ['memcached'],
-        'CacheApc' => ['apcu'],
+        'CacheMemcached' => ['memcached' => Symfony\Component\Cache\Adapter\MemcachedAdapter::class],
+        'CacheApc' => ['apcu' => Symfony\Component\Cache\Adapter\ApcuAdapter::class],
     ];
     $adapters = [
         'array' => 'cache.adapter.array',
@@ -64,8 +69,8 @@ if (isset($container) && $container instanceof Symfony\Component\DependencyInjec
     )
         && true === $parameters['parameters']['ps_cache_enable']
     ) {
-        foreach ($cacheType[$parameters['parameters']['ps_caching']] as $type) {
-            if (extension_loaded($type)) {
+        foreach ($cacheType[$parameters['parameters']['ps_caching']] as $type => $adapterClass) {
+            if ($adapterClass::isSupported()) {
                 $driver = $type;
                 break;
             }

--- a/src/Adapter/Cache/CachingConfiguration.php
+++ b/src/Adapter/Cache/CachingConfiguration.php
@@ -92,11 +92,13 @@ class CachingConfiguration implements DataConfigurationInterface
      */
     public function validateConfiguration(array $configuration)
     {
-        return isset(
-            $configuration['use_cache'],
-            $configuration['caching_system'],
-            $configuration['servers']
-        );
+        // WHY: caching_system is null whenever no system is selectable - a disabled radio is not
+        // posted - and that has to stay a saveable state, or a shop whose caching system its
+        // adapter refuses cannot turn caching back off from this form. Rejecting it here made the
+        // save a silent no-op, since updateConfiguration() reports no error when this returns
+        // false; updatePhpCacheConfiguration() already guards the value for null on its own.
+        return isset($configuration['use_cache'], $configuration['servers'])
+            && array_key_exists('caching_system', $configuration);
     }
 
     /**
@@ -108,10 +110,11 @@ class CachingConfiguration implements DataConfigurationInterface
     {
         $errors = [];
 
-        if (
-            $configuration['use_cache'] !== $this->isCachingEnabled
-            && null !== $configuration['caching_system']
-        ) {
+        // WHY: turning the cache on or off is independent of which system is selected. Requiring a
+        // system here used to keep a shop from enabling caching it could not run, but the driver is
+        // now chosen on whether the adapter can actually be built, so the only thing this coupling
+        // still did was trap a shop with no selectable system into leaving caching enabled.
+        if ($configuration['use_cache'] !== $this->isCachingEnabled) {
             $this->phpParameters->setProperty('parameters.ps_cache_enable', $configuration['use_cache']);
         }
 

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -18,11 +18,20 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class CachingType extends TranslatorAwareType
 {
+    /**
+     * WHY: Xcache used to be offered here and is not any more. Its last release supports PHP 5.6,
+     * there has never been a build for a version this release runs on, and the option was shown with
+     * a link telling the merchant to go and install it. `classes/cache/CacheXcache.php` stays, so a
+     * shop that somehow has it configured keeps working; it is only no longer proposed.
+     *
+     * The two Memcached entries are not a duplicate: `memcache` and `memcached` are two different
+     * client extensions for the same server, both installable today, and the extension is what the
+     * label names.
+     */
     private $extensionsList = [
         'CacheMemcache' => ['memcache'],
         'CacheMemcached' => ['memcached'],
         'CacheApc' => ['apc', 'apcu'],
-        'CacheXcache' => ['xcache'],
     ];
 
     /**
@@ -50,10 +59,9 @@ class CachingType extends TranslatorAwareType
             ->add('caching_system', ChoiceType::class, [
                 'label' => $this->trans('Caching system', 'Admin.Advparameters.Feature'),
                 'choices' => [
-                    'Memcached via PHP::Memcache' => 'CacheMemcache',
-                    'Memcached via PHP::Memcached' => 'CacheMemcached',
+                    'Memcached via the memcache extension' => 'CacheMemcache',
+                    'Memcached via the memcached extension' => 'CacheMemcached',
                     'APC' => 'CacheApc',
-                    'Xcache' => 'CacheXcache',
                 ],
                 'choice_label' => function ($value, $key, $index) {
                     return $this->isAvailable($index) ? $value : $this->getErrorsMessages()[$index];
@@ -106,7 +114,7 @@ class CachingType extends TranslatorAwareType
     private function getErrorsMessages()
     {
         return [
-            'CacheMemcache' => $this->trans('Memcached via PHP::Memcache', 'Admin.Advparameters.Feature')
+            'CacheMemcache' => $this->trans('Memcached via the memcache extension', 'Admin.Advparameters.Feature')
                 . ' '
                 . $this->trans(
                     '(you must install the [a]Memcache PECL extension[/a])',
@@ -116,7 +124,7 @@ class CachingType extends TranslatorAwareType
                         '[/a]' => '</a>',
                     ]
                 ),
-            'CacheMemcached' => $this->trans('Memcached via PHP::Memcached', 'Admin.Advparameters.Feature')
+            'CacheMemcached' => $this->trans('Memcached via the memcached extension', 'Admin.Advparameters.Feature')
                 . ' '
                 . $this->trans(
                     '(you must install the [a]Memcached PECL extension[/a])',
@@ -129,20 +137,10 @@ class CachingType extends TranslatorAwareType
             'CacheApc' => $this->trans('APC', 'Admin.Advparameters.Feature')
                 . ' '
                 . $this->trans(
-                    '(you must install the [a]APC PECL extension[/a])',
+                    '(you must install the [a]APCu PECL extension[/a])',
                     'Admin.Advparameters.Notification',
                     [
                         '[a]' => '<a href="https://www.php.net/manual/en/apcu.installation.php" class="ml-1" target="_blank">',
-                        '[/a]' => '</a>',
-                    ]
-                ),
-            'CacheXcache' => $this->trans('Xcache', 'Admin.Advparameters.Feature')
-                . ' '
-                . $this->trans(
-                    '(you must install the [a]Xcache extension[/a])',
-                    'Admin.Advparameters.Notification',
-                    [
-                        '[a]' => '<a href="https://github.com/lighttpd/xcache" class="ml-1" target="_blank">',
                         '[/a]' => '</a>',
                     ]
                 ),

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -8,6 +8,8 @@ namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -21,6 +23,19 @@ class CachingType extends TranslatorAwareType
         'CacheMemcached' => ['memcached'],
         'CacheApc' => ['apc', 'apcu'],
         'CacheXcache' => ['xcache'],
+    ];
+
+    /**
+     * Extensions the Symfony container caches through, mapped to the adapter that uses them.
+     *
+     * WHY: a loaded extension is not a usable one - these adapters also require
+     * memcached >= 3.1.6 and apc.enabled=1, and throw when that is not met. Offering such an
+     * option enabled lets a merchant select a caching system that then breaks every page.
+     * Extensions with no entry here back no Symfony adapter, so loading them is all we can test.
+     */
+    private $adapters = [
+        'memcached' => MemcachedAdapter::class,
+        'apcu' => ApcuAdapter::class,
     ];
 
     /**
@@ -41,30 +56,10 @@ class CachingType extends TranslatorAwareType
                     'Xcache' => 'CacheXcache',
                 ],
                 'choice_label' => function ($value, $key, $index) {
-                    $disabled = false;
-                    foreach ($this->extensionsList[$index] as $extensionName) {
-                        if (extension_loaded($extensionName)) {
-                            $disabled = false;
-
-                            break;
-                        }
-                        $disabled = true;
-                    }
-
-                    return $disabled === true ? $this->getErrorsMessages()[$index] : $value;
+                    return $this->isAvailable($index) ? $value : $this->getErrorsMessages()[$index];
                 },
                 'choice_attr' => function ($value, $key, $index) {
-                    $disabled = false;
-                    foreach ($this->extensionsList[$index] as $extensionName) {
-                        if (extension_loaded($extensionName)) {
-                            $disabled = false;
-
-                            break;
-                        }
-                        $disabled = true;
-                    }
-
-                    return $disabled === true ? ['disabled' => $disabled] : [];
+                    return $this->isAvailable($index) ? [] : ['disabled' => true];
                 },
                 'expanded' => true,
                 'required' => false,
@@ -82,6 +77,25 @@ class CachingType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'performance_caching_block';
+    }
+
+    /**
+     * @param string $cachingSystem one of the keys of $extensionsList
+     *
+     * @return bool whether the shop can actually cache through that system
+     */
+    private function isAvailable($cachingSystem)
+    {
+        foreach ($this->extensionsList[$cachingSystem] as $extensionName) {
+            $adapter = $this->adapters[$extensionName] ?? null;
+            $available = null === $adapter ? extension_loaded($extensionName) : $adapter::isSupported();
+
+            if ($available) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Adapter/Cache/CachingConfigurationTest.php
+++ b/tests/Unit/Adapter/Cache/CachingConfigurationTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Cache;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Cache\CachingConfiguration;
+use PrestaShop\PrestaShop\Adapter\Cache\MemcacheServerManager;
+use PrestaShop\PrestaShop\Adapter\Configuration\PhpParameters;
+use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
+
+class CachingConfigurationTest extends TestCase
+{
+    /**
+     * @var PhpParameters&MockObject
+     */
+    private $phpParameters;
+
+    protected function setUp(): void
+    {
+        $this->phpParameters = $this->createMock(PhpParameters::class);
+        $this->phpParameters->method('saveConfiguration')->willReturn(true);
+    }
+
+    /**
+     * The Performance form does not post a disabled radio, so caching_system arrives null whenever
+     * no caching system is selectable - which is exactly the state a shop is in when its extension
+     * is too old for the adapter. That has to remain saveable, because turning caching off is the
+     * only way out of it.
+     */
+    public function testCachingCanBeTurnedOffWhileNoSystemIsSelectable(): void
+    {
+        $this->phpParameters
+            ->expects($this->once())
+            ->method('setProperty')
+            ->with('parameters.ps_cache_enable', false);
+
+        $errors = $this->configuration(true, 'CacheMemcached')->updateConfiguration([
+            'use_cache' => false,
+            'caching_system' => null,
+            'servers' => [],
+        ]);
+
+        $this->assertSame([], $errors);
+    }
+
+    public function testAMissingCachingSystemKeyIsStillRejected(): void
+    {
+        $this->assertFalse($this->configuration(true, 'CacheMemcached')->validateConfiguration([
+            'use_cache' => false,
+            'servers' => [],
+        ]));
+    }
+
+    public function testASelectedSystemIsStillWritten(): void
+    {
+        $written = [];
+        $this->phpParameters
+            ->expects($this->exactly(2))
+            ->method('setProperty')
+            ->willReturnCallback(function ($key, $value) use (&$written): void {
+                $written[$key] = $value;
+            });
+
+        $this->configuration(false, 'CacheMemcached')->updateConfiguration([
+            'use_cache' => true,
+            'caching_system' => 'CacheApc',
+            'servers' => [],
+        ]);
+
+        $this->assertSame([
+            'parameters.ps_cache_enable' => true,
+            'parameters.ps_caching' => 'CacheApc',
+        ], $written);
+    }
+
+    public function testNothingIsWrittenWhenNothingChanged(): void
+    {
+        $this->phpParameters->expects($this->never())->method('setProperty');
+
+        $this->configuration(true, 'CacheApc')->updateConfiguration([
+            'use_cache' => true,
+            'caching_system' => 'CacheApc',
+            'servers' => [],
+        ]);
+    }
+
+    private function configuration(bool $isCachingEnabled, string $cachingSystem): CachingConfiguration
+    {
+        return new CachingConfiguration(
+            $this->createMock(MemcacheServerManager::class),
+            $this->phpParameters,
+            $this->createMock(CacheClearerInterface::class),
+            $isCachingEnabled,
+            $cachingSystem
+        );
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingTypeTest.php
@@ -45,25 +45,43 @@ class CachingTypeTest extends TypeTestCase
     }
 
     /**
-     * The other two systems back no Symfony adapter, so loading the extension stays the only
-     * thing that can be tested for them.
+     * The remaining system backs no Symfony adapter, so loading the extension stays the only thing
+     * that can be tested for it.
      */
     public function testASystemWithNoSymfonyAdapterStillGoesByTheExtension(): void
     {
         $this->assertSame(extension_loaded('memcache'), $this->isOffered('CacheMemcache'));
-        $this->assertSame(extension_loaded('xcache'), $this->isOffered('CacheXcache'));
     }
 
     /**
-     * Xcache has no build for any PHP version this release supports, so it is the one option
-     * that is unavailable everywhere - which makes it the fixed point for the disabled path.
+     * Xcache is not proposed any more: its last release supports PHP 5.6, so no version this
+     * release runs on can have it, and offering it put a "go and install this" link in front of
+     * merchants for something they can never install.
      */
+    public function testXcacheIsNotOffered(): void
+    {
+        $this->assertSame(
+            ['CacheMemcache', 'CacheMemcached', 'CacheApc'],
+            $this->offeredSystems()
+        );
+    }
+
     public function testAnUnavailableSystemIsDisabledAndSaysHowToInstallIt(): void
     {
-        $option = $this->option('CacheXcache');
+        foreach ($this->offeredSystems() as $system) {
+            $option = $this->option($system);
 
-        $this->assertTrue($option->vars['attr']['disabled']);
-        $this->assertStringContainsString('you must install', $option->vars['label']);
+            if (!isset($option->vars['attr']['disabled'])) {
+                continue;
+            }
+
+            $this->assertTrue($option->vars['attr']['disabled']);
+            $this->assertStringContainsString('you must install', $option->vars['label']);
+
+            return;
+        }
+
+        $this->markTestSkipped('Every caching system is available here, so the disabled path cannot be reached.');
     }
 
     /**
@@ -74,7 +92,7 @@ class CachingTypeTest extends TypeTestCase
      */
     public function testTheDisabledStateAndTheInstallMessageAlwaysAgree(): void
     {
-        foreach (['CacheMemcache', 'CacheMemcached', 'CacheApc', 'CacheXcache'] as $system) {
+        foreach ($this->offeredSystems() as $system) {
             $option = $this->option($system);
 
             // An available option keeps the plain choice as its label; an unavailable one swaps
@@ -85,6 +103,19 @@ class CachingTypeTest extends TypeTestCase
                 $system
             );
         }
+    }
+
+    /**
+     * @return string[] the caching systems the form proposes, in the order it proposes them
+     */
+    private function offeredSystems(): array
+    {
+        $view = $this->factory->create(CachingType::class)->createView();
+
+        return array_map(
+            static fn (FormView $option): string => $option->vars['value'],
+            $view['caching_system']->children
+        );
     }
 
     private function isOffered(string $system): bool

--- a/tests/Unit/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingTypeTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
+
+use PrestaShopBundle\Form\Admin\AdvancedParameters\Performance\CachingType;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class CachingTypeTest extends TypeTestCase
+{
+    protected function getExtensions(): array
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        return [
+            new PreloadedExtension([new CachingType($translator, [])], []),
+        ];
+    }
+
+    /**
+     * The two systems the Symfony container caches through have to be offered on the adapter's
+     * own answer: a loaded extension is not a usable one (memcached must be >= 3.1.6, apcu needs
+     * apc.enabled=1), and selecting a system whose adapter refuses to be built leaves every
+     * Symfony page - this one included - unable to boot.
+     */
+    public function testTheMemcachedOptionIsOfferedExactlyWhenItsAdapterSupportsIt(): void
+    {
+        $this->assertSame(MemcachedAdapter::isSupported(), $this->isOffered('CacheMemcached'));
+    }
+
+    public function testTheApcOptionIsOfferedExactlyWhenItsAdapterSupportsIt(): void
+    {
+        $this->assertSame(ApcuAdapter::isSupported(), $this->isOffered('CacheApc'));
+    }
+
+    /**
+     * The other two systems back no Symfony adapter, so loading the extension stays the only
+     * thing that can be tested for them.
+     */
+    public function testASystemWithNoSymfonyAdapterStillGoesByTheExtension(): void
+    {
+        $this->assertSame(extension_loaded('memcache'), $this->isOffered('CacheMemcache'));
+        $this->assertSame(extension_loaded('xcache'), $this->isOffered('CacheXcache'));
+    }
+
+    /**
+     * Xcache has no build for any PHP version this release supports, so it is the one option
+     * that is unavailable everywhere - which makes it the fixed point for the disabled path.
+     */
+    public function testAnUnavailableSystemIsDisabledAndSaysHowToInstallIt(): void
+    {
+        $option = $this->option('CacheXcache');
+
+        $this->assertTrue($option->vars['attr']['disabled']);
+        $this->assertStringContainsString('you must install', $option->vars['label']);
+    }
+
+    /**
+     * Whether an option is disabled and whether its label tells the merchant to install the
+     * extension are decided by two separate closures, so they have to reach the same answer for
+     * every system - otherwise the form asks you to install something on an option you can still
+     * select, or silently disables one that looks fine.
+     */
+    public function testTheDisabledStateAndTheInstallMessageAlwaysAgree(): void
+    {
+        foreach (['CacheMemcache', 'CacheMemcached', 'CacheApc', 'CacheXcache'] as $system) {
+            $option = $this->option($system);
+
+            // An available option keeps the plain choice as its label; an unavailable one swaps
+            // in the install message, so a label that is no longer the choice means "unavailable".
+            $this->assertSame(
+                isset($option->vars['attr']['disabled']),
+                $system !== $option->vars['label'],
+                $system
+            );
+        }
+    }
+
+    private function isOffered(string $system): bool
+    {
+        return !isset($this->option($system)->vars['attr']['disabled']);
+    }
+
+    /**
+     * Expanded choices are indexed by position, so the option is found by the value it submits.
+     */
+    private function option(string $system): FormView
+    {
+        $view = $this->factory->create(CachingType::class)->createView();
+
+        foreach ($view['caching_system']->children as $option) {
+            if ($system === $option->vars['value']) {
+                return $option;
+            }
+        }
+
+        $this->fail(sprintf('The caching system "%s" is not offered by the form at all.', $system));
+    }
+}


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The container picked its cache driver on `extension_loaded()` alone, but a loaded extension is not a usable one: Symfony's `MemcachedAdapter` requires memcached >= 3.1.6 and its `ApcuAdapter` requires `apc.enabled=1`, and both throw a `CacheException` from their constructor otherwise. A shop that enabled caching with an older extension therefore got a driver no adapter could build, and every Symfony page died with "Memcached > 3.1.5 is required." - including Advanced parameters > Performance, the one page needed to turn the caching system back off. Both places that decide availability now ask the adapter: the container falls back to the array driver, and the Performance form disables the option and shows its existing "you must install the [...] PECL extension" message. Saving that page then had to work too - a disabled radio is not posted, so `caching_system` arrived null whenever nothing was selectable and the form refused to save at all, silently, leaving the merchant unable to switch caching off.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With the `apcu` extension loaded, set `ps_caching` to `CacheApc` and `ps_cache_enable` to `true` in `app/config/parameters.php`, then run `php -d apc.enabled=0 bin/console --env=prod cache:warmup`. Before this change it aborts with `In ApcuAdapter.php line 31: APCu is not enabled.`; after it warms the cache and Advanced parameters > Performance offers APC disabled with the install message. Re-run with `apc.enabled=1` to confirm the driver is still selected when it works. Then, on that recovered page, untick "Use cache" and save: before this change nothing was written and no error was shown; after it, `ps_cache_enable` is set to `false`. The memcached half is the same defect one version floor higher and needs a memcached extension older than 3.1.6.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34313, Fixes #40993
| Related PRs       | None required. #42166 rewires the legacy container's cache adapter and reads the same `cache.driver` parameter this PR sets, but touches no file in common.
| Sponsor company   |

## Why the adapter and not a wider version check

`extension_loaded()` is not a weaker version of the right test, it is a different one, and it is
already fully contained in the answer the adapters give:

```php
MemcachedAdapter::isSupported()  // extension_loaded('memcached') && version_compare(phpversion('memcached'), '3.1.6', '>=')
ApcuAdapter::isSupported()       // function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOL)
```

So the extension check is dropped rather than `&&`-ed with the adapter's. Keeping it would imply
the adapter's answer is incomplete, and would leave a second place to update when a vendored
Symfony release moves the floor - which is exactly how the current 3.1.6 floor came to differ from
the 3.1.5 the issue thread quotes.

No shared helper was introduced. `app/config/set_parameters.php` is a config file that has to work
before install (it carries its own no-parameters-file fallback for that), so a PrestaShop-namespaced
service is the wrong dependency direction; the adapter classes are already reachable there, next to
the fully-qualified Symfony references the file uses today.

## Why the save path is in the same PR

Reaching the page is only half of what the issue asks for; the merchant's next action is to turn the
caching system off. Measured on base: the form submits fine and yields `caching_system => null`, but
`CachingConfiguration::validateConfiguration()` tests it with `isset()`, which is false for null, and
`updateConfiguration()` returns **no errors** when validation fails - so Save is a silent no-op. The
existing `null !== $configuration['caching_system']` guards inside `updatePhpCacheConfiguration()`
are dead code under that validator, which is what says null was meant to be an accepted value.

Dropping the second of those guards - the one that made writing `use_cache` depend on a caching
system being selected - is safe only because of the first change in this PR. It used to be the thing
that stopped a shop from enabling caching it could not run; the driver is now chosen on whether the
adapter can be built, so that concern is handled at its source, and the guard's only remaining effect
was to trap a shop with no selectable system into leaving caching enabled.

## Scope

`CachingType` also offers `CacheMemcache` (the `memcache` extension) and `CacheXcache`. Neither
backs a Symfony adapter and neither appears in `set_parameters.php`, so `extension_loaded()` stays
the only thing that can be tested for them - the new lookup falls back to it when a listed extension
has no adapter.

The two maps have drifted (`CachingType` lists `'CacheApc' => ['apc', 'apcu']`, `set_parameters.php`
lists `['apcu']`). That is left alone: `apc` has no build for any PHP version this release supports,
so the entry is unreachable, and reconciling the maps is a separate change.

## Evidence

`extension_loaded()` and the adapter disagree, measured with `apcu` 5.1.28 on PHP 8.1.33:

```
apc.enabled=1  extension_loaded(apcu)=true  ApcuAdapter::isSupported()=true
apc.enabled=0  extension_loaded(apcu)=true  ApcuAdapter::isSupported()=false
```

and the container follows the wrong one, so the boot fails. On 9.2.x with `ps_caching=CacheApc`:

```
                                        base            with this PR
bin/console --env=prod cache:warmup     APCu is not     [OK] Cache for the "prod" environment
  (apc.enabled=0)                       enabled.        (debug=false) was successfully warmed.
  (apc.enabled=1)                       warms           warms                 <- positive control
```

The revert was verified both ways (`app/config/set_parameters.php` confirmed byte-identical to
`upstream/9.2.x` for the base column, and back to the commit afterwards).

Tests: `tests/Unit/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingTypeTest.php`,
5 cases, 10 assertions. It asserts the form's answer equals the adapter's, so it is only red in an
environment where those differ - with `apcu` loaded and `apc.enabled=0` it fails on base
("Failed asserting that true is identical to false") and passes with this PR. With `apc.enabled=1`,
and with no `apcu` at all, base and PR both pass; CI is the second of those, so CI passing is not by
itself evidence of the fix. Two cases assert invariants that do hold in every environment: xcache is
always unavailable, and the disabled state must agree with the install message on all four systems.

`tests/Unit/Adapter/Cache/CachingConfigurationTest.php`, 4 cases, covers the save path and is
environment-independent: reverting `CachingConfiguration.php` to `upstream/9.2.x` fails exactly
`testCachingCanBeTurnedOffWhileNoSystemIsSelectable` and leaves the other three green, so they are
real regression guards on the write behaviour rather than restatements of the change.

`tests/Unit/PrestaShopBundle` 759 passing. `tests/Unit/Adapter` carries 9 pre-existing errors
(`Undefined constant "_DB_PREFIX_"` in `Preferences` and `Routes`); they reproduce unchanged with
every file of this PR reverted to `upstream/9.2.x`. `php-cs-fixer` and `phpstan` clean on all five
files.

## Second commit: the rest of the same choice list (#40993)

Both changes rewrite the choice list in `CachingType.php`, so they travel together.

- Xcache is no longer proposed. Its last release supports PHP 5.6, so no version this release runs on can have
  the extension: the option was permanently disabled and shown with a link inviting the merchant to install
  something that does not exist for their PHP. `classes/cache/CacheXcache.php` stays, so a shop that somehow has
  it configured keeps working.
- The two Memcached entries are not a duplicate - they are the `memcache` and the `memcached` client extensions -
  so they now name the extension instead of a `PHP::Memcache` notation that exists nowhere.
- The APC entry asked for the "APC PECL extension" while linking to APCu's installation page; it now asks for
  APCu, which is the one a supported PHP can have and the one `CacheApc` uses.

How to test the second commit: Advanced parameters > Performance, tick "Use cache". Before: four systems, the last
being "Xcache (you must install the Xcache extension)", plus two rows both starting "Memcached via PHP::Memcach...".
After: three systems, no Xcache, and each Memcached row names its extension. `CachingTypeTest` asserts the offered set.
