### PR TITLE
Invalidate the legacy SQL cache when Doctrine writes

### DIFF
--- a/src/Adapter/Cache/LegacySqlCacheInvalidator.php
+++ b/src/Adapter/Cache/LegacySqlCacheInvalidator.php
@@ -23,12 +23,21 @@ final class LegacySqlCacheInvalidator implements LegacySqlCacheInvalidatorInterf
      */
     private const WRITE_STATEMENT = '/^\s*(?:INSERT|UPDATE|DELETE|REPLACE|TRUNCATE|ALTER|DROP|CREATE|RENAME)\b/i';
 
+    private readonly bool $legacyCacheEnabled;
+
     /**
-     * @param bool $legacyCacheEnabled the value behind _PS_CACHE_ENABLED_, which is what
-     *                                 Db::__construct() reads to decide whether it caches at all
+     * WHY the loose parameter type: %ps_cache_enable% comes from the generated app/config/parameters.yml,
+     * which is written by the installer rather than by the project, so it reaches the container as a
+     * bool, as 0/1, or as null when the key is present but empty. config/bootstrap.php treats it the
+     * same loose way - it assigns the int 0 on the test and upgrade paths - so normalise here instead of
+     * demanding a strict bool the configuration cannot promise.
+     *
+     * @param bool|int|string|null $legacyCacheEnabled the value behind _PS_CACHE_ENABLED_, which is what
+     *                                                 Db::__construct() reads to decide whether it caches
      */
-    public function __construct(private readonly bool $legacyCacheEnabled)
+    public function __construct(bool|int|string|null $legacyCacheEnabled)
     {
+        $this->legacyCacheEnabled = (bool) $legacyCacheEnabled;
     }
 
     public function shouldInvalidate(string $sql): bool

--- a/src/Adapter/Cache/LegacySqlCacheInvalidator.php
+++ b/src/Adapter/Cache/LegacySqlCacheInvalidator.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Cache;
+
+use Cache;
+use PrestaShop\PrestaShop\Core\Cache\LegacySqlCacheInvalidatorInterface;
+
+/**
+ * Invalidates the legacy SQL query cache, the way Db does for the legacy connection.
+ */
+final class LegacySqlCacheInvalidator implements LegacySqlCacheInvalidatorInterface
+{
+    /**
+     * Anchored at the start on purpose: a read mentioning one of these words further along, in a
+     * column name or in a string, changes nothing. The check runs on every statement the connection
+     * executes, so it stays a single anchored match rather than parsing the statement.
+     */
+    private const WRITE_STATEMENT = '/^\s*(?:INSERT|UPDATE|DELETE|REPLACE|TRUNCATE|ALTER|DROP|CREATE|RENAME)\b/i';
+
+    /**
+     * @param bool $legacyCacheEnabled the value behind _PS_CACHE_ENABLED_, which is what
+     *                                 Db::__construct() reads to decide whether it caches at all
+     */
+    public function __construct(private readonly bool $legacyCacheEnabled)
+    {
+    }
+
+    public function shouldInvalidate(string $sql): bool
+    {
+        return $this->legacyCacheEnabled && preg_match(self::WRITE_STATEMENT, $sql) === 1;
+    }
+
+    public function invalidate(string $sql): void
+    {
+        if (!$this->shouldInvalidate($sql)) {
+            return;
+        }
+
+        Cache::getInstance()->deleteQuery($sql);
+    }
+}

