### PR TITLE
Name the module in the failed action error instead of saying undefined

### DIFF
--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -417,10 +417,18 @@ export default class ModuleCard {
         }
       })
       .fail(() => {
-        const moduleItem = jqElementObj.closest('module-item-list');
-        const techName = moduleItem.data('techName');
+        // WHY: the module item carries `module-item-list` as a CLASS - see moduleItemListSelector above,
+        // and ModuleCardMap.moduleItemList - so the bare element-name selector used here matched nothing
+        // and the name was always undefined. The message read "for module undefined", which is what the
+        // merchant sees when an action fails.
+        const techName = jqElementObj
+          .closest(this.moduleItemListSelector)
+          .attr('data-tech-name');
+
         $.growl.error({
-          message: `Could not perform action ${action} for module ${techName}`,
+          message: techName
+            ? `Could not perform action ${action} for module ${techName}`
+            : `Could not perform action ${action}`,
           fixed: true,
         });
       })


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When a module action fails, the growl reads `Could not perform action update for module undefined`. The failure handler looks the module up with `jqElementObj.closest('module-item-list')`, which is a bare element-name selector; the module item carries `module-item-list` as a **class**. `moduleItemListSelector` a few lines above is `'.module-item-list'` and `ModuleCardMap.moduleItemList()` builds the same selector, so every other lookup in the file gets it right and only this one does not. It matched nothing, so the name was always `undefined`. It now uses that selector and reads `data-tech-name` the way the rest of the file does, and omits the name rather than printing `undefined` when it genuinely cannot be determined.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make a module action fail - for instance stop the web server mid-request, or point the form action at a URL that 500s - and read the red growl. Before: `Could not perform action update for module undefined`. After: the module's technical name.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #35814
| Related PRs       |
| Sponsor company   |

### Measured

The markup is `src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig:8`, which sets
`class="module-item module-item-list ..."` and `data-tech-name="{{ module.attributes.name }}"` on the same
element. Replaying both selectors against it with jsdom and the theme's own jQuery:

```
closest('module-item-list')   -> undefined   (length 0)
closest('.module-item-list')  -> "ps_facetedsearch"

message before: Could not perform action update for module undefined
message after : Could not perform action update for module ps_facetedsearch
```

The first line is the string in the screenshots on the issue, and @kalukramer reports the same on 9.0.1.

### Why the name can still be missing, and why that is handled

`Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig:29` uses
`<div class="module-item-list">` as a **container** around several modules, with no `data-tech-name` on it.
On that page the corrected selector finds the container and the attribute is undefined, so the message drops
the name instead of printing `undefined` again.

### No unit test, deliberately

The theme's mocha suite has no DOM harness - every spec under `admin-dev/themes/new-theme/tests` is a
pure-function test, none of them loads jsdom or jQuery. Standing that up, plus a `window.prestashop`
stub for the constructor, to cover a selector fix would be the first DOM test in the suite and out of
proportion to the change. The reproduction above is deterministic and runs in a few lines; happy to add
the harness if you would rather have it.

### Scope

The issue also carries a feature request - having the upgrade flow offer to remove PrestaShop modules that
are no longer shipped - which is labelled `Waiting for PM` and is not touched here.
