### PR TITLE
Honour the locale argument of trans() outside the Symfony container

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -442,6 +442,12 @@ class ContextCore
         $cacheDir = _PS_CACHE_DIR_ . 'translations';
         $translator = new Translator($locale, null, $cacheDir, false);
 
+        // Wired before the early return below, so a translator served straight from the cache can
+        // still resolve a wording explicitly requested in another language.
+        $translator->setLanguageLoader(function (string $requestedLocale) use ($translator): void {
+            $this->loadTranslatorLanguage($translator, $requestedLocale);
+        });
+
         // In case we have at least 1 translated message, we return the current translator.
         // If some translations are missing, clear cache
         if (empty($locale) || count($translator->getCatalogue($locale)->all())) {
@@ -461,35 +467,51 @@ class ContextCore
 
         $translator->clearLanguage($locale);
 
-        $adminContext = defined('_PS_ADMIN_DIR_');
-        // Do not load DB translations when $this->language is InstallLanguage
-        // because it means that we're looking for the installer translations, so we're not yet connected to the DB
-        $withDB = !$this->language instanceof InstallLanguage;
-        $theme = $this->shop !== null ? $this->shop->theme : null;
-
-        if ($this instanceof Context) {
-            try {
-                $containerFinder = new ContainerFinder($this);
-                $container = $containerFinder->getContainer();
-                $translatorLoader = $container->get('prestashop.translation.translator_language_loader');
-            } catch (ContainerNotFoundException|ServiceNotFoundException $exception) {
-                $translatorLoader = null;
-            }
-
-            if (null === $translatorLoader) {
-                // If a container is still not found, instantiate manually the translator loader
-                // This will happen in the Front as we have legacy controllers, the Sf container won't be available.
-                // As we get the translator in the controller's constructor and the container is built in the init method, we won't find it here
-                $translatorLoader = (new TranslatorLanguageLoader(new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_)));
-            }
-
-            $translatorLoader
-                ->setIsAdminContext($adminContext)
-                ->loadLanguage($translator, $locale, $withDB, $theme)
-            ;
-        }
+        $this->loadTranslatorLanguage($translator, $locale);
 
         return $translator;
