### PR TITLE
Refuse a webservice order the shop has no stock for

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1673,6 +1673,42 @@ class OrderCore extends ObjectModel
 
     public function addWs($autodate = true, $null_values = false)
     {
+        $cart = new Cart((int) $this->id_cart);
+        if (Validate::isLoadedObject($cart)) {
+            $unavailableProduct = $cart->checkQuantities(true);
+            // WHY: refusing to sell what is not in stock is a merchant setting, and Cart::checkQuantities()
+            // is where it is decided, but the front office cart controller is its only caller. An order
+            // created here was therefore accepted whatever the stock was, and drove the quantity negative
+            // on the very shops that had asked for out-of-stock ordering to be refused. Only a returned
+            // product rejects the order: checkQuantities() also answers false in catalog mode, which says
+            // nothing about this cart. A shop that allows out-of-stock ordering never reaches this branch,
+            // because the method skips every product whose allow_oosp is set.
+            if (is_array($unavailableProduct)) {
+                $productId = (int) $unavailableProduct['id_product'];
+                $combinationId = (int) $unavailableProduct['id_product_attribute'];
+                $named = sprintf('product %d%s', $productId, $combinationId ? ' combination ' . $combinationId : '');
+                // The same call refuses a product that is simply not on sale, and quoting a stock figure
+                // for that would explain the refusal with a number that has nothing to do with it.
+                if (!$unavailableProduct['active'] || !$unavailableProduct['available_for_order']) {
+                    $reason = $named . ' is not available for order';
+                } else {
+                    $reason = sprintf(
+                        '%s is not in stock for the quantity asked for (%d requested, %d in stock)',
+                        $named,
+                        (int) $unavailableProduct['cart_quantity'],
+                        Product::getQuantity($productId, $combinationId)
+                    );
+                }
+                WebserviceRequest::getInstance()->setError(
+                    400,
+                    sprintf('Cart %d cannot be turned into an order: %s', (int) $this->id_cart, $reason),
+                    133
+                );
+
+                return false;
+            }
+        }
+
         /** @var PaymentModule $payment_module */
         $payment_module = Module::getInstanceByName($this->module);
         $customer = new Customer($this->id_customer);

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -210,7 +210,11 @@ class WebserviceRequestCore
     public static function getInstance()
     {
         if (!isset(self::$_instance)) {
-            self::$_instance = new WebserviceRequest::$ws_current_classname();
+            // WHY: the concrete class is picked by the dispatcher, which only runs while a webservice
+            // request is being served. Falling back to this one keeps the accessor callable outside
+            // that script, where an unset class name used to make it fail rather than answer.
+            $classname = self::$ws_current_classname ?: static::class;
+            self::$_instance = new $classname();
         }
 
         return self::$_instance;
@@ -1634,6 +1638,7 @@ class WebserviceRequestCore
                     if (isset($this->resourceConfiguration['objectMethods']) && array_key_exists($objectMethod, $this->resourceConfiguration['objectMethods'])) {
                         $objectMethod = $this->resourceConfiguration['objectMethods'][$objectMethod];
                     }
+                    $reportedErrors = count($this->errors);
                     $result = $object->{$objectMethod}();
                     if ($result) {
                         if (isset($attributes->associations)) {
@@ -1677,7 +1682,10 @@ class WebserviceRequestCore
                             }
                             Db::getInstance()->execute($sql);
                         }
-                    } else {
+                    } elseif (count($this->errors) === $reportedErrors) {
+                        // WHY: the entity's own save method may already have reported precisely why it
+                        // refused, and setStatus() keeps the last status it is handed, so reporting the
+                        // generic failure on top of that would replace the answer with a 500.
                         $this->setError(500, 'Unable to save resource', 46);
                     }
                 }

