### PR TITLE
Publish the shop's return policy in product structured data

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1563,6 +1563,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             ];
         }
 
+        // Add the shop's return policy, when it publishes one
+        $merchantReturnPolicy = $this->getMerchantReturnPolicyStructuredData();
+        if ($merchantReturnPolicy !== null) {
+            $structuredData['product']['hasMerchantReturnPolicy'] = $merchantReturnPolicy;
+        }
+
         // Add offer data if price is shown
         if ($product['show_price']) {
             $structuredData['product']['offers'] = [
@@ -1629,6 +1635,55 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'value' => $featureValue,
             ];
         }
+    }
+
+    /**
+     * Build the schema.org MerchantReturnPolicy of the current shop from its order return settings.
+     *
+     * WHY nothing is published when returns are switched off: PS_ORDER_RETURN only governs the built-in
+     * merchandise return feature, so turning it off says the merchant does not process returns through
+     * the back office - not that returns are refused. Publishing MerchantReturnNotPermitted on that
+     * basis would state a policy the merchant never set, and would contradict the statutory withdrawal
+     * right that applies in the EU and elsewhere.
+     *
+     * @return array<string, mixed>|null the policy, or null when the shop publishes none
+     */
+    protected function getMerchantReturnPolicyStructuredData(): ?array
+    {
+        $shopId = (int) $this->context->shop->id;
+
+        if (!Configuration::get('PS_ORDER_RETURN', null, null, $shopId)) {
+            return null;
+        }
+
+        // WHY this pair and this order: applicableCountry is where the goods are sold and returned to,
+        // so it is the shop's own address country. Shop::getAddress() resolves that exact question the
+        // same way, falling back to the localisation default when the shop address has no country set.
+        $countryId = (int) Configuration::get('PS_SHOP_COUNTRY_ID', null, null, $shopId)
+            ?: (int) Configuration::get('PS_COUNTRY_DEFAULT', null, null, $shopId);
+
+        $country = new Country($countryId);
+        if (!Validate::isLoadedObject($country)) {
+            return null;
+        }
+
+        $policy = [
+            '@type' => 'MerchantReturnPolicy',
+            'applicableCountry' => $country->iso_code,
+        ];
+
+        // WHY the zero case is a different category: Order::getNumberOfDays() returns true as soon as
+        // PS_ORDER_RETURN_NB_DAYS is 0, so zero means "no time limit" here. Publishing it verbatim as
+        // merchantReturnDays would advertise the opposite - a window that closes on the delivery date.
+        $returnWindowInDays = (int) Configuration::get('PS_ORDER_RETURN_NB_DAYS', null, null, $shopId);
+        if ($returnWindowInDays > 0) {
+            $policy['returnPolicyCategory'] = 'https://schema.org/MerchantReturnFiniteReturnWindow';
+            $policy['merchantReturnDays'] = $returnWindowInDays;
+        } else {
+            $policy['returnPolicyCategory'] = 'https://schema.org/MerchantReturnUnlimitedWindow';
+        }
+
+        return $policy;
     }
 
     protected function addProductCustomizationData(array $product_full)

