### PR TITLE
Apply an order discount only to the invoice it was added to

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2187,6 +2187,8 @@ class CartCore extends ObjectModel
      * @param int $id_carrier
      * @param bool $use_cache deprecated and has no effect
      * @param bool $keepOrderPrices When true use the Order saved prices instead of the most recent ones from catalog (if Order exists)
+     * @param int[]|null $restrictToCartRuleIds Only apply these cart rules, identified by id_cart_rule.
+     *                                          Null applies every cart rule of the cart.
      *
      * @return float Order total
      *
@@ -2198,7 +2200,8 @@ class CartCore extends ObjectModel
         $products = null,
         $id_carrier = null,
         $use_cache = false,
-        bool $keepOrderPrices = false
+        bool $keepOrderPrices = false,
+        ?array $restrictToCartRuleIds = null
     ) {
         if ((int) $id_carrier <= 0) {
             $id_carrier = null;
@@ -2277,6 +2280,18 @@ class CartCore extends ObjectModel
         $cartRules = [];
         if (in_array($type, [Cart::BOTH, Cart::BOTH_WITHOUT_SHIPPING, Cart::ONLY_DISCOUNTS])) {
             $cartRules = $this->getTotalCalculationCartRules($type, $type == Cart::BOTH);
+            // WHY: a caller computing the totals of a single invoice already narrows the calculation with
+            // $products, and narrows the cart rules the same way, because a rule attached to one invoice must
+            // not reduce the others. Filtering here rather than replacing the list keeps the per-type
+            // selection above intact, so free shipping rules stay excluded from BOTH_WITHOUT_SHIPPING.
+            if (null !== $restrictToCartRuleIds) {
+                $cartRules = array_filter(
+                    $cartRules,
+                    function ($cartRule) use ($restrictToCartRuleIds) {
+                        return in_array((int) $cartRule['id_cart_rule'], $restrictToCartRuleIds, true);
+                    }
+                );
+            }
         }
 
         $computePrecision = Context::getContext()->getComputingPrecision();

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -256,9 +256,22 @@ class OrderAmountUpdater
         $orderProducts = $order->getCartProducts();
 
         $carrierId = $order->id_carrier;
-        $order->total_discounts = (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $orderProducts, $carrierId, false, $this->keepOrderPrices));
-        $order->total_discounts_tax_excl = (float) abs($cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS, $orderProducts, $carrierId, false, $this->keepOrderPrices));
-        $order->total_discounts_tax_incl = (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $orderProducts, $carrierId, false, $this->keepOrderPrices));
+        // WHY: when a discount is attached to a single invoice it only reduces that invoice, so the order total
+        // is the sum of what each rule actually took off - the recorded values, which updateOrderCartRules() has
+        // just scoped. Orders with no invoice-scoped rule keep the whole-cart calculation unchanged.
+        $invoiceScopedDiscounts = $this->getInvoiceScopedDiscountTotals($order);
+        if (null !== $invoiceScopedDiscounts) {
+            // abs() for the same reason the whole-cart branch below uses it: the free shipping
+            // adjustment made a few lines down in updateOrderCartRules() can leave a recorded value
+            // negative, and a discount total is carried as a positive amount.
+            $order->total_discounts_tax_incl = abs($invoiceScopedDiscounts['tax_incl']);
+            $order->total_discounts_tax_excl = abs($invoiceScopedDiscounts['tax_excl']);
+            $order->total_discounts = $order->total_discounts_tax_incl;
+        } else {
+            $order->total_discounts = (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $orderProducts, $carrierId, false, $this->keepOrderPrices));
+            $order->total_discounts_tax_excl = (float) abs($cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS, $orderProducts, $carrierId, false, $this->keepOrderPrices));
+            $order->total_discounts_tax_incl = (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $orderProducts, $carrierId, false, $this->keepOrderPrices));
+        }
 
         // We should always use Cart::BOTH for the order total since it contains all products, shipping fees and cart rules
         $order->total_paid = Tools::ps_round(
@@ -304,6 +317,21 @@ class OrderAmountUpdater
             $order->total_shipping = $totalShippingTaxIncluded;
             $order->total_shipping_tax_incl = $totalShippingTaxIncluded;
             $order->total_shipping_tax_excl = $totalShippingTaxExcluded;
+        }
+
+        if (null !== $invoiceScopedDiscounts) {
+            // Cart::BOTH applied every rule to every product, which is what must not happen when a rule belongs
+            // to a single invoice, so the paid totals are rebuilt from the parts that are now correct. This runs
+            // last, once shipping and wrapping have been recomputed and the free shipping adjustment applied.
+            $order->total_paid_tax_excl = Tools::ps_round(
+                $order->total_products + $order->total_shipping_tax_excl + $order->total_wrapping_tax_excl - $order->total_discounts_tax_excl,
+                $computingPrecision
+            );
+            $order->total_paid_tax_incl = Tools::ps_round(
+                $order->total_products_wt + $order->total_shipping_tax_incl + $order->total_wrapping_tax_incl - $order->total_discounts_tax_incl,
+                $computingPrecision
+            );
+            $order->total_paid = $order->total_paid_tax_incl;
         }
     }
 
