### PR TITLE
Stop building the attribute combinations array nothing reads

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -335,8 +335,15 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         // Assign template vars related to the price and tax
         $this->assignPriceAndTax();
 
-        // Assign attributes combinations to the template
-        $this->assignAttributesCombinations();
+        // WHY: assignAttributesCombinations() is not called any more. It builds an array sized by the
+        // product's attributes times its combinations and str2url()s every cell of it, and nothing in
+        // core, in either shipped theme or in any native module reads the `attributesCombinations`
+        // variable it produced - it was last used by a 1.6 theme. The separator it also assigned is a
+        // single Configuration read, so that one is kept.
+        $this->context->smarty->assign(
+            'attribute_anchor_separator',
+            Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR')
+        );
 
         // Add notification about this product being in cart
         $this->addCartQuantityNotification();
@@ -855,6 +862,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     /**
      * Get and assign attributes combinations informations.
+     *
+     * @deprecated since 9.2.0 and will be removed in 10.0.0. It is no longer called: the
+     *             `attributesCombinations` variable it assigns has not been read by core or by a shipped
+     *             theme since 1.6, while building it costs one row per attribute per combination and a
+     *             Tools::str2url() call on every cell of every row. Call it from an override if a theme
+     *             still needs that variable.
      */
     protected function assignAttributesCombinations(): void
     {

--- a/tests/Integration/Classes/Controller/ProductAttributesCombinationsTest.php
+++ b/tests/Integration/Classes/Controller/ProductAttributesCombinationsTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use Configuration;
+use Context;
+use FilesystemIterator;
+use Product;
+use ProductController;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Smarty;
+use SplFileInfo;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * assignAttributesCombinations() is deprecated and no longer called by the controller, but it stays
+ * callable so an override that still wants the `attributesCombinations` variable keeps working. This pins
+ * that promise, and the shape it hands over.
+ */
+class ProductAttributesCombinationsTest extends KernelTestCase
+{
+    private const PRODUCT_WITH_COMBINATIONS = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+    }
+
+    public function testTheDeprecatedMethodStillAssignsItsVariables(): void
+    {
+        $product = new Product(self::PRODUCT_WITH_COMBINATIONS, false, (int) Configuration::get('PS_LANG_DEFAULT'));
+        self::assertTrue($product->hasCombinations(), 'the fixture product must carry combinations');
+
+        $smarty = $this->recordingSmarty();
+        $controller = new class() extends ProductController {
+            public function __construct()
+            {
+                // the controller's own constructor initialises the whole front office; this test only
+                // exercises one protected method, so it is deliberately skipped
+            }
+
+            public function callAssignAttributesCombinations(Product $product, $smarty): array
+            {
+                $this->product = $product;
+                $this->context = Context::getContext();
+                $originalSmarty = $this->context->smarty;
+                $this->context->smarty = $smarty;
+
+                try {
+                    $this->assignAttributesCombinations();
+                } finally {
+                    $this->context->smarty = $originalSmarty;
+                }
+
+                return $smarty->assigned;
+            }
+        };
+
+        $assigned = $controller->callAssignAttributesCombinations($product, $smarty);
+
+        self::assertArrayHasKey('attributesCombinations', $assigned);
+        self::assertIsArray($assigned['attributesCombinations']);
+        self::assertNotEmpty($assigned['attributesCombinations'], 'a product with combinations must produce rows');
+        self::assertArrayHasKey('attribute', $assigned['attributesCombinations'][0]);
+        self::assertArrayHasKey('group', $assigned['attributesCombinations'][0]);
+        self::assertSame(
+            Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'),
+            $assigned['attribute_anchor_separator']
+        );
+    }
+
+    /**
+     * The premise that makes dropping the call safe: nothing shipped reads the variable. If a consumer is
+     * ever added, it will read an undefined variable, and this says so before that ships.
+     */
+    public function testNothingShippedReadsTheVariable(): void
+    {
+        $root = _PS_ROOT_DIR_;
+        $roots = [$root . '/classes', $root . '/controllers', $root . '/src', $root . '/themes'];
+        $consumers = [];
+
+        foreach ($roots as $dir) {
+            if (!is_dir($dir)) {
+                continue;
+            }
+            $files = new RecursiveIteratorIterator(
+                new RecursiveCallbackFilterIterator(
+                    new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+                    static fn (SplFileInfo $file) => 'node_modules' !== $file->getFilename()
+                )
+            );
+            /** @var SplFileInfo $file */
+            foreach ($files as $file) {
+                if (!$file->isFile() || !in_array($file->getExtension(), ['php', 'tpl'], true)) {
+                    continue;
+                }
+                $path = $file->getPathname();
+                if (str_ends_with($path, 'controllers/front/ProductController.php')) {
+                    continue; // the deprecated method itself
+                }
+                if (str_contains((string) file_get_contents($path), 'attributesCombinations')) {
+                    $consumers[] = substr($path, strlen($root) + 1);
+                }
+            }
+        }
+
+        self::assertSame([], $consumers, 'the attributesCombinations variable is no longer assigned');
+    }
+
+    private function recordingSmarty()
+    {
+        return new class() extends Smarty {
+            /** @var array<string, mixed> */
+            public array $assigned = [];
+
+            public function assign($tpl_var, $value = null, $nocache = false)
+            {
+                if (is_array($tpl_var)) {
+                    $this->assigned = array_merge($this->assigned, $tpl_var);
+                } else {
+                    $this->assigned[$tpl_var] = $value;
+                }
+
+                return $this;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ProductController::assignAttributesCombinations()` runs on every product page. `Product::getAttributesInformationsByProduct()` returns one row per attribute per combination - its SELECT carries `pa.reference`, `pa.ean13`, `pa.isbn`, `pa.upc` and `pa.mpn`, so `DISTINCT` does not collapse it to one row per attribute - and the method then calls `Tools::str2url()` on every cell of every row before assigning the result as `attributesCombinations`. Nothing reads that variable: not core, not classic, not hummingbird, not a native module. The controller no longer calls the method; it assigns only the `attribute_anchor_separator` the method also set, which is a single `Configuration::get()`. The method itself stays, callable, and is marked deprecated for removal in 10.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Open a product page with many combinations and compare the time in `ProductController::initContent()`. `tests/Integration/Classes/Controller/ProductAttributesCombinationsTest.php` covers the two promises: the deprecated method still assigns `attributesCombinations` and `attribute_anchor_separator` when called explicitly, and nothing under `classes/`, `controllers/`, `src/` or `themes/` reads `attributesCombinations` any more.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36051
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/36056, https://github.com/PrestaShop/PrestaShop/pull/36039
| Sponsor company   |

### Measured on 9.2.x

The transform, replayed over the row shape the query returns (9 columns), on top of fetching those rows:

```
rows     cells      transform
 1000     9000        22 ms
 5000    45000        68 ms
20000   180000       275 ms
```

The reporter's product - 4 attributes over 5000 combinations - is the 20000-row line: roughly a quarter of
a second of pure CPU per page view, thrown away.

### Why not simply delete the method, and why not only deprecate it

Both were proposed on #36056 and both were half right.

Deleting it outright is what @kpodemski objected to, and correctly - it is a documented extension point and
an override may call it. It stays.

Deprecating it *while still calling it* was @the-ge's objection, also correct - the deprecation notice would
be addressed to core, which is the only caller, and the cost would remain. So the call goes and the method
stays.

The only observable change is that `attributesCombinations` is no longer assigned. Searched for a consumer
in core, in `classic` (develop), in `hummingbird` (2.x) and in the native modules of a 9.2 install: none. A
theme that still wants it can call the method from an override in one line, which the deprecation note says.

`attribute_anchor_separator` is kept because it costs one `Configuration::get()` and is the only part of
the method a template could plausibly use on its own.

### A lazier alternative I did not take

The variable could be kept by assigning a lazy `ArrayAccess`/`IteratorAggregate` wrapper that computes on
first access, so a template that reads it still works while a page that does not pays nothing. That is
about sixty lines of new infrastructure for a variable with no known consumer, and `{if $var}` on an object
is always truthy, which changes behaviour in its own way. Say so and I will build it instead.

### Test

Reverting only `controllers/front/ProductController.php` leaves both cases passing, because the change
removes a call rather than altering a result - the second case is mutation-checked by adding a file that
mentions the variable, which makes it fail naming that file.