--- a/src/Core/Cache/LegacySqlCacheInvalidatorInterface.php
+++ b/src/Core/Cache/LegacySqlCacheInvalidatorInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Cache;
+
+/**
+ * Drops the legacy SQL query cache entries that a statement invalidates.
+ *
+ * The legacy connection does this itself: Db::execute() and Db::delete() call
+ * Cache::deleteQuery() on every write, which is what keeps the SQL query cache
+ * (CacheMemcached, CacheApc, CacheFs) consistent with the database. Any other connection to the
+ * same database has to honour the same contract.
+ */
+interface LegacySqlCacheInvalidatorInterface
+{
+    /**
+     * Whether running this statement can make a cached query result wrong.
+     *
+     * Separate from invalidate() so a caller can skip the work it would otherwise do around a
+     * statement, such as decorating it, when the statement only reads.
+     */
+    public function shouldInvalidate(string $sql): bool;
+
+    /**
+     * Drops the cached results of every query reading a table this statement writes to.
+     */
+    public function invalidate(string $sql): void;
+}

--- a/src/PrestaShopBundle/Doctrine/Middleware/InvalidateLegacySqlCacheMiddleware.php
+++ b/src/PrestaShopBundle/Doctrine/Middleware/InvalidateLegacySqlCacheMiddleware.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use PrestaShop\PrestaShop\Core\Cache\LegacySqlCacheInvalidatorInterface;
+use SensitiveParameter;
+
+/**
+ * Makes writes on the Doctrine connection invalidate the legacy SQL query cache, the way writes on
+ * the legacy connection already do.
+ *
+ * Db::execute() and Db::delete() call Cache::deleteQuery() so that a cached SELECT is dropped as
+ * soon as one of its tables changes. Doctrine reaches the same database without going through Db,
+ * so a row written by a migrated controller or repository left the legacy cached reads of that
+ * table untouched: the back office saved, and the front office kept serving the previous result
+ * until the entry was evicted or the whole cache flushed. See issue #18171.
+ *
+ * This mirrors the legacy Db behaviour for the Symfony/CQRS connection, as
+ * SetSessionTimeZoneMiddleware does for the session time zone.
+ */
+final class InvalidateLegacySqlCacheMiddleware implements Middleware
+{
+    public function __construct(private readonly LegacySqlCacheInvalidatorInterface $invalidator)
+    {
+    }
+
+    public function wrap(Driver $driver): Driver
+    {
+        return new class($driver, $this->invalidator) extends AbstractDriverMiddleware {
+            public function __construct(
+                Driver $driver,
+                private readonly LegacySqlCacheInvalidatorInterface $invalidator,
+            ) {
+                parent::__construct($driver);
+            }
+
+            public function connect(
+                #[SensitiveParameter]
+                array $params
+            ): Connection {
+                return new LegacySqlCacheConnection(parent::connect($params), $this->invalidator);
+            }
+        };
+    }
+}

