### PR TITLE
Clear the ecotax on combinations when the feature is disabled

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7197,9 +7197,19 @@ class ProductCore extends ObjectModel
      */
     public static function resetEcoTax()
     {
-        return ObjectModel::updateMultishopTable('product', [
+        $productsReset = ObjectModel::updateMultishopTable('product', [
             'ecotax' => 0,
         ]);
+
+        // WHY combinations too: priceCalculation() prefers the combination's ecotax over the
+        // product's, so a value left on product_attribute keeps being added to the price after the
+        // feature is switched off - and the back office hides the ecotax inputs at that point, so
+        // there is no way left to clear it.
+        $combinationsReset = ObjectModel::updateMultishopTable('Combination', [
+            'ecotax' => 0,
+        ]);
+
+        return $productsReset && $combinationsReset;
     }
 
     /**

--- a/tests/Integration/Classes/Product/ResetEcoTaxTest.php
+++ b/tests/Integration/Classes/Product/ResetEcoTaxTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Product;
+
+use Db;
+use PHPUnit\Framework\TestCase;
+use Product;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * Switching "Enable ecotax" off runs Product::resetEcoTax(). Product::priceCalculation() prefers a
+ * combination's ecotax over the product's, so anything left on product_attribute keeps being charged
+ * after the feature is off - and the back office hides the inputs then, so nothing can clear it.
+ */
+class ResetEcoTaxTest extends TestCase
+{
+    private const PRODUCT_ECOTAX = 3.0;
+    private const COMBINATION_ECOTAX = 7.0;
+
+    private int $productId;
+    private int $combinationId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->productId = (int) Db::getInstance()->getValue(
+            'SELECT id_product FROM ' . _DB_PREFIX_ . 'product_attribute ORDER BY id_product'
+        );
+        $this->combinationId = (int) Db::getInstance()->getValue(
+            'SELECT id_product_attribute FROM ' . _DB_PREFIX_ . 'product_attribute WHERE id_product = '
+            . $this->productId . ' ORDER BY id_product_attribute'
+        );
+
+        $this->setEcotax('product', 'id_product', $this->productId, self::PRODUCT_ECOTAX);
+        $this->setEcotax('product_shop', 'id_product', $this->productId, self::PRODUCT_ECOTAX);
+        $this->setEcotax('product_attribute', 'id_product_attribute', $this->combinationId, self::COMBINATION_ECOTAX);
+        $this->setEcotax('product_attribute_shop', 'id_product_attribute', $this->combinationId, self::COMBINATION_ECOTAX);
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(['product', 'product_shop', 'product_attribute', 'product_attribute_shop']);
+
+        parent::tearDown();
+    }
+
+    public function testItClearsTheEcotaxOnProductsAndOnTheirCombinations(): void
+    {
+        // Guards against a fixture that was already zero, which would make every assertion vacuous.
+        $this->assertSame(self::PRODUCT_ECOTAX, $this->ecotaxOf('product', 'id_product', $this->productId));
+        $this->assertSame(self::COMBINATION_ECOTAX, $this->ecotaxOf('product_attribute', 'id_product_attribute', $this->combinationId));
+
+        $this->assertTrue(Product::resetEcoTax());
+
+        $this->assertSame(0.0, $this->ecotaxOf('product', 'id_product', $this->productId));
+        $this->assertSame(0.0, $this->ecotaxOf('product_shop', 'id_product', $this->productId));
+        $this->assertSame(0.0, $this->ecotaxOf('product_attribute', 'id_product_attribute', $this->combinationId));
+        $this->assertSame(0.0, $this->ecotaxOf('product_attribute_shop', 'id_product_attribute', $this->combinationId));
+    }
+
+    /**
+     * The symptom the reset exists to prevent: the combination stays priced with an ecotax the
+     * merchant has switched off and can no longer edit.
+     */
+    public function testTheCombinationIsNoLongerPricedWithTheEcotaxAfterTheReset(): void
+    {
+        $withEcotax = $this->combinationPrice();
+
+        Product::resetEcoTax();
+        $afterReset = $this->combinationPrice();
+
+        $this->assertEqualsWithDelta(self::COMBINATION_ECOTAX, $withEcotax - $afterReset, 0.01);
+    }
+
+    private function combinationPrice(): float
+    {
+        Product::flushPriceCache();
+        $specificPrice = null;
+
+        return (float) Product::getPriceStatic(
+            $this->productId,
+            false,
+            $this->combinationId,
+            6,
+            null,
+            false,
+            false,
+            1,
+            false,
+            null,
+            null,
+            null,
+            $specificPrice,
+            true
+        );
+    }
+
+    private function setEcotax(string $table, string $key, int $id, float $value): void
+    {
+        Db::getInstance()->execute(
+            'UPDATE ' . _DB_PREFIX_ . $table . ' SET ecotax = ' . $value . ' WHERE ' . $key . ' = ' . $id
+        );
+    }
+
+    private function ecotaxOf(string $table, string $key, int $id): float
+    {
+        return (float) Db::getInstance()->getValue(
+            'SELECT ecotax FROM ' . _DB_PREFIX_ . $table . ' WHERE ' . $key . ' = ' . $id
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Product::resetEcoTax()` runs when a merchant switches "Enable ecotax" off. It cleared `product` and `product_shop` but never `product_attribute`, so a combination kept its value - and `priceCalculation()` prefers the combination's ecotax over the product's, so the combination went on being sold with an ecotax the shop no longer charges. The back office hides the ecotax inputs once the feature is off, so nothing was left to clear it with. `Combination::$definition` declares `ecotax` with `'shop' => true` exactly as `Product` does, so one more `updateMultishopTable()` call reaches both of its tables.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Give a product an ecotax and one of its combinations a different one, then International > Taxes > switch "Enable ecotax" off. Before this change the combination is still priced with its ecotax and no field remains to edit it; after, both are cleared. `php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/Product/ResetEcoTaxTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42689
| Related PRs       |
| Sponsor company   |

## Deliberately not included

The issue also reports the `!$this->shopContext->isAllShopContext()` condition in
`TaxOptionsConfiguration::updateEcotax()`. **Left alone on purpose.** `PS_USE_ECOTAX` is multistore
overridable, so disabling it from the all-shops context writes the all-shops value while a shop with its
own override keeps the feature ON. `ObjectModel::updateMultishopTable()` joins through
`Shop::addSqlAssociation()` against the current shop context, so deleting the condition would make the
all-shops save wipe `product.ecotax` and `product_attribute.ecotax` for every shop - including the ones
still charging it. Irreversible and wrong for those shops, not merely broad. Clearing the values from
that context correctly means scoping to shops that do not override the setting, which is a different
change and needs its own issue. Said so on the thread.

## Evidence

Measured on 9.2, driving `Product::resetEcoTax()` with product ecotax 3.00 and combination ecotax 7.00:

```
                    product / product_shop    combination / combination_shop    combination price excl
  before                 3.00 / 3.00                 7.00 / 7.00                       1524.80
  after resetEcoTax()    0.00 / 0.00                 7.00 / 7.00                       1524.80   <- bug
  clearing it by hand    0.00 / 0.00                 0.00 / 0.00                       1519.20   <- control
  after, with this fix   0.00 / 0.00                 0.00 / 0.00                       1519.20
```

Test: `tests/Integration/Classes/Product/ResetEcoTaxTest.php`, 2 cases, 8 assertions - the four columns,
and the price delta the reset is supposed to remove. The first case asserts the fixture is non-zero
before resetting, so it cannot pass vacuously. Mutation: reverting `classes/Product.php` to the base
branch fails both.

`'Combination'` casing matters: lowercase works while the shop is serving requests but raises
`Class "combination" not found` from `ObjectModel::getDefinition()` under the integration kernel. The
capitalised form is what the rest of `classes/Product.php` already uses (lines 1918, 1936, 1953, 4307).