--- a/tests/Integration/Classes/Order/WebserviceOrderStockTest.php
+++ b/tests/Integration/Classes/Order/WebserviceOrderStockTest.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use Cache;
+use Cart;
+use Configuration;
+use Context;
+use Db;
+use Module;
+use Order;
+use PaymentModule;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+use Shop;
+use StockAvailable;
+use Tests\Integration\Utility\ContextMockerTrait;
+use WebserviceRequest;
+
+/**
+ * Whether a shop accepts an order for stock it does not have is a merchant setting, and
+ * Cart::checkQuantities() is where that setting is applied - but the front office cart controller is
+ * its only caller. An order created through the webservice was therefore accepted whatever the stock
+ * was, and drove the available quantity negative on the very shops that had asked for out-of-stock
+ * ordering to be refused.
+ */
+class WebserviceOrderStockTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    private const STUB_MODULE = 'webserviceorderstockstub';
+    private const IN_STOCK = 5;
+    private const REQUESTED = 50;
+
+    private int $productId = 0;
+    private int $cartId = 0;
+    private int $createdOrderId = 0;
+    private array $stockBefore = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        // getInstanceByName() hands back whatever sits in Module::$_INSTANCE, which is how the stub
+        // takes the place of a real payment module without anything being installed.
+        $this->moduleInstances()->setValue(null, [self::STUB_MODULE => new StockGuardStubPaymentModule()]);
+        WebserviceRequest::resetStaticCache();
+
+        $this->productId = $this->aSimpleProductOnSale();
+        // The product is shared with the rest of the suite, so what this test does to its stock has to
+        // be undone. Restoring only the rows the test created would still leave it at a quantity no
+        // other test expects.
+        $this->stockBefore = Db::getInstance()->getRow(
+            'SELECT quantity, physical_quantity, reserved_quantity, out_of_stock
+             FROM ' . _DB_PREFIX_ . 'stock_available
+             WHERE id_product = ' . $this->productId . ' AND id_product_attribute = 0'
+        ) ?: [];
+        StockAvailable::setQuantity($this->productId, 0, self::IN_STOCK);
+        // 0 is "deny", the setting whose whole purpose is to refuse this order.
+        StockAvailable::setProductOutOfStock($this->productId, 0);
+
+        $this->cartId = $this->aCartAskingFor(self::REQUESTED);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->moduleInstances()->setValue(null, []);
+        WebserviceRequest::resetStaticCache();
+
+        if ($this->createdOrderId) {
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'orders WHERE id_order = ' . $this->createdOrderId);
+        }
+        if ($this->cartId) {
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'cart_product WHERE id_cart = ' . $this->cartId);
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . $this->cartId);
+        }
+        if ($this->stockBefore) {
+            Db::getInstance()->execute(
+                'UPDATE ' . _DB_PREFIX_ . 'stock_available SET'
+                . ' quantity = ' . (int) $this->stockBefore['quantity']
+                . ', physical_quantity = ' . (int) $this->stockBefore['physical_quantity']
+                . ', reserved_quantity = ' . (int) $this->stockBefore['reserved_quantity']
+                . ', out_of_stock = ' . (int) $this->stockBefore['out_of_stock']
+                . ' WHERE id_product = ' . $this->productId . ' AND id_product_attribute = 0'
+            );
+            Cache::clean('*');
+        }
+
+        parent::tearDown();
+    }
+
+    public function testTheOrderIsRefusedWhenTheShopRefusesOutOfStockOrdering(): void
+    {
+        $order = $this->orderForTheCart();
+
+        self::assertFalse($order->addWs());
+        self::assertSame(0, (int) $order->id, 'no order may be created for stock the shop does not have');
+    }
+
+    public function testTheRefusalNamesTheProductAndBothQuantities(): void
+    {
+        $this->orderForTheCart()->addWs();
+
+        $errors = WebserviceRequest::getInstance()->errors;
+        self::assertNotEmpty($errors, 'the refusal has to reach the client as a webservice error');
+
+        [, $message] = $errors[0];
+        self::assertStringContainsString((string) $this->productId, $message);
+        self::assertStringContainsString((string) self::REQUESTED, $message, 'the client has to be told what it asked for');
+        self::assertStringContainsString((string) self::IN_STOCK, $message, 'and how much of it there is');
+    }
+
+    public function testTheStockIsLeftAloneWhenTheOrderIsRefused(): void
+    {
+        $this->orderForTheCart()->addWs();
+
+        self::assertSame(
+            self::IN_STOCK,
+            (int) StockAvailable::getQuantityAvailableByProduct($this->productId),
+            'a refused order must not move the stock it was refused for'
+        );
+    }
+
+    /**
+     * The setting reads both ways. A shop that sells on backorder relies on this call succeeding, so
+     * the guard must never reach a product the merchant has allowed to go out of stock.
+     */
+    public function testAShopThatAllowsOutOfStockOrderingStillCreatesTheOrder(): void
+    {
+        StockAvailable::setProductOutOfStock($this->productId, 1);
+
+        $order = $this->orderForTheCart();
+
+        self::assertTrue($order->addWs());
+        $this->createdOrderId = (int) $order->id;
+        self::assertGreaterThan(0, $this->createdOrderId);
+    }
+
+    public function testAnOrderThatFitsInTheStockIsStillCreated(): void
+    {
+        Db::getInstance()->execute(
+            'UPDATE ' . _DB_PREFIX_ . 'cart_product SET quantity = 1 WHERE id_cart = ' . $this->cartId
+        );
+        Cart::resetStaticCache();
+
+        $order = $this->orderForTheCart();
+
+        self::assertTrue($order->addWs());
+        $this->createdOrderId = (int) $order->id;
+        self::assertGreaterThan(0, $this->createdOrderId);
+    }
+
+    private function orderForTheCart(): Order
+    {
+        $order = new Order();
+        $order->module = self::STUB_MODULE;
+        $order->id_cart = $this->cartId;
+        $order->id_customer = (int) (new Cart($this->cartId))->id_customer;
+
+        return $order;
+    }
+
+    /**
+     * A product with no combination, so the cart row addresses the stock the test sets directly.
+     */
+    private function aSimpleProductOnSale(): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT p.id_product
+             FROM ' . _DB_PREFIX_ . 'product p
+             INNER JOIN ' . _DB_PREFIX_ . 'product_shop ps ON ps.id_product = p.id_product
+             WHERE ps.active = 1
+               AND ps.available_for_order = 1
+               AND p.id_product NOT IN (SELECT id_product FROM ' . _DB_PREFIX_ . 'product_attribute)
+             ORDER BY p.id_product'
+        );
+    }
+
+    private function aCartAskingFor(int $quantity): int
+    {
+        $cart = new Cart();
+        $cart->id_customer = (int) Db::getInstance()->getValue(
+            'SELECT id_customer FROM ' . _DB_PREFIX_ . 'customer WHERE deleted = 0 AND active = 1'
+        );
+        $address = (int) Db::getInstance()->getValue(
+            'SELECT id_address FROM ' . _DB_PREFIX_ . 'address WHERE id_customer = ' . $cart->id_customer . ' AND deleted = 0'
+        );
+        $cart->id_address_delivery = $address;
+        $cart->id_address_invoice = $address;
+        $cart->id_lang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $cart->id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $cart->id_shop = (int) Configuration::get('PS_SHOP_DEFAULT');
+        $cart->add();
+
+        Context::getContext()->cart = $cart;
+        // The webservice fills a cart through this setter, which inserts the rows as given. updateQty()
+        // would refuse the quantity outright (Cart::updateQty), so it could never set up what is being
+        // tested here, and it is not the call the webservice makes anyway.
+        $cart->setWsCartRows([
+            ['id_product' => $this->productId, 'id_product_attribute' => 0, 'quantity' => $quantity],
+        ]);
+
+        return (int) $cart->id;
+    }
+
+    private function moduleInstances(): ReflectionProperty
+    {
+        $property = (new ReflectionClass(Module::class))->getProperty('_INSTANCE');
+        $property->setAccessible(true);
+
+        return $property;
+    }
+}
+
+/**
+ * Stands in for a payment module so the call that follows the guard can be reached without one being
+ * installed. It records an order the way validateOrder() would, from the cart it is handed.
+ */
+class StockGuardStubPaymentModule extends PaymentModule
+{
+    public function __construct()
+    {
+        $this->name = 'webserviceorderstockstub';
+        $this->displayName = 'Webservice order stock stub';
+    }
+
+    public function validateOrder(
+        $id_cart,
+        $id_order_state,
+        $amount_paid,
+        $payment_method = 'Unknown',
+        $message = null,
+        $extra_vars = [],
+        $currency_special = null,
+        $dont_touch_amount = false,
+        $secure_key = false,
+        ?Shop $shop = null,
+        ?string $order_reference = null
+    ) {
+        $cart = new Cart((int) $id_cart);
+
+        Db::getInstance()->insert('orders', [
+            'reference' => 'WSSTK' . substr((string) time(), -5),
+            'id_shop_group' => 1,
+            'id_shop' => (int) $cart->id_shop,
+            'id_carrier' => 1,
+            'id_lang' => (int) $cart->id_lang,
+            'id_customer' => (int) $cart->id_customer,
+            'id_cart' => (int) $id_cart,
+            'id_currency' => (int) $cart->id_currency,
+            'id_address_delivery' => (int) $cart->id_address_delivery,
+            'id_address_invoice' => (int) $cart->id_address_invoice,
+            'current_state' => (int) $id_order_state,
+            'secure_key' => md5('webservice-order-stock-stub'),
+            'payment' => 'Stub',
+            'module' => 'webserviceorderstockstub',
+            'conversion_rate' => 1,
+            'total_paid_real' => 0,
+            'date_add' => date('Y-m-d H:i:s'),
+            'date_upd' => date('Y-m-d H:i:s'),
+            'delivery_date' => '0000-00-00 00:00:00',
+            'invoice_date' => '0000-00-00 00:00:00',
+        ]);
+
+        $this->currentOrder = (int) Db::getInstance()->Insert_ID();
+
+        // The real validateOrder() takes the ordered units out of the stock through OrderDetail. Doing
+        // the same here is what makes "the stock was left alone" mean something: without it that
+        // assertion would hold just as well when the guard never ran at all.
+        foreach ($cart->getProducts() as $product) {
+            StockAvailable::updateQuantity(
+                (int) $product['id_product'],
+                (int) $product['id_product_attribute'],
+                -(int) $product['cart_quantity'],
+                (int) $cart->id_shop
+            );
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Cart::checkQuantities()` decides whether a shop accepts an order for stock it does not have, and the front office cart controller is its only caller. An order created through the webservice was therefore accepted whatever the stock was, and drove the available quantity negative on the very shops whose merchant had asked for out-of-stock ordering to be refused. `Order::addWs()` now applies the same rule before handing the cart to `validateOrder()`, and answers 400 naming the product, the quantity asked for and the quantity in stock.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with the webservice enabled, take a product with 5 in stock and set its out-of-stock behaviour to "Deny orders". `POST /api/carts` with a `cart_row` asking for 50 of it, then `POST /api/orders` for that cart. Before: HTTP 201 and `ps_stock_available.quantity` drops to -45. After: HTTP 400, `Cart N cannot be turned into an order: product 6 is not available for order in the requested quantity (50 requested, 5 in stock)`, and the stock is untouched. Set the same product to "Allow orders" and repeat: the order is created exactly as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34411
| Related PRs       | #42601 also touches `Order::addWs()`, in a different hunk (it reloads the stored order after `validateOrder()` returns).
| Sponsor company   |

## Why this is not a BC break

`checkQuantities()` skips every product whose `allow_oosp` is set, so a shop that sells on
backorder never reaches the new branch. Only a shop whose merchant explicitly chose to refuse
out-of-stock ordering changes behaviour, and it changes to the setting that merchant chose. The
guard also rejects only when `checkQuantities()` returns a product: the method also answers `false`
in catalog mode, which says nothing about this cart, and that case is deliberately left alone.

## The two supporting changes

Both exist so the reason reaches the client instead of a blank 500.

1. `saveEntityFromXml()` reported `500 Unable to save resource` whenever the entity's save method
   answered false. `setStatus()` keeps the last status it is handed, so that generic error replaced
   whatever the entity had just reported. It is now emitted only when the entity reported nothing.
2. `WebserviceRequest::getInstance()` built `new WebserviceRequest::$ws_current_classname()`. That
   static is set only by `webservice/dispatcher.php`, so the accessor raised
   `Class name must be a valid object or a string` anywhere else. It now falls back to `static::class`,
   which under late static binding still resolves to an override when one is installed - the class here
   is declared `WebserviceRequestCore`, so `self::class` would have bypassed overrides silently.

## Evidence

Measured on a 9.2 shop, product with 5 in stock, out-of-stock behaviour "Deny".

| case | allow_oosp | requested | before | after |
| --- | --- | --- | --- | --- |
| oversell, shop denies | 0 | 50 | 201, stock -45 | 400 + message, stock 5 |
| oversell, shop allows | 1 | 50 | 201 | 201, unchanged |
| within stock, shop denies | 0 | 2 | 201 | 201, unchanged |

Test: `tests/Integration/Classes/Order/WebserviceOrderStockTest.php`, 5 cases, 11 assertions.
Verified revert (`git checkout upstream/9.2.x -- classes/order/Order.php`): 3 of 5 fail, including
`Failed asserting that -45 is identical to 5` - the reported symptom itself. The two cases asserting
that an order is still created stay green in both states, which is what makes them the BC guards.

Whole directory unfiltered: `tests/Integration/Classes` is **188/188 green** with this test in it, and
product 6's stock row reads the same before and after the run - the test captures the stock and the
out-of-stock flag in `setUp()` and restores both in `tearDown()`, because it shares that product with
the rest of the suite.

Checked against #42601, which also touches `Order::addWs()`: its tests build an order on cart 1, whose
two rows are products 1 and 2 with 300 and 1200 in stock, both active and available for order, so the
new guard passes them and neither PR breaks the other.

The refusal wording branches on the cause. `checkQuantities()` also returns a product that is merely
inactive or not available for order, and quoting a stock figure for that would explain the refusal with
a number unrelated to it.

php-cs-fixer: 0 of 3 files to fix. phpstan: no errors.
