### PR TITLE
Round with the rounding mode of the shop in context

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -113,6 +113,14 @@ class ToolsCore
      */
     protected static $untrusted_url_resolve_cache = [];
 
+    /**
+     * @deprecated Since 9.2.0. Never read by the core: PS_PRICE_ROUND_MODE is shop scoped, and
+     *             caching it here for the whole process made every shop after the first round with
+     *             the first one's mode. ps_round() resolves it from Configuration, which is itself
+     *             an in-memory cache and is shop aware.
+     *
+     * @var int|null
+     */
     public static $round_mode = null;
 
     /**
@@ -1662,24 +1670,24 @@ class ToolsCore
     }
 
     /**
-     * Returns the rounded value of $value to specified precision, according to your configuration.
+     * Returns the rounded value of $value, using the rounding mode configured for the current shop.
+     *
+     * Only the rounding mode comes from the configuration. The number of decimals is $precision,
+     * which the caller supplies and which defaults to none - price code usually passes
+     * Context::getContext()->getComputingPrecision().
      *
      * Warning - this method accepts our own PS rounding constants with different integer values.
      *
      * @param float $value
-     * @param int $precision
-     * @param int<0,5>|null $round_mode
+     * @param int $precision number of decimals to keep, 0 by default
+     * @param int<0,5>|null $round_mode PS_ROUND_* constant, or null to use PS_PRICE_ROUND_MODE
      *
      * @return float
      */
     public static function ps_round($value, $precision = 0, $round_mode = null)
     {
         if ($round_mode === null) {
-            if (Tools::$round_mode == null) {
-                Tools::$round_mode = (int) Configuration::get('PS_PRICE_ROUND_MODE');
-            }
-
-            $round_mode = Tools::$round_mode;
+            $round_mode = (int) Configuration::get('PS_PRICE_ROUND_MODE');
         }
 
         switch ($round_mode) {

--- a/tests/Integration/Classes/ToolsPsRoundShopScopeTest.php
+++ b/tests/Integration/Classes/ToolsPsRoundShopScopeTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration as LegacyConfiguration;
+use Db;
+use Shop as LegacyShop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+use Tools;
+
+class ToolsPsRoundShopScopeTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['shop', 'shop_group', 'configuration'];
+
+    /**
+     * 1.999 separates the two modes used here: rounding half up keeps 2.0, rounding down keeps 1.99.
+     */
+    private const VALUE = 1.999;
+    private const PRECISION = 2;
+
+    private static int $secondShopId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyConfiguration::resetStaticCache();
+        LegacyShop::resetStaticCache();
+        self::bootKernel();
+
+        $configuration = self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        $db = Db::getInstance();
+        $db->insert('shop_group', [
+            'name' => 'test_group_round', 'color' => '', 'share_customer' => 0,
+            'share_order' => 0, 'share_stock' => 0, 'active' => 1, 'deleted' => 0,
+        ]);
+        $secondGroupId = (int) $db->Insert_ID();
+        $db->insert('shop', [
+            'id_shop_group' => $secondGroupId, 'name' => 'test_shop_round', 'color' => '',
+            'id_category' => 2, 'theme_name' => 'classic', 'active' => 1, 'deleted' => 0,
+        ]);
+        self::$secondShopId = (int) $db->Insert_ID();
+        LegacyShop::resetStaticCache();
+
+        LegacyConfiguration::updateValue('PS_PRICE_ROUND_MODE', PS_ROUND_HALF_UP, false, null, 1);
+        LegacyConfiguration::updateValue('PS_PRICE_ROUND_MODE', PS_ROUND_DOWN, false, null, self::$secondShopId);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        LegacyShop::setContext(LegacyShop::CONTEXT_ALL);
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        LegacyShop::resetStaticCache();
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Start from the state a fresh process has, so a reintroduced cache is measured on this
+        // test's own calls rather than on a value another test left behind.
+        Tools::$round_mode = null;
+    }
+
+    /**
+     * PS_PRICE_ROUND_MODE is shop scoped, so two shops configured differently must round
+     * differently in the same process. ps_round() used to resolve the mode once into a static and
+     * keep it for the rest of the request, so whichever shop was served first imposed its mode on
+     * every shop after it.
+     */
+    public function testItRoundsWithTheModeOfTheShopInContext(): void
+    {
+        self::bootKernel();
+
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, 1);
+        $firstShop = Tools::ps_round(self::VALUE, self::PRECISION);
+
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, self::$secondShopId);
+        $secondShop = Tools::ps_round(self::VALUE, self::PRECISION);
+
+        // The fixture is only meaningful while the two shops disagree.
+        $this->assertSame('2', (string) LegacyConfiguration::get('PS_PRICE_ROUND_MODE', null, null, 1));
+        $this->assertSame('1', (string) LegacyConfiguration::get('PS_PRICE_ROUND_MODE', null, null, self::$secondShopId));
+
+        $this->assertSame(2.0, $firstShop, 'Shop 1 rounds half up.');
+        $this->assertSame(1.99, $secondShop, 'The second shop rounds down.');
+    }
+
+    /**
+     * Same defect from the other side: whichever shop is served first must not win. Reversing the
+     * order has to reverse the results, otherwise only one of the two shops is actually resolved.
+     */
+    public function testTheShopServedFirstDoesNotImposeItsMode(): void
+    {
+        self::bootKernel();
+
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, self::$secondShopId);
+        $secondShop = Tools::ps_round(self::VALUE, self::PRECISION);
+
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, 1);
+        $firstShop = Tools::ps_round(self::VALUE, self::PRECISION);
+
+        $this->assertSame(1.99, $secondShop, 'The second shop rounds down.');
+        $this->assertSame(2.0, $firstShop, 'Shop 1 rounds half up.');
+    }
+
+    /**
+     * The mode also has to be re-read after it is changed, rather than staying at the value the
+     * process happened to resolve first.
+     */
+    public function testItFollowsAConfigurationChange(): void
+    {
+        self::bootKernel();
+        LegacyShop::setContext(LegacyShop::CONTEXT_SHOP, 1);
+
+        $this->assertSame(2.0, Tools::ps_round(self::VALUE, self::PRECISION));
+
+        LegacyConfiguration::updateValue('PS_PRICE_ROUND_MODE', PS_ROUND_DOWN, false, null, 1);
+        $this->assertSame(1.99, Tools::ps_round(self::VALUE, self::PRECISION));
+
+        LegacyConfiguration::updateValue('PS_PRICE_ROUND_MODE', PS_ROUND_HALF_UP, false, null, 1);
+        $this->assertSame(2.0, Tools::ps_round(self::VALUE, self::PRECISION));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PS_PRICE_ROUND_MODE` is shop scoped, but `Tools::ps_round()` resolved it once into the public static `Tools::$round_mode` and reused that value for the rest of the process. Whichever shop was served first therefore imposed its rounding mode on every shop handled after it in the same request, and a change to the setting was ignored until the process ended. `Configuration::get()` is already an in-memory cache and is shop aware, so the mode is now read from it on every call. The static is deprecated rather than removed, because it is public.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | On a multistore installation, set Preferences > Round mode to "Round up" on one shop and "Round down" on another, then price the same product in both within one request. Before this change both shops round the way the first one resolved; after, each shop uses its own mode. `tests/Integration/Classes/ToolsPsRoundShopScopeTest.php` covers it in both orders.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | See #18808
| Related PRs       | #42524 corrects how the same configuration key is mapped in `Core\Pricing\Rounding\RoundingService`, the modern side of the same setting. #42685 also touches `classes/Tools.php` on `9.2.x`, around 600 lines away.
| Sponsor company   |

`Deprecations?` is yes for `Tools::$round_mode`; see below for why it is kept.

## What was measured

Two shops on 9.2, `PS_PRICE_ROUND_MODE` = 2 (`PS_ROUND_HALF_UP`) on shop 1 and 1 (`PS_ROUND_DOWN`) on
shop 2, one process, `Tools::ps_round(1.999, 2)`:

```
A. shop context switches, as production does
   shop 1   Configuration::get = '2'   Tools::$round_mode = NULL   ps_round = 2.0
   shop 2   Configuration::get = '1'   Tools::$round_mode = 2      ps_round = 2.0     <- wrong, 1.99

B. control, static cleared between the two calls
   shop 1   Configuration::get = '2'   ps_round = 2.0
   shop 2   Configuration::get = '1'   ps_round = 1.99

C. control, reverse order
   shop 2   ps_round = 1.99
   shop 1   ps_round = 1.99                                        <- wrong, 2.0
```

`Configuration::get()` returns the correct per-shop value throughout, so the shop scoping works and
only `ps_round()` ignores it. C makes it symmetric: it is not that one shop is broken, it is that the
first shop resolved wins.

Blast radius: instrumenting `ps_round()` while a ten line cart runs `getOrderTotal(true, Cart::BOTH)`
counts 645 calls, **all 645** of them on the branch that resolves the mode from configuration - no
call site on that path passes an explicit mode. In a request touching more than one shop, every
rounded amount after the first shop uses the wrong shop's mode.

## Why it went unnoticed for five years

The guard was `if (Tools::$round_mode == null)`, a loose comparison, and `PS_ROUND_UP` is `0`. On any
shop configured to round up the cache therefore never held and the setting was re-read on every call,
so those installations never saw the bug. Removing the static removes that inconsistency too.

The existing coverage in `tests/Unit/Classes/ToolsTest.php` passes an explicit `$round_mode` in every
case, so the branch that resolves the mode from configuration was never exercised.

## Why the static is deprecated and not deleted

`Tools::$round_mode` is `public` - the only public static property on `Tools`, every other one is
`protected` - so it is reachable from any module and removing it on a patch branch would break the
backward compatibility promise. It is marked `@deprecated`, nothing in core reads it any more, and a
major version can drop it.

The two test helpers that reset it (`Tests\Integration\Utility\ContextMocker` and the Behat
`CommonConfigurationFeatureContext`) are deliberately left in place. They no longer have anything to
reset, but they still catch a reintroduced read of the static.

## Performance

Resolving on every call costs an array lookup rather than a query: `Configuration::get()` is served
from `Configuration::$_cache`. Measured over 1,000,000 iterations, a static property read is 6.3 ns
and `Configuration::get('PS_PRICE_ROUND_MODE')` is 178.6 ns, so 172 ns is added per `ps_round()` call
that does not pass an explicit mode. Instrumented, a ten line cart's `getOrderTotal(true, Cart::BOTH)`
issues 645 `ps_round()` calls, all of them on that path, which is 111 microseconds added to an
operation dominated by database round trips.

Caching per shop id instead would restore the second half of the bug - the setting would still not be
re-read after it changes - and would duplicate a cache that already exists and is already shop aware.

## Scope

This fixes the defect the report describes and that @PierreRambaud confirmed in the thread, quoting
his words, that the function is malformed and `Tools::$round_mode` should not be public nor cached.
The issue was later retitled to deprecating `ps_round()` in favour of Decimal and moved under the
developer features epic #21632; that is a separate piece of work across 176 call sites in 29 files, so
this PR references the issue without a closing keyword and leaves the decision to a maintainer.

The original report also observed that `$precision` defaults to `0` while the docblock said "according
to your configuration". Changing that default would silently alter all 176 call sites, so the docblock
is corrected instead: only the mode comes from configuration, the number of decimals is the caller's.

## Tests

`tests/Integration/Classes/ToolsPsRoundShopScopeTest.php`, 3 cases: the shop context is followed, the
shop served first does not impose its mode (the reverse order), and a change to the setting is picked
up within the process. Each asserts the two shops actually disagree before comparing results.
Restoring the static makes all three fail, with the second one failing in the mirror direction of the
first. Full `tests/Unit` suite is byte-identical to a clean `9.2.x` baseline (5484 tests, same 21
pre-existing failures), `tests/Integration/Classes/CartTest.php` green, php-cs-fixer and phpstan clean.
