### PR TITLE
Read a listing category name once per category instead of once per product

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -89,6 +89,9 @@ class CategoryCore extends ObjectModel
 
     protected static $_links = [];
 
+    /** @var array<string, string|false> keyed by id_category-id_lang-id_shop */
+    protected static $_names = [];
+
     /**
      * @see ObjectModel::$definition
      */
@@ -1382,6 +1385,42 @@ class CategoryCore extends ObjectModel
         }
 
         return self::$_links[$idCategory . '-' . $idLang];
+    }
+
+    /**
+     * Get a category name without loading the Category, memoized per request.
+     *
+     * The instance getName() reads an already loaded object; this one is for callers that hold an id
+     * and would otherwise pay a query each time. A product listing asks for the same handful of
+     * categories once per product, so the memo is what keeps that from scaling with the listing.
+     *
+     * @param int $idCategory
+     * @param int $idLang
+     * @param int|null $idShop defaults to the current shop
+     *
+     * @return string|false
+     */
+    public static function getNameById($idCategory, $idLang, $idShop = null)
+    {
+        if (!Validate::isUnsignedId($idCategory) || !Validate::isUnsignedId($idLang)) {
+            return false;
+        }
+
+        if (null === $idShop) {
+            $idShop = (int) Context::getContext()->shop->id;
+        }
+
+        $key = $idCategory . '-' . $idLang . '-' . (int) $idShop;
+        if (!isset(self::$_names[$key])) {
+            self::$_names[$key] = Db::getInstance()->getValue('
+            SELECT cl.`name`
+            FROM `' . _DB_PREFIX_ . 'category_lang` cl
+            WHERE cl.`id_shop` = ' . (int) $idShop . '
+            AND cl.`id_lang` = ' . (int) $idLang . '
+            AND cl.`id_category` = ' . (int) $idCategory);
+        }
+
+        return self::$_names[$key];
     }
 
     /**

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -12,7 +12,6 @@ use Combination;
 use Context;
 use Customization;
 use DateTime;
-use Db;
 use Language;
 use Link;
 use Manufacturer;
@@ -648,16 +647,10 @@ class ProductLazyArray extends AbstractLazyArray
     public function getCategoryName()
     {
         if (!isset($this->product['category_name'])) {
-            $categoryName = (string) Db::getInstance()->getValue(
-                'SELECT name FROM ' .
-                    _DB_PREFIX_ .
-                    'category_lang
-                WHERE id_shop = ' .
-                    (int) Context::getContext()->shop->id .
-                    ' AND id_lang = ' .
-                    (int) $this->language->id .
-                    ' AND id_category = ' .
-                    (int) $this->product['id_category_default']
+            $categoryName = (string) Category::getNameById(
+                (int) $this->product['id_category_default'],
+                (int) $this->language->id,
+                (int) Context::getContext()->shop->id
             );
             $this->product['category_name'] = !empty($categoryName)
                 ? $categoryName

--- a/tests/Integration/Classes/CategoryNameByIdTest.php
+++ b/tests/Integration/Classes/CategoryNameByIdTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Category;
+use Configuration;
+use Db;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Category::getNameById() memoizes per request because a product listing asks for the same handful of
+ * categories once per product. The memo is observed the only way a memo can be observed without
+ * counting queries: change the row underneath it and see that the answer does not follow.
+ */
+class CategoryNameByIdTest extends KernelTestCase
+{
+    /**
+     * @var int
+     */
+    private $idLang;
+
+    /**
+     * @var int
+     */
+    private $idShop;
+
+    /**
+     * @var array<int, string> original names, restored in tearDown
+     */
+    private $originalNames = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $this->idShop = (int) Configuration::get('PS_SHOP_DEFAULT');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalNames as $idCategory => $name) {
+            $this->writeName($idCategory, $name);
+        }
+
+        parent::tearDown();
+    }
+
+    private function readName(int $idCategory): string
+    {
+        return (string) Db::getInstance()->getValue(
+            'SELECT name FROM ' . _DB_PREFIX_ . 'category_lang'
+            . ' WHERE id_category = ' . $idCategory
+            . ' AND id_lang = ' . $this->idLang
+            . ' AND id_shop = ' . $this->idShop
+        );
+    }
+
+    private function writeName(int $idCategory, string $name): void
+    {
+        Db::getInstance()->update(
+            'category_lang',
+            ['name' => pSQL($name)],
+            'id_category = ' . $idCategory . ' AND id_lang = ' . $this->idLang
+                . ' AND id_shop = ' . $this->idShop
+        );
+    }
+
+    /**
+     * @return int[] two category ids that have a name in the default language and shop
+     */
+    private function getTwoCategoryIds(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT id_category FROM ' . _DB_PREFIX_ . 'category_lang'
+            . ' WHERE id_lang = ' . $this->idLang
+            . ' AND id_shop = ' . $this->idShop
+            . " AND name <> '' ORDER BY id_category LIMIT 2"
+        );
+        $ids = array_map('intval', array_column((array) $rows, 'id_category'));
+        self::assertCount(2, $ids, 'the fixture needs two named categories');
+
+        return $ids;
+    }
+
+    public function testTheNameIsReadOnlyOnceForTheSameCategory(): void
+    {
+        [$idCategory] = $this->getTwoCategoryIds();
+        $this->originalNames[$idCategory] = $this->readName($idCategory);
+
+        $first = Category::getNameById($idCategory, $this->idLang, $this->idShop);
+        self::assertSame($this->originalNames[$idCategory], $first);
+
+        // Only a second query would see this.
+        $this->writeName($idCategory, $this->originalNames[$idCategory] . ' CHANGED');
+
+        self::assertSame(
+            $first,
+            Category::getNameById($idCategory, $this->idLang, $this->idShop),
+            'the name was read from the database a second time'
+        );
+    }
+
+    public function testEachCategoryKeepsItsOwnName(): void
+    {
+        [$first, $second] = $this->getTwoCategoryIds();
+
+        // Guards the memo key: one entry per category, not one entry for all of them.
+        self::assertNotSame(
+            Category::getNameById($first, $this->idLang, $this->idShop),
+            Category::getNameById($second, $this->idLang, $this->idShop)
+        );
+    }
+
+    public function testAnInvalidIdIsRejectedWithoutQuerying(): void
+    {
+        self::assertFalse(Category::getNameById(0, $this->idLang, $this->idShop));
+        self::assertFalse(Category::getNameById(-1, $this->idLang, $this->idShop));
+        self::assertFalse(Category::getNameById(1, 0, $this->idShop));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ProductLazyArray::getCategoryName()` ran a raw uncached `Db::getValue()` for every presented product, so a product listing paid one query per product even though products share a handful of default categories. `Category::getLinkRewrite()`, one method above in the same class, already memoizes the same table the same way. The lookup moves next to it as `Category::getNameById()` with a per-request memo keyed on category, language and shop, and the presenter reads it from there - which also removes the last `Db::getInstance()` from that presenter.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable `_PS_DEBUG_PROFILING_` and open a listing whose products share default categories. Before this change `SELECT name FROM category_lang ...` appears once per product in the Doubles tab; after, once per distinct category. The rendered category name is unchanged.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42597
| Related PRs       | Same listing hot path as #41957 (cover images) and #42061 (colour variants); #42063 proposes the shared batching seam for that class of lookup. Independent of all three - no overlapping hunks, and this one is a memo rather than a batch.
| Sponsor company   |

## Why a memo and not a bulk prefetch

The listing asks for the same category repeatedly, it does not ask for many different ones. At 18
products there were 5 distinct default categories, so deduplication recovers everything a batch would
and needs no prefetch pass, no new plumbing and no ordering assumptions. `Category::getLinkRewrite()`
is the same shape on the same table one method above, so this follows the code that is already there
rather than introducing a second pattern beside it.

The lookup moved to `Category` rather than gaining a static inside the presenter because a raw
`Db::getValue()` in `src/Adapter/Presenter/` is the actual defect underneath the missing memo. The name
is `getNameById()` because `Category::getName()` already exists as an instance method reading a loaded
object's `$name`; the two are complementary, not duplicates.

## Evidence

`ps_featuredproducts` on a 9.2 shop, 18 active products. The probe resolves every `ProductLazyArray`
with `json_encode()` because the array is lazy, and does one render per process with no warm-up run - a
per-request memo lives for the process, so a second render in the same process shows a saving
production never sees. Counts are deterministic across repeated runs.

```
  products presented    before    after    saved    distinct default categories
        1                  61       61       0                 1
        6                 177      175       2                 4
       12                 280      272       8                 4
       18                 388      375      13                 5
```

The saving is `N - distinct categories` in every row, which is exactly what a memo can deliver and
nothing more - a useful self-check that the numbers are measuring the change and not something else.

Test: `tests/Integration/Classes/CategoryNameByIdTest.php`, 3 cases, 8 assertions. The memo is observed
the only way a memo can be observed without counting queries - the row is changed underneath it and the
answer must not follow. Mutation targets the optimisation rather than the feature: replacing the
`isset()` guard with `if (true)` keeps `getNameById()` working and fails only the memo case, with
"the name was read from the database a second time". `tests/Integration/Classes` plus
`tests/Integration/Adapter` report 321 tests with the same 8 errors and 2 failures as the untouched
base branch (318 there, the difference being the three added cases). `php-cs-fixer` and `phpstan` clean.

## Context

Posted the full 9.2 re-measurement the maintainer asked for on the issue: the listing costs 19.2
queries per additional product on 9.2.x for this widget alone, measured at 4 values of N. This PR
removes one row of that table. The two largest remaining contributors (`stock_available` at 57
executions, `cart_product` at 29) are not traced to their call sites yet and nothing is claimed about
them.

## Not a duplicate

Six of my open PRs touch one of the two files; none overlaps. In `classes/Category.php` mine are at
old lines 89 and 1384 against #42582 (517), #41854 (1541-1566) and #41888 (1748). In
`ProductLazyArray.php` mine are at 12 and 648 against #42650 (34, 145), #42063 (92-120, 674, 800, 954)
and #42338 (1041-1196). The nearest is #42063 at 674, ten lines past the end of this change's 648-664
hunk. No other author has an open PR on either file.
