### PR TITLE
Make the Import action of a grid open the import page on its entity

### DIFF
--- a/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
@@ -171,7 +171,7 @@ final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinit
                 ->setOptions([
                     'route' => 'admin_import',
                     'route_params' => [
-                        'import_type' => 'attributes',
+                        'import_type' => 'combinations',
                     ],
                 ])
             )

--- a/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
@@ -136,7 +136,7 @@ final class AttributeGroupGridDefinitionFactory extends AbstractFilterableGridDe
                 ->setOptions([
                     'route' => 'admin_import',
                     'route_params' => [
-                        'import_type' => 'attribute_groups',
+                        'import_type' => 'combinations',
                     ],
                 ])
             )

--- a/src/Core/Grid/Definition/Factory/FeatureGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/FeatureGridDefinitionFactory.php
@@ -137,7 +137,7 @@ class FeatureGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setOptions([
                     'route' => 'admin_import',
                     'route_params' => [
-                        'import_type' => 'features',
+                        'import_type' => 'products',
                     ],
                 ])
             )

--- a/src/Core/Grid/Definition/Factory/StoreGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/StoreGridDefinitionFactory.php
@@ -152,7 +152,7 @@ class StoreGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setOptions([
                     'route' => 'admin_import',
                     'route_params' => [
-                        'import_type' => 'stores',
+                        'import_type' => 'contacts',
                     ],
                 ])
             )

--- a/src/Core/Grid/Factory/FeatureValueGridFactory.php
+++ b/src/Core/Grid/Factory/FeatureValueGridFactory.php
@@ -155,7 +155,7 @@ class FeatureValueGridFactory extends GridFactory
                 ->setOptions([
                     'route' => 'admin_import',
                     'route_params' => [
-                        'import_type' => 'features',
+                        'import_type' => 'products',
                     ],
                 ])
             )

--- a/src/Core/Import/Configuration/ImportConfigFactory.php
+++ b/src/Core/Import/Configuration/ImportConfigFactory.php
@@ -6,6 +6,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Import\Configuration;
 
+use PrestaShop\PrestaShop\Core\Import\Entity;
+use PrestaShop\PrestaShop\Core\Import\Exception\NotSupportedImportTypeException;
 use PrestaShop\PrestaShop\Core\Import\ImportSettings;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -31,7 +33,7 @@ final class ImportConfigFactory implements ImportConfigFactoryInterface
 
         return new ImportConfig(
             $request->request->get('csv', $request->getSession()->get('csv')),
-            $request->request->getInt('entity', $request->getSession()->get('entity', 0)),
+            $this->resolveEntityType($request),
             $request->request->get('iso_lang', $request->getSession()->get('iso_lang')),
             $separator,
             $multivalueSeparator,
@@ -42,5 +44,38 @@ final class ImportConfigFactory implements ImportConfigFactoryInterface
             $request->request->getBoolean('sendemail', $request->getSession()->get('sendemail', true)),
             $request->request->getInt('skip', 0)
         );
+    }
+
+    /**
+     * Resolve which entity the import page should start on.
+     *
+     * WHY: every importable grid links here through a LinkGridAction carrying an
+     * "import_type" query parameter naming its own entity, and ImportType converts such a
+     * name back to an entity type. Only this hop was missing, so the deep link had no effect.
+     * A submitted form takes precedence over it, otherwise an "import_type" left over in the
+     * URL of a POST would silently override the entity the user picked in the drop-down.
+     * An unrecognised name is ignored rather than fatal, because it comes from the query string.
+     *
+     * @param Request $request
+     *
+     * @return int
+     */
+    private function resolveEntityType(Request $request): int
+    {
+        if ($request->request->has('entity')) {
+            return $request->request->getInt('entity');
+        }
+
+        $importType = (string) $request->query->get('import_type', '');
+
+        if ('' !== $importType) {
+            try {
+                return Entity::getFromName($importType);
+            } catch (NotSupportedImportTypeException $e) {
+                // Unknown entity name, fall back to the session value below.
+            }
+        }
+
+        return (int) $request->getSession()->get('entity', 0);
     }
 }