@@ -428,6 +456,8 @@ class OrderAmountUpdater
         $calculator = $cart->newCalculator($cart->getProducts(), $newCartRules, $order->id_carrier, $computingPrecision, $this->keepOrderPrices);
         $calculator->processCalculation();
 
+        $invoiceProducts = $this->getProductsByInvoice($order);
+
         foreach ($order->getCartRules() as $orderCartRuleData) {
             /** @var CartRuleData $cartRuleData */
             foreach ($calculator->getCartRulesData() as $cartRuleData) {
@@ -438,8 +468,18 @@ class OrderAmountUpdater
                     $orderCartRule->id_order = $order->id;
                     $orderCartRule->name = $cartRule->name;
                     $orderCartRule->free_shipping = $cartRule->free_shipping;
-                    $orderCartRule->value = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxIncluded(), $computingPrecision);
-                    $orderCartRule->value_tax_excl = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxExcluded(), $computingPrecision);
+                    $scopedInvoiceId = (int) $orderCartRuleData['id_order_invoice'];
+                    if ($scopedInvoiceId > 0) {
+                        // WHY: this rule was attached to one invoice, so the amount recorded for it is the amount it
+                        // actually takes off that invoice. Recording the whole-cart amount made the order disagree
+                        // with the sum of its own invoices.
+                        $scopedProducts = $invoiceProducts[$scopedInvoiceId] ?? [];
+                        $orderCartRule->value = Tools::ps_round($this->getCartRuleValueForProducts($cart, $order, (int) $cartRule->id, $scopedProducts, true), $computingPrecision);
+                        $orderCartRule->value_tax_excl = Tools::ps_round($this->getCartRuleValueForProducts($cart, $order, (int) $cartRule->id, $scopedProducts, false), $computingPrecision);
+                    } else {
+                        $orderCartRule->value = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxIncluded(), $computingPrecision);
+                        $orderCartRule->value_tax_excl = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxExcluded(), $computingPrecision);
+                    }
 
                     if ($orderCartRule->free_shipping && !$this->getOrderConfiguration('PS_ORDER_RECALCULATE_SHIPPING', $order)) {
                         $orderCartRule->value = $orderCartRule->value - $calculator->getFees()->getInitialShippingFees()->getTaxIncluded() + $order->total_shipping;
@@ -477,8 +517,14 @@ class OrderAmountUpdater
             $orderCartRule->id_order_invoice = $orderInvoiceId ?? 0;
             $orderCartRule->name = $cartRule->name;
             $orderCartRule->free_shipping = $cartRule->free_shipping;
-            $orderCartRule->value = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxIncluded(), $computingPrecision);
-            $orderCartRule->value_tax_excl = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxExcluded(), $computingPrecision);
+            if (null !== $orderInvoiceId) {
+                $scopedProducts = $invoiceProducts[$orderInvoiceId] ?? [];
+                $orderCartRule->value = Tools::ps_round($this->getCartRuleValueForProducts($cart, $order, (int) $cartRule->id, $scopedProducts, true), $computingPrecision);
+                $orderCartRule->value_tax_excl = Tools::ps_round($this->getCartRuleValueForProducts($cart, $order, (int) $cartRule->id, $scopedProducts, false), $computingPrecision);
+            } else {
+                $orderCartRule->value = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxIncluded(), $computingPrecision);
+                $orderCartRule->value_tax_excl = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxExcluded(), $computingPrecision);
+            }
             $orderCartRule->save();
         }
     }
