### PR TITLE
Leave the ecotax out of cart row prices when PS_USE_ECOTAX is disabled

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1090,13 +1090,17 @@ class CartCore extends ObjectModel
         &$specificPriceOutput
     ): array {
         $cartPrices = [];
+        // WHY: getOrderTotal() reads the same setting for the rows it builds itself (see the CartRow
+        // loop below), so hard-coding the ecotax in here made the cart disagree with its own total as
+        // soon as the feature was switched off while a product still carried an ecotax value.
+        $withEcoTax = (bool) $this->configuration->get('PS_USE_ECOTAX');
         $cartPrices['price_without_reduction'] = $this->getCartPriceFromCatalog(
             (int) $productRow['id_product'],
             isset($productRow['id_product_attribute']) ? (int) $productRow['id_product_attribute'] : null,
             (int) $productRow['id_customization'],
             true,
             false,
-            true,
+            $withEcoTax,
             $productQuantity,
             $addressId,
             $shopContext,
@@ -1109,7 +1113,7 @@ class CartCore extends ObjectModel
             (int) $productRow['id_customization'],
             false,
             false,
-            true,
+            $withEcoTax,
             $productQuantity,
             $addressId,
             $shopContext,
@@ -1122,7 +1126,7 @@ class CartCore extends ObjectModel
             (int) $productRow['id_customization'],
             true,
             true,
-            true,
+            $withEcoTax,
             $productQuantity,
             $addressId,
             $shopContext,
@@ -1135,7 +1139,7 @@ class CartCore extends ObjectModel
             (int) $productRow['id_customization'],
             false,
             true,
-            true,
+            $withEcoTax,
             $productQuantity,
             $addressId,
             $shopContext,

--- a/tests/Integration/Classes/CartTest.php
+++ b/tests/Integration/Classes/CartTest.php
@@ -35,6 +35,11 @@ class CartTest extends KernelTestCase
      */
     private static $id_address;
 
+    /**
+     * @var string|bool
+     */
+    private $useEcotaxBackup;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
@@ -312,6 +317,16 @@ class CartTest extends KernelTestCase
         Configuration::set('PS_CART_RULE_FEATURE_ACTIVE', true);
         Configuration::set('PS_GROUP_FEATURE_ACTIVE', true);
         Configuration::set('PS_ATCP_SHIPWRAP', false);
+        // The ecotax tests below flip this one, and a leaked value would silently change every price
+        // computed by the tests that run after them.
+        $this->useEcotaxBackup = Configuration::get('PS_USE_ECOTAX');
+    }
+
+    protected function tearDown(): void
+    {
+        Configuration::set('PS_USE_ECOTAX', $this->useEcotaxBackup);
+
+        parent::tearDown();
     }
 
     public function testBasicOnlyProducts(): void
@@ -455,5 +470,58 @@ class CartTest extends KernelTestCase
             $cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS),
             $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS)
         );
