### PR TITLE
Estimate the cost of goods sold from the margin's complement

### DIFF
--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -450,6 +450,21 @@ class AdminStatsControllerCore extends AdminStatsTabController
         return round($messages / $threads, 1);
     }
 
+    /**
+     * Share of a sale price that the goods cost, as a percentage, used to estimate the cost of goods
+     * sold for order lines that carry no wholesale price.
+     *
+     * WHY: CONF_AVERAGE_PRODUCT_MARGIN holds the average GROSS MARGIN, which its own help text defines
+     * as ((total sales revenue) - (cost of goods sold)) / (total sales revenue) * 100. The cost is
+     * therefore the complement of that percentage, not the percentage itself.
+     *
+     * @return int
+     */
+    public static function getAverageCostPercentage()
+    {
+        return 100 - (int) Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN');
+    }
+
     public static function getPurchases($date_from, $date_to, $granularity = false)
     {
         if ($granularity == 'day') {
@@ -461,7 +476,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 				SUM(od.`product_quantity` * IF(
 					od.`purchase_supplier_price` > 0,
 					od.`purchase_supplier_price` / `conversion_rate`,
-					od.`original_product_price` * ' . (int) Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN') . ' / 100
+					od.`original_product_price` * ' . self::getAverageCostPercentage() . ' / 100
 				)) as total_purchase_price
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order
@@ -481,7 +496,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			SELECT SUM(od.`product_quantity` * IF(
 				od.`purchase_supplier_price` > 0,
 				od.`purchase_supplier_price` / `conversion_rate`,
-				od.`original_product_price` * ' . (int) Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN') . ' / 100
+				od.`original_product_price` * ' . self::getAverageCostPercentage() . ' / 100
 			)) as total_purchase_price
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order