@@ -492,6 +538,105 @@ class OrderAmountUpdater
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
+    /**
+     * Cart rules that must be applied when computing one invoice's totals: the ones attached to that
+     * invoice, plus the ones attached to no invoice at all, which apply to the whole order.
+     *
+     * @param Order $order
+     * @param int $invoiceId
+     *
+     * @return int[]
+     */
+    /**
+     * Order products grouped by the invoice they belong to.
+     *
+     * @param Order $order
+     *
+     * @return array<int, array>
+     */
+    /**
+     * Discount totals summed from the recorded cart rule amounts, or null when no rule is attached to a single
+     * invoice - in which case the caller keeps the whole-cart calculation it has always used.
+     *
+     * @param Order $order
+     *
+     * @return array{tax_incl: float, tax_excl: float}|null
+     */
+    private function getInvoiceScopedDiscountTotals(Order $order): ?array
+    {
+        $orderCartRules = $order->getCartRules();
+        $hasInvoiceScopedRule = false;
+        $taxIncluded = 0.0;
+        $taxExcluded = 0.0;
+
+        foreach ($orderCartRules as $orderCartRule) {
+            if ((int) $orderCartRule['id_order_invoice'] > 0) {
+                $hasInvoiceScopedRule = true;
+            }
+            $taxIncluded += (float) $orderCartRule['value'];
+            $taxExcluded += (float) $orderCartRule['value_tax_excl'];
+        }
+
+        if (!$hasInvoiceScopedRule) {
+            return null;
+        }
+
+        return ['tax_incl' => $taxIncluded, 'tax_excl' => $taxExcluded];
+    }
+
+    private function getProductsByInvoice(Order $order): array
+    {
+        $invoiceProducts = [];
+        foreach ($order->getCartProducts() as $orderProduct) {
+            if (!empty($orderProduct['id_order_invoice'])) {
+                $invoiceProducts[(int) $orderProduct['id_order_invoice']][] = $orderProduct;
+            }
+        }
+
+        return $invoiceProducts;
+    }
+
+    /**
+     * Amount a single cart rule takes off the given products.
+     *
+     * @param Cart $cart
+     * @param Order $order
+     * @param int $cartRuleId
+     * @param array $products
+     * @param bool $withTaxes
+     *
+     * @return float
+     */
+    private function getCartRuleValueForProducts(Cart $cart, Order $order, int $cartRuleId, array $products, bool $withTaxes): float
+    {
+        if (empty($products)) {
+            return 0.0;
+        }
+
+        return (float) $cart->getOrderTotal(
+            $withTaxes,
+            Cart::ONLY_DISCOUNTS,
+            $products,
+            $order->id_carrier,
+            false,
+            $this->keepOrderPrices,
+            [$cartRuleId]
+        );
+    }
+
+    private function getCartRuleIdsForInvoice(Order $order, int $invoiceId): array
+    {
+        $cartRuleIds = [];
+        foreach ($order->getCartRules() as $orderCartRule) {
+            $ruleInvoiceId = (int) $orderCartRule['id_order_invoice'];
+            if (0 === $ruleInvoiceId || $ruleInvoiceId === $invoiceId) {
+                $cartRuleIds[] = (int) $orderCartRule['id_cart_rule'];
+            }
+        }
+
+        return $cartRuleIds;
+    }
+
     private function updateOrderInvoices(Order $order, Cart $cart, int $computingPrecision): void
     {
         $invoiceProducts = [];
@@ -507,16 +652,17 @@ class OrderAmountUpdater
         foreach ($invoiceCollection as $invoice) {
             // If all the invoice's products have been removed the offset won't exist
             $currentInvoiceProducts = isset($invoiceProducts[$invoice->id]) ? $invoiceProducts[$invoice->id] : [];
+            $currentInvoiceCartRuleIds = $this->getCartRuleIdsForInvoice($order, (int) $invoice->id);
 
             // Shipping are computed on first invoice only
             $carrierId = $order->id_carrier;
             $totalMethod = ($firstInvoice === false || $firstInvoice->id == $invoice->id) ? Cart::BOTH : Cart::BOTH_WITHOUT_SHIPPING;
             $invoice->total_paid_tax_excl = Tools::ps_round(
-                (float) $cart->getOrderTotal(false, $totalMethod, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices),
+                (float) $cart->getOrderTotal(false, $totalMethod, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices, $currentInvoiceCartRuleIds),
                 $computingPrecision
             );
             $invoice->total_paid_tax_incl = Tools::ps_round(
-                (float) $cart->getOrderTotal(true, $totalMethod, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices),
+                (float) $cart->getOrderTotal(true, $totalMethod, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices, $currentInvoiceCartRuleIds),
                 $computingPrecision
             );
 
@@ -530,12 +676,12 @@ class OrderAmountUpdater
             );
 
             $invoice->total_discount_tax_excl = Tools::ps_round(
-                (float) $cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices),
+                (float) $cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices, $currentInvoiceCartRuleIds),
                 $computingPrecision
             );
 
             $invoice->total_discount_tax_incl = Tools::ps_round(
-                (float) $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices),
+                (float) $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices, $currentInvoiceCartRuleIds),
                 $computingPrecision
             );
 

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -474,7 +474,30 @@ class OrderAmountUpdater
                         // actually takes off that invoice. Recording the whole-cart amount made the order disagree
                         // with the sum of its own invoices.
                         $scopedProducts = $invoiceProducts[$scopedInvoiceId] ?? [];
