### PR TITLE
Declare doctrine/annotations, which the core uses directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "composer/installers": "^2.2.0",
         "curl/curl": "^2.3.2",
         "defuse/php-encryption": "^2.3.1",
+        "doctrine/annotations": "^1.13.1",
         "doctrine/cache": "^2.0",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/orm": "^2.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89e2352d6f6b0e1d065a196d5b00e993",
+    "content-hash": "77fe8324e1e25db796974c671953a2b9",
     "packages": [
         {
             "name": "api-platform/core",


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Four core classes import `Doctrine\Common\Annotations` and three of them take a `Reader` as a constructor dependency, but the package is not in `require`. It arrives only through `doctrine/doctrine-bundle`, which stopped requiring it in 2.8.0 - and the root constraint is `^2.3`, so `composer update doctrine/doctrine-bundle --with-all-dependencies` removes `doctrine/annotations` from vendor and the shop dies with `LogicException: The annotation metadata driver cannot be enabled because the "doctrine/annotations" library is not installed.` Declaring the dependency stops an unrelated bundle bump from taking it away.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `composer why doctrine/annotations` names `doctrine/doctrine-bundle 2.6.4` as the only requirer. Then `composer update doctrine/doctrine-bundle --with-all-dependencies --dry-run`: on the base branch it reports `1 removal - Removing doctrine/annotations (1.14.4)`, with this change `0 removals`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #35517
| Related PRs       |
| Sponsor company   |

## The undeclared usage

```
src/PrestaShopBundle/EventListener/Admin/AdminSecurityListener.php:30   private readonly Reader $annotationReader
                                                                  :65   getMethodAnnotation(..., AdminSecurityAnnotation::class)
src/PrestaShopBundle/EventListener/Admin/AccessDeniedListener.php:35    private readonly Reader $annotationReader
                                                                 :76    getMethodAnnotation(..., AdminSecurityAnnotation::class)
src/PrestaShopBundle/Service/Database/DoctrineNamingStrategy.php:27     private Reader $reader
src/Adapter/Presenter/Order/OrderLazyArray.php:18                      use ...\AnnotationException
```

`src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php:87` additionally
builds a `Doctrine\ORM\Mapping\Driver\AnnotationDriver` around that reader so module entities keep being
mapped - psgdpr, for one, still ships annotated entities.

## Measured

```
$ composer why doctrine/annotations
doctrine/doctrine-bundle 2.6.4   requires  doctrine/annotations (^1)
doctrine/orm             2.20.0  conflicts doctrine/annotations (<1.13 || >= 3.0)
symfony/framework-bundle v6.4.45 conflicts doctrine/annotations (<1.13.1)
...
```

Exactly one requirer; every other line is a conflict rule, not a dependency. Then, within the root's own
`"doctrine/doctrine-bundle": "^2.3"`:

```
base branch
$ composer update doctrine/doctrine-bundle --with-all-dependencies --dry-run
Lock file operations: 0 installs, 9 updates, 1 removal
  - Removing doctrine/annotations (1.14.4)
  - Upgrading doctrine/doctrine-bundle (2.6.4 => 2.19.0)

with this change
Lock file operations: 0 installs, 9 updates, 0 removals
  - Upgrading doctrine/annotations (1.14.4 => 1.14.4)
  - Upgrading doctrine/doctrine-bundle (2.6.4 => 2.19.0)
```

`composer.lock` changes by one line, the `content-hash`, produced by `composer update --lock`; no package
version moves. `composer validate` passes.

## Notes

The constraint is `^1.13.1`: `doctrine/orm` conflicts with `>= 3.0`, several Symfony components conflict
with `< 1.13.1`, and `doctrine-bundle 2.6.4` requires `^1`, so that is the window the current lock can
actually resolve. Widening to `|| ^2.0` was not tested here.

`doctrine/annotations` is abandoned upstream, which is an argument for migrating `AdminSecurity` to a PHP
attribute rather than for leaving the dependency undeclared - and `doctrine/cache`, already in `require`,
is abandoned too, so an abandoned package in this file is not new. Declaring what the code uses is
orthogonal to that migration and does not compete with it.

No test: this is dependency metadata, and the check that would catch a regression is the
`composer update --dry-run` above rather than a PHPUnit case.
