### PR TITLE
Test the generated class names in the override uniq-id guards

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3052,7 +3052,10 @@ abstract class ModuleCore implements ModuleInterface
             // Get a uniq id for the class, because you can override a class (or remove the override) twice in the same session and we need to avoid redeclaration
             do {
                 $uniq = uniqid();
-            } while (class_exists($classname . 'OverrideOriginal_remove', false));
+            } while (
+                class_exists($classname . 'OverrideOriginal' . $uniq, false)
+                || class_exists($classname . 'Override' . $uniq, false)
+            );
 
             // Make a reflection of the override class and the module override class
             $override_file = file($override_path);
@@ -3154,7 +3157,7 @@ abstract class ModuleCore implements ModuleInterface
             if ($orig_path) {
                 do {
                     $uniq = uniqid();
-                } while (class_exists($classname . 'OverrideOriginal_remove', false));
+                } while (class_exists($classname . 'Override' . $uniq, false));
                 eval(
                     preg_replace(
                         [
@@ -3276,7 +3279,11 @@ abstract class ModuleCore implements ModuleInterface
             // Get a uniq id for the class, because you can override a class (or remove the override) twice in the same session and we need to avoid redeclaration
             do {
                 $uniq = uniqid();
-            } while (class_exists($classname . 'OverrideOriginal_remove', false));
+            } while (
+                class_exists($classname . 'OverrideOriginal_remove' . $uniq, false)
+                || class_exists($classname . 'Override_remove' . $uniq, false)
+                || class_exists($classname . 'OverrideOriginal_check' . $uniq, false)
+            );
 
             // Make a reflection of the override class and the module override class
             $override_file = file($override_path);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The three loops that pick a unique suffix for the temporary classes used while merging and removing module overrides checked `class_exists($classname . 'OverrideOriginal_remove', false)` - a name with no suffix appended, which nothing in the codebase ever declares. The condition never depended on the value the loop body produces, so it could only ever be false: the guard was inert, and in the case it was written for it could not have terminated. Each loop now tests the names its own block goes on to declare.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | There is no behaviour to demonstrate: the guard has been inert since 1.6, so installing and removing a module override behaves exactly as before. What changes is that the condition now refers to the classes actually declared a few lines below it. Reviewable by reading: for each of the three loops, compare the names in the `while` against the `'class ' . $classname . '<suffix>' . $uniq` strings that follow it.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #30364
| Related PRs       | #40239 (mcaldex, base `develop`) rewrites `installOverrides` / `addOverride` / `removeOverride` in the same file but leaves every `uniqid()` line untouched - verified on its diff, where those lines appear only as context. Its `@@ -3278,7 +3335,8 @@` hunk edits a comment two lines below the third guard, so a textual conflict there is near certain. Different base branches (`9.2.x` here, `develop` there); whichever lands second rebases.
| Sponsor company   |

## What was wrong

Reported by @eyedmax in 2022 and confirmed by @dreanmer. All three loops had the same shape:

```php
do {
    $uniq = uniqid();
} while (class_exists($classname . 'OverrideOriginal_remove', false));
```

`$uniq` never appears in the condition. The tested name is also a string nothing declares - grepping the
tree, the only occurrences of `OverrideOriginal_remove` *without* `. $uniq` were the three guards
themselves. Two consequences, both real:

- the redeclaration protection the comment describes does not exist;
- if the condition ever were true, the body could not change it, so the loop would not end.

The origin is visible in the third block, which declares `...OverrideOriginal_remove` . `$uniq`: the
guard is that same string with the concatenation dropped. Blocks one and two were copied from it and
carry a `_remove` suffix that does not even match the classes they declare.

## What each block declares, and what it now guards

Each `$uniq` is reused by every class its block eval-declares, so the invariant is that all of them are free:

| loop | classes declared with that `$uniq` |
| ---- | ---------------------------------- |
| `addOverride`, first  | `<class>OverrideOriginal<uniq>`, `<class>Override<uniq>` |
| `addOverride`, second | `<class>Override<uniq>` |
| `removeOverride`      | `<class>OverrideOriginal_remove<uniq>`, `<class>Override_remove<uniq>`, `<class>OverrideOriginal_check<uniq>` |

The third one includes `OverrideOriginal_check`, declared later in the same `if ($orig_path)` branch
where that `$uniq` is assigned.

## No test

Deliberate. The guard is unreachable as written - `class_exists()` there is always false - so there is no
failing case to pin, and `uniqid()` does not repeat within a process, so a collision cannot be provoked
without adding an injection seam to a legacy hot path whose only consumer would be the test. `php -l`,
php-cs-fixer and phpstan are clean on the file.
