### PR TITLE
Save a catalog price rule against the shop actually in use

### DIFF
--- a/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
@@ -119,7 +119,7 @@
 		</div>
 	</div>
 {if !$is_multishop}
-	<input type="hidden" name="id_shop" value="1" />
+	<input type="hidden" name="id_shop" value="{$current_shop_id|intval}" />
 {/if}
 </div>
 {/block}

--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -313,7 +313,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
             'from_quantity' => (($value = $this->getFieldValue($this->object, 'from_quantity')) ? $value : 1),
             'reduction' => number_format(($value = $this->getFieldValue($this->object, 'reduction')) ? $value : 0, 6),
             'leave_bprice_on' => $price ? 0 : 1,
-            'shop_id' => (($value = $this->getFieldValue($this->object, 'id_shop')) ? $value : 1),
+            'shop_id' => (($value = $this->getFieldValue($this->object, 'id_shop')) ? $value : (int) Shop::getContextShopID()),
         ];
 
         $attribute_groups = [];
@@ -343,6 +343,12 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
             'categories' => Category::getSimpleCategories((int) $this->context->language->id),
             'conditions' => $this->object->getConditions(),
             'is_multishop' => Shop::isFeatureActive(),
+            /*
+             * WHY: with a single shop the form has no store selector, so it posts the id itself. That id
+             * has to be the shop being worked on - it is not necessarily 1, because the original shop can
+             * have been deleted after a multistore setup was folded back into one.
+             */
+            'current_shop_id' => (int) Shop::getContextShopID(),
         ];
 
         return parent::renderForm();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | With multistore disabled the catalog price rule form has no store selector, so it posts the shop id in a hidden field - and that field carried the literal `1`, as did the fallback that preselects the store when editing. The shop in use is not necessarily shop 1: a shop created under multistore becomes the only one once the original is deleted, and a rule saved for shop 1 is then filtered out by `SpecificPriceRule::apply()`, so it silently never applies. Both places now use `Shop::getContextShopID()`, which the store selector in this same form already uses for its default value.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Needs a shop whose id is not 1 and multistore off. Enable multistore, add a second shop, set it as the default in Advanced Parameters > Multistore, delete the first shop, then turn multistore off. Create a catalog price rule and read `ps_specific_price_rule.id_shop`: before this change it is `1` and the rule never applies; after, it is the id of the shop in use. With multistore on, the store selector is shown and nothing changes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29580
| Related PRs       | Shares `controllers/admin/AdminSpecificPriceRuleController.php` with my open #42520, whose only hunk there is at `processSave()` (`@@ -372,10 +372,33 @@`) - far from the `fields_value` change here, so they do not conflict.
| Sponsor company   |

## Reproduction

Measured on 9.2.0 after folding a two-shop setup back to one, leaving shop 2 as the only shop:

```
PS_MULTISHOP_FEATURE_ACTIVE = 0
PS_SHOP_DEFAULT             = 2
Shop::isFeatureActive()     = false      -> $is_multishop false, so the hidden field is emitted
Shop::getContextShopID()    = 2
Context shop->id            = 2
hardcoded value in the form = 1
```

`SpecificPriceRule::apply()` resolves `$shop_id = $this->id_shop ?: Context::getContext()->shop->id` and
then filters `ps.id_shop = <that>` (`classes/SpecificPriceRule.php:199,210`), so a rule stored against
shop 1 is never matched for shop 2. The rule appears saved and does nothing.

## Why this is not a specification question

The issue carries `Needs Specs` and `Waiting for PM`, applied in 2022 right after a failed reproduction
attempt rather than after a design discussion. There is no choice to make here: the same form already
declares the store selector with `'default_value' => Shop::getContextShopID()`
(`AdminSpecificPriceRuleController.php:195`), so the multistore branch has always used the right value
and only the two single-shop paths kept the literal. This aligns them.

## Verification

`Shop::getContextShopID()` returns `self::$context_id_shop`, which is initialised from
`PS_SHOP_DEFAULT` when the multistore feature is off - measured above as `2`, not `1`.

The template variable reaches the form through `tpl_form_vars`: `AdminController::renderForm()` assigns
`$helper->tpl_vars = $this->getTemplateFormVars()` (`classes/controller/AdminController.php:2515,2547`),
and seven other keys of that array (`is_multishop`, `conditions`, `categories`, `features`,
`attributes_group`, `suppliers`, `manufacturers`) are already read by this exact template.

The template compiles with PrestaShop's Smarty instance, with the unmodified template as a control:

```
COMPILES OK (PrestaShop smarty, plugins registered)
base COMPILES OK
```

php-cs-fixer and phpstan are clean on the controller.

## No automated test

`AdminSpecificPriceRuleController` is not in `AdminControllerTest::getControllersClasses()`, and the only
harness for legacy admin controllers mocks the context, container, employee and Smarty to call `run()`.
Pinning a `fields_value` default through it would need that whole scaffold plus the DB-backed statics
`renderForm()` calls, which is disproportionate to replacing two literals in a legacy Smarty form. The
reproduction above is deterministic and scripted instead.