--- a/tests/Integration/Classes/Stats/AdminStatsControllerPurchasesTest.php
+++ b/tests/Integration/Classes/Stats/AdminStatsControllerPurchasesTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Stats;
+
+use AdminStatsController;
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+
+class AdminStatsControllerPurchasesTest extends TestCase
+{
+    private const PRODUCT_PRICE = 100.0;
+    private const QUANTITY = 2;
+
+    /** @var int|null */
+    private $orderId;
+
+    /** @var string|null */
+    private $originalMargin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalMargin = Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN');
+        $this->createLogableOrderWithoutWholesalePrice();
+    }
+
+    protected function tearDown(): void
+    {
+        if (null !== $this->orderId) {
+            Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'order_detail` WHERE id_order = ' . (int) $this->orderId);
+            Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'orders` WHERE id_order = ' . (int) $this->orderId);
+        }
+        if (null !== $this->originalMargin) {
+            Configuration::updateValue('CONF_AVERAGE_PRODUCT_MARGIN', $this->originalMargin);
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * The configured percentage is the average GROSS MARGIN: its own help text defines it as
+     * ((revenue) - (cost of goods sold)) / (revenue) * 100. The estimated cost of goods sold is
+     * therefore the complement of it, which the two extremes pin down exactly.
+     *
+     * @dataProvider provideMarginsAndExpectedCost
+     */
+    public function testEstimatedCostOfGoodsSoldIsTheComplementOfTheGrossMargin(int $margin, float $expectedCost): void
+    {
+        Configuration::updateValue('CONF_AVERAGE_PRODUCT_MARGIN', $margin);
+
+        $purchases = (float) AdminStatsController::getPurchases($this->dateFrom(), $this->dateTo());
+
+        $this->assertEqualsWithDelta($expectedCost, $purchases, 0.01);
+    }
+
+    public static function provideMarginsAndExpectedCost(): array
+    {
+        $revenue = self::PRODUCT_PRICE * self::QUANTITY;
+
+        return [
+            'no margin at all means the goods cost the whole sale price' => [0, $revenue],
+            'a quarter of the sale price is margin' => [25, $revenue * 0.75],
+            'a 40 percent margin leaves 60 percent of cost' => [40, $revenue * 0.60],
+            'everything is margin, so the goods cost nothing' => [100, 0.0],
+        ];
+    }
+
+    public function testAWholesalePriceIsUsedInsteadOfTheEstimate(): void
+    {
+        Db::getInstance()->execute(
+            'UPDATE `' . _DB_PREFIX_ . 'order_detail` SET purchase_supplier_price = 10 WHERE id_order = ' . (int) $this->orderId
+        );
+        Configuration::updateValue('CONF_AVERAGE_PRODUCT_MARGIN', 40);
+
+        $purchases = (float) AdminStatsController::getPurchases($this->dateFrom(), $this->dateTo());
+
+        // 2 units at a recorded wholesale price of 10, the configured margin is not consulted
+        $this->assertEqualsWithDelta(20.0, $purchases, 0.01);
+    }
+
+    private function dateFrom(): string
+    {
+        return date('Y-m-d', strtotime('-10 day'));
+    }
+
+    private function dateTo(): string
+    {
+        return date('Y-m-d', strtotime('+1 day'));
+    }
+
+    private function createLogableOrderWithoutWholesalePrice(): void
+    {
+        $db = Db::getInstance();
+        $logableState = (int) $db->getValue('SELECT id_order_state FROM `' . _DB_PREFIX_ . 'order_state` WHERE logable = 1');
+        $invoiceDate = date('Y-m-d H:i:s', strtotime('-1 day'));
+
+        $db->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'orders`
+             (id_address_delivery, id_address_invoice, id_cart, id_currency, id_lang, id_customer, id_carrier,
+              current_state, conversion_rate, payment, module, total_paid, total_paid_real, total_products,
+              total_products_wt, total_paid_tax_excl, total_paid_tax_incl, total_shipping_tax_excl,
+              invoice_date, date_add, date_upd, id_shop, id_shop_group, reference, secure_key)
+             VALUES (1, 1, 1, 1, 1, 1, 1, ' . $logableState . ', 1, "test", "test", 0, 0, 0, 0, 0, 0, 0,
+              "' . pSQL($invoiceDate) . '", NOW(), NOW(), 1, 1, "TESTMARGIN", "")'
+        );
+        $this->orderId = (int) $db->Insert_ID();
+
+        $db->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'order_detail`
+             (id_order, id_shop, product_id, product_quantity, original_product_price, purchase_supplier_price, product_name)
+             VALUES (' . (int) $this->orderId . ', 1, 1, ' . self::QUANTITY . ', ' . self::PRODUCT_PRICE . ', 0, "test product")'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CONF_AVERAGE_PRODUCT_MARGIN` holds the average gross margin, defined by its own help text as `((total sales revenue) - (cost of goods sold)) / (total sales revenue) * 100`. `AdminStatsController::getPurchases()` multiplied the sale price by that percentage to estimate the cost of the goods, so it used the share that is profit as if it were the share that is cost. The dashboard net profit is `sales - expenses - purchases`, so a higher configured margin produced a lower reported profit. Only order lines with no wholesale price recorded are affected.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With no wholesale price set on the products, place an order and set `Average gross margin percentage` to 0, then to 100, in the dashboard settings. Before, 0 reported the whole sale as profit and 100 reported none of it. After, 0 reports no profit and 100 reports the whole sale, which is what the help text's formula says.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #19632
| Related PRs       |
| Sponsor company   |

## The two extremes are the whole argument

Measured on a 9.2 shop with one order, no wholesale price, sales of 59.80 tax excluded:

```
BASE   margin=  0%  ->  estimated cost of goods  0.00   reported profit 59.80
       margin= 40%  ->  estimated cost of goods 23.92   reported profit 35.88
       margin= 90%  ->  estimated cost of goods 53.82   reported profit  5.98
       margin=100%  ->  estimated cost of goods 59.80   reported profit  0.00
```

A gross margin of 0 means the goods cost the entire sale price, so the profit is 0, and a margin of
100 means they cost nothing, so the profit is the whole sale. Both ends are reported backwards, and
the reporter proposed exactly this test in 2020.

The QA reply of 2020-06-18 states the calculation is correct and then demonstrates the inversion in
its own arithmetic: for a 40 percent margin it computes `41.67 * 60/100 = 25.00` and calls that the
profit, which is revenue times the complement of the margin. #19632 also carries an independent
confirmation from 2025-11-30, where a 90 percent margin produced a negative net profit.

## Scope

Only the branch that estimates a cost is touched, at both call sites in `getPurchases()` - the daily
granularity query and the total query. An order line carrying `purchase_supplier_price` takes the
other side of the `IF` and is unchanged, which is why shops that fill in wholesale prices never saw
this.

The other two terms of the KPI were checked and are correct, so this is not half a fix to a
three-term formula. `getExpenses()` multiplies shipping by `CONF_<carrier>_SHIP`, and that setting is
documented as a cost share, not a margin: "indicate the domestic delivery costs in percentage of the
price charged to customers", with the example "if you charge $10 ... but you really pay $4 ... indicate
40". Multiplying by the percentage yields 4, which is what the example says. The two adjacent settings
genuinely use opposite conventions - one is the margin share, the other the cost share - which is
probably how the inversion got in.

A shop that has stored `0` for this setting will now see the estimated cost equal the sale price
rather than zero. That is what a 0 percent gross margin means, and it is a deliberate consequence
rather than an oversight: the alternative, treating 0 as "no estimate", would contradict the formula
the help text states. The value seeded at install is 40, not 0, so this affects only shops that
chose 0.

Not addressed here: the KPI is named `Net profit` while it is computed as a gross profit, which is
the wording question asked on the issue in 2021 and never answered. `netprofit_visit` is a KPI key
and a translation string, so renaming it is a product decision with a migration tail and belongs in
its own change. Also left alone: revenue comes from `total_paid_tax_excl - total_shipping_tax_excl`
while the cost estimate multiplies `original_product_price`, so the estimate ignores order-level
discounts. That approximation predates this bug and is independent of it.

## Test

`tests/Integration/Classes/Stats/AdminStatsControllerPurchasesTest.php`, 5 cases. Four pin the
estimated cost to the complement of the margin, including both extremes; the fifth asserts that a
recorded wholesale price is used instead of the estimate.

Mutation proof: on the base branch the four margin cases fail with exactly the complement values
(`0 -> 0.00` where `200.00` is expected, `100 -> 200.00` where `0.00` is expected) while the
wholesale-price case stays green, so the test discriminates this defect rather than failing on
anything. With the fix all five pass. `php-cs-fixer` reports 0 of 2 files to fix and `phpstan`
reports no errors.