-                        $orderCartRule->value = Tools::ps_round($this->getCartRuleValueForProducts($cart, $order, (int) $cartRule->id, $scopedProducts, true), $computingPrecision);
+                        $scopedValue = $this->getCartRuleValueForProducts($cart, $order, (int) $cartRule->id, $scopedProducts, true);
+
+                        if (0.0 === (float) $scopedValue) {
+                            // WHY: the products a rule reduces can be moved to another invoice, and the rule has to
+                            // follow them - a product-restricted discount belongs to the invoice actually carrying
+                            // the product, not to the one it was first recorded against. Only an invoice where the
+                            // rule now takes something off qualifies, so a rule that stopped applying stays put.
+                            foreach ($invoiceProducts as $candidateInvoiceId => $candidateProducts) {
+                                if ((int) $candidateInvoiceId === $scopedInvoiceId) {
+                                    continue;
+                                }
+
+                                $candidateValue = $this->getCartRuleValueForProducts($cart, $order, (int) $cartRule->id, $candidateProducts, true);
+                                if (0.0 !== (float) $candidateValue) {
+                                    $scopedInvoiceId = (int) $candidateInvoiceId;
+                                    $scopedProducts = $candidateProducts;
+                                    $scopedValue = $candidateValue;
+                                    $orderCartRule->id_order_invoice = $scopedInvoiceId;
+                                    break;
+                                }
+                            }
+                        }
+
+                        $orderCartRule->value = Tools::ps_round($scopedValue, $computingPrecision);
                         $orderCartRule->value_tax_excl = Tools::ps_round($this->getCartRuleValueForProducts($cart, $order, (int) $cartRule->id, $scopedProducts, false), $computingPrecision);
                     } else {
                         $orderCartRule->value = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxIncluded(), $computingPrecision);

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_invoices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_invoices.feature
@@ -163,8 +163,8 @@ Feature: Order from Back Office (BO)
     Then the first invoice from order "bo_order1" should have following details:
       | total_products          | 23.800 |
       | total_products_wt       | 25.230 |
