### PR TITLE
Report the files a cache clear could not delete instead of warning about them

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1029,23 +1029,30 @@ class ToolsCore
         $dirname = rtrim($dirname, '/') . '/';
         if (file_exists($dirname)) {
             if ($files = scandir($dirname, SCANDIR_SORT_NONE)) {
+                $deletedEverything = true;
+
                 foreach ($files as $file) {
                     if ($file != '.' && $file != '..' && $file != '.svn') {
                         if (is_dir($dirname . $file)) {
-                            Tools::deleteDirectory($dirname . $file);
-                        } elseif (file_exists($dirname . $file)) {
-                            unlink($dirname . $file);
+                            // WHY: the result used to be discarded, so a subdirectory that could not be
+                            // emptied still counted as a success for the whole tree.
+                            $deletedEverything = Tools::deleteDirectory($dirname . $file) && $deletedEverything;
+                        } else {
+                            // WHY: no file_exists() first. It cannot make this safe - the file can go away,
+                            // or become locked, between the check and the call - and unlink() reports the
+                            // same condition anyway. The diagnostic is silenced because a file another
+                            // process still holds is an expected outcome when clearing a cache, and the
+                            // caller is told through the return value instead of through a PHP warning.
+                            $deletedEverything = @unlink($dirname . $file) && $deletedEverything;
                         }
                     }
                 }
 
-                if ($delete_self) {
-                    if (!rmdir($dirname)) {
-                        return false;
-                    }
+                if ($delete_self && !@rmdir($dirname)) {
+                    return false;
                 }
 
-                return true;
+                return $deletedEverything;
             }
         }
 
@@ -1066,8 +1073,11 @@ class ToolsCore
             $exclude_files = [$exclude_files];
         }
 