+    }
+
+    /**
+     * A cart has to add up to its own rows. Product::priceCalculation() adds the ecotax whenever the
+     * product carries one, so with the feature disabled the row prices kept including it while
+     * getOrderTotal() - which reads PS_USE_ECOTAX for the rows it builds itself - left it out.
+     */
+    public function testProductRowsLeaveOutTheEcotaxWhenTheFeatureIsDisabled(): void
+    {
+        Configuration::set('PS_USE_ECOTAX', false);
+
+        $product = self::makeProduct('Ecotax Disabled Product', 10, self::getIdTaxRulesGroup(20));
+        $product->ecotax = 7;
+        self::assertTrue($product->save());
+
+        $cart = self::makeCart();
+        $cart->updateQty(1, $product->id);
+
+        $rows = $cart->getProducts(true);
+        self::assertCount(1, $rows);
+
+        $this->assertEquals(
+            $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS),
+            $rows[0]['total'],
+            'the cart total does not match the sum of its own rows'
+        );
+        // And the value left out is the ecotax, not something else that happened to cancel out.
+        $this->assertEquals(10, $rows[0]['total']);
+    }
+
+    /**
+     * The control: with the feature enabled nothing changes, rows and total both carry the ecotax.
+     */
+    public function testProductRowsKeepTheEcotaxWhenTheFeatureIsEnabled(): void
+    {
+        Configuration::set('PS_USE_ECOTAX', true);
+
+        $product = self::makeProduct('Ecotax Enabled Product', 10, self::getIdTaxRulesGroup(20));
+        $product->ecotax = 7;
+        self::assertTrue($product->save());
+
+        $cart = self::makeCart();
+        $cart->updateQty(1, $product->id);
+
+        $rows = $cart->getProducts(true);
+        self::assertCount(1, $rows);
+
+        $this->assertEquals(
+            $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS),
+            $rows[0]['total'],
+            'the cart total does not match the sum of its own rows'
+        );
+        $this->assertGreaterThan(10, $rows[0]['total'], 'the ecotax is missing from the row price');
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Cart::getOrderTotal()` reads `PS_USE_ECOTAX` for the rows it builds itself, but `Cart::getCartPrices()` passed `$withEcoTax = true` unconditionally to all four of its `getCartPriceFromCatalog()` calls. `Product::priceCalculation()` adds the ecotax whenever the product carries a non-zero one and never consults the setting, so with the feature disabled a cart stopped adding up to its own rows. The four call sites now read the setting the same way `getOrderTotal()` does.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the ecotax, give a product a non-zero ecotax, disable the ecotax again, then put a value back on `ps_product_shop.ecotax` (or use a combination, whose value `resetEcoTax()` never clears - see #42689). Add one unit to a cart. Before this change the cart row price includes the ecotax while `getOrderTotal(false, Cart::ONLY_PRODUCTS)` excludes it; after, both exclude it. With the ecotax enabled nothing changes in either direction.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42686
| Related PRs       |
| Sponsor company   |

## Why the four call sites and not `priceCalculation()`

`Product::getPriceStatic()` declares `$with_ecotax = true` as its default (`classes/Product.php:3377`).
A config read inside `priceCalculation()` would therefore override the explicit `true` that deliberate
callers pass, and the parameter would stop meaning what it says. The policy belongs to the caller that
knows the context; the seam stays in the callee. `Cart::getCartPrices()` is that caller, and it now
resolves the setting exactly as `Cart::getOrderTotal()` does at `classes/Cart.php:2361`, through
`$this->configuration` rather than a static `Configuration::get()`, so the row and the total cannot
resolve different values under a shop constraint.

## Existing orders are unaffected

Order re-pricing does not go through this path. `Product::getPriceFromOrder()`
(`classes/Product.php:3852`) reads `unit_price_tax_excl`, `original_product_price` and `ecotax` straight
out of `ps_order_detail`, so a stored order keeps the values it was written with. Only new carts change.

## Evidence

One line of product 1 (1519.20 tax excl.) with `ps_product.ecotax = 7.00`, tax-excluded row total
against `getOrderTotal(false, Cart::ONLY_PRODUCTS)`, measured on a 9.2 shop:

```
                            cart rows   ONLY_PRODUCTS    diff
  base,    PS_USE_ECOTAX=1    1524.80       1524.80      0.00
  base,    PS_USE_ECOTAX=0    1524.80       1519.20      5.60
  patched, PS_USE_ECOTAX=1    1524.80       1524.80      0.00
  patched, PS_USE_ECOTAX=0    1519.20       1519.20      0.00
```

Row 1 is the control that pins the direction: the totals path already moves with the setting, the rows
path never does. Row 3 is identical to row 1, so the change is inert while the feature is on.

Test: two cases in `tests/Integration/Classes/CartTest.php`. Reverting the four call sites fails the
disabled case at 17.00 against a cart total of 10.00 and leaves the enabled control green.
`tests/Integration/Classes` plus `tests/Integration/Adapter` report the same 8 errors and 2 failures as
the untouched base branch (320 tests against 318, the difference being the two added cases).
`php-cs-fixer` and `phpstan` clean on both files.

## Scope

Covers the cart disagreeing with its own rows, which is measurable. The front office product page price
raised in the issue's expected-behaviour section goes through `Product::getPriceStatic()` directly and is
the display question discussed in #35245; deliberately not addressed here.

## Not a duplicate

#35232 (nelero, open, base `develop`) is ecotax-related but a different defect - the order of operations
between a discount and the ecotax - and touches `classes/Product.php` only. Of my own 366 open core PRs,
11 touch `classes/Cart.php`; the nearest hunk to this one is #42194 at old line 1318, 176 lines clear of
this change's 1090-1142 range.
