### PR TITLE
Stop charging EU VAT on the United Kingdom in the localization packs

### DIFF
--- a/localization/at.xml
+++ b/localization/at.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="AT Reduced Rate (13%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="AT Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="AT Foodstuff Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="AT Zero Rate (0%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -192,7 +188,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="at" id_tax="1"/>
@@ -206,7 +201,6 @@
       <taxRule iso_code_country="es" id_tax="12"/>
       <taxRule iso_code_country="fi" id_tax="13"/>
       <taxRule iso_code_country="fr" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
       <taxRule iso_code_country="gr" id_tax="16"/>
       <taxRule iso_code_country="hr" id_tax="17"/>
       <taxRule iso_code_country="hu" id_tax="18"/>

--- a/localization/be.xml
+++ b/localization/be.xml
@@ -69,7 +69,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="BE Reduced Rate (12%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -100,7 +99,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="BE Super Reduced Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -131,7 +129,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="BE Foodstuff Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -162,7 +159,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="BE Books Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -193,7 +189,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -207,7 +202,6 @@
       <taxRule iso_code_country="es" id_tax="11"/>
       <taxRule iso_code_country="fi" id_tax="12"/>
       <taxRule iso_code_country="fr" id_tax="13"/>
-      <taxRule iso_code_country="gb" id_tax="14"/>
       <taxRule iso_code_country="gr" id_tax="15"/>
       <taxRule iso_code_country="hr" id_tax="16"/>
       <taxRule iso_code_country="hu" id_tax="17"/>

--- a/localization/bg.xml
+++ b/localization/bg.xml
@@ -67,7 +67,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="BG Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -98,7 +97,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="BG Zero Rate (0%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -129,7 +127,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="bg" id_tax="1"/>
@@ -143,7 +140,6 @@
       <taxRule iso_code_country="es" id_tax="11"/>
       <taxRule iso_code_country="fi" id_tax="12"/>
       <taxRule iso_code_country="fr" id_tax="13"/>
-      <taxRule iso_code_country="gb" id_tax="14"/>
       <taxRule iso_code_country="gr" id_tax="15"/>
       <taxRule iso_code_country="hr" id_tax="16"/>
       <taxRule iso_code_country="hu" id_tax="17"/>

--- a/localization/cy.xml
+++ b/localization/cy.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="CY Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="CY Super Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="CY Books Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="cy" id_tax="1"/>
@@ -175,7 +171,6 @@
       <taxRule iso_code_country="es" id_tax="11"/>
       <taxRule iso_code_country="fi" id_tax="12"/>
       <taxRule iso_code_country="fr" id_tax="13"/>
-      <taxRule iso_code_country="gb" id_tax="14"/>
       <taxRule iso_code_country="gr" id_tax="15"/>
       <taxRule iso_code_country="hr" id_tax="16"/>
       <taxRule iso_code_country="hu" id_tax="17"/>

--- a/localization/cz.xml
+++ b/localization/cz.xml
@@ -66,7 +66,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="CZ Snížená sazba (12%)">
       <taxRule iso_code_country="be" id_tax="32"/>
@@ -97,7 +96,6 @@
       <taxRule iso_code_country="sk" id_tax="32"/>
       <taxRule iso_code_country="fi" id_tax="32"/>
       <taxRule iso_code_country="se" id_tax="32"/>
-      <taxRule iso_code_country="gb" id_tax="32"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="cz" id_tax="1"/>
@@ -111,7 +109,6 @@
       <taxRule iso_code_country="es" id_tax="10"/>
       <taxRule iso_code_country="fi" id_tax="11"/>
       <taxRule iso_code_country="fr" id_tax="12"/>
-      <taxRule iso_code_country="gb" id_tax="13"/>
       <taxRule iso_code_country="gr" id_tax="14"/>
       <taxRule iso_code_country="hr" id_tax="15"/>
       <taxRule iso_code_country="hu" id_tax="16"/>

--- a/localization/de.xml
+++ b/localization/de.xml
@@ -66,7 +66,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="DE Reduced Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -97,7 +96,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="DE Foodstuff Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -128,7 +126,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="DE Books Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -159,7 +156,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="de" id_tax="1"/>
@@ -173,7 +169,6 @@
       <taxRule iso_code_country="es" id_tax="10"/>
       <taxRule iso_code_country="fi" id_tax="11"/>
       <taxRule iso_code_country="fr" id_tax="12"/>
-      <taxRule iso_code_country="gb" id_tax="13"/>
       <taxRule iso_code_country="gr" id_tax="14"/>
       <taxRule iso_code_country="hr" id_tax="15"/>
       <taxRule iso_code_country="hu" id_tax="16"/>

--- a/localization/dk.xml
+++ b/localization/dk.xml
@@ -65,7 +65,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="dk" id_tax="1"/>
@@ -79,7 +78,6 @@
       <taxRule iso_code_country="es" id_tax="9"/>
       <taxRule iso_code_country="fi" id_tax="10"/>
       <taxRule iso_code_country="fr" id_tax="11"/>
-      <taxRule iso_code_country="gb" id_tax="12"/>
       <taxRule iso_code_country="gr" id_tax="13"/>
       <taxRule iso_code_country="hr" id_tax="14"/>
       <taxRule iso_code_country="hu" id_tax="15"/>

--- a/localization/ee.xml
+++ b/localization/ee.xml
@@ -66,7 +66,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="EE Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -97,7 +96,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EE Foodstuff Rate (20%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -128,7 +126,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="EE Books Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -159,7 +156,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="ee" id_tax="1"/>
@@ -173,7 +169,6 @@
       <taxRule iso_code_country="es" id_tax="10"/>
       <taxRule iso_code_country="fi" id_tax="11"/>
       <taxRule iso_code_country="fr" id_tax="12"/>
-      <taxRule iso_code_country="gb" id_tax="13"/>
       <taxRule iso_code_country="gr" id_tax="14"/>
       <taxRule iso_code_country="hr" id_tax="15"/>
       <taxRule iso_code_country="hu" id_tax="16"/>

--- a/localization/es.xml
+++ b/localization/es.xml
@@ -67,7 +67,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="ES Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -98,7 +97,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="ES Super Reduced Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -129,7 +127,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="ES Foodstuff Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -160,7 +157,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="ES Books Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -191,7 +187,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="es" id_tax="1"/>
@@ -205,7 +200,6 @@
       <taxRule iso_code_country="ee" id_tax="11"/>
       <taxRule iso_code_country="fi" id_tax="12"/>
       <taxRule iso_code_country="fr" id_tax="13"/>
-      <taxRule iso_code_country="gb" id_tax="14"/>
       <taxRule iso_code_country="gr" id_tax="15"/>
       <taxRule iso_code_country="hr" id_tax="16"/>
       <taxRule iso_code_country="hu" id_tax="17"/>

--- a/localization/fi.xml
+++ b/localization/fi.xml
@@ -67,7 +67,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="FI Reduced Rate (13.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -98,7 +97,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="FI Super Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -129,7 +127,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="FI Foodstuff Rate (13.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -160,7 +157,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="FI Books Rate (10%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -191,7 +187,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="fi" id_tax="1"/>
@@ -205,7 +200,6 @@
       <taxRule iso_code_country="ee" id_tax="11"/>
       <taxRule iso_code_country="es" id_tax="12"/>
       <taxRule iso_code_country="fr" id_tax="13"/>
-      <taxRule iso_code_country="gb" id_tax="14"/>
       <taxRule iso_code_country="gr" id_tax="15"/>
       <taxRule iso_code_country="hr" id_tax="16"/>
       <taxRule iso_code_country="hu" id_tax="17"/>

--- a/localization/fr.xml
+++ b/localization/fr.xml
@@ -77,7 +77,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="FR Taux réduit (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -108,7 +107,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="FR Taux réduit (5.5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -139,7 +137,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="FR Taux super réduit (2.1%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -170,7 +167,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="fr" id_tax="1"/>
@@ -184,7 +180,6 @@
       <taxRule iso_code_country="ee" id_tax="12"/>
       <taxRule iso_code_country="es" id_tax="13"/>
       <taxRule iso_code_country="fi" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
       <taxRule iso_code_country="gr" id_tax="16"/>
       <taxRule iso_code_country="hr" id_tax="17"/>
       <taxRule iso_code_country="hu" id_tax="18"/>

--- a/localization/gr.xml
+++ b/localization/gr.xml
@@ -67,7 +67,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="GR Reduced Rate (13%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -98,7 +97,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="GR Super Reduced Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -129,7 +127,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="gr" id_tax="1"/>
@@ -144,7 +141,6 @@
       <taxRule iso_code_country="es" id_tax="12"/>
       <taxRule iso_code_country="fi" id_tax="13"/>
       <taxRule iso_code_country="fr" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
       <taxRule iso_code_country="hr" id_tax="16"/>
       <taxRule iso_code_country="hu" id_tax="17"/>
       <taxRule iso_code_country="ie" id_tax="18"/>

--- a/localization/hr.xml
+++ b/localization/hr.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="Croatia Reduced Rate 13%">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="Croatia Reduced Rate 5%">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="Croatia Zero Rate 0%">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="uk" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="hr" id_tax="1"/>
@@ -176,7 +172,6 @@
       <taxRule iso_code_country="es" id_tax="13"/>
       <taxRule iso_code_country="fi" id_tax="14"/>
       <taxRule iso_code_country="fr" id_tax="15"/>
-      <taxRule iso_code_country="gb" id_tax="16"/>
       <taxRule iso_code_country="gr" id_tax="17"/>
       <taxRule iso_code_country="hu" id_tax="18"/>
       <taxRule iso_code_country="ie" id_tax="19"/>

--- a/localization/hu.xml
+++ b/localization/hu.xml
@@ -67,7 +67,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="HU Reduced Rate (18%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -98,7 +97,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="HU Super Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -129,7 +127,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="HU Foodstuff Rate (27%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -160,7 +157,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="HU Books Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -191,7 +187,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="hu" id_tax="1"/>
@@ -206,7 +201,6 @@
       <taxRule iso_code_country="es" id_tax="12"/>
       <taxRule iso_code_country="fi" id_tax="13"/>
       <taxRule iso_code_country="fr" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
       <taxRule iso_code_country="gr" id_tax="16"/>
       <taxRule iso_code_country="hr" id_tax="17"/>
       <taxRule iso_code_country="ie" id_tax="18"/>

--- a/localization/ie.xml
+++ b/localization/ie.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="IE Reduced Rate (13.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="IE Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="IE Super Reduced Rate (4.8%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="ie" id_tax="1"/>
@@ -176,7 +172,6 @@
       <taxRule iso_code_country="es" id_tax="13"/>
       <taxRule iso_code_country="fi" id_tax="14"/>
       <taxRule iso_code_country="fr" id_tax="15"/>
-      <taxRule iso_code_country="gb" id_tax="16"/>
       <taxRule iso_code_country="gr" id_tax="17"/>
       <taxRule iso_code_country="hr" id_tax="18"/>
       <taxRule iso_code_country="hu" id_tax="19"/>

--- a/localization/it.xml
+++ b/localization/it.xml
@@ -69,7 +69,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="IT Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -100,7 +99,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="IT Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -131,7 +129,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="IT Reduced Rate (4%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -162,7 +159,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="IT Zero Rate (0%)">
       <taxRule iso_code_country="be" id_tax="5"/>
@@ -193,7 +189,6 @@
       <taxRule iso_code_country="sk" id_tax="5"/>
       <taxRule iso_code_country="fi" id_tax="5"/>
       <taxRule iso_code_country="se" id_tax="5"/>
-      <taxRule iso_code_country="gb" id_tax="5"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="it" id_tax="1"/>
@@ -208,7 +203,6 @@
       <taxRule iso_code_country="es" id_tax="14"/>
       <taxRule iso_code_country="fi" id_tax="15"/>
       <taxRule iso_code_country="fr" id_tax="16"/>
-      <taxRule iso_code_country="gb" id_tax="17"/>
       <taxRule iso_code_country="gr" id_tax="18"/>
       <taxRule iso_code_country="hr" id_tax="19"/>
       <taxRule iso_code_country="hu" id_tax="20"/>

--- a/localization/lt.xml
+++ b/localization/lt.xml
@@ -67,7 +67,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="LT Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -98,7 +97,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="LT Super Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -129,7 +127,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="LT Foodstuff Rate (21%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -160,7 +157,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="LT Books Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -191,7 +187,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="lt" id_tax="1"/>
@@ -206,7 +201,6 @@
       <taxRule iso_code_country="es" id_tax="12"/>
       <taxRule iso_code_country="fi" id_tax="13"/>
       <taxRule iso_code_country="fr" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
       <taxRule iso_code_country="gr" id_tax="16"/>
       <taxRule iso_code_country="hr" id_tax="17"/>
       <taxRule iso_code_country="hu" id_tax="18"/>

--- a/localization/lu.xml
+++ b/localization/lu.xml
@@ -69,7 +69,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Reduced Rate (14%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -100,7 +99,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Reduced Rate (8%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -131,7 +129,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Super Reduced Rate (3%)">
       <taxRule iso_code_country="be" id_tax="5"/>
@@ -162,7 +159,6 @@
       <taxRule iso_code_country="sk" id_tax="5"/>
       <taxRule iso_code_country="fi" id_tax="5"/>
       <taxRule iso_code_country="se" id_tax="5"/>
-      <taxRule iso_code_country="gb" id_tax="5"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Foodstuff Rate (3%)">
       <taxRule iso_code_country="be" id_tax="5"/>
@@ -193,7 +189,6 @@
       <taxRule iso_code_country="sk" id_tax="5"/>
       <taxRule iso_code_country="fi" id_tax="5"/>
       <taxRule iso_code_country="se" id_tax="5"/>
-      <taxRule iso_code_country="gb" id_tax="5"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Books Rate (3%)">
       <taxRule iso_code_country="be" id_tax="5"/>
@@ -224,7 +219,6 @@
       <taxRule iso_code_country="sk" id_tax="5"/>
       <taxRule iso_code_country="fi" id_tax="5"/>
       <taxRule iso_code_country="se" id_tax="5"/>
-      <taxRule iso_code_country="gb" id_tax="5"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="lu" id_tax="1"/>
@@ -239,7 +233,6 @@
       <taxRule iso_code_country="es" id_tax="14"/>
       <taxRule iso_code_country="fi" id_tax="15"/>
       <taxRule iso_code_country="fr" id_tax="16"/>
-      <taxRule iso_code_country="gb" id_tax="17"/>
       <taxRule iso_code_country="gr" id_tax="18"/>
       <taxRule iso_code_country="hr" id_tax="19"/>
       <taxRule iso_code_country="hu" id_tax="20"/>

--- a/localization/lv.xml
+++ b/localization/lv.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="LV Reduced Rate (12%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="LV Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="LV Zero Rate (0%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="lv" id_tax="1"/>
@@ -176,7 +172,6 @@
       <taxRule iso_code_country="es" id_tax="13"/>
       <taxRule iso_code_country="fi" id_tax="14"/>
       <taxRule iso_code_country="fr" id_tax="15"/>
-      <taxRule iso_code_country="gb" id_tax="16"/>
       <taxRule iso_code_country="gr" id_tax="17"/>
       <taxRule iso_code_country="hr" id_tax="18"/>
       <taxRule iso_code_country="hu" id_tax="19"/>

--- a/localization/mc.xml
+++ b/localization/mc.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="MC Taux réduit (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="MC Taux réduit (5.5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="MC Taux super réduit (2.1%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="mc" id_tax="1"/>
@@ -176,7 +172,6 @@
       <taxRule iso_code_country="es" id_tax="13"/>
       <taxRule iso_code_country="fi" id_tax="14"/>
       <taxRule iso_code_country="fr" id_tax="15"/>
-      <taxRule iso_code_country="gb" id_tax="16"/>
       <taxRule iso_code_country="gr" id_tax="17"/>
       <taxRule iso_code_country="hr" id_tax="18"/>
       <taxRule iso_code_country="hu" id_tax="19"/>

--- a/localization/mt.xml
+++ b/localization/mt.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="MT Reduced Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="MT Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="MT Reduced Rate (0%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="mt" id_tax="1"/>
@@ -176,7 +172,6 @@
       <taxRule iso_code_country="es" id_tax="13"/>
       <taxRule iso_code_country="fi" id_tax="14"/>
       <taxRule iso_code_country="fr" id_tax="15"/>
-      <taxRule iso_code_country="gb" id_tax="16"/>
       <taxRule iso_code_country="gr" id_tax="17"/>
       <taxRule iso_code_country="hr" id_tax="18"/>
       <taxRule iso_code_country="hu" id_tax="19"/>

--- a/localization/nl.xml
+++ b/localization/nl.xml
@@ -66,7 +66,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="NL Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -97,7 +96,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="NL Foodstuff Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -128,7 +126,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="NL Books Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -159,7 +156,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="nl" id_tax="1"/>
@@ -174,7 +170,6 @@
       <taxRule iso_code_country="es" id_tax="11"/>
       <taxRule iso_code_country="fi" id_tax="12"/>
       <taxRule iso_code_country="fr" id_tax="13"/>
-      <taxRule iso_code_country="gb" id_tax="14"/>
       <taxRule iso_code_country="gr" id_tax="15"/>
       <taxRule iso_code_country="hr" id_tax="16"/>
       <taxRule iso_code_country="hu" id_tax="17"/>

--- a/localization/pl.xml
+++ b/localization/pl.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="PL Reduced Rate (8%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="PL Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -129,7 +127,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="PL Exempted Rate (0%)">
       <taxRule iso_code_country="be" id_tax="6"/>
@@ -159,7 +156,6 @@
       <taxRule iso_code_country="sk" id_tax="6"/>
       <taxRule iso_code_country="fi" id_tax="6"/>
       <taxRule iso_code_country="se" id_tax="6"/>
-      <taxRule iso_code_country="gb" id_tax="6"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="pl" id_tax="1"/>
@@ -174,7 +170,6 @@
       <taxRule iso_code_country="es" id_tax="15"/>
       <taxRule iso_code_country="fi" id_tax="16"/>
       <taxRule iso_code_country="fr" id_tax="17"/>
-      <taxRule iso_code_country="gb" id_tax="18"/>
       <taxRule iso_code_country="gr" id_tax="19"/>
       <taxRule iso_code_country="hr" id_tax="20"/>
       <taxRule iso_code_country="hu" id_tax="21"/>

--- a/localization/pt.xml
+++ b/localization/pt.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="PT Reduced Rate (13%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="PT Super Reduced Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="PT Zero Rate (0%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="pt" id_tax="1"/>
@@ -176,7 +172,6 @@
       <taxRule iso_code_country="es" id_tax="13"/>
       <taxRule iso_code_country="fi" id_tax="14"/>
       <taxRule iso_code_country="fr" id_tax="15"/>
-      <taxRule iso_code_country="gb" id_tax="16"/>
       <taxRule iso_code_country="gr" id_tax="17"/>
       <taxRule iso_code_country="hr" id_tax="18"/>
       <taxRule iso_code_country="hu" id_tax="19"/>

--- a/localization/ro.xml
+++ b/localization/ro.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="RO Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="RO Super Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="RO Zero Rate (0%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="gb" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="ro" id_tax="1"/>
@@ -176,7 +172,6 @@
       <taxRule iso_code_country="es" id_tax="13"/>
       <taxRule iso_code_country="fi" id_tax="14"/>
       <taxRule iso_code_country="fr" id_tax="15"/>
-      <taxRule iso_code_country="gb" id_tax="16"/>
       <taxRule iso_code_country="gr" id_tax="17"/>
       <taxRule iso_code_country="hr" id_tax="18"/>
       <taxRule iso_code_country="hu" id_tax="19"/>

--- a/localization/se.xml
+++ b/localization/se.xml
@@ -68,7 +68,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="SE Reduced Rate (12%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -99,7 +98,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SE Super Reduced Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -130,7 +128,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="SE Zero Rate (0%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -161,7 +158,6 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="uk" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="se" id_tax="1"/>
@@ -176,7 +172,6 @@
       <taxRule iso_code_country="es" id_tax="13"/>
       <taxRule iso_code_country="fi" id_tax="14"/>
       <taxRule iso_code_country="fr" id_tax="15"/>
-      <taxRule iso_code_country="gb" id_tax="16"/>
       <taxRule iso_code_country="gr" id_tax="17"/>
       <taxRule iso_code_country="hr" id_tax="18"/>
       <taxRule iso_code_country="hu" id_tax="19"/>

--- a/localization/si.xml
+++ b/localization/si.xml
@@ -66,7 +66,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="SI Reduced Rate (9.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -97,7 +96,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SI Foodstuff Rate (9.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -128,7 +126,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SI Books Rate (9.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -159,7 +156,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="si" id_tax="1"/>
@@ -174,7 +170,6 @@
       <taxRule iso_code_country="es" id_tax="11"/>
       <taxRule iso_code_country="fi" id_tax="12"/>
       <taxRule iso_code_country="fr" id_tax="13"/>
-      <taxRule iso_code_country="gb" id_tax="14"/>
       <taxRule iso_code_country="gr" id_tax="15"/>
       <taxRule iso_code_country="hr" id_tax="16"/>
       <taxRule iso_code_country="hu" id_tax="17"/>

--- a/localization/sk.xml
+++ b/localization/sk.xml
@@ -67,7 +67,6 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="SK Reduced Rate 1 (19%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -98,7 +97,6 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SK Reduced Rate 2 (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -129,7 +127,6 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="sk" id_tax="1"/>
@@ -144,7 +141,6 @@
       <taxRule iso_code_country="es" id_tax="12"/>
       <taxRule iso_code_country="fi" id_tax="13"/>
       <taxRule iso_code_country="fr" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
       <taxRule iso_code_country="gr" id_tax="16"/>
       <taxRule iso_code_country="hr" id_tax="17"/>
       <taxRule iso_code_country="hu" id_tax="18"/>

--- a/tests/Unit/Localization/LocalizationPackTaxRuleCountriesTest.php
+++ b/tests/Unit/Localization/LocalizationPackTaxRuleCountriesTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Localization;
+
+use PHPUnit\Framework\TestCase;
+use SimpleXMLElement;
+
+/**
+ * The tax rules a localization pack ships are matched to countries by ISO code at install time
+ * (LocalizationPack::_installTaxes()), and an ISO that matches nothing is skipped without a word.
+ */
+class LocalizationPackTaxRuleCountriesTest extends TestCase
+{
+    private const UNITED_KINGDOM = 'GB';
+
+    /**
+     * @var string[] uppercase ISO codes of every country the installer creates
+     */
+    private static array $knownCountries;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $countries = new SimpleXMLElement((string) file_get_contents(self::rootDir() . '/install-dev/data/xml/country.xml'), 0, false);
+        self::$knownCountries = [];
+        foreach ($countries->entities->country as $country) {
+            self::$knownCountries[] = strtoupper((string) $country['id']);
+        }
+    }
+
+    /**
+     * A tax rule naming a country that does not exist is dead weight: it never becomes a rule, and
+     * nothing reports it. `uk` sat in two packs this way, next to a working `gb` entry.
+     */
+    public function testEveryTaxRuleNamesACountryTheInstallerCreates(): void
+    {
+        $this->assertGreaterThan(200, count(self::$knownCountries));
+
+        $unknown = [];
+        $rules = 0;
+        foreach ($this->taxRules() as $pack => $isoCodes) {
+            foreach ($isoCodes as $isoCode) {
+                ++$rules;
+                if (!in_array(strtoupper($isoCode), self::$knownCountries, true)) {
+                    $unknown[] = $pack . ' -> ' . $isoCode;
+                }
+            }
+        }
+
+        $this->assertGreaterThan(500, $rules, 'the scan found too few tax rules to be trusted');
+        $this->assertSame([], $unknown);
+    }
+
+    /**
+     * The United Kingdom left the EU VAT area on 1 January 2021, so an EU pack charging its domestic
+     * VAT there is wrong. Every pack but the United Kingdom's own lists EU countries only.
+     */
+    public function testNoPackButTheUnitedKingdomsOwnTaxesTheUnitedKingdom(): void
+    {
+        $offenders = [];
+        foreach ($this->taxRules() as $pack => $isoCodes) {
+            if ('gb' === $pack) {
+                continue;
+            }
+            if (in_array(self::UNITED_KINGDOM, array_map('strtoupper', $isoCodes), true)) {
+                $offenders[] = $pack;
+            }
+        }
+
+        $this->assertSame([], $offenders);
+    }
+
+    public function testTheUnitedKingdomsOwnPackStillTaxesIt(): void
+    {
+        $isoCodes = array_map('strtoupper', $this->taxRules()['gb'] ?? []);
+
+        $this->assertContains(self::UNITED_KINGDOM, $isoCodes);
+    }
+
+    /**
+     * @return array<string, string[]> pack name => the iso codes its tax rules name
+     */
+    private function taxRules(): array
+    {
+        $packs = [];
+        foreach ((array) glob(self::rootDir() . '/localization/*.xml') as $path) {
+            $name = basename((string) $path, '.xml');
+            if ('default' === $name) {
+                continue;
+            }
+
+            $isoCodes = [];
+            $xml = new SimpleXMLElement((string) file_get_contents((string) $path), 0, false);
+            foreach ($xml->xpath('//taxRule[@iso_code_country]') ?: [] as $rule) {
+                $isoCodes[] = (string) $rule['iso_code_country'];
+            }
+            $packs[$name] = $isoCodes;
+        }
+
+        $this->assertGreaterThan(50, count($packs), 'the localization packs were not found');
+
+        return $packs;
+    }
+
+    private static function rootDir(): string
+    {
+        return dirname(__DIR__, 3);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The United Kingdom left the EU VAT area on 1 January 2021, but 28 localization packs still list it alongside the member states in every one of their domestic VAT rules, so installing one makes a shop charge, for example, Italian 22% VAT to a British customer. Removing the entry leaves the sale untaxed, which is how the packs already treat every other country outside the union. Two of those packs named it `uk`, which is not a country ISO code, so `LocalizationPack::_installTaxes()` skipped those nine rules silently - dead entries next to working `gb` ones. The United Kingdom's own pack is untouched.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a shop with the Italian localization pack and open International > Taxes > Tax rules > "IT Standard Rate (22%)". Before this change the list ends with United Kingdom; after, it holds EU member states and Monaco only. `php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Localization/LocalizationPackTaxRuleCountriesTest.php`
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42687
| Related PRs       | #37704 (gregmag) also edits a localization pack, `ch.xml`, which is not in this change set.
| Sponsor company   |

## Scope

28 packs, 141 rules: at be bg cy cz de dk ee es fi fr gr hr hu ie it lt lu lv mc mt nl pl pt ro se si sk.
`gb.xml` is deliberately excluded. Italy's standard rate before the change reads
`be bg cz dk de ee gr hr es fr mc ie it cy lv lt lu hu mt nl at pl pt ro si sk fi se gb` - every entry an
EU member state except `mc`, which is inside the French VAT territory, and the `gb` leftover. So the
packs already express "EU only"; nothing else needs adding, because an absent country is untaxed.

## The second defect, same data

`hr.xml` and `se.xml` name the country `uk` in nine rules. `uk` is not a country ISO code -
`install-dev/data/xml/country.xml` has `GB` - and `LocalizationPack::_installTaxes()`
(`classes/LocalizationPack.php:252`) resolves it, gets 0 and `continue`s without a word, so those rules
have never existed on any installed shop. They sat next to working `gb` entries in the same groups,
which is why it went unseen. Scanning every `iso_code_country` in all 96 packs against `country.xml`,
those two files hold the only ISO codes that match nothing.

## Northern Ireland

Recorded, deliberately not coded around: under the Windsor Framework Northern Ireland remains inside the
EU VAT area for goods. PrestaShop has one "United Kingdom" country and no way to express the split, so
the default follows the majority case, Great Britain. A merchant selling into Northern Ireland adds the
country back deliberately - a better default than charging every British customer EU VAT.

## Evidence

Test: `tests/Unit/Localization/LocalizationPackTaxRuleCountriesTest.php`, 3 cases, 8 assertions, no
database. It asserts every tax rule names a country the installer creates, that no pack but `gb.xml`
taxes the United Kingdom, and that `gb.xml` still does. Count guards on the country list (>200), the rule
scan (>500) and the pack scan (>50) keep it from passing vacuously. Mutation-proved per property:
re-adding a `gb` rule to `it.xml` fails only the second case; re-adding a `uk` rule to `se.xml` fails
only the first. All 96 packs re-parse as valid XML and no tax rules group was left empty.
