### PR TITLE
Match configuration keys exactly, case and accents included

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -110,7 +110,8 @@ class ConfigurationCore extends ObjectModel
         $sql = 'SELECT `' . bqSQL(self::$definition['primary']) . '`
                 FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`
                 WHERE name = \'' . pSQL($key) . '\'
-                ' . Configuration::sqlRestriction($idShopGroup, $idShop);
+                ' . Configuration::sqlExactName($key)
+                . Configuration::sqlRestriction($idShopGroup, $idShop);
 
         return (int) Db::getInstance()->getValue($sql);
     }
@@ -465,7 +466,7 @@ class ConfigurationCore extends ObjectModel
                     $result &= Db::getInstance()->update(self::$definition['table'], [
                         'value' => pSQL($value, $html),
                         'date_upd' => date('Y-m-d H:i:s'),
-                    ], '`name` = \'' . pSQL($key) . '\'' . Configuration::sqlRestriction($idShopGroup, $idShop), 1, true);
+                    ], '`name` = \'' . pSQL($key) . '\'' . Configuration::sqlExactName($key) . Configuration::sqlRestriction($idShopGroup, $idShop), 1, true);
                 } else {
                     // Update multi lang
                     $sql = 'UPDATE `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '_lang` cl
@@ -476,6 +477,7 @@ class ConfigurationCore extends ObjectModel
                                     SELECT c.`' . bqSQL(self::$definition['primary']) . '`
                                     FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '` c
                                     WHERE c.name = \'' . pSQL($key) . '\''
+                                        . Configuration::sqlExactName($key, 'c')
                                         . Configuration::sqlRestriction($idShopGroup, $idShop)
                                 . ')';
                     $result &= Db::getInstance()->execute($sql);
@@ -564,12 +566,12 @@ class ConfigurationCore extends ObjectModel
         WHERE `' . bqSQL(self::$definition['primary']) . '` IN (
             SELECT `' . bqSQL(self::$definition['primary']) . '`
             FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`
-            WHERE `name` = "' . pSQL($key) . '"
+            WHERE `name` = "' . pSQL($key) . '"' . Configuration::sqlExactName($key) . '
         )');
 
         $result2 = Db::getInstance()->execute('
         DELETE FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`
-        WHERE `name` = "' . pSQL($key) . '"');
+        WHERE `name` = "' . pSQL($key) . '"' . Configuration::sqlExactName($key) . '');
 
         self::$_cache = null;
         self::$_new_cache_shop = null;
@@ -718,6 +720,26 @@ class ConfigurationCore extends ObjectModel
         } else {
             return ' AND (id_shop_group IS NULL OR id_shop_group = 0) AND (id_shop IS NULL OR id_shop = 0)';
         }
