### PR TITLE
Let a form initialize its choice trees with initComponents

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.ts
@@ -9,6 +9,7 @@ import {EventEmitter} from '@components/event-emitter';
 // Core components
 import ChoiceTable from '@js/components/choice-table';
 import ChoiceTree from '@js/components/form/choice-tree';
+import ChoiceTreeWidget from '@js/components/form/choice-tree-widget';
 import ColorPicker from '@js/app/utils/colorpicker';
 import CountryDniRequiredToggler from '@components/country-dni-required-toggler';
 import CountryStateSelectionToggler from '@components/country-state-selection-toggler';
@@ -122,6 +123,7 @@ const initPrestashopComponents = (): void => {
     // @todo: add all standard components in this list
     ChoiceTable,
     ChoiceTree,
+    ChoiceTreeWidget,
     ColorPicker,
     CountryDniRequiredToggler,
     CountryStateSelectionToggler,

--- a/admin-dev/themes/new-theme/js/components/form/choice-tree-widget.ts
+++ b/admin-dev/themes/new-theme/js/components/form/choice-tree-widget.ts
@@ -1,0 +1,67 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+import ChoiceTree, {
+  CHOICE_TREE_CONTAINER_SELECTOR,
+  CHOICE_TREE_DATA_KEY,
+} from '@js/components/form/choice-tree';
+
+const {$} = window;
+
+/**
+ * Initializes every choice tree rendered on the page.
+ *
+ * ChoiceTree itself handles one tree and needs to be told which, which is why the pages that own a
+ * tree build it themselves. A form that only needs the expanding and collapsing behaviour has
+ * nothing to build, and no way to ask for it: initComponents() constructs every component with no
+ * argument, so ChoiceTree was given no container and quietly bound its handlers to an empty
+ * selection. This component is the missing step, so adding a CategoryChoiceTreeType - or any other
+ * choice tree - to a form works with:
+ *
+ *   window.prestashop.component.initComponents(['ChoiceTreeWidget']);
+ *
+ * It deliberately builds a plain ChoiceTree. Automatic checking of children is a separate opt-in
+ * that only the form knows it wants, so a page needing it still builds its own tree and calls
+ * enableAutoCheckChildren() on it.
+ */
+export default class ChoiceTreeWidget {
+  private readonly containerSelector: string;
+
+  constructor(options: Record<string, any> = {}) {
+    const opts = options || {};
+
+    this.containerSelector = opts.containerSelector || CHOICE_TREE_CONTAINER_SELECTOR;
+
+    this.init();
+  }
+
+  /**
+   * Returns the tree bound to a container, whether this component or the page built it.
+   *
+   * @param {JQuery} $container container of a single tree
+   */
+  // eslint-disable-next-line class-methods-use-this
+  getChoiceTree($container: JQuery): ChoiceTree | undefined {
+    return $container.data(CHOICE_TREE_DATA_KEY);
+  }
+
+  /**
+   * @private
+   */
+  private init(): void {
+    $(this.containerSelector).each((index: number, container: HTMLElement): void => {
+      const $container = $(container);
+
+      // WHY: a page that builds its own tree keeps ownership of it. Building a second one over the
+      // same container would bind the toggle handlers twice, so every click would expand and then
+      // immediately collapse the same branch.
+      if ($container.data(CHOICE_TREE_DATA_KEY)) {
+        return;
+      }
+
+      new ChoiceTree($container);
+    });
+  }
+}

--- a/admin-dev/themes/new-theme/js/components/form/choice-tree.ts
+++ b/admin-dev/themes/new-theme/js/components/form/choice-tree.ts
@@ -5,6 +5,12 @@
 
 const {$} = window;
 
+/** Marks the container of one tree, as rendered by the material choice tree form theme. */
+export const CHOICE_TREE_CONTAINER_SELECTOR = '.js-choice-tree-container';
+
+/** Key under which a tree keeps its instance on its own container. */
+export const CHOICE_TREE_DATA_KEY = 'choiceTree';
+
 /**
  * Handles UI interactions of choice tree
  */
@@ -12,10 +18,26 @@ export default class ChoiceTree {
   $container: JQuery<HTMLElement>;
 
   /**
-   * @param {String} treeSelector
+   * @param {String|JQuery} tree selector for, or container of, a single tree
    */
-  constructor(treeSelector: string) {
-    this.$container = $(treeSelector);
+  constructor(tree: string | JQuery<HTMLElement>) {
+    // WHY: this class is exposed through window.prestashop.component, where initComponents() builds
+    // every component with no argument. Built that way it used to bind its handlers to $(undefined),
+    // an empty selection, and do nothing at all without reporting anything - so point the caller at
+    // the component that does support that contract. An empty selection is still accepted, because
+    // several pages build a tree unconditionally on a form that does not always render one.
+    if (!tree) {
+      throw new Error(
+        'ChoiceTree must be constructed with the selector or the container of a single tree. '
+          + 'To initialize every choice tree of a page at once, use the ChoiceTreeWidget component instead.',
+      );
+    }
+
+    this.$container = typeof tree === 'string' ? $(tree) : tree;
+
+    // The instance is reachable through the container's data, which is how ChoiceTreeWidget can
+    // tell a tree a page has already built from one that still needs building.
+    this.$container.data(CHOICE_TREE_DATA_KEY, this);
 
     this.$container.on('click', '.js-input-wrapper', (event) => {
       const $inputWrapper = $(event.currentTarget);
@@ -87,7 +109,7 @@ export default class ChoiceTree {
    * @private
    */
   private toggleTree($action: JQuery<HTMLElement>): void {
-    const $parentContainer = $action.closest('.js-choice-tree-container');
+    const $parentContainer = $action.closest(CHOICE_TREE_CONTAINER_SELECTOR);
     const action: string = $action.data('action');
 
     // toggle action configuration

--- a/admin-dev/themes/new-theme/package-lock.json
+++ b/admin-dev/themes/new-theme/package-lock.json
@@ -84,6 +84,8 @@
         "hot-accept-webpack-plugin": "^4.0.2",
         "html-webpack-plugin": "^5.6.0",
         "imports-loader": "^5.0.0",
+        "jquery": "^3.6.3",
+        "jsdom": "^19.0.0",
         "mini-css-extract-plugin": "^2.9.1",
         "mocha": "^10.7.3",
         "path": "^0.12.7",

--- a/admin-dev/themes/new-theme/package.json
+++ b/admin-dev/themes/new-theme/package.json
@@ -92,6 +92,8 @@
     "hot-accept-webpack-plugin": "^4.0.2",
     "html-webpack-plugin": "^5.6.0",
     "imports-loader": "^5.0.0",
+    "jquery": "^3.6.3",
+    "jsdom": "^19.0.0",
     "mini-css-extract-plugin": "^2.9.1",
     "mocha": "^10.7.3",
     "path": "^0.12.7",

--- a/admin-dev/themes/new-theme/tests/components/choice-tree-widget.spec.js
+++ b/admin-dev/themes/new-theme/tests/components/choice-tree-widget.spec.js
@@ -1,0 +1,119 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+const {expect} = require('chai');
+const {JSDOM} = require('jsdom');
+
+const TREE = `
+  <div class="material-choice-tree-container js-choice-tree-container" id="form_id_parent">
+    <ul class="choice-tree">
+      <li class="expanded">
+        <span class="js-input-wrapper"><input type="checkbox" value="1"></span>
+        <ul><li><span class="js-input-wrapper"><input type="checkbox" value="2"></span></li></ul>
+      </li>
+    </ul>
+  </div>`;
+
+/**
+ * The components read `const {$} = window` when the module is evaluated, so the DOM and jQuery have
+ * to exist as globals before they are required. That is why this file requires them lazily instead
+ * of importing them at the top.
+ */
+const load = (body) => {
+  const dom = new JSDOM(`<!doctype html><html><body>${body}</body></html>`, {url: 'http://localhost/'});
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  // Fresh module instances per test, so one test's captured `$` never leaks into the next. jQuery is
+  // reloaded too: its UMD wrapper exports a factory only while no global document exists, and returns
+  // a jQuery already bound to the global once one does, so the shape depends on load order.
+  Object.keys(require.cache)
+    .filter((key) => key.includes('choice-tree') || key.includes(`${'jquery'}`))
+    .forEach((key) => delete require.cache[key]);
+
+  /* eslint-disable global-require */
+  const jqExport = require('jquery');
+  const jq = typeof jqExport === 'function' && !jqExport.fn ? jqExport(dom.window) : jqExport;
+  /* eslint-enable global-require */
+  global.$ = jq;
+  global.jQuery = jq;
+  dom.window.$ = jq;
+  dom.window.jQuery = jq;
+
+  /* eslint-disable global-require */
+  const ChoiceTree = require('../../js/components/form/choice-tree').default;
+  const ChoiceTreeWidget = require('../../js/components/form/choice-tree-widget').default;
+  /* eslint-enable global-require */
+
+  return {dom, $: jq, ChoiceTree, ChoiceTreeWidget};
+};
+
+const clickFirstWrapper = (dom) => dom.window.document.querySelector('.js-input-wrapper').click();
+const firstItemClass = (dom) => dom.window.document.querySelector('li').className;
+
+describe('ChoiceTreeWidget', () => {
+  /**
+   * initComponents() constructs every component with no argument. ChoiceTree then received no
+   * container, bound its handlers to an empty selection and did nothing at all - without throwing,
+   * which is why the report describes a component that "is loaded" but "doesn't respond". It now
+   * says so, and names the component that can be initialized that way.
+   */
+  it('refuses to be built with no container, and names the alternative', () => {
+    const {ChoiceTree} = load(TREE);
+
+    expect(() => new ChoiceTree()).to.throw('ChoiceTreeWidget');
+  });
+
+  /**
+   * A page that builds a tree for a form that did not render one must keep working: the guard is
+   * about a missing argument, not about a selector that matched nothing.
+   */
+  it('still accepts a selection that matched nothing', () => {
+    const {ChoiceTree} = load(TREE);
+
+    expect(() => new ChoiceTree('#no-such-tree')).to.not.throw();
+  });
+
+  it('makes the tree respond when initialized with no argument, as initComponents does', () => {
+    const {dom, ChoiceTreeWidget} = load(TREE);
+
+    new ChoiceTreeWidget();
+    clickFirstWrapper(dom);
+
+    expect(firstItemClass(dom)).to.equal('collapsed');
+  });
+
+  it('initializes every tree on the page', () => {
+    const {dom, $, ChoiceTreeWidget} = load(TREE + TREE.replace('form_id_parent', 'form_id_other'));
+
+    new ChoiceTreeWidget();
+
+    expect($('.js-choice-tree-container').filter((i, el) => !!$(el).data('choiceTree')).length).to.equal(2);
+  });
+
+  /**
+   * A page that builds its own tree keeps ownership of it: building a second one over the same
+   * container would bind the toggle twice, so a click would expand and immediately collapse again.
+   */
+  it('leaves a tree the page already built alone', () => {
+    const {dom, $, ChoiceTree, ChoiceTreeWidget} = load(TREE);
+
+    const owned = new ChoiceTree('#form_id_parent');
+    new ChoiceTreeWidget();
+
+    expect($('#form_id_parent').data('choiceTree')).to.equal(owned);
+
+    clickFirstWrapper(dom);
+    expect(firstItemClass(dom)).to.equal('collapsed');
+  });
+
+  it('exposes the instance bound to a container', () => {
+    const {$, ChoiceTreeWidget} = load(TREE);
+
+    const widget = new ChoiceTreeWidget();
+
+    expect(widget.getChoiceTree($('#form_id_parent'))).to.not.equal(undefined);
+    expect(widget.getChoiceTree($('#form_id_missing'))).to.equal(undefined);
+  });
+});

--- a/admin-dev/themes/new-theme/tsconfig.json
+++ b/admin-dev/themes/new-theme/tsconfig.json
@@ -25,6 +25,7 @@
     },
   },
   "ts-node": {
+    "files": true,
     "compilerOptions": {
       "module": "commonjs"
     }


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `initComponents()` constructs every registered component with no argument, but `ChoiceTree` needs to be told which tree it handles. Built that way it called `$(undefined)`, bound its handlers to an empty selection and did nothing at all, without reporting anything - so a module form that followed the documented initialization got a tree that never expanded or collapsed. `ChoiceTreeWidget` is the missing step: it builds a `ChoiceTree` for every tree rendered on the page and skips any container a page has already claimed. `ChoiceTree` itself now refuses a missing container instead of failing silently, and names the widget.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add a `CategoryChoiceTreeType` to a module form and initialize it with `window.prestashop.component.initComponents(['ChoiceTreeWidget'])`. Before this change the only way to make the tree interactive was `new window.prestashop.component.ChoiceTree('#form_id_parent')`; `initComponents(['ChoiceTree'])` bound nothing and reported nothing. After, the tree expands and collapses. Every back office page that builds its own tree is untouched.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34335
| Related PRs       | Shares the ts-node test-harness change with the branch prepared for #34667 (`"files": true` plus `jsdom`/`jquery` devDependencies). Identical in both; whichever lands first, the other drops those three lines on rebase.
| Sponsor company   |

## Why a separate widget, and not a fix inside initComponents

An arity check in `initComponents` looks tempting and does not work.
`Function.prototype.length` is **1 for `ChoiceTree`, which breaks, and also 1 for
`TranslatableField` and `TinyMCEEditor`, which do not** - both guard their argument with
`options || {}`, and both are the components the documentation's own example passes to
`initComponents`. A guard based on arity would print an error for the documented happy path, so the
registry cannot tell the two cases apart mechanically. Measured, not assumed.

## Scope

Ten of the thirty registered components have a constructor parameter, but only some genuinely break:
`ChoiceTree`, the two country togglers, `Grid` and `PreviewOpener` bind to `$(undefined)` and fail
silently; `TaggableField` and `EntitySearchInput` destructure it and throw; `TranslatableField`,
`TinyMCEEditor` and `FormFieldToggler` guard it and work. There is no single coherent change for the
rest - `Grid` needs a specific id and `PreviewOpener` navigates on construction, so a zero-argument
meaning does not exist for them. This PR fixes the reported one.

## Behaviour kept deliberately

The widget builds a plain `ChoiceTree`. `enableAutoCheckChildren()` is a separate opt-in that only
the form knows it wants - 15 of the 16 core pages that build a tree call it - and nothing in the
markup says whether a given tree should. A page that needs it still builds its own tree, exactly as
those 16 do today.

The new guard rejects a **missing** argument only, never a selection that matched nothing: several
pages build a tree unconditionally for a form that does not always render one. All 20 construction
arguments in the back office are non-empty literal selectors or map constants, so none of them can
reach the guard.

## Evidence

Measured with jsdom and the theme's own jQuery, with a positive control:

```
$(undefined).length         = 0    binds to nothing
handler fired after click   = 0    silent no-op, no error thrown
control, with a selector    = 1    the component works when given one
```

Test: `admin-dev/themes/new-theme/tests/components/choice-tree-widget.spec.js`, 6 cases. Two
surgical mutations, each failing exactly one case and leaving the other five green: removing the
missing-container guard fails only "refuses to be built with no container", and removing the
widget's ownership check fails only "leaves a tree the page already built alone". Full theme suite
127 passing (121 before this branch). `tsc --noEmit` and `eslint` clean on the touched files.