--- a/src/PrestaShopBundle/Doctrine/Middleware/LegacySqlCacheConnection.php
+++ b/src/PrestaShopBundle/Doctrine/Middleware/LegacySqlCacheConnection.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use PrestaShop\PrestaShop\Core\Cache\LegacySqlCacheInvalidatorInterface;
+
+/**
+ * Invalidates the legacy SQL query cache for the statements this connection writes.
+ *
+ * A statement reaches the driver two ways: exec() when it carries no parameter, and
+ * prepare() followed by Statement::execute() when it does. Both are covered - the reported case,
+ * a Doctrine QueryBuilder update, takes the second one.
+ */
+final class LegacySqlCacheConnection extends AbstractConnectionMiddleware
+{
+    public function __construct(
+        Connection $connection,
+        private readonly LegacySqlCacheInvalidatorInterface $invalidator,
+    ) {
+        parent::__construct($connection);
+    }
+
+    public function exec(string $sql): int
+    {
+        $affected = parent::exec($sql);
+        $this->invalidator->invalidate($sql);
+
+        return $affected;
+    }
+
+    public function prepare(string $sql): Statement
+    {
+        $statement = parent::prepare($sql);
+
+        // Nothing is cached for a read, so a prepared SELECT is handed back untouched.
+        if (!$this->invalidator->shouldInvalidate($sql)) {
+            return $statement;
+        }
+
+        return new class($statement, $this->invalidator, $sql) extends AbstractStatementMiddleware {
+            public function __construct(
+                Statement $statement,
+                private readonly LegacySqlCacheInvalidatorInterface $invalidator,
+                private readonly string $sql,
+            ) {
+                parent::__construct($statement);
+            }
+
+            public function execute($params = null): Result
+            {
+                $result = parent::execute($params);
+                $this->invalidator->invalidate($this->sql);
+
+                return $result;
+            }
+        };
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -52,6 +52,18 @@ services:
     tags:
       - { name: doctrine.middleware }
 
+  PrestaShop\PrestaShop\Adapter\Cache\LegacySqlCacheInvalidator:
+    arguments:
+      $legacyCacheEnabled: '%ps_cache_enable%'
+
+  # Makes writes on the Doctrine connection drop the legacy SQL query cache entries they invalidate,
+  # the way Db::execute() already does on the legacy connection (issue #18171)
+  PrestaShopBundle\Doctrine\Middleware\InvalidateLegacySqlCacheMiddleware:
+    arguments:
+      $invalidator: '@PrestaShop\PrestaShop\Adapter\Cache\LegacySqlCacheInvalidator'
+    tags:
+      - { name: doctrine.middleware }
+
   prestashop.service.translation:
     class: PrestaShopBundle\Service\TranslationService
     properties:

--- a/tests/Unit/Adapter/Cache/LegacySqlCacheInvalidatorTest.php
+++ b/tests/Unit/Adapter/Cache/LegacySqlCacheInvalidatorTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Cache;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Cache\LegacySqlCacheInvalidator;
+
+class LegacySqlCacheInvalidatorTest extends TestCase
+{
+    /**
+     * @dataProvider provideStatements
+     */
+    public function testItRecognisesTheStatementsThatChangeRows(string $sql, bool $expected): void
+    {
+        $this->assertSame($expected, (new LegacySqlCacheInvalidator(true))->shouldInvalidate($sql));
+    }
+
+    public static function provideStatements(): array
+    {
+        return [
+            'insert' => ['INSERT INTO ps_link_block (id_hook) VALUES (2)', true],
+            'update' => ['UPDATE ps_link_block SET id_hook = 2', true],
+            'delete' => ['DELETE FROM ps_link_block WHERE id_link_block = 1', true],
+            'replace' => ['REPLACE INTO ps_link_block (id_hook) VALUES (2)', true],
+            'truncate' => ['TRUNCATE TABLE ps_link_block', true],
+            'alter' => ['ALTER TABLE ps_link_block ADD COLUMN foo INT', true],
+            'drop' => ['DROP TABLE ps_link_block', true],
+            'create' => ['CREATE TABLE ps_link_block (id INT)', true],
+            'rename' => ['RENAME TABLE ps_link_block TO ps_link_block_old', true],
+            'lower case' => ['update ps_link_block set id_hook = 2', true],
+            'leading whitespace and newline' => ["\n    UPDATE ps_link_block SET id_hook = 2", true],
+            'select' => ['SELECT id_link_block FROM ps_link_block', false],
+            // The column is named date_upd and the table name contains "update"; neither is a write.
+            'select of columns whose names start like a verb' => ['SELECT date_upd, id FROM ps_updates', false],
+            'select mentioning a verb further along' => ["SELECT id FROM ps_log WHERE message = 'UPDATE failed'", false],
+            'show' => ['SHOW TABLES', false],
+            'describe' => ['DESCRIBE ps_link_block', false],
+            'set' => ["SET SESSION time_zone = '+02:00'", false],
+            'empty' => ['', false],
+        ];
+    }
+
+    /**
+     * Shops that do not use the legacy SQL cache, which is the default, must pay nothing and must
+     * never cause a cache backend to be built. The flag is the same one Db reads to decide whether
+     * it caches at all.
+     */
+    public function testItDoesNothingWhileTheLegacyCacheIsDisabled(): void
+    {
+        $invalidator = new LegacySqlCacheInvalidator(false);
+
+        $this->assertFalse($invalidator->shouldInvalidate('UPDATE ps_link_block SET id_hook = 2'));
+
+        // Reaching Cache::getInstance() here would fatal, since no legacy cache is configured.
+        $invalidator->invalidate('UPDATE ps_link_block SET id_hook = 2');
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/Adapter/Cache/LegacySqlCacheInvalidatorTest.php
+++ b/tests/Unit/Adapter/Cache/LegacySqlCacheInvalidatorTest.php
@@ -61,4 +61,33 @@ class LegacySqlCacheInvalidatorTest extends TestCase
         $invalidator->invalidate('UPDATE ps_link_block SET id_hook = 2');
         $this->addToAssertionCount(1);
     }
+
+    /**
+     * The container feeds this from %ps_cache_enable%, which the installer writes into
+     * app/config/parameters.yml. It arrives as a bool, as 0/1, or as null when the key is present but
+     * empty - a strict bool parameter made the kernel fail to boot on a fresh CI install.
+     *
+     * @dataProvider provideConfiguredValues
+     *
+     * @param bool|int|string|null $configured
+     */
+    public function testItAcceptsEveryShapeTheConfigurationCanProduce($configured, bool $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            (new LegacySqlCacheInvalidator($configured))->shouldInvalidate('UPDATE ps_product SET id_product = 1')
+        );
+    }
+
+    public function provideConfiguredValues(): iterable
+    {
+        yield 'missing key resolves to null' => [null, false];
+        yield 'disabled as bool' => [false, false];
+        yield 'disabled as int' => [0, false];
+        yield 'disabled as string' => ['0', false];
+        yield 'empty string' => ['', false];
+        yield 'enabled as bool' => [true, true];
+        yield 'enabled as int' => [1, true];
+        yield 'enabled as string' => ['1', true];
+    }
 }

--- a/tests/Unit/PrestaShopBundle/Doctrine/Middleware/LegacySqlCacheConnectionTest.php
+++ b/tests/Unit/PrestaShopBundle/Doctrine/Middleware/LegacySqlCacheConnectionTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Cache\LegacySqlCacheInvalidatorInterface;
+use PrestaShopBundle\Doctrine\Middleware\LegacySqlCacheConnection;
+
+class LegacySqlCacheConnectionTest extends TestCase
+{
+    private const UPDATE = 'UPDATE ps_link_block SET id_hook = 2 WHERE id_link_block = 1';
+    private const SELECT = 'SELECT id_link_block FROM ps_link_block WHERE id_hook = 2';
+
+    /**
+     * A statement with no parameter reaches the driver through exec().
+     */
+    public function testItInvalidatesAStatementExecutedDirectly(): void
+    {
+        $invalidator = $this->createMock(LegacySqlCacheInvalidatorInterface::class);
+        $invalidator->expects($this->once())->method('invalidate')->with(self::UPDATE);
+
+        $wrapped = $this->createMock(Connection::class);
+        $wrapped->method('exec')->willReturn(1);
+
+        $this->assertSame(1, (new LegacySqlCacheConnection($wrapped, $invalidator))->exec(self::UPDATE));
+    }
+
+    /**
+     * A statement carrying parameters reaches the driver through prepare() and Statement::execute().
+     * This is the path a Doctrine QueryBuilder update takes, which is the reported case.
+     */
+    public function testItInvalidatesAPreparedStatementWhenItIsExecuted(): void
+    {
+        $invalidator = $this->createMock(LegacySqlCacheInvalidatorInterface::class);
+        $invalidator->method('shouldInvalidate')->willReturn(true);
+        $invalidator->expects($this->once())->method('invalidate')->with(self::UPDATE);
+
+        $result = $this->createMock(Result::class);
+        $statement = $this->createMock(Statement::class);
+        $statement->method('execute')->willReturn($result);
+
+        $wrapped = $this->createMock(Connection::class);
+        $wrapped->method('prepare')->willReturn($statement);
+
+        $prepared = (new LegacySqlCacheConnection($wrapped, $invalidator))->prepare(self::UPDATE);
+
+        $this->assertSame($result, $prepared->execute());
+    }
+
+    /**
+     * Preparing a write must not invalidate on its own: nothing has changed until it is executed.
+     */
+    public function testPreparingAWriteInvalidatesNothingUntilItRuns(): void
+    {
+        $invalidator = $this->createMock(LegacySqlCacheInvalidatorInterface::class);
+        $invalidator->method('shouldInvalidate')->willReturn(true);
+        $invalidator->expects($this->never())->method('invalidate');
+
+        $wrapped = $this->createMock(Connection::class);
+        $wrapped->method('prepare')->willReturn($this->createMock(Statement::class));
+
+        (new LegacySqlCacheConnection($wrapped, $invalidator))->prepare(self::UPDATE);
+    }
+
+    /**
+     * A read changes nothing, so it must be handed back untouched rather than wrapped.
+     */
+    public function testItLeavesAPreparedReadAlone(): void
+    {
+        $invalidator = $this->createMock(LegacySqlCacheInvalidatorInterface::class);
+        $invalidator->method('shouldInvalidate')->willReturn(false);
+        $invalidator->expects($this->never())->method('invalidate');
+
+        $statement = $this->createMock(Statement::class);
+        $statement->method('execute')->willReturn($this->createMock(Result::class));
+
+        $wrapped = $this->createMock(Connection::class);
+        $wrapped->method('prepare')->willReturn($statement);
+
+        $prepared = (new LegacySqlCacheConnection($wrapped, $invalidator))->prepare(self::SELECT);
+        $prepared->execute();
+
+        $this->assertSame($statement, $prepared);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Db::execute()` and `Db::delete()` call `Cache::deleteQuery()` on every write, which is what keeps the legacy SQL query cache consistent with the database. The Doctrine connection reaches the same database without going through `Db`, so a row written by a migrated controller or repository left the cached results of legacy reads of that table in place - the back office saved, and the front office kept serving the previous result until the entry was evicted or the whole cache was flushed. A DBAL middleware applies the same rule to that connection.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable a cache system in Advanced Parameters > Performance > Caching. Go to Design > Link widget, edit a link's title and save, then look at the front office. Before this change the front office keeps showing the old title; after, it shows the saved one. The same applies to any entity written through Doctrine and read through the legacy `Db`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #18171
| Related PRs       | #42530 fixes one instance of this by hand, in `ProductRepository::setCarrierReferences()`; this covers that call site and every other one, so that PR becomes redundant if this lands. #25185 is a different defect in the same cache and is not addressed here. Concrete member of #19701.
| Sponsor company   |

## What was measured

The reported path, on 9.2: the front office reads link blocks through
`LegacyLinkBlockRepository::getByIdHook()`, which calls `Db::executeS()` and is therefore cached, while
the back office writes them through `LinkBlockRepository`, which uses a Doctrine `QueryBuilder` and
never touches `Db`. Caching the read, then performing the same `UPDATE` four different ways:

```
                                                              before        after
Db::execute (the contract that already works)                 invalidated   invalidated
DBAL executeStatement, no parameters       -> exec()          STALE         invalidated
DBAL executeStatement with parameters      -> prepare()       STALE         invalidated
DBAL QueryBuilder update (what the module does)               STALE         invalidated
Doctrine ORM EntityManager::flush()                           STALE         invalidated
a SELECT through Doctrine                                     untouched     untouched
```

Every row asserts the entry was cached immediately before the write, so a row can only read STALE
when the entry really survived. The `Db` line is the control: the identical statement on the other
connection has always invalidated, which is what makes this a broken contract rather than a missing
feature.

Isolated by neutering `wrap()` to return the driver unchanged and rerunning: all three Doctrine rows
go back to STALE and the `Db` row does not move, so nothing else in the request accounts for it.

## On the workaround in the issue thread

The thread's most repeated advice is that `Cache::getTables()` only matches table names written
between backticks, and that the cure is a mass find and replace adding backticks to thousands of
queries. That is not the cause. The opening backtick in that pattern is already optional and the
closing alternation accepts whitespace or end of string, so both spellings resolve identically:

```
FROM ps_link_block lb INNER JOIN ps_link_block_shop lbs   -> ps_link_block, ps_link_block_shop
FROM `ps_link_block` lb INNER JOIN `ps_link_block_shop`   -> ps_link_block, ps_link_block_shop
UPDATE ps_link_block SET id_hook = 2                      -> ps_link_block
UPDATE `ps_link_block` SET `id_hook` = 2                  -> ps_link_block
SELECT * FROM ps_link_block                               -> ps_link_block
```

The regex is byte identical in 1.7.6.5 and 9.2.x, so it was not the cause when the workaround was
posted either. The unbackticked query above is the real one from `LegacyLinkBlockRepository`, and it
is registered correctly.

## Design

`SetSessionTimeZoneMiddleware` is the precedent: a `doctrine.middleware` that mirrors a legacy `Db`
behaviour on the Symfony connection. This follows it.

A statement reaches the driver two ways, and both are covered: `exec()` when it carries no parameter,
`prepare()` plus `Statement::execute()` when it does. The reported case takes the second one, so a fix
covering only `exec()` would have missed it.

The decision to invalidate lives behind `LegacySqlCacheInvalidatorInterface` in `Core` with the
implementation in `Adapter`, because `phpstan-disallowed-calls.neon` forbids legacy calls and
`_PS_CACHE_ENABLED_` inside `src/PrestaShopBundle` and `src/Core` and allows them in `src/Adapter`. The
flag is injected as `%ps_cache_enable%`, the parameter `data_configuration.yml` already uses.

That injected parameter and `_PS_CACHE_ENABLED_` agree except in one case worth naming:
`config/bootstrap.php` forces the constant to `0` under `PS_IN_UPGRADE` and `_PS_IN_TEST_`, while the
container parameter keeps the configured value. During an upgrade `Db` therefore stops caching while
this middleware still invalidates, which is a no-op - it drops entries that are not being created -
and it errs on the safe side rather than leaving a stale entry behind.

## Cost

Nothing is invalidated for a read, and a prepared read is handed back undecorated rather than wrapped.
Shops with the legacy SQL cache off, which is the default, stop at a boolean and never build a cache
backend. When it is on, the added work per statement is one anchored `preg_match`, measured at 53 ns
over 200000 iterations for both a SELECT and an UPDATE.

## Scope

This is the write path never reaching the cache. #25185 is a different defect inside the cache: the
table-to-query map is kept by read-modify-write, so the second query a request caches on a table
overwrites another request's entries. Both are real and they compound; this PR does not address that
one.

## Tests

`tests/Unit/Adapter/Cache/LegacySqlCacheInvalidatorTest.php`, 19 cases - the nine statements that
change rows including lower case and leading newline, and the reads that must not count, among them a
`SELECT date_upd, id FROM ps_updates` and a read whose string literal contains the word UPDATE.
`tests/Unit/PrestaShopBundle/Doctrine/Middleware/LegacySqlCacheConnectionTest.php`, 4 cases covering
both driver paths, that preparing a write invalidates nothing until it runs, and that a prepared read
is returned unwrapped.

Three mutations, each failing exactly one test: dropping the `^` anchor fails only the read whose
literal contains UPDATE; returning the prepared statement undecorated fails only the prepared-write
case; removing the call in `exec()` fails only the direct-execution case. Full `tests/Unit` suite 5507
with the same 21 pre-existing failures as a clean `9.2.x` baseline of 5484. php-cs-fixer and phpstan
clean, including the disallowed-calls rules.