-        if (file_exists($file) && is_file($file) && array_search(basename($file), $exclude_files) === false) {
-            return unlink($file);
+        // WHY: is_file() already implies the file exists, and unlink() reports a file that disappeared
+        // or is locked on its own. Silenced for the same reason as deleteDirectory(): the caller reads
+        // the return value.
+        if (is_file($file) && array_search(basename($file), $exclude_files) === false) {
+            return @unlink($file);
         }
 
         return false;

--- a/tests/Unit/Classes/ToolsDeleteDirectoryTest.php
+++ b/tests/Unit/Classes/ToolsDeleteDirectoryTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use PHPUnit\Framework\TestCase;
+use Tools;
+
+/**
+ * Clearing a cache is the main caller of these two helpers, and a file another process still holds is an
+ * expected outcome there. What must not happen is the caller being told the directory is empty when it is
+ * not, or a PHP warning reaching the page.
+ */
+class ToolsDeleteDirectoryTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/ps_delete_directory_' . uniqid();
+        mkdir($this->root . '/sub', 0777, true);
+        file_put_contents($this->root . '/sub/kept.txt', 'x');
+        file_put_contents($this->root . '/removable.txt', 'x');
+    }
+
+    protected function tearDown(): void
+    {
+        @chmod($this->root . '/sub', 0777);
+        @unlink($this->root . '/sub/kept.txt');
+        @rmdir($this->root . '/sub');
+        @unlink($this->root . '/removable.txt');
+        @rmdir($this->root);
+    }
+
+    public function testItEmptiesADirectory(): void
+    {
+        self::assertTrue(Tools::deleteDirectory($this->root, false));
+        self::assertFileDoesNotExist($this->root . '/removable.txt');
+        self::assertDirectoryDoesNotExist($this->root . '/sub');
+        self::assertDirectoryExists($this->root);
+    }
+
+    public function testItRemovesTheDirectoryItself(): void
+    {
+        self::assertTrue(Tools::deleteDirectory($this->root));
+        self::assertDirectoryDoesNotExist($this->root);
+    }
+
+    public function testItReportsAFileItCouldNotDelete(): void
+    {
+        // read + execute only: the entry cannot be unlinked from it
+        chmod($this->root . '/sub', 0500);
+        if (@unlink($this->root . '/sub/kept.txt')) {
+            self::markTestSkipped('the filesystem ignores directory permissions, most likely running as root');
+        }
+
+        $warnings = [];
+        set_error_handler(static function (int $number, string $message) use (&$warnings): bool {
+            // WHY: a custom handler is still called for a diagnostic the @ operator suppressed. What
+            // marks it as suppressed is error_reporting() being masked down inside the call.
+            if (0 === (error_reporting() & $number)) {
+                return true;
+            }
+            $warnings[] = $message;
+
+            return true;
+        });
+
+        try {
+            $result = Tools::deleteDirectory($this->root, false);
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertFalse($result, 'a directory that still holds a file must not report success');
+        self::assertFileExists($this->root . '/sub/kept.txt');
+        self::assertFileDoesNotExist($this->root . '/removable.txt', 'what could be deleted still is');
+        self::assertSame([], $warnings, 'the failure is reported through the return value, not a PHP warning');
+    }
+
+    public function testDeleteFileReportsAFileItCouldNotDelete(): void
+    {
+        chmod($this->root . '/sub', 0500);
+        if (@unlink($this->root . '/sub/kept.txt')) {
+            self::markTestSkipped('the filesystem ignores directory permissions, most likely running as root');
+        }
+
+        $warnings = [];
+        set_error_handler(static function (int $number, string $message) use (&$warnings): bool {
+            // WHY: a custom handler is still called for a diagnostic the @ operator suppressed. What
+            // marks it as suppressed is error_reporting() being masked down inside the call.
+            if (0 === (error_reporting() & $number)) {
+                return true;
+            }
+            $warnings[] = $message;
+
+            return true;
+        });
+
+        try {
+            $result = Tools::deleteFile($this->root . '/sub/kept.txt');
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertFalse($result);
+        self::assertSame([], $warnings);
+    }
+
+    public function testDeleteFileSkipsAnExcludedName(): void
+    {
+        self::assertFalse(Tools::deleteFile($this->root . '/removable.txt', ['removable.txt']));
+        self::assertFileExists($this->root . '/removable.txt');
+    }
+
+    public function testDeleteFileIgnoresADirectory(): void
+    {
+        self::assertFalse(Tools::deleteFile($this->root . '/sub'));
+        self::assertDirectoryExists($this->root . '/sub');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Tools::deleteDirectory()` calls `file_exists()` immediately before `unlink()`, then throws away what `unlink()` and its own recursive call return. A file another process still holds - the normal case on Windows, and reachable anywhere through a permissions or concurrency race - therefore produces a PHP warning on the page *and* is reported as a successful delete. The existence check cannot close that window and `unlink()` reports the same condition by itself, so it is dropped, the diagnostic is silenced, and the caller is told through the return value instead. `Tools::deleteFile()` carried the same redundant check; `is_file()` already implies existence.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `tests/Unit/Classes/ToolsDeleteDirectoryTest.php`. On 9.2.x, a directory holding one unremovable file makes `deleteDirectory()` return `true` after printing `unlink(): Permission denied` and `rmdir(): Directory not empty`; with this change it returns `false` and prints nothing, while everything that could be removed still is.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36282
| Related PRs       |
| Sponsor company   |

### Measured on 9.2.x

One directory, one file that cannot be unlinked (its parent is `0500`), one that can:

```
                          before      after
deleteDirectory() returns  true       false
unremovable file left      yes        yes
its directory left         yes        yes
removable file deleted     yes        yes
PHP warnings emitted        2          0
```

The two warnings are `unlink(...): Permission denied` and `rmdir(...): Directory not empty`.

### Why not just `@unlink`, which the issue suggests

That fixes the visible half and makes the other half worse: the call would then fail silently *and* still
report success. The return value is the part that was wrong. Note the recursion at the old line 1035 also
discarded its result, so a subdirectory that could not be emptied never affected the outcome either.

### Why not `Symfony\Component\Filesystem::remove()`

It is already a dependency and used a few hundred lines below in `removeSymfonyCache()`, and it would be the
natural replacement - but it signals failure by throwing `IOException`, while all six callers of
`deleteDirectory()` ignore the return value entirely and none is inside a try/catch. Swapping a bool API for
a throwing one there is a behaviour change well beyond this report. Keeping the bool contract and making it
honest is the smaller and safer move; converting the callers is a separate piece of work.

### Callers

All six discard the result (`classes/Language.php` x5, `src/PrestaShopBundle/Install/Install.php`), so
returning `false` where the old code returned `true` breaks nothing. It only stops a partial delete from
looking complete.

### Verification

- 6 unit tests, 16 assertions. Reverting only `classes/Tools.php` fails exactly the two behaviour cases -
  the lying return value and the unsuppressed warning - while the four control cases keep passing.
- `tests/Unit/Classes` + `tests/Unit/Adapter/ToolsTest.php`: 726 tests, 1 failure, and `upstream/9.2.x`
  produces the identical single failure at 720 tests (`ValidateCoreTest::testIsBirthDate`, which breaks on
  today's date). Base control run this session.
- php-cs-fixer clean, phpstan `[OK] No errors`.

### Test gotcha worth knowing

A custom `set_error_handler` is still invoked for a diagnostic the `@` operator suppressed, so asserting
"no warning" needs `0 === (error_reporting() & $number)` inside the handler. Without that check the test
fails against the fixed code.
