### PR TITLE
Register a module on the hook an alias stands for

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -621,7 +621,13 @@ class HookCore extends ObjectModel
             ]);
 
             // Get hook id
-            $id_hook = Hook::getIdByName($hook_name, false);
+            // WHY: aliases are resolved here too. Ignoring them made an alias look like a hook nobody
+            // had declared, so the branch below created a second hook row carrying the alias as its
+            // name and registered the module against that. Everything that reads the registration
+            // resolves the alias to its canonical hook instead, and so never found the module again.
+            // Calling the listener is unaffected: callHookOn() tries the canonical method name and
+            // then every alias of it, so a module that only implements the aliased name still runs.
+            $id_hook = Hook::getIdByName($hook_name);
 
             // If hook does not exist, we create it
             if (!$id_hook) {
@@ -733,7 +739,10 @@ class HookCore extends ObjectModel
             }
         } else {
             // If we received hook name as a string, we try to find it's ID
-            $hook_id = Hook::getIdByName($hook_identifier, false);
+            // WHY: resolved the same way registerHook() resolves it. If one of the two honoured
+            // aliases and the other did not, a module could register under a name it could never
+            // unregister under, and the row would outlive the module that owns it.
+            $hook_id = Hook::getIdByName($hook_identifier);
             $hook_name = $hook_identifier;
         }
 

--- a/tests/Integration/Classes/Hook/HookAliasRegistrationTest.php
+++ b/tests/Integration/Classes/Hook/HookAliasRegistrationTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Hook;
+
+use Cache;
+use Db;
+use Hook;
+use Module;
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+/**
+ * Registering on a hook alias used to resolve the name without aliases, so the alias looked like a
+ * hook nobody had declared and a second hook row was created carrying the alias as its name. The
+ * module was attached to that row, while everything reading the registration resolves the alias to
+ * its canonical hook - which is why TaxManagerFactory never saw a module hooked on `taxManager`.
+ */
+class HookAliasRegistrationTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    /** A declared alias of actionTaxManager, see install-dev/data/xml/hook_alias.xml */
+    private const ALIAS = 'taxManager';
+    private const CANONICAL = 'actionTaxManager';
+    private const STUB_MODULE = 'hookaliasregistrationstub';
+
+    private int $moduleId = 0;
+    private int $canonicalHookId = 0;
+    private HookAliasStubModule $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+        Cache::clean('*');
+
+        $this->canonicalHookId = (int) Hook::getIdByName(self::CANONICAL, false, true);
+        self::assertGreaterThan(0, $this->canonicalHookId, self::CANONICAL . ' must exist for this test to mean anything');
+
+        Db::getInstance()->insert('module', ['name' => self::STUB_MODULE, 'active' => 1, 'version' => '1.0.0']);
+        $this->moduleId = (int) Db::getInstance()->Insert_ID();
+
+        $this->module = new HookAliasStubModule();
+        $this->module->id = $this->moduleId;
+        $this->module->name = self::STUB_MODULE;
+    }
+
+    protected function tearDown(): void
+    {
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'hook_module WHERE id_module = ' . $this->moduleId);
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'module WHERE id_module = ' . $this->moduleId);
+        // Any hook row the registration should no longer be creating, so a failure cannot leak into
+        // the next test or into the rest of the suite.
+        foreach ([self::ALIAS, 'aHookNameNobodyHasDeclared'] as $name) {
+            $ids = Db::getInstance()->executeS(
+                'SELECT id_hook FROM ' . _DB_PREFIX_ . "hook WHERE name = '" . pSQL($name) . "'"
+            );
+            foreach ((array) $ids as $row) {
+                $id = (int) $row['id_hook'];
+                Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'hook_module WHERE id_hook = ' . $id);
+                Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'hook WHERE id_hook = ' . $id);
+            }
+        }
+        Cache::clean('*');
+
+        parent::tearDown();
+    }
+
+    /**
+     * The assertion that matters is the id the registration wrote, not merely that some lookup
+     * later answers. A test that only checked "the module is found" would also pass while the row
+     * pointed at a duplicate hook, because which of the two ids a name resolves to then depends on
+     * the order the UNION in getAllHookIds() happens to return.
+     */
+    public function testRegisteringOnAnAliasAttachesTheModuleToTheCanonicalHook(): void
+    {
+        Hook::registerHook($this->module, self::ALIAS);
+
+        self::assertSame(
+            [$this->canonicalHookId],
+            $this->registeredHookIds(),
+            'the registration must point at the canonical hook, not at a row named after the alias'
+        );
+    }
+
+    public function testRegisteringOnAnAliasCreatesNoSecondHook(): void
+    {
+        Hook::registerHook($this->module, self::ALIAS);
+
+        self::assertSame(0, $this->hookRowsNamed(self::ALIAS), 'an alias must not become a hook of its own');
+    }
+
+    /**
+     * TaxManagerFactory looks the modules up exactly this way.
+     */
+    public function testTheModuleIsVisibleWhereTheFactoryLooksForIt(): void
+    {
+        Hook::registerHook($this->module, self::ALIAS);
+        Cache::clean('*');
+
+        $modules = Hook::getModulesFromHook(Hook::getIdByName(self::ALIAS, true, true));
+
+        self::assertContains(self::STUB_MODULE, array_column($modules, 'name'));
+    }
+
+    /**
+     * Registering and unregistering have to resolve the name the same way, or a module can end up
+     * holding a row it has no way to remove.
+     */
+    public function testAnAliasRegistrationCanBeUndoneUnderTheSameAliasName(): void
+    {
+        Hook::registerHook($this->module, self::ALIAS);
+        self::assertNotEmpty($this->registeredHookIds(), 'nothing to unregister, the test would be vacuous');
+
+        Hook::unregisterHook($this->module, self::ALIAS);
+
+        self::assertSame([], $this->registeredHookIds());
+    }
+
+    /**
+     * A name that is neither a hook nor an alias must still be created, which is what lets a module
+     * declare a hook of its own.
+     */
+    public function testAnUndeclaredHookNameIsStillCreated(): void
+    {
+        Hook::registerHook($this->module, 'aHookNameNobodyHasDeclared');
+
+        self::assertSame(1, $this->hookRowsNamed('aHookNameNobodyHasDeclared'));
+    }
+
+    /**
+     * @return int[] the distinct hook ids this module is registered on
+     */
+    private function registeredHookIds(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT DISTINCT id_hook FROM ' . _DB_PREFIX_ . 'hook_module WHERE id_module = ' . $this->moduleId
+        );
+
+        return array_map('intval', array_column((array) $rows, 'id_hook'));
+    }
+
+    private function hookRowsNamed(string $name): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM ' . _DB_PREFIX_ . "hook WHERE name = '" . pSQL($name) . "'"
+        );
+    }
+}
+
+/**
+ * Implements the listener under the aliased name, which is the case the report is about and the one
+ * registerHook()'s own guard accepts through isHookCallableOn().
+ */
+class HookAliasStubModule extends Module
+{
+    public function __construct()
+    {
+        $this->name = 'hookaliasregistrationstub';
+        $this->version = '1.0.0';
+        $this->author = 'PrestaShop';
+        parent::__construct();
+    }
+
+    public function hookTaxManager(array $params)
+    {
+        return null;
+    }
+
+    public function hookAHookNameNobodyHasDeclared(array $params)
+    {
+        return null;
+    }
+}


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Hook::registerHook()` resolved the hook name with aliases turned off, so a name declared in `hook_alias` looked like a hook nobody had declared and the next branch created a second hook row carrying the alias as its name, attaching the module to that row. Everything that reads the registration resolves the alias to its canonical hook, so the module was never found again - which is why a module hooked on `taxManager` is invisible to `TaxManagerFactory`. `unregisterHook()` is resolved the same way, so a registration made under an alias can still be undone under it.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a module that implements `hookTaxManager` and registers itself with `registerHook('taxManager')`. Before this change, `ps_hook` gains a row named `taxManager` and the module is attached to it, while `Hook::getModulesFromHook(Hook::getIdByName('taxManager'))` returns the id of `actionTaxManager` and does not list the module - so `TaxManagerFactory::execHookTaxManagerFactory()` never calls it. After, no second hook row is created, the module is attached to `actionTaxManager`, and the factory finds it.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34355
| Related PRs       |
| Sponsor company   |

## Why calling the listener still works

The module in the report implements `hookTaxManager`, not `hookActionTaxManager`, and it is now
registered on the canonical hook. `Hook::callHookOn()` already tries the exact method name for the
hook and then falls back over `getAllKnownNames()`, which is the canonical name followed by every
alias of it, so the aliased method is still the one invoked. `Hook::isHookCallableOn()` - the guard
inside `registerHook()` itself - checks the same list, so registration is not refused either.
`Hook::getHookModuleExecList()` likewise already adds modules registered on aliases of the hook it is
asked about. The read and execute paths all treated an alias as equivalent to its canonical hook
already; only the write path did not, and that asymmetry is the bug.

## Measured on 9.2

Registering `taxManager` (a declared alias of `actionTaxManager`, id 116 on a stock install):

```
                                          before            after