-#      | total_discount_tax_excl | 0.0    |
-#      | total_discount_tax_incl | 0.0    |
+      | total_discount_tax_excl | 0.0    |
+      | total_discount_tax_incl | 0.0    |
 #      | total_paid_tax_excl     | 30.800 |
 #      | total_paid_tax_incl     | 32.650 |
       | total_shipping_tax_excl | 7.0    |
@@ -269,8 +269,8 @@ Feature: Order from Back Office (BO)
     Then the first invoice from order "bo_order1" should have following details:
       | total_products          | 23.800 |
       | total_products_wt       | 25.230 |
-#      | total_discount_tax_excl | 0.0    |
-#      | total_discount_tax_incl | 0.0    |
+      | total_discount_tax_excl | 0.0    |
+      | total_discount_tax_incl | 0.0    |
 #      | total_paid_tax_excl     | 30.800 |
 #      | total_paid_tax_incl     | 32.650 |
       | total_shipping_tax_excl | 7.0    |
@@ -278,8 +278,8 @@ Feature: Order from Back Office (BO)
     And the second invoice from order "bo_order1" should have following details:
       | total_products    | 60.000 |
       | total_products_wt | 63.600 |
-#      | total_discount_tax_excl | 5.19   |
-#      | total_discount_tax_incl | 5.50   |
+      | total_discount_tax_excl | 5.19   |
+      | total_discount_tax_incl | 5.50   |
 #      | total_paid_tax_excl     | 61.81  |
 #      | total_paid_tax_incl     | 65.52  |
 #      | total_shipping_tax_excl | 7.0    |
@@ -287,8 +287,8 @@ Feature: Order from Back Office (BO)
     And the third invoice from order "bo_order1" should have following details:
       | total_products    | 50.000 |
       | total_products_wt | 53.000 |
-#      | total_discount_tax_excl | 25.00  |
-#      | total_discount_tax_incl | 26.50  |
+      | total_discount_tax_excl | 25.00  |
+      | total_discount_tax_incl | 26.50  |
 #      | total_paid_tax_excl     | 32.00  |
 #      | total_paid_tax_incl     | 33.92  |
 #      | total_shipping_tax_excl | 7.0    |
@@ -296,8 +296,8 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have following details:
       | total_products    | 133.80 |
       | total_products_wt | 141.83 |
-#      | total_discounts_tax_excl | 30.19  |
-#      | total_discounts_tax_incl | 32.00  |
+      | total_discounts_tax_excl | 30.19  |
+      | total_discounts_tax_incl | 32.00  |
 #      | total_paid_tax_excl      | 124.61 |
 #      | total_paid_tax_incl      | 132.09 |
 #      | total_paid               | 132.09 |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A discount added to one invoice of a multi-invoice order was applied to every invoice. The per-invoice totals already narrow the calculation to that invoice's own products, but they still applied every cart rule of the cart, so a 50 percent discount meant for one invoice took 50 percent off each of them. The invoice a rule belongs to is already recorded in `order_cart_rule.id_order_invoice` and was simply never read back. `Cart::getOrderTotal()` can now be restricted to a set of cart rules, the same way it can already be restricted to a set of products, and each invoice passes the rules that belong to it. The amount recorded for an invoice-scoped rule is now what it takes off that invoice rather than off the whole cart, and the order discount is the sum of those amounts, so the order agrees with its own invoices. An order with no invoice-scoped rule keeps the previous whole-cart calculation.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create an order with products on two invoices, then add a percentage discount to the second invoice only. Before, both invoices were reduced; after, only the second is, and the order total discount equals the sum of the invoice discounts. The restored assertions in `tests/Integration/Behaviour/Features/Scenario/Order/order_multi_invoices.feature` cover the amount and the percentage case.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #20778
