### PR TITLE
Keep class overrides working when profiling is enabled

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -58,12 +58,34 @@ if (is_file(_PS_CUSTOM_CONFIG_FILE_)) {
 
 if (_PS_DEBUG_PROFILING_) {
     include_once _PS_TOOL_DIR_ . 'profiling/Profiler.php';
-    include_once _PS_TOOL_DIR_ . 'profiling/Controller.php';
-    include_once _PS_TOOL_DIR_ . 'profiling/ObjectModel.php';
-    include_once _PS_TOOL_DIR_ . 'profiling/Db.php';
-    include_once _PS_TOOL_DIR_ . 'profiling/Hook.php';
-    include_once _PS_TOOL_DIR_ . 'profiling/Module.php';
-    include_once _PS_TOOL_DIR_ . 'profiling/Tools.php';
+
+    // WHY: each of these files declares the final class name, which is the same name a shop's own
+    // override declares. Including one claims the single `X extends XCore` inheritance slot outright,
+    // so the autoloader is never asked for the class and override/classes/X.php never loads - every
+    // call to an override-only method then dies with `Call to undefined method`, in code that has
+    // nothing to do with profiling. The two cannot share that slot, so the override keeps it and the
+    // class goes unprofiled, said out loud rather than silently.
+    $unprofiledOverriddenClasses = [];
+    foreach (['Controller', 'ObjectModel', 'Db', 'Hook', 'Module', 'Tools'] as $profiledClass) {
+        if (file_exists(_PS_OVERRIDE_DIR_ . 'classes/' . $profiledClass . '.php')) {
+            $unprofiledOverriddenClasses[] = $profiledClass;
+
+            continue;
+        }
+
+        include_once _PS_TOOL_DIR_ . 'profiling/' . $profiledClass . '.php';
+    }
+
+    if ($unprofiledOverriddenClasses !== []) {
+        trigger_error(
+            'Profiling is not applied to ' . implode(', ', $unprofiledOverriddenClasses)
+            . ': these classes are overridden, and a class override takes precedence over its profiling'
+            . ' variant. Remove the override to profile them.',
+            E_USER_NOTICE
+        );
+    }
+
+    unset($profiledClass, $unprofiledOverriddenClasses);
 }
 
 if (Tools::convertBytes(ini_get('upload_max_filesize')) < Tools::convertBytes('100M')) {

--- a/tests/Unit/Classes/ProfilingIncludesRespectOverridesTest.php
+++ b/tests/Unit/Classes/ProfilingIncludesRespectOverridesTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every file in tools/profiling/ that declares a bare class name claims the same
+ * `X extends XCore` inheritance slot an override/classes/X.php declares. Including one unconditionally
+ * means the autoloader is never asked for that class, so the override never loads and any call to an
+ * override-only method dies with `Call to undefined method`. config/config.inc.php therefore has to
+ * include each of them behind an override check, and has to keep doing so for any profiling class
+ * added later.
+ */
+class ProfilingIncludesRespectOverridesTest extends TestCase
+{
+    private const PROFILING_DIR = _PS_ROOT_DIR_ . '/tools/profiling/';
+
+    private const BOOTSTRAP = _PS_ROOT_DIR_ . '/config/config.inc.php';
+
+    /**
+     * @return string the `if (_PS_DEBUG_PROFILING_) { ... }` block, so a failure prints that rather
+     *                than the whole bootstrap
+     */
+    private function getProfilingBlock(): string
+    {
+        $bootstrap = file_get_contents(self::BOOTSTRAP);
+        $start = strpos($bootstrap, 'if (_PS_DEBUG_PROFILING_) {');
+        self::assertNotFalse($start, 'the profiling block is gone from ' . self::BOOTSTRAP);
+
+        $end = strpos($bootstrap, "\n}\n", $start);
+        self::assertNotFalse($end);
+
+        return substr($bootstrap, $start, $end - $start);
+    }
+
+    /**
+     * @return string[] the profiling files that declare a class an override can also declare
+     */
+    private function getOverridableProfilingClasses(): array
+    {
+        $classes = [];
+        foreach (glob(self::PROFILING_DIR . '*.php') as $file) {
+            $source = file_get_contents($file);
+            if (!preg_match('/^(?:abstract )?class ([A-Za-z0-9_]+) extends ([A-Za-z0-9_]+)/m', $source, $matches)) {
+                continue;
+            }
+            // Only a class extending its own Core counterpart competes with an override.
+            if ($matches[2] !== $matches[1] . 'Core') {
+                continue;
+            }
+            $classes[] = $matches[1];
+        }
+
+        sort($classes);
+
+        return $classes;
+    }
+
+    public function testTheProfilingDirectoryStillHoldsClassesAnOverrideCanClaim(): void
+    {
+        // Guards the two tests below against passing vacuously if the directory is ever restructured.
+        $this->assertSame(
+            ['Controller', 'Db', 'Hook', 'Module', 'ObjectModel', 'Tools'],
+            $this->getOverridableProfilingClasses()
+        );
+    }
+
+    public function testNoProfilingClassIsIncludedUnconditionally(): void
+    {
+        $block = $this->getProfilingBlock();
+
+        foreach ($this->getOverridableProfilingClasses() as $class) {
+            $this->assertStringNotContainsString(
+                "include_once _PS_TOOL_DIR_ . 'profiling/" . $class . ".php';",
+                $block,
+                sprintf(
+                    'profiling/%s.php is included by name, which silently disables override/classes/%s.php.',
+                    $class,
+                    $class
+                )
+            );
+        }
+    }
+
+    public function testTheBootstrapGuardsEveryOverridableProfilingClass(): void
+    {
+        $block = $this->getProfilingBlock();
+
+        $this->assertMatchesRegularExpression(
+            '/file_exists\(_PS_OVERRIDE_DIR_ \. \'classes\/\' \. \$\w+ \. \'\.php\'\)/',
+            $block,
+            'the profiling includes are no longer guarded by an override check'
+        );
+
+        // The guarded list has to name every class the directory offers, or a newly added one is
+        // included unconditionally again.
+        $this->assertSame(1, preg_match('/foreach \(\[([^\]]+)\] as \$\w+\) \{/', $block, $matches));
+
+        $guarded = array_map(
+            static fn (string $name): string => trim($name, " \t\n'"),
+            explode(',', $matches[1])
+        );
+        sort($guarded);
+
+        $this->assertSame($this->getOverridableProfilingClasses(), $guarded);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | With `_PS_DEBUG_PROFILING_` on, `config/config.inc.php` includes six files from `tools/profiling/` that each declare the bare class name - the same name `override/classes/<Class>.php` declares. The include claims the single `X extends XCore` inheritance slot before the autoloader is ever asked for the class, so the override never loads and every call to an override-only method fails with `Call to undefined method`, in code unrelated to profiling. Each profiling variant is now included only when the class is not overridden, and the classes left unprofiled are named in an `E_USER_NOTICE` rather than failing later somewhere else.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add `override/classes/Tools.php` declaring `class Tools extends ToolsCore` with a `myHelper()` method, clear the cache and confirm a page calling it renders. Set `_PS_DEBUG_PROFILING_` to `true` (`config/defines_custom.inc.php` is enough, `defines.inc.php` guards the define) and clear the cache again. Before this change `Tools` resolves to `tools/profiling/Tools.php` and the call is a fatal error; after, it resolves to the override, the call works, and a notice names `Tools` as unprofiled. With no override present nothing changes in either direction.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42598
| Related PRs       |
| Sponsor company   |

## Why the override wins the slot, rather than some reconciliation

`override/classes/Tools.php` declares `class Tools extends ToolsCore` and so does
`tools/profiling/Tools.php`. That is one inheritance slot with two claimants, and the autoloader
(`PrestaShop\Autoload\Autoloader::load()`, in the `prestashop/autoload` package) either requires the
override's path or evaluates `class Tools extends ToolsCore {}` - neither can insert a profiling layer
that a merchant-written override does not already extend. No change makes a class both overridden and
profiled, so the only real question is which one wins and whether the loser is announced. A shop that
cannot run is worse than a report with a gap in it, so the override wins and the gap is named.

## Why a notice and not a silent skip

The complaint in the issue is not only the fatal error, it is that the failure looks like a defect in
the shop's own code. A silent skip reproduces that in the other direction: profiling appears to work
and quietly measures different classes than the merchant thinks. The notice names the skipped classes
explicitly. It is `trigger_error(..., E_USER_NOTICE)` because line 59 of the bootstrap runs before the
container and before any logger exists.

## The loss is specific and small

`tools/profiling/Tools.php` carries no profiler instrumentation at all. Its three methods exist to
defer `Tools::redirect()` through `Context::getContext()->controller->setRedirectAfter()` so the report
survives a redirect. An overridden `Tools` therefore costs the report on redirecting requests only;
every other page still profiles.

## Evidence

Measured on a 9.2 shop with `override/classes/Tools.php` adding a `myHelper()` method, reading
`(new ReflectionClass('Tools'))->getFileName()` after bootstrap:

```
                                          Tools resolves to           myHelper()      Db queries / tables
  base,    profiling off, override      override/classes/Tools.php    returns                 -
  base,    profiling on,  override      tools/profiling/Tools.php     FATAL                   -
  patched, profiling on,  override      override/classes/Tools.php    returns              19 / 15
  patched, profiling on,  no override   tools/profiling/Tools.php     -                    19 / 15
```

The last two rows are the ones that matter together: the profiler collects the same 19 queries across
15 tables and 6 `ObjectModel` entries whether or not a class was skipped, so skipping degrades the
report rather than breaking it, and the change is inert when no override is present.

Test: `tests/Unit/Classes/ProfilingIncludesRespectOverridesTest.php`, 3 cases, 14 assertions, no
database. It derives the overridable class list from `tools/profiling/` instead of hard-coding it and
asserts the bootstrap guards exactly that list, so a seventh profiling class added later fails the test
until it is guarded too. Reverting `config/config.inc.php` fails two of the three cases; the third is
the guard against the other two passing vacuously. Full unit suite 5487 tests with the same 20 errors
and 1 failure as the untouched base branch. `php-cs-fixer` and `phpstan` clean.

## Not a duplicate

#42028 (luigimassa, open, base `develop`) is the only other open PR in this area. It adds a Markdown
export to the profiling report and touches `tools/profiling/Controller.php`, `Profiler.php` and
`templates/links.tpl` - no overlap with `config/config.inc.php`. Of my own 366 open core PRs, one
touches `config/` at all (#42179, `config/smarty.config.inc.php`).
