### PR TITLE
Do not assume IMAP message headers carry a date and a sender

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -1061,7 +1061,10 @@ class AdminCustomerThreadsControllerCore extends AdminController
                 $subject = '';
             }
             // Creating an md5 to check if message has been allready processed
-            $md5 = md5($overview->date . $overview->from . $subject . $overview->msgno);
+            // WHY: date and from come from the message headers and a malformed mail can omit
+            // either, so they are coalesced rather than assumed. A missing property already
+            // stringified to '' here, so the resulting key is unchanged for every mail.
+            $md5 = md5(($overview->date ?? '') . ($overview->from ?? '') . $subject . $overview->msgno);
             $exist = Db::getInstance()->getValue(
                 'SELECT `md5_header`
 						 FROM `' . _DB_PREFIX_ . 'customer_message_sync_imap`


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `imap_fetch_overview()` returns only the header fields a message actually carries, so a malformed mail with no `Date` raised `Undefined property: stdClass::$date` while the customer service sync built its deduplication key. `from` is read on the same line and is exposed to the same thing - it is only checked further down, at :1091. Both are now coalesced. A missing property already stringified to an empty string, so the key is byte-identical for every message and no row of `customer_message_sync_imap` is invalidated.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Needs an IMAP mailbox holding a mail with no `Date` header (spam commonly omits it). Configure Customer Service > IMAP, save, reload the page with debug mode on. Before: `Undefined property: stdClass::$date` from `AdminCustomerThreadsController.php:1064`. After: no notice, and the message syncs. The measured before/after of the key expression is in the Evidence section below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #25860
| Related PRs       | `#41680` (PrestaEdit) also touches this controller but in `openUploadedFile()` around :535, ~530 lines away and on a different concern, and targets `develop`. No overlap.
| Sponsor company   |

## Evidence

Measured in the container on PHP 8.1.33, with a complete header as the control:

```
                                       notices   key
complete header, current expression        0     6b15ea0bbb65
complete header, guarded expression        0     6b15ea0bbb65
no Date, current expression                1     4e894d6ef136   Undefined property: stdClass::$date
no Date, guarded expression                0     4e894d6ef136
no From, current expression                1     68778f48005c   Undefined property: stdClass::$from
no From, guarded expression                0     68778f48005c
```

The identical keys are the point: coalescing cannot invalidate a stored `md5_header`, so no shop
re-imports its retained mail after the upgrade.

## No automated test, deliberately

`syncImap()` wraps `imap_*` calls directly with no injection seam, and the test container has no imap
extension. Extracting a helper to unit-test a null-coalesce would reshape the method to assert something
PHP already guarantees. The measured before/after above is the verification.

## Scope: what was deliberately NOT changed

The `msgno` component of the key is a real defect and is left alone here. `msgno` is a sequence position,
not an identity, so it shifts whenever an earlier message is removed - including `imap_expunge()` at
:1185 - and every retained message then hashes to a new key and is re-imported as a duplicate thread.
`uid` is the correct key, but `customer_message_sync_imap` stores only `md5_header`, with no uid and no
message reference, so existing rows can neither be migrated to a new formula nor matched against one.
Changing the formula alone would re-import every retained message once, per shop, which is the failure it
would be meant to prevent. It needs a schema column plus an upgrade path - a separate change, recorded in
the issue comment.

The report's second symptom, the `count(): Parameter must be an array` warning, is already fixed on
`9.2.x` (:1032 guards with `is_array($errors) &&`). Point 2 of the report (deletion defaults, large-mailbox
warning, confirmation on the delete toggle) is a product decision per matks 2021-10-08, not in scope.