--- a/tests/Integration/Controller/Front/ProductMerchantReturnPolicyTest.php
+++ b/tests/Integration/Controller/Front/ProductMerchantReturnPolicyTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Controller\Front;
+
+use Configuration;
+use ProductController;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Google reports a product as missing hasMerchantReturnPolicy when the shop publishes no return policy
+ * in its structured data. The shop already records whether it accepts returns and for how long, so the
+ * policy is built from that rather than from anything the merchant has to restate.
+ */
+class ProductMerchantReturnPolicyTest extends KernelTestCase
+{
+    private string $originalOrderReturn;
+    private string $originalReturnDays;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->originalOrderReturn = (string) Configuration::get('PS_ORDER_RETURN');
+        $this->originalReturnDays = (string) Configuration::get('PS_ORDER_RETURN_NB_DAYS');
+    }
+
+    protected function tearDown(): void
+    {
+        Configuration::updateValue('PS_ORDER_RETURN', $this->originalOrderReturn);
+        Configuration::updateValue('PS_ORDER_RETURN_NB_DAYS', $this->originalReturnDays);
+
+        parent::tearDown();
+    }
+
+    public function testNoPolicyIsPublishedWhenReturnsAreDisabled(): void
+    {
+        Configuration::updateValue('PS_ORDER_RETURN', 0);
+
+        $this->assertNull($this->buildPolicy());
+    }
+
+    public function testAReturnWindowIsPublishedAsAFiniteWindow(): void
+    {
+        Configuration::updateValue('PS_ORDER_RETURN', 1);
+        Configuration::updateValue('PS_ORDER_RETURN_NB_DAYS', 14);
+
+        $policy = $this->buildPolicy();
+
+        $this->assertNotNull($policy);
+        $this->assertSame('MerchantReturnPolicy', $policy['@type']);
+        $this->assertSame('https://schema.org/MerchantReturnFiniteReturnWindow', $policy['returnPolicyCategory']);
+        $this->assertSame(14, $policy['merchantReturnDays']);
+        $this->assertNotEmpty($policy['applicableCountry']);
+    }
+
+    /**
+     * Order::getNumberOfDays() accepts any return once PS_ORDER_RETURN_NB_DAYS is 0, so zero is an
+     * unlimited window. Published verbatim as merchantReturnDays it would say the opposite.
+     */
+    public function testAZeroReturnWindowIsPublishedAsUnlimitedRatherThanZeroDays(): void
+    {
+        Configuration::updateValue('PS_ORDER_RETURN', 1);
+        Configuration::updateValue('PS_ORDER_RETURN_NB_DAYS', 0);
+
+        $policy = $this->buildPolicy();
+
+        $this->assertNotNull($policy);
+        $this->assertSame('https://schema.org/MerchantReturnUnlimitedWindow', $policy['returnPolicyCategory']);
+        $this->assertArrayNotHasKey('merchantReturnDays', $policy);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function buildPolicy(): ?array
+    {
+        return (new class() extends ProductController {
+            public function buildMerchantReturnPolicy(): ?array
+            {
+                return $this->getMerchantReturnPolicyStructuredData();
+            }
+        })->buildMerchantReturnPolicy();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Google Search Console reports products as missing `hasMerchantReturnPolicy`, because the Product JSON-LD has never carried one - even though the shop already records whether it accepts returns and for how long.<br><br>`ProductController::getStructuredData()` now builds a `MerchantReturnPolicy` from `PS_ORDER_RETURN`, `PS_ORDER_RETURN_NB_DAYS` and the shop's own address country (`PS_SHOP_COUNTRY_ID`, falling back to `PS_COUNTRY_DEFAULT` exactly as `Shop::getAddress()` does). Those cover exactly the properties Google lists as required (`applicableCountry` + `returnPolicyCategory`, plus `merchantReturnDays` for a finite window); `returnFees` and `returnMethod` are only recommended and PrestaShop does not model them, so they are left out rather than guessed.<br><br>Two deliberate choices. A return window of `0` means "no time limit" in `Order::getNumberOfDays()`, so it is published as `MerchantReturnUnlimitedWindow` rather than as `merchantReturnDays: 0`, which would advertise a window closing on the delivery date. And nothing at all is published when `PS_ORDER_RETURN` is off: that setting governs the built-in merchandise return feature, so switching it off says the merchant does not process returns through the back office, not that returns are refused - publishing `MerchantReturnNotPermitted` on that basis would state a policy the merchant never set and contradict the statutory withdrawal right in the EU and elsewhere.<br><br>All configuration reads are shop-scoped, so a multistore setup publishes each shop's own policy.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable Customer Service > Merchandise returns and set a return window, then open any product page and read the `application/ld+json` block: the `Product` now carries `hasMerchantReturnPolicy` with `applicableCountry`, `returnPolicyCategory` and `merchantReturnDays`. Set the window to `0` and the category becomes `MerchantReturnUnlimitedWindow` with no `merchantReturnDays`. Switch returns off and the property disappears. Covered by `tests/Integration/Controller/Front/ProductMerchantReturnPolicyTest.php`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34813
| Related PRs       |
| Sponsor company   |

### Scope: which themes this reaches

The Product JSON-LD comes from the core since 9.2 and the theme only prints it, but only a theme that
actually renders `$structured_data` picks this up. hummingbird does (`_partials/head.tpl`, which keeps its
hand-written `head-jsonld.tpl` only as an `{else}` fallback it marks for removal), so hummingbird shops get
the policy from this change alone. **classic-theme does not**: its `_partials/head.tpl` still includes
`head-jsonld.tpl` unconditionally and builds its own JSON-LD, so a classic shop is unaffected until that
theme is migrated to the core array. That migration is a separate change in the `PrestaShop/classic-theme`
repository and is not folded in here, because on its own it would also drop the `aggregateRating` that
classic currently emits from product comments and the core array does not carry.

### What this deliberately does not do

The issue asks for `shippingDetails` as well. That one is not derivable from what the shop knows: a
representative `shippingRate` needs a destination, and PrestaShop prices shipping per carrier, per zone and
per weight or price range, so any single figure published on the product page would be wrong for most
visitors. @Maofree raised exactly this on the issue ("si le site vendait egalement dans toute l'Europe,
serait-il necessaire de declarer toutes les donnees d'expedition pour chaque pays ?"), and it has no correct
answer without new merchant-facing configuration for a declared shipping policy. It is left for a separate
issue rather than guessed at here, since publishing a wrong shipping rate is worse than publishing none.
