### PR TITLE
Initialize EntitySearchInputType widgets through the components registry

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.ts
@@ -30,6 +30,7 @@ import TinyMCEEditor from '@js/components/tinymce-editor';
 import TranslatableField from '@js/components/translatable-field';
 import TranslatableInput from '@js/components/translatable-input';
 import EntitySearchInput from '@js/components/entity-search-input';
+import EntitySearchWidget from '@js/components/entity-search-widget';
 import MultipleZoneChoice from '@js/components/form/multiple-zone-choice';
 import ToggleChildrenChoice from '@js/components/form/toggle-children-choice';
 import FilterLinkGroup from '@components/filter/filter-link-group';
@@ -147,6 +148,7 @@ const initPrestashopComponents = (): void => {
     TranslatableField,
     TranslatableInput,
     EntitySearchInput,
+    EntitySearchWidget,
     EmailInput,
     MultipleZoneChoice,
     ToggleChildrenChoice,

--- a/admin-dev/themes/new-theme/js/components/components-map.ts
+++ b/admin-dev/themes/new-theme/js/components/components-map.ts
@@ -52,6 +52,7 @@ export default {
     specificLocale: (selectedLocale: string): string => `.nav-item a[data-locale="${selectedLocale}"]`,
   },
   entitySearchInput: {
+    widgetSelector: '.entity-search-widget',
     searchInputSelector: '.entity-search-input',
     entitiesContainerSelector: '.entities-list',
     listContainerSelector: '.entities-list-container',

--- a/admin-dev/themes/new-theme/js/components/entity-search-input.ts
+++ b/admin-dev/themes/new-theme/js/components/entity-search-input.ts
@@ -13,6 +13,12 @@ import {escape} from 'lodash';
 
 const EntitySearchInputMap = ComponentsMap.entitySearchInput;
 
+/**
+ * jQuery data key holding the instance bound to a widget container, so that a container is never
+ * initialized twice and an already initialized widget can be retrieved by its owner.
+ */
+export const ENTITY_SEARCH_INPUT_DATA_KEY = 'entitySearchInput';
+
 type RemoveFunction = (item: any) => void;
 type SelectFunction = ($node: JQuery, item: any) => void;
 type SuggestionFunction = (entity: any) => string;
@@ -77,10 +83,25 @@ export default class EntitySearchInput {
 
   private autoSearch!: AutoCompleteSearch;
 
-  constructor($entitySearchInputContainer: JQuery, options: OptionsObject) {
+  constructor($entitySearchInputContainer: JQuery, options: OptionsObject = {}) {
+    // WHY: this class is exposed via window.prestashop.component, where every other component is
+    // built with no argument. Called that way it used to fail deep inside buildOptions with an
+    // opaque "Cannot read properties of undefined", so point the caller at the component that does
+    // support that contract instead. An empty selection stays a silent no-op, as before, because
+    // several pages build their manager unconditionally on widgets that are not always rendered.
+    if (!$entitySearchInputContainer) {
+      throw new Error(
+        'EntitySearchInput must be constructed with the container of a single widget. '
+          + 'To initialize every EntitySearchInputType widget of a page at once, use the '
+          + 'EntitySearchWidget component instead.',
+      );
+    }
+
     this.$entitySearchInputContainer = $entitySearchInputContainer;
     this.options = <EntitySearchInputOptions>{};
     this.buildOptions(options);
+
+    this.$entitySearchInputContainer.data(ENTITY_SEARCH_INPUT_DATA_KEY, this);
 
     this.$entitySearchInput = $(this.options.searchInputSelector, this.$entitySearchInputContainer);
     this.$entitiesContainer = $(this.options.entitiesContainerSelector, this.$entitySearchInputContainer);

--- a/admin-dev/themes/new-theme/js/components/entity-search-widget.ts
+++ b/admin-dev/themes/new-theme/js/components/entity-search-widget.ts
@@ -1,0 +1,63 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+import ComponentsMap from '@components/components-map';
+import EntitySearchInput, {ENTITY_SEARCH_INPUT_DATA_KEY} from '@components/entity-search-input';
+
+/**
+ * Initializes every widget rendered by EntitySearchInputType on the page.
+ *
+ * EntitySearchInput itself handles one widget and needs its container, which is why pages that
+ * customize a widget build it themselves. Forms that only need the default behaviour have nothing
+ * to build: the twig template already exposes the whole configuration as data attributes, and
+ * EntitySearchInput reads them with the priority "option > data attribute > default". This
+ * component is the missing step that turns those attributes into live widgets, so adding an
+ * EntitySearchInputType to a form works with:
+ *
+ *   window.prestashop.component.initComponents(['EntitySearchWidget']);
+ */
+export default class EntitySearchWidget {
+  private readonly widgetSelector: string;
+
+  constructor(options: Record<string, any> = {}) {
+    const opts = options || {};
+
+    this.widgetSelector = opts.widgetSelector || ComponentsMap.entitySearchInput.widgetSelector;
+
+    this.init(opts.entitySearchInputOptions || {});
+  }
+
+  /**
+   * Returns the widget bound to a container, whether this component or the page built it. Useful to
+   * attach callbacks to an automatically initialized widget.
+   *
+   * @param {JQuery} $container container of a single widget
+   */
+  // eslint-disable-next-line class-methods-use-this
+  getEntitySearchInput($container: JQuery): EntitySearchInput | undefined {
+    return $container.data(ENTITY_SEARCH_INPUT_DATA_KEY);
+  }
+
+  /**
+   * @param {Object} entitySearchInputOptions options forwarded to each widget
+   *
+   * @private
+   */
+  private init(entitySearchInputOptions: Record<string, any>): void {
+    $(this.widgetSelector).each((index: number, widget: HTMLElement): void => {
+      const $widget = $(widget);
+
+      // WHY: a page that builds a widget itself, to pass callbacks that no generic initialization
+      // can provide, must keep ownership of it. Initializing it twice would bind two typeaheads to
+      // the same input and add every selected entity to both.
+      if ($widget.data(ENTITY_SEARCH_INPUT_DATA_KEY)) {
+        return;
+      }
+
+      // The instance is reachable through the container's data, which getEntitySearchInput reads.
+      new EntitySearchInput($widget, entitySearchInputOptions);
+    });
+  }
+}

--- a/admin-dev/themes/new-theme/package-lock.json
+++ b/admin-dev/themes/new-theme/package-lock.json
@@ -84,6 +84,8 @@
         "hot-accept-webpack-plugin": "^4.0.2",
         "html-webpack-plugin": "^5.6.0",
         "imports-loader": "^5.0.0",
+        "jquery": "^3.6.3",
+        "jsdom": "^19.0.0",
         "mini-css-extract-plugin": "^2.9.1",
         "mocha": "^10.7.3",
         "path": "^0.12.7",

--- a/admin-dev/themes/new-theme/package.json
+++ b/admin-dev/themes/new-theme/package.json
@@ -92,6 +92,8 @@
     "hot-accept-webpack-plugin": "^4.0.2",
     "html-webpack-plugin": "^5.6.0",
     "imports-loader": "^5.0.0",
+    "jquery": "^3.6.3",
+    "jsdom": "^19.0.0",
     "mini-css-extract-plugin": "^2.9.1",
     "mocha": "^10.7.3",
     "path": "^0.12.7",

--- a/admin-dev/themes/new-theme/tests/components/entity-search-widget.spec.js
+++ b/admin-dev/themes/new-theme/tests/components/entity-search-widget.spec.js
@@ -1,0 +1,50 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+const {expect} = require('chai');
+const {JSDOM} = require('jsdom');
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+// jquery binds to the ambient document when there is one, so publish the jsdom globals first
+global.window = dom.window;
+global.document = dom.window.document;
+const $ = require('jquery');
+dom.window.$ = $;
+dom.window.jQuery = $;
+global.$ = $;
+global.jQuery = $;
+
+const {default: EntitySearchWidget} = require('../../js/components/entity-search-widget');
+const {default: EntitySearchInput, ENTITY_SEARCH_INPUT_DATA_KEY} = require('../../js/components/entity-search-input');
+
+// What EntitySearchInputType renders, reduced to the parts this component looks at
+const widget = (id) => `<div id="${id}" class="entity-search-widget" data-remote-url="/search?q=__QUERY__"></div>`;
+
+describe('EntitySearchWidget', () => {
+  it('leaves widgets already built by the page alone, so no input gets two typeaheads', () => {
+    document.body.innerHTML = widget('owned_a') + widget('owned_b');
+    const owners = {owned_a: 'page instance A', owned_b: 'page instance B'};
+    Object.keys(owners).forEach((id) => $(`#${id}`).data(ENTITY_SEARCH_INPUT_DATA_KEY, owners[id]));
+
+    new EntitySearchWidget();
+
+    Object.keys(owners).forEach((id) => {
+      expect($(`#${id}`).data(ENTITY_SEARCH_INPUT_DATA_KEY), id).to.equal(owners[id]);
+    });
+  });
+
+  it('only considers the containers rendered by EntitySearchInputType', () => {
+    document.body.innerHTML = `${widget('a')}<div id="unrelated"></div>`;
+    $('#a').data(ENTITY_SEARCH_INPUT_DATA_KEY, 'page instance');
+
+    const searchWidget = new EntitySearchWidget();
+
+    expect(searchWidget.getEntitySearchInput($('#a'))).to.equal('page instance');
+    expect(searchWidget.getEntitySearchInput($('#unrelated'))).to.be.undefined;
+  });
+
+  it('tells the caller what to use when EntitySearchInput is built without a container', () => {
+    expect(() => new EntitySearchInput()).to.throw(/EntitySearchWidget/);
+  });
+});

--- a/admin-dev/themes/new-theme/tsconfig.json
+++ b/admin-dev/themes/new-theme/tsconfig.json
@@ -25,6 +25,7 @@
     },
   },
   "ts-node": {
+    "files": true,
     "compilerOptions": {
       "module": "commonjs"
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Adding an `EntitySearchInputType` to a form renders a dead input: the search box does nothing and the delete buttons do nothing, unless the page ships its own bundle to build the widget by hand. #36306 exposed `EntitySearchInput` in `window.prestashop.component` so modules could do that without webpack, but it does not satisfy that registry's contract - `initComponents()` builds every component with no argument, while `EntitySearchInput` requires the container of a single widget, so `initComponents(['EntitySearchInput'])` throws `TypeError: Cannot read properties of undefined (reading 'data')` inside `initOption`. It is the only entry in the registry that is not constructible with no argument.<br><br>The widget is already fully self-describing: `entity_search_input.html.twig` puts the whole configuration on the container as `data-*` attributes and marks it `entity-search-widget`, and `initOption` resolves options with the priority option > data attribute > default. That container class had no consumer at all - 0 references across `admin-dev/themes/new-theme/js`, against 6 instantiations each bound to a page-specific selector. Only the initialization step was missing.<br><br>`EntitySearchWidget` supplies it: it initializes every widget rendered by `EntitySearchInputType` and skips any a page built itself, so pages that pass callbacks keep ownership of their instance and no input ever gets two typeaheads. Building `EntitySearchInput` with no container now reports which component to use instead of failing inside `buildOptions`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add an `EntitySearchInputType` to any admin form from a module, then call `window.prestashop.component.initComponents(['EntitySearchWidget'])` on that page. Before this change the input is dead and `initComponents(['EntitySearchInput'])` throws in the console; after it, the search and the delete buttons work with no JavaScript configuration. Existing pages that build the widget themselves (related products, attachments, product and category redirect targets, discount free gift and specific products) are unchanged. Covered by `admin-dev/themes/new-theme/tests/components/entity-search-widget.spec.js`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34667
| Related PRs       |
| Sponsor company   |

### Scope

No core page opts in, so nothing changes for core: all 14 `initComponents([...])` call sites were
checked and none lists `EntitySearchInput` or `EntitySearchWidget`. The six existing page-specific
managers keep their instances.

The guard is deliberately one-directional. `EntitySearchWidget` skips a container that already carries
an instance, so page code that runs first keeps ownership; `EntitySearchInput` does not skip anything,
because a page constructing one explicitly - with the callbacks a generic initialization cannot supply -
should take ownership. A page that opted in and also built a widget by hand would therefore need to do
so before `EntitySearchWidget` runs, and page bundles are separate webpack entries from `theme.ts`.
Nothing in core is in that position today, and a page in that position should drop its bespoke
construction in favour of `getEntitySearchInput()`.

The guard on `EntitySearchInput`'s constructor rejects a missing argument only, not an empty
selection: three of the six existing call sites build their manager unconditionally on widgets that
are not always rendered, so an empty jQuery set has to stay the silent no-op it has always been.

### Test infrastructure

`tsconfig.json` gains ts-node's `"files": true`. Without it ts-node never loads
`js/@types/global.d.ts`, so any spec importing a component fails to compile - measured at 14 type
errors on the base branch for a spec that merely imports `entity-search-input.ts`. This is why every
existing spec tests a pure function. The option is scoped to the `ts-node` block and does not affect
the webpack build; `tsc --noEmit` reports the same 16 pre-existing `node_modules` errors before and
after. Note this tsconfig declares neither `files` nor `include`, so ts-node now compiles the whole
theme rather than only the spec's import graph - `npm test` passes at 124 with that full type-check,
which is a stronger guarantee than the option was reached for. `jsdom` and `jquery` were already present as transitive dependencies at the pinned versions
and are now declared, which adds two lines to the lock file.

### Verification

RED: `new EntitySearchInput()` - exactly what `initComponents(['EntitySearchInput'])` does - throws
`TypeError: Cannot read properties of undefined (reading 'data')` at `initOption`.
GREEN: 124 passing, up from 121. Both guards were mutation-checked: removing the double-init guard
fails 2 cases, removing the constructor guard fails 1 with the original opaque message.
