### PR TITLE
Re-run the Docker install when the previous one stopped partway

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -115,7 +115,13 @@ else
   echo "error_log=/var/www/html/var/logs/php.log" >> /usr/local/etc/php/php.ini
 fi
 
-if [ ! -f ./app/config/parameters.php ]; then
+# app/config/parameters.php is written by the installer's FIRST step, so on its own it only says that
+# an install was started. var/.install.prestashop is created at that same moment and removed by
+# Install::finalize(), so a leftover lock means the previous attempt stopped partway - before
+# processConfigureShop(), which is what creates the administrator - and the shop cannot be logged into.
+# Running the installer again is what the user wants there; it defaults to --db_clear=1, so it starts
+# from a clean schema.
+if [ ! -f ./app/config/parameters.php ] || [ -f ./var/.install.prestashop ]; then
     if [ $PS_INSTALL_AUTO = 1 ]; then
 
         echo "\n* Installing PrestaShop, this may take a while ...";
@@ -140,14 +146,17 @@ if [ ! -f ./app/config/parameters.php ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        # `set -e` is in effect, so testing $? after the command could never report anything - the shell
+        # had already left. Test the command itself so a failed install says why it failed.
+        if ! runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="Marc" --lastname="Beier" \
         --password="$ADMIN_PASSWD" --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-        --all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL --fixtures=$PS_INSTALL_DEMO_PRODUCTS
-
-        if [ $? -ne 0 ]; then
-            echo 'warning: PrestaShop installation failed.'
+        --all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL --fixtures=$PS_INSTALL_DEMO_PRODUCTS; then
+            echo >&2 'error: PrestaShop installation failed. No administrator account exists yet, so the'
+            echo >&2 '  credentials printed by this script would not work. Fix the cause above and run'
+            echo >&2 '  "docker compose up" again - the installer will start over.'
+            exit 1
         fi
     fi
 else


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `.docker/docker_run_git.sh` decides the shop is installed from `app/config/parameters.php` alone. The installer writes that file in its first step and creates the administrator six steps later, so an install that stops in between leaves a checkout that reports "PrestaShop Core already installed...", cannot be logged into, ignores a changed `ADMIN_PASSWD`, and ignores `PS_ERASE_DB` too - that block sits inside the same skipped branch. `var/.install.prestashop` already tells the two states apart, so gate on it as well. Separately, the script's own failure branch could never run: `set -e` had already ended the shell before `[ $? -ne 0 ]` was reached.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a checkout with `app/config/parameters.php` present and `var/.install.prestashop` left behind, run `docker compose up`. Before this change the log says "PrestaShop Core already installed..." and the printed credentials do not work; after it the installer runs and they do. A healthy install - `parameters.php` present, no lock - must still skip the installer.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #35140
| Related PRs       | PrestaShop/PrestaShop#38083 and PrestaShop/PrestaShop#38084 also touch this file, on different lines.
| Sponsor company   |

## Why parameters.php is the wrong signal

`install-dev/controllers/console/process.php`:

```
:117  processGenerateSettingsFile()   <- writes app/config/parameters.php
:139  processInstallDatabase()
:143  processInstallDefaultData()
:146  processPopulateDatabase()
:150  processConfigureShop()          <- passes admin_password / admin_email, creates the employee
```

Six steps separate the file from the account. Anything failing in between - a MySQL hiccup, a killed
container, a timeout - leaves `parameters.php` on disk and no administrator, and
`.docker/docker_run_git.sh:118` then takes the "already installed" branch forever after.

`var/.install.prestashop` is written next to it at `:111-113` and removed by `Install::finalize()`
(`src/PrestaShopBundle/Install/Install.php:1040`), so its presence means the previous attempt did not
finish. Both installed checkouts here have no lock file, which is the control for the healthy case.

Re-running is safe: `install-dev/classes/datas.php:93-97` gives `database_clear` a default of `1`
("Drop existing tables"), and `step` defaults to `all` at `:40-44`, so `finalize` is reached and the lock
is cleared on success.

## Measured

The real script was run in a throwaway `debian:12-slim` container with `mysql`, `runuser` and
`apache2-foreground` stubbed, over the four states that matter:

```
                                          base                               with this change
fresh          (no params, no lock)       installs                           installs
half-installed (params + lock)            "already installed", SKIPPED       installs
installed      (params, no lock)          "already installed"                "already installed"
install fails  (installer exits 1)        no message at all, exit 1          error: ... , exit 1
```

Only the two broken states change; the healthy ones behave exactly as before.

## The unreachable failure branch

```sh
runuser ... index_cli.php ...

if [ $? -ne 0 ]; then
    echo 'warning: PrestaShop installation failed.'
fi
```

`set -e` is set at `:106`, so a non-zero exit from `runuser` ended the shell before the test - the run
above confirms it, the base script printing nothing at all when the installer fails. Testing the command
directly makes the message reachable and lets it say what a failed install means for the credentials the
script is about to print. shellcheck agrees: `SC2181` was reported on the base at line 149 and is the only
finding this change removes; it introduces none.

## Not done here

The banner still prints `ADMIN_MAIL` / `ADMIN_PASSWD` unconditionally, which is misleading on a shop that
was already installed with different values. PrestaShop/PrestaShop#38084 is open on exactly those lines,
so this branch leaves them alone rather than competing; with the gate fixed, the case that actually
stranded the reporter no longer reaches that code.