+    }
+
+    /**
+     * Restricts a name comparison to the exact key, case and accents included.
+     *
+     * WHY: the name column collates as _ci, so `name = 'x'` also matches a row differing only by
+     * case or accent, while every read goes through a PHP array and matches exactly. The two
+     * disagreeing meant a write could resolve to another key's row. The plain equality is kept
+     * beside this so the index on name still drives the seek and this only filters what it returns.
+     *
+     * @param string $key
+     * @param string $alias table alias used by the query, if any
+     *
+     * @return string
+     */
+    protected static function sqlExactName($key, $alias = '')
+    {
+        $column = ('' !== $alias ? bqSQL($alias) . '.' : '') . '`name`';
+
+        return ' AND CAST(' . $column . ' AS BINARY) = CAST(\'' . pSQL($key) . '\' AS BINARY)';
     }
 
     /**

--- a/tests/Integration/Classes/ConfigurationTest.php
+++ b/tests/Integration/Classes/ConfigurationTest.php
@@ -43,4 +43,47 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('RESULT_GROUP_SHOP_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_GROUP_SHOP_OVERRIDDEN'));
         $this->assertFalse(Configuration::getGlobalValue('PS_TEST_DOES_NOT_EXIST'));
     }
+
+    /**
+     * The name column collates case insensitively while every read goes through a PHP array, so a
+     * key differing from an existing one only by case used to resolve to that other key's row: the
+     * insert was skipped because the row "existed", the update was skipped because the cache said it
+     * did not, and updateValue() returned true having written nothing.
+     */
+    public function testKeysDifferingOnlyByCaseAreDistinct(): void
+    {
+        Configuration::deleteByName('PS_TEST_CASE_KEY');
+        Configuration::deleteByName('ps_test_case_key');
+
+        Configuration::updateValue('PS_TEST_CASE_KEY', 'upper');
+        Configuration::updateValue('ps_test_case_key', 'lower');
+
+        $this->assertSame('upper', Configuration::get('PS_TEST_CASE_KEY'));
+        $this->assertSame('lower', Configuration::get('ps_test_case_key'));
+
+        // updating one leaves the other alone
+        Configuration::updateValue('PS_TEST_CASE_KEY', 'upper again');
+
+        $this->assertSame('upper again', Configuration::get('PS_TEST_CASE_KEY'));
+        $this->assertSame('lower', Configuration::get('ps_test_case_key'));
+
+        // and so does deleting one
+        Configuration::deleteByName('ps_test_case_key');
+
+        $this->assertSame('upper again', Configuration::get('PS_TEST_CASE_KEY'));
+        $this->assertFalse(Configuration::get('ps_test_case_key'));
+
+        Configuration::deleteByName('PS_TEST_CASE_KEY');
+    }
+
+    public function testGetIdByNameMatchesTheExactKeyOnly(): void
+    {
+        Configuration::deleteByName('PS_TEST_CASE_ID');
+        Configuration::updateValue('PS_TEST_CASE_ID', 'value');
+
+        $this->assertGreaterThan(0, Configuration::getIdByName('PS_TEST_CASE_ID'));
+        $this->assertSame(0, Configuration::getIdByName('ps_test_case_id'));
+
+        Configuration::deleteByName('PS_TEST_CASE_ID');
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `configuration.name` collates case and accent insensitively, so every SQL lookup on it matched keys differing only in those, while every read goes through a PHP array keyed by the stored name and matches exactly. The two disagreeing lost writes outright: for a key with no language dimension `hasKey()` returned false and sent `updateValue()` down the create branch, `getIdByName()` then found the other key's row so the INSERT was skipped, the multilang block was skipped because there was no language, and the method returned `true` having written nothing at all. The same mismatch let `deleteByName()` remove every case variant of a key. Comparisons on `name` are now paired with an exact one.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `Configuration::updateValue('FOO_BAR', 1);` then, in a later request, `Configuration::updateValue('foo_bar', 2);` and `Configuration::get('foo_bar')`. Before: no row is created, `FOO_BAR` keeps its value, `get('foo_bar')` returns false, and `updateValue()` returned true throughout. After: `foo_bar` gets its own row and reads back as 2, `FOO_BAR` still reads 1. Also `Configuration::deleteByName('foo_bar')` no longer removes `FOO_BAR`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #24413
| Related PRs       |
| Sponsor company   |

## Why this is not a BC break

The read path has always been case sensitive, so no working code can depend on the current behaviour:
a module that writes `foo` and reads `FOO` is already broken today. The only behaviour that changes is a
write that currently vanishes, and a delete that currently reaches further than asked. Shops already
holding mixed-case rows are improved rather than migrated - `getIdByName` picks among them arbitrarily
today (the query has no `ORDER BY`) and becomes deterministic.

This answers the 2021 objection on the thread that it would need a major version. matks had already
agreed the behaviour is wrong and reopened the issue; matthieu-rolland's concern was BC, which is the
part that does not apply.

## Implementation

One helper, applied at all four SQL sites (`getIdByNameFromGivenContext`, the non-lang UPDATE in
`updateValue`, its multilang subquery, and both queries in `deleteByName`):

```php
protected static function sqlExactName($key, $alias = '')
{
    $column = ('' !== $alias ? bqSQL($alias) . '.' : '') . '`name`';

    return ' AND CAST(' . $column . ' AS BINARY) = CAST(\'' . pSQL($key) . '\' AS BINARY)';
}
```

Two deliberate choices:

- **the plain equality stays**, so the index drives the seek and the exact test only filters what it
  returns. `loadConfiguration()` reads this table on every request, so a bare
  `WHERE name COLLATE utf8mb4_bin = ...` would have been the wrong shape. Verified: `EXPLAIN` on the
  paired condition gives `type: ref`, `key: name`, `rows: 1`, `Using index`.
- **`CAST(... AS BINARY)` rather than the `BINARY` operator**, which is deprecated from MySQL 8.0.27.

Accents are covered too, not just case: the column collates `utf8mb4_0900_ai_ci`, measured
`'FOO' = 'FOO-with-diaeresis'` -> 1 under that collation and 0 under a binary comparison.

## Evidence

```
write QA24413_TEST=1        rows: QA24413_TEST=1
write qa24413_test=2        rows: QA24413_TEST=1 | qa24413_test=2
get('qa24413_test')         '2'
get('QA24413_TEST')         '1'
update QA24413_TEST=42      get('QA24413_TEST')='42'   get('qa24413_test')='2'
deleteByName('qa24413_test')  rows: QA24413_TEST=42
control: getIdByName('PS_LANG_DEFAULT')=1   getIdByName('ps_lang_default')=0
```

Tests: two cases in `tests/Integration/Classes/ConfigurationTest.php`. RED proof - with only
`classes/Configuration.php` restored to `upstream/9.2.x` both fail
("Failed asserting that false is identical to 'upper again'", "Failed asserting that 323 is identical to
0") while the pre-existing `testGetGlobalValue` stays green.

Suites: `tests/Integration/Classes/` 185 tests / 2082 assertions green. Full unit suite has **21**
failures on this branch and **21** on `upstream/9.2.x`, set difference empty - all pre-existing
(`FolderThemeCatalogTest` and friends), none in this area. cs-fixer and phpstan clean on both files.

## Sites deliberately left alone

`get()`, `hasKey()` and `getMultiple()` read the PHP cache and were already exact; `getMultiple()` simply
loops over `get()`. Nothing in the cache layer needed changing - the fix is to bring SQL up to the
behaviour the cache already had, not the reverse.