ps_hook rows named taxManager             1 (new, id 1163)  0
ps_hook_module.id_hook for the module     1163              116
getIdByName('taxManager')                 116               116
getModulesFromHook(that id)               0 modules         module listed
```

Test: `tests/Integration/Classes/Hook/HookAliasRegistrationTest.php`, 5 cases, 11 assertions.
Verified revert (`git checkout upstream/9.2.x -- classes/Hook.php`): 3 of 5 fail - wrong hook id, a
second hook row created, and the module absent where the factory looks. The other two cases pass in
both states on purpose: they pin the behaviour that must not change - a hook name that is neither a
hook nor an alias is still created, and an alias registration can still be removed under its alias.

`tests/Integration/Classes` runs 188/188 with this test in it, and the `hook`, `module` and
`hook_module` row counts are identical before and after the run.

## Scope, and what this does not do

Fix is forward-only. A shop that already has a module attached to a duplicate hook row stays that way
until the module is reinstalled: with both rows present, `getIdByName()` was measured returning the
canonical id (3 runs of 3), so the lookup keeps missing the old registration. A data migration would
have to move `ps_hook_module` rows onto the canonical hook, and since the primary key is
`(id_module, id_hook, id_shop)` a module registered on both ids would collide, so it needs
de-duplication rather than a plain UPDATE. That is deliberately not in this PR.

`Hook::exec()` has the same `withAliases = false` call at `classes/Hook.php:944`, reached only after
`getHookModuleExecList()` has already returned a non-empty list. It is a different path from the one
this issue reports and changing it would touch every hook call in the shop, so it is left alone here.

`stockManager`, named in the issue title alongside `taxManager`, is **not** affected: it is neither a
hook nor an alias in a stock install, and `StockManagerModule::install()` and `StockManagerFactory`
both use that same literal name, so the row is created on install and both sides agree.