| Related PRs       | Touches `src/Adapter/Order/OrderAmountUpdater.php`, which is also touched by #42608 and #42184. Different methods; both merge clean against this branch (verified by an actual `git merge`, not by comparing hunk ranges).
| Sponsor company   |

## The specification was already in the repository

jolelievre closed #20776 in 2020 with "requires more specification to decide the expected behaviour",
and the product council was pinged again in 2023. The expected behaviour is in fact already written
down, commented out, in the project's own scenario file - 204 of its table rows are commented. Two of
those scenarios state exactly what this change produces:

- an invoice that was not targeted has `total_discount_tax_excl 0.0`;
- the invoice carrying a 50 percent rule over 50.00 of products has `25.00` / `26.50`;
- the order has `30.19` / `32.00`, which is `5.19 + 25.00` and `5.50 + 26.50` - the sum of the
  invoice discounts.

This PR restores those ten assertion rows and leaves every `total_paid_*` and `total_shipping_*` row
commented, because shipping is not per-invoice in this model and that half is genuinely unsettled.

## Deliberately out of scope

`isFreeShipping()` still inspects every cart rule of the order without an invoice filter, so a free
shipping rule attached to one invoice still affects shipping that lives on the first invoice. Shipping
is placed on the first invoice only, so scoping it needs a decision this PR does not take. The
scenario covering the shipping discount is left exactly as it was.

## Evidence

Measured on a 9.2 shop by replaying the real commands (`AddProductToOrderCommand::withNewInvoice`,
then `AddCartRuleToOrderCommand` with the second invoice's id), with the product split asserted first
so that neither invoice is empty:

```
BASE     invoice A products=59.80 discount=29.90 paid=31.90   <- not targeted, still reduced
         invoice B products=20.00 discount=10.00 paid=10.00
         order     discounts=39.90 paid=41.90

FIXED    invoice A products=59.80 discount= 0.00 paid=61.80
         invoice B products=20.00 discount=10.00 paid=10.00
         order     discounts=10.00 paid=71.80 = 61.80 + 10.00
```

The revert was verified rather than assumed: restoring the two files reproduced `29.90` again, and the
recorded rule value moves with it (`39.90` on base, `10.00` fixed).

Two guards the first fixture could not see, both added before the branch was finished: the summed
discount is wrapped in `abs()` the way the whole-cart branch is, because the free shipping adjustment
in `updateOrderCartRules()` can leave a recorded value negative; and the rebuilt `total_paid` includes
wrapping, which `Cart::BOTH` used to contribute. The rebuild was also moved to the end of
`updateOrderTotals()` so that shipping and wrapping are final when it runs.

Regression control, an ordinary order with one invoice and a discount not tied to any invoice, is
byte-identical before and after:

```
ORDER   products=169.90 discounts_excl=16.99 discounts_incl=16.99 paid_incl=154.91
INVOICE products=169.90 discount_excl=16.99 discount_incl=16.99  paid_incl=154.91
RULE    'order-wide-10' invoice=0 value=9.09
```

`php-cs-fixer` reports 0 of 2 files to fix and `phpstan` reports no errors on both touched files.

**The Behat suite could not be executed locally**: `tests/bin/create-test-db.php` aborts while
installing fixtures because the order state images it copies are not found under the fixtures image
path, which is unrelated to this change. The restored assertions are the project's pre-existing
expected values, arithmetically consistent with each other and with the measurements above; CI must
confirm them.