+    }
+
+    /**
+     * Register a locale's translation resources on the given translator.
+     *
+     * @param Translator $translator
+     * @param string $locale IETF language tag (eg. "en-US")
+     */
+    private function loadTranslatorLanguage($translator, $locale): void
+    {
+        // ContainerFinder needs the concrete Context; the sub-classes that extend ContextCore
+        // without being one (the installer's) have no container to find anyway.
+        if (!$this instanceof Context) {
+            return;
+        }
+
+        try {
+            $containerFinder = new ContainerFinder($this);
+            $container = $containerFinder->getContainer();
+            $translatorLoader = $container->get('prestashop.translation.translator_language_loader');
+        } catch (ContainerNotFoundException|ServiceNotFoundException $exception) {
+            $translatorLoader = null;
+        }
+
+        if (null === $translatorLoader) {
+            // If a container is still not found, instantiate manually the translator loader
+            // This will happen in the Front as we have legacy controllers, the Sf container won't be available.
+            // As we get the translator in the controller's constructor and the container is built in the init method, we won't find it here
+            $translatorLoader = (new TranslatorLanguageLoader(new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_)));
+        }
+
+        $translatorLoader
+            ->setIsAdminContext(defined('_PS_ADMIN_DIR_'))
+            // Do not load DB translations when $this->language is InstallLanguage
+            // because it means that we're looking for the installer translations, so we're not yet connected to the DB
+            ->loadLanguage(
+                $translator,
+                $locale,
+                !$this->language instanceof InstallLanguage,
+                $this->shop !== null ? $this->shop->theme : null
+            )
+        ;
     }
 
     /**

--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -35,6 +35,12 @@ trait PrestaShopTranslatorTrait
             $locale = null;
         }
 
+        // Only an explicit locale can be one this translator never loaded; the default path is
+        // untouched.
+        if (null !== $locale && method_exists($this, 'loadLanguageOnDemand')) {
+            $this->loadLanguageOnDemand($locale);
+        }
+
         if ($this->shouldFallbackToLegacyModuleTranslation($id, $domain, $locale)) {
             return $this->translateUsingLegacySystem($id, $parameters, $domain, $locale);
         }

--- a/src/PrestaShopBundle/Translation/TranslatorLanguageTrait.php
+++ b/src/PrestaShopBundle/Translation/TranslatorLanguageTrait.php
@@ -12,6 +12,49 @@ namespace PrestaShopBundle\Translation;
 trait TranslatorLanguageTrait
 {
     /**
+     * @var callable|null registers the translation resources of one locale on this translator
+     */
+    private $languageLoader;
+
+    /**
+     * @var array<string, bool> locales this translator has already been asked to register
+     */
+    private $requestedLanguages = [];
+
+    /**
+     * @param callable $languageLoader called with a locale code, to register that locale's resources
+     */
+    public function setLanguageLoader(callable $languageLoader): void
+    {
+        $this->languageLoader = $languageLoader;
+    }
+
+    /**
+     * Register the resources of a locale this translator never loaded.
+     *
+     * WHY: resources are registered for the translator's own locale only, so a wording explicitly
+     * asked for in another language found no catalogue and came back as the wording itself - the
+     * $locale argument of trans() silently did nothing outside the Symfony container.
+     *
+     * @param string $locale Locale code to make available
+     */
+    public function loadLanguageOnDemand(string $locale): void
+    {
+        if (null === $this->languageLoader
+            || isset($this->requestedLanguages[$locale])
+            || $this->isLanguageLoaded($locale)
+        ) {
+            return;
+        }
+
+        // WHY marked before the call rather than after: loading registers resources, which Symfony
+        // answers by dropping the cached catalogue, so a locale that resolves to nothing must not
+        // rebuild every catalogue again on each following lookup.
+        $this->requestedLanguages[$locale] = true;
+        ($this->languageLoader)($locale);
+    }
+
+    /**
      * @param string $locale Locale code for the catalogue to check if loaded
      *
      * @return bool

--- a/tests/Unit/PrestaShopBundle/Translation/TranslatorOnDemandLocaleTest.php
+++ b/tests/Unit/PrestaShopBundle/Translation/TranslatorOnDemandLocaleTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Translation;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Translation\TranslatorComponent;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+
+/**
+ * Catalogues are registered for the translator's own locale only, so asking trans() for a wording in
+ * another language used to return the wording itself: the $locale argument silently did nothing
+ * outside the Symfony container, which is every front office and CLI context.
+ */
+class TranslatorOnDemandLocaleTest extends TestCase
+{
+    /**
+     * @var string[] locales the loader was asked to register
+     */
+    private array $requested = [];
+
+    private function buildTranslator(): TranslatorComponent
+    {
+        $this->requested = [];
+        $translator = new TranslatorComponent('en-US');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', ['Save' => 'Save'], 'en-US', 'AdminGlobal');
+        $translator->setLanguageLoader(function (string $locale) use ($translator): void {
+            $this->requested[] = $locale;
+            $translator->addResource('array', ['Save' => 'Enregistrer'], $locale, 'AdminGlobal');
+        });
+
+        return $translator;
+    }
+
+    public function testAnExplicitLocaleIsLoadedSoItsTranslationIsReturned(): void
+    {
+        $translator = $this->buildTranslator();
+
+        $this->assertSame('Enregistrer', $translator->trans('Save', [], 'Admin.Global', 'fr-FR'));
+        $this->assertSame(['fr-FR'], $this->requested);
+    }
+
+    public function testTheDefaultPathNeverAsksForAnotherLocale(): void
+    {
+        $translator = $this->buildTranslator();
+
+        $this->assertSame('Save', $translator->trans('Save', [], 'Admin.Global'));
+        $this->assertSame([], $this->requested);
+    }
+
+    /**
+     * Registering resources makes Symfony drop the cached catalogue, so repeating the request must
+     * not rebuild it on every lookup.
+     */
+    public function testALocaleIsOnlyRequestedOnce(): void
+    {
+        $translator = $this->buildTranslator();
+
+        $translator->trans('Save', [], 'Admin.Global', 'fr-FR');
+        $translator->trans('Save', [], 'Admin.Global', 'fr-FR');
+        $translator->trans('Save', [], 'Admin.Global', 'fr-FR');
+
+        $this->assertSame(['fr-FR'], $this->requested);
+    }
+
+    public function testAnAlreadyLoadedLocaleIsNotRequested(): void
+    {
+        $translator = $this->buildTranslator();
+
+        // Force the en-US catalogue to exist, as it does for the translator's own locale.
+        $translator->trans('Save', [], 'Admin.Global');
+
+        $this->assertSame('Save', $translator->trans('Save', [], 'Admin.Global', 'en-US'));
+        $this->assertSame([], $this->requested);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Translation resources are registered for the translator's own locale only (`TranslatorLanguageLoader::loadLanguage()` finds `*.$locale.xlf` for the one locale it is given), so asking `trans()` for a wording in another language found no catalogue at all and returned the wording itself. The `$locale` argument therefore did nothing outside the Symfony container - that is the whole front office and every CLI script - silently, and for every domain, not just module ones: a translator whose locale is `en-US` answered `Save` instead of `Enregistrer` for `Admin.Global` with `fr-FR`.<br><br>The translator now registers a requested locale's resources the first time one is asked for, through the very loader `Context` already uses for its own locale. Only calls that pass an explicit locale reach the new code, so the default path is untouched, and each locale is registered at most once because registering resources makes Symfony drop the cached catalogue.<br><br>`Context::getTranslatorFromLocale()` keeps its behaviour; the loader-resolution block it already contained is extracted into a private method so the lazy path and the eager one cannot drift apart.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with a second language installed, from a front office context or a plain CLI script (`require config/config.inc.php`): `Context::getContext()->getTranslator()->trans('Save', [], 'Admin.Global', 'fr-FR')`. Before this change it returns `Save`; after it, `Enregistrer`. The same holds for a module domain and for `Module::trans($id, [], $domain, $locale)`. Covered by `tests/Unit/PrestaShopBundle/Translation/TranslatorOnDemandLocaleTest.php`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34789
| Related PRs       |
| Sponsor company   |

### Scope

The reported symptom, a module tab created during install with per-language names, is already fixed
on 9.2: `bin/console prestashop:module install` runs with the Symfony container, where the container
translator does resolve other locales. What remains, and what this fixes, is every context where the
container is absent.

Core has one caller that passes an explicit locale,
`ProductDuplicator::duplicate()` (`Admin.Catalog.Feature`, `copy of %s`, per language), and it runs in
the back office, so no core behaviour changes today. The change matters for front-office and CLI code -
notably modules translating into a customer's language rather than the context one.
