### PR TITLE
Print only the discounts that belong to the invoice

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -400,6 +400,27 @@ class OrderInvoiceCore extends ObjectModel
     }
 
     /**
+     * Returns the cart rules that apply to this invoice.
+     *
+     * A discount added from the order page can be attached to one invoice, which is stored in
+     * order_cart_rule.id_order_invoice. A rule with 0 there was not attached to any invoice - it
+     * came with the cart, so it belongs to the order as a whole and applies to every invoice.
+     *
+     * @return array|false
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    public function getCartRules()
+    {
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+        SELECT *
+        FROM `' . _DB_PREFIX_ . 'order_cart_rule` ocr
+        WHERE ocr.`deleted` = 0
+            AND ocr.`id_order` = ' . (int) $this->id_order . '
+            AND (ocr.`id_order_invoice` = 0 OR ocr.`id_order_invoice` = ' . (int) $this->id . ')');
+    }
+
+    /**
      * Returns the shipping taxes breakdown.
      *
      * @param Order $order

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -236,7 +236,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             $carrier->name = $shipmentCarrierNames;
         }
 
-        $cart_rules = $this->order->getCartRules();
+        $cart_rules = $this->order_invoice->getCartRules();
         $free_shipping = false;
         foreach ($cart_rules as $key => $cart_rule) {
             if ($cart_rule['free_shipping']) {

--- a/tests/Integration/Classes/InvoiceScopedCartRuleDisplayTest.php
+++ b/tests/Integration/Classes/InvoiceScopedCartRuleDisplayTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Context;
+use Currency;
+use Db;
+use HTMLTemplateInvoice;
+use OrderCartRule;
+use OrderInvoice;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * A discount added from the order page can be attached to a single invoice, which is stored in
+ * order_cart_rule.id_order_invoice. The invoice template listed the discounts of the whole order,
+ * so a discount belonging to one invoice was printed on every invoice of that order - displayed
+ * there but not counted in that invoice's totals.
+ */
+class InvoiceScopedCartRuleDisplayTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['order_invoice', 'order_cart_rule'];
+    private const ORDER_ID = 1;
+
+    private static int $invoiceA;
+    private static int $invoiceB;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        self::bootKernel();
+
+        self::$invoiceA = self::createInvoice();
+        self::$invoiceB = self::createInvoice();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'order_cart_rule WHERE id_order = ' . self::ORDER_ID);
+    }
+
+    private static function createInvoice(): int
+    {
+        $invoice = new OrderInvoice();
+        $invoice->id_order = self::ORDER_ID;
+        $invoice->number = 0;
+        $invoice->total_discount_tax_excl = 0;
+        $invoice->total_discount_tax_incl = 0;
+        $invoice->total_paid_tax_excl = 20.0;
+        $invoice->total_paid_tax_incl = 20.0;
+        $invoice->total_products = 20.0;
+        $invoice->total_products_wt = 20.0;
+        $invoice->total_shipping_tax_excl = 2.0;
+        $invoice->total_shipping_tax_incl = 2.0;
+        $invoice->add();
+
+        return (int) $invoice->id;
+    }
+
+    private function addCartRule(int $invoiceId, string $name, float $value, bool $freeShipping = false): void
+    {
+        $rule = new OrderCartRule();
+        $rule->id_order = self::ORDER_ID;
+        $rule->id_cart_rule = 0;
+        $rule->id_order_invoice = $invoiceId;
+        $rule->name = $name;
+        $rule->value = $value;
+        $rule->value_tax_excl = $value;
+        $rule->free_shipping = $freeShipping;
+        $rule->add();
+    }
+
+    /**
+     * The rules the invoice itself reports. What the template prints follows from these, but the
+     * two are asserted separately: testTheOtherInvoicesDiscountIsNotPrinted goes through the page.
+     *
+     * @return string[]
+     */
+    private function invoiceCartRuleNames(int $invoiceId): array
+    {
+        $names = [];
+        foreach ((new OrderInvoice($invoiceId))->getCartRules() as $rule) {
+            $names[] = $rule['name'];
+        }
+
+        return $names;
+    }
+
+    public function testADiscountAttachedToOneInvoiceIsNotListedOnTheOthers(): void
+    {
+        $this->addCartRule(self::$invoiceB, 'SECOND_INVOICE_ONLY', 5.0);
+
+        $this->assertSame([], $this->invoiceCartRuleNames(self::$invoiceA));
+        $this->assertSame(['SECOND_INVOICE_ONLY'], $this->invoiceCartRuleNames(self::$invoiceB));
+    }
+
+    /**
+     * A rule with no invoice attached came with the cart, so it belongs to the order as a whole and
+     * has to keep appearing on every invoice. Without this the fix would hide the ordinary case.
+     */
+    public function testADiscountWithNoInvoiceStaysOnEveryInvoice(): void
+    {
+        $this->addCartRule(0, 'WHOLE_ORDER', 5.0);
+
+        $this->assertSame(['WHOLE_ORDER'], $this->invoiceCartRuleNames(self::$invoiceA));
+        $this->assertSame(['WHOLE_ORDER'], $this->invoiceCartRuleNames(self::$invoiceB));
+    }
+
+    public function testAnInvoiceWithoutDiscountsListsNone(): void
+    {
+        $this->assertSame([], $this->invoiceCartRuleNames(self::$invoiceA));
+        $this->assertSame([], $this->invoiceCartRuleNames(self::$invoiceB));
+    }
+
+    /**
+     * End to end through the template: the printed invoice must not carry the other invoice's
+     * discount. This is the symptom the report describes, so it is asserted on the rendered page.
+     */
+    public function testTheOtherInvoicesDiscountIsNotPrinted(): void
+    {
+        $this->addCartRule(self::$invoiceB, 'SECOND_INVOICE_ONLY', 5.0);
+
+        $this->assertStringNotContainsString('SECOND_INVOICE_ONLY', $this->render(self::$invoiceA));
+        $this->assertStringContainsString('SECOND_INVOICE_ONLY', $this->render(self::$invoiceB));
+    }
+
+    private function render(int $invoiceId): string
+    {
+        $context = Context::getContext();
+        $context->container = self::$kernel->getContainer();
+        // A printed invoice needs a currency to resolve its computing precision.
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        smartyRegisterFunction($context->smarty, 'function', 'displayPrice', ['Tools', 'displayPriceSmarty']);
+
+        $template = new HTMLTemplateInvoice(new OrderInvoice($invoiceId), $context->smarty);
+
+        $previousHandler = set_error_handler(static fn () => true);
+        try {
+            return $template->getContent();
+        } finally {
+            set_error_handler($previousHandler);
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A discount added from the order page can be attached to a single invoice, which is stored in `order_cart_rule.id_order_invoice`. Nothing ever read that column back, so `HTMLTemplateInvoice` listed the discounts of the whole order and a discount belonging to one invoice was printed on every invoice of that order - displayed there, but not counted in that invoice's totals, which is exactly what the report describes. `OrderInvoice::getCartRules()` returns the rules of one invoice and keeps the ones with no invoice attached, since those came with the cart and belong to the order as a whole.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On an order with two invoices, add a discount from the order page and attach it to the second invoice only. Print the first invoice: before this change it carries the discount row while its totals ignore it; after, the row appears only on the invoice the discount belongs to. A discount that came with the cart, which has no invoice attached, keeps appearing on both.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #18807
| Related PRs       | #42553 does the same for `getProductTaxesBreakdown()`, the other place an invoice was reporting order-wide rows. The amount side of this data model - an invoice-attached discount not being deducted from the right invoice's totals - is #20778 and touches different files.
| Sponsor company   |

## What was measured

Order with two invoices, A and B, one discount attached to B only, printing both invoices through
`HTMLTemplateInvoice::getContent()` and looking for the discount name in the output. Same five
fixtures before and after the change, on 9.2:

```
                                                        before            after
1. discount attached to invoice B only        A: SHOWN  B: SHOWN     A: absent  B: SHOWN
2. discount with no invoice (came with cart)  A: SHOWN  B: SHOWN     A: SHOWN   B: SHOWN
3. order-wide free shipping, value 2.00,
   invoice shipping 2.00, nets to zero        A: absent B: absent    A: absent  B: absent
4. order-wide free shipping worth 7.00,
   nets to 5.00 after shipping                A: SHOWN  B: SHOWN     A: SHOWN   B: SHOWN
5. no discounts at all                        A: absent              A: absent
```

Only line 1 moves. Line 2 is the case that must not regress: a rule that came with the cart carries
`id_order_invoice = 0` and still belongs to every invoice. Lines 3 and 4 exercise the free-shipping
block just below the change, which subtracts this invoice's shipping from the rule's value and drops
the row when the remainder is zero - both are identical before and after. Line 5 is the control that
the check is not trivially true.

## Where the two values come from

`Order::addCartRule()` takes the invoice id and defaults it to `0`. Checkout writes `0` through
`PaymentModule`, so cart discounts are order-wide. The order page writes a real id through
`AddCartRuleToOrderHandler` and `OrderAmountUpdater`, which is the case the report covers. On an order
with a single invoice every rule is either `0` or that invoice, so nothing changes there.

## Not changed

`OrderInvoice::getShippingTaxesBreakdown()` reads the same order-wide list to decide whether shipping
was free, so a free-shipping discount attached to one invoice suppresses the shipping tax breakdown on
the others. That is the same root cause but it moves tax figures rather than a printed row, so it needs
its own before and after on the breakdown and is left for a separate change.

## Tests

`tests/Integration/Classes/InvoiceScopedCartRuleDisplayTest.php`, 4 cases: a discount attached to one
invoice is not listed on the other, a discount with no invoice stays on every invoice, an invoice
without discounts lists none, and the end to end case asserting on the rendered invoice page rather
than on the variable behind it. Two mutations, each failing a different set: pointing the template back
at `$this->order->getCartRules()` fails only the rendered case, which is what shows that case really
goes through the template; dropping the invoice predicate from the accessor fails the rendered case and
the first one, leaving the order-wide and empty cases green because neither discriminates on it.

Full `tests/Unit` suite is byte-identical to a clean `9.2.x` baseline (5484 tests, the same 21
pre-existing failures), `CartTest` and `ObjectModelTest` green, php-cs-fixer and phpstan clean.