--- a/tests/Unit/Core/Grid/GridImportTypeTest.php
+++ b/tests/Unit/Core/Grid/GridImportTypeTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Grid;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Import\Entity;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * A grid offering an Import action links to the import page with an "import_type" naming the
+ * entity to preselect, and ImportConfigFactory resolves that name through Entity::getFromName().
+ * A name outside Entity::AVAILABLE_TYPES therefore silently leaves the page on its default
+ * entity, which is how the Stores grid ended up pointing at a non-existent "stores" entity.
+ */
+class GridImportTypeTest extends TestCase
+{
+    public function testEveryGridImportsAnEntityThatExists(): void
+    {
+        $importTypes = $this->findImportTypesInGridFactories();
+
+        // Guards against the scan silently matching nothing and passing vacuously.
+        $this->assertGreaterThanOrEqual(
+            10,
+            count($importTypes),
+            'Expected the import actions of the grids to be found, the scan matched almost nothing.'
+        );
+
+        foreach ($importTypes as $file => $names) {
+            foreach ($names as $name) {
+                $this->assertArrayHasKey(
+                    $name,
+                    Entity::AVAILABLE_TYPES,
+                    sprintf('%s links to the import page with the unknown entity name "%s".', $file, $name)
+                );
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string[]> file name => entity names it links with
+     */
+    private function findImportTypesInGridFactories(): array
+    {
+        $directory = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(_PS_ROOT_DIR_ . '/src/Core/Grid')
+        );
+
+        $importTypes = [];
+        foreach ($directory as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            if (preg_match_all(
+                "/'import_type'\s*=>\s*'([^']*)'/",
+                (string) file_get_contents($file->getPathname()),
+                $matches
+            )) {
+                $importTypes[$file->getFilename()] = $matches[1];
+            }
+        }
+
+        return $importTypes;
+    }
+}

--- a/tests/Unit/Core/Import/Configuration/ImportConfigFactoryTest.php
+++ b/tests/Unit/Core/Import/Configuration/ImportConfigFactoryTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Import\Configuration;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Import\Configuration\ImportConfigFactory;
+use PrestaShop\PrestaShop\Core\Import\Entity;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+class ImportConfigFactoryTest extends TestCase
+{
+    /**
+     * @var ImportConfigFactory
+     */
+    private $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new ImportConfigFactory();
+    }
+
+    /**
+     * Every name an importable grid links here with must select its entity.
+     *
+     * @dataProvider provideImportTypeNames
+     */
+    public function testItSelectsTheEntityNamedInTheQuery(string $importType, int $expectedEntityType): void
+    {
+        $request = $this->createRequest('GET', ['import_type' => $importType]);
+
+        $this->assertSame($expectedEntityType, $this->factory->buildFromRequest($request)->getEntityType());
+    }
+
+    public static function provideImportTypeNames(): array
+    {
+        return [
+            'categories' => ['categories', Entity::TYPE_CATEGORIES],
+            'products' => ['products', Entity::TYPE_PRODUCTS],
+            'combinations' => ['combinations', Entity::TYPE_COMBINATIONS],
+            'customers' => ['customers', Entity::TYPE_CUSTOMERS],
+            'addresses' => ['addresses', Entity::TYPE_ADDRESSES],
+            'manufacturers' => ['manufacturers', Entity::TYPE_MANUFACTURERS],
+            'suppliers' => ['suppliers', Entity::TYPE_SUPPLIERS],
+            'alias' => ['alias', Entity::TYPE_ALIAS],
+            'contacts' => ['contacts', Entity::TYPE_STORE_CONTACTS],
+        ];
+    }
+
+    /**
+     * The name reaches the factory through the query string, so it cannot be trusted.
+     *
+     * @dataProvider provideUnusableImportTypes
+     */
+    public function testItIgnoresAnImportTypeItCannotResolve(string $importType): void
+    {
+        $request = $this->createRequest('GET', ['import_type' => $importType]);
+        $request->getSession()->set('entity', Entity::TYPE_SUPPLIERS);
+
+        $this->assertSame(
+            Entity::TYPE_SUPPLIERS,
+            $this->factory->buildFromRequest($request)->getEntityType()
+        );
+    }
+
+    public static function provideUnusableImportTypes(): array
+    {
+        return [
+            'unknown name' => ['not_an_entity'],
+            'former slug of the stores grid' => ['stores'],
+            'entity name spelled as the grid' => ['attributes'],
+            'numeric string' => ['2'],
+            'empty' => [''],
+        ];
+    }
+
+    /**
+     * A submitted form wins, otherwise an import_type still present in the URL of a POST
+     * would override the entity the user selected in the drop-down.
+     */
+    public function testASubmittedEntityWinsOverTheQuery(): void
+    {
+        $request = $this->createRequest(
+            'POST',
+            ['import_type' => 'categories'],
+            ['entity' => (string) Entity::TYPE_CUSTOMERS]
+        );
+
+        $this->assertSame(
+            Entity::TYPE_CUSTOMERS,
+            $this->factory->buildFromRequest($request)->getEntityType()
+        );
+    }
+
+    public function testItFallsBackToTheSessionWithoutAnImportType(): void
+    {
+        $request = $this->createRequest('GET');
+        $request->getSession()->set('entity', Entity::TYPE_ADDRESSES);
+
+        $this->assertSame(
+            Entity::TYPE_ADDRESSES,
+            $this->factory->buildFromRequest($request)->getEntityType()
+        );
+    }
+
+    public function testItDefaultsToCategories(): void
+    {
+        $request = $this->createRequest('GET');
+
+        $this->assertSame(
+            Entity::TYPE_CATEGORIES,
+            $this->factory->buildFromRequest($request)->getEntityType()
+        );
+    }
+
+    private function createRequest(string $method, array $query = [], array $body = []): Request
+    {
+        $request = Request::create('/configure/advanced/import/', $method, $method === 'POST' ? $body : []);
+        $request->query->replace($query);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        return $request;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Every grid that offers an Import action links to the import page through a `LinkGridAction` carrying an `import_type` query parameter naming the entity to preselect, and `ImportType` still holds the transformer that converts such a name back to an entity type. The hop between them was missing: `ImportConfigFactory::buildFromRequest()` reads only the submitted form and the session, so the parameter reached nothing and all eleven of those links opened the page on its default entity. Five of the names were unusable as well - the Stores grid asked for `stores` while the entity is named `contacts`, and the Attributes, Attribute groups, Features and Feature values grids named themselves although the importer creates those records through the Combinations and Products imports.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open Catalog > Attributes and click Import. Before this change the import page opens on Categories whichever grid you came from; after it opens on Combinations, which is the import that creates attributes and their values. Same for Catalog > Features (opens on Products), Shop Parameters > Contact > Stores (opens on Store contacts), and Catalog > Categories / Products, Customers, Brands, Suppliers, which now preselect their own entity instead of falling back to Categories. Selecting an entity in the drop-down and submitting still wins over the parameter.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #19225
| Related PRs       | None. #41911 (mattgoud) builds a feature-flagged CQRS import subsystem on `develop` and shares no file with this change.
| Sponsor company   |

## What was measured

`Entity::getFromName()` against every name the eleven grid buttons emit on `9.2.x`:

```
categories         -> 0          stores             -> NotSupportedImportTypeException
products           -> 1          attributes         -> NotSupportedImportTypeException
customers          -> 3          attribute_groups   -> NotSupportedImportTypeException
manufacturers      -> 5          features           -> NotSupportedImportTypeException
suppliers          -> 6          (control) contacts -> 8
```

And whether the parameter arrives at all, with a positive control:

```
GET ?import_type=products       -> entity type 0
GET ?entity=1 (query)           -> entity type 0
POST entity=1 (control, works)  -> entity type 1
```

So the six names that do resolve were as ineffective as the five that do not.

## Why rewiring the four buttons rather than removing them

`Attributes`, `Attribute groups`, `Features` and `Feature values` have no importer of their own, so
the options are to remove the button or to point it at the import that does create those records.

- 1.7.6.5 pointed them at that import already: `AdminAttributesGroupsController` built its toolbar
  link with `'import_type' => 'combinations'`, which is also the URL quoted in the issue report. The
  grid migration renamed the slug to match the grid rather than the importer, which is what broke it.
- The maintainer comment on the issue says the feature field is included in the Products import, so
  the path being linked to is the one already described there.
- Removing the button deletes the only discoverable entry point to a real import.

The page names the entity it lands on: `FormFieldToggle`'s constructor calls `toggleForm()` on load,
which fills the `js-entity-name` placeholder from the selected option, so the truncate label reads
"Delete all combinations before import" rather than leaving the user guessing.

## Precedence and untrusted input

The name now arrives from the query string, so `resolveEntityType()` orders the sources explicitly:
a submitted `entity` wins, then `import_type`, then the session, then the default. Without that
order an `import_type` still present in the URL of a POST would silently override the entity the
user picked in the drop-down. `Entity::getFromName()` throws on an unknown name, so it is caught and
the request falls back to the session rather than failing the page.

## Not changed

`AdminSearchConfController` is a twelfth producer, appending `&import_type=alias` to the import link
on the Aliases page. `alias` is a valid name and the concatenation is well formed - the generated URL
already carries a query string, so the bare `&` is a separator rather than part of the path:

```
router->generate('admin_import', [])                        -> /configure/advanced/import/?_token=
router->generate('admin_import', ['import_type' => 'alias']) -> /configure/advanced/import/?import_type=alias&_token=
```

It therefore needs no change and starts working with this fix.

The other fields `buildFromRequest()` reads from the submitted form - `csv`, `iso_lang`, `separator`,
`truncate` and the rest - are deliberately left as they are. `import_type` is the only one anything
links here with; every other reference to the `admin_import` route in the codebase is a bare redirect
carrying no parameters.

## Tests

`tests/Unit/Core/Import/Configuration/ImportConfigFactoryTest.php`, 17 cases - the nine valid names,
five unusable ones including `stores` and `attributes`, POST precedence, session fallback, default.
Two mutations: restoring the original one-line `getInt('entity', session)` fails 8 of the 9 name
cases and nothing else (the `categories` case survives because 0 is also the default, so it is not
discriminating on its own); letting the query win over a submitted form fails only the precedence
case.

`tests/Unit/Core/Grid/GridImportTypeTest.php` asserts every `import_type` under `src/Core/Grid` is a
key of `Entity::AVAILABLE_TYPES` - the guard that would have caught `stores`. Pointing one grid back
at `stores` fails it with the file name and the bad name; breaking its own scan pattern fails the
count assertion, so it cannot pass vacuously.

Full `tests/Unit` suite: 5502 tests, and the 21 pre-existing failures (MailTemplate/FolderThemeCatalog
and Module/SourceHandler) are byte-identical to a baseline run on `upstream/9.2.x` with these changes
stashed - 5484 tests there, so the delta is exactly the 18 added. php-cs-fixer and phpstan clean.
