### PR TITLE
Refresh the module cache when a module main class is edited

### DIFF
--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -137,11 +137,7 @@ class ModuleRepository implements ModuleRepositoryInterface
      */
     public function getModule(string $moduleName): ModuleInterface
     {
-        $filePath = $this->getModulePath($moduleName);
-
-        $filemtime = $filePath === null
-            ? 0
-            : (int) @filemtime($filePath);
+        $filemtime = $this->getModuleFilemtime($moduleName);
 
         $cacheKey = $this->getCacheKey($moduleName);
 
@@ -166,6 +162,27 @@ class ModuleRepository implements ModuleRepositoryInterface
         $this->cacheProvider->save($cacheKey, $coreModule);
 
         return $this->enrichModuleAttributesFromHook($coreModule);
+    }
+
+    /*
+     * WHY: a directory's mtime only moves when an entry is added, renamed or removed inside it, not
+     * when a file it already contains is edited in place. Keying the cache on the module folder alone
+     * therefore missed the one change a developer makes most often - bumping $this->version in the main
+     * class - and the stale module was served until something else cleared the cache. Every attribute
+     * cached here is read from that file, so its own mtime has to be part of the freshness check. The
+     * folder is still consulted so that adding or removing files keeps invalidating the entry.
+     */
+    private function getModuleFilemtime(string $moduleName): int
+    {
+        $modulePath = $this->getModulePath($moduleName);
+        if ($modulePath === null) {
+            return 0;
+        }
+
+        return max(
+            (int) @filemtime($modulePath),
+            (int) @filemtime($modulePath . '/' . $moduleName . '.php')
+        );
     }
 
     public function getModulePath(string $moduleName): ?string

--- a/tests/Integration/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Integration/Core/Module/ModuleRepositoryTest.php
@@ -117,4 +117,76 @@ class ModuleRepositoryTest extends TestCase
         $this->assertEquals('overridden full description', $dummy_module->get('fullDescription'));
         $this->assertEquals('added value', $dummy_module->get('testAttribute'));
     }
+
+    public function testGetModuleIsRefreshedWhenTheMainClassIsEditedInPlace(): void
+    {
+        $moduleName = 'qamodulecachetest';
+        $modulesDir = sys_get_temp_dir() . '/ps-module-cache-' . uniqid() . '/';
+        $moduleDir = $modulesDir . $moduleName;
+        $mainClass = $moduleDir . '/' . $moduleName . '.php';
+
+        mkdir($moduleDir, 0777, true);
+        file_put_contents($mainClass, "<?php\n// version 1.0.0\n");
+
+        try {
+            $repository = $this->createRepositoryFor($modulesDir);
+
+            $initialFilemtime = $repository->getModule($moduleName)->getDiskAttributes()->get('filemtime');
+            $directoryMtime = filemtime($moduleDir);
+
+            // Editing a file that already exists does not touch the folder holding it, which is exactly
+            // what happens when a developer bumps $this->version in the main class.
+            file_put_contents($mainClass, "<?php\n// version 1.0.1\n");
+            touch($mainClass, $initialFilemtime + 10);
+            touch($moduleDir, $directoryMtime);
+            clearstatcache();
+
+            $this->assertSame(
+                $directoryMtime,
+                filemtime($moduleDir),
+                'The folder mtime must stay put, otherwise this test is not reproducing the reported case.'
+            );
+
+            $this->assertSame(
+                $initialFilemtime + 10,
+                $repository->getModule($moduleName)->getDiskAttributes()->get('filemtime'),
+                'The cached module must be rebuilt once its main class changes.'
+            );
+        } finally {
+            @unlink($mainClass);
+            @rmdir($moduleDir);
+            @rmdir($modulesDir);
+        }
+    }
+
+    private function createRepositoryFor(string $modulesDir): ModuleRepository
+    {
+        $moduleDataProvider = $this->createMock(ModuleDataProvider::class);
+        $moduleDataProvider->method('can')->willReturn(true);
+
+        $hookManager = $this->createMock(HookManager::class);
+        $hookManager->method('exec')->willReturn([]);
+
+        /** @var CacheProvider $cacheProvider */
+        $cacheProvider = DoctrineProvider::wrap(new ArrayAdapter());
+
+        return new ModuleRepository(
+            $moduleDataProvider,
+            $this->createMock(AdminModuleDataProvider::class),
+            $cacheProvider,
+            $hookManager,
+            $modulesDir,
+            new LanguageContext(
+                1,
+                'English',
+                'en',
+                'en-US',
+                'en-us',
+                false,
+                'm/d/Y',
+                'm/d/Y H:i:s',
+                $this->createMock(LocaleInterface::class),
+            ),
+        );
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The module cache entry was only invalidated when the module folder's own mtime moved. A directory's mtime changes when an entry is added, renamed or removed inside it - not when a file it already holds is edited in place - so bumping `$this->version` in the main class left the entry untouched, and Module Manager kept reporting the old version until something else cleared the cache. Every attribute cached for a module is read from that main class, so its mtime is now part of the freshness check alongside the folder's.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Edit `modules/ps_banner/ps_banner.php` in place and bump `$this->version`, then reload Module Manager. Before this change no update was offered until `bin/console cache:clear` (or resetting another module) ran; after it, the new version is picked up on the next page load. Editing must be a real in-place write - `sed -i` and most unzip flows replace the file, which moves the folder's mtime and hides the bug.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #30980
| Related PRs       | Touches `src/Core/Module/ModuleRepository.php`, which #42272 also edits. The hunks are separate - #42272 changes the two `return` statements of `getModule()` to add override enrichment, this one changes the `$filemtime` computation above them and adds a private helper - but #42272 adds a constructor argument, so whichever lands second updates the `new ModuleRepository(...)` call in the integration test on rebase.
| Sponsor company   |

## Root cause

`ModuleRepository::getModule()` computed its freshness key as `filemtime($this->getModulePath($moduleName))`,
and `getModulePath()` checks `is_file()` on the main class but returns the **folder**. Measured filesystem
behaviour:

```
in-place edit of mymod.php            file mtime moved, folder mtime UNCHANGED   -> stale
adding a new upgrade/ subdirectory    folder mtime moved                         -> invalidated
adding a 2nd file to existing upgrade/  folder mtime UNCHANGED                   -> stale
```

So the one edit a developer makes most often was the one the cache could not see. It also explains the
contradictory reproductions on the issue: `sed -i` and most editors/unzips write a new inode and rename,
which *does* move the folder mtime and hides the bug entirely.

## Evidence

Measured on 9.2.0 through the real `ModuleRepository` service:

```
1. version from repository: 2.1.2   (dir mtime=1788692124, file mtime=1788692124)
2. file on disk now says:   9.9.9   (dir mtime=1788692124, file mtime=1788692441)
3. version from repository: 2.1.2   <-- stale
```

Test: `tests/Integration/Core/Module/ModuleRepositoryTest.php::testGetModuleIsRefreshedWhenTheMainClassIsEditedInPlace`.
It pins the folder mtime with `touch()` so the scenario is deterministic rather than timing-dependent, and
asserts the folder did not move before asserting the rebuild. Mutation: reverting only
`src/Core/Module/ModuleRepository.php` to base fails exactly this test
(`Failed asserting that 1788692615 is identical to 1788692625`) and leaves the other two green.
`tests/Unit/Core/Module/` is identical with and without the change (72 tests, 13 errors, 1 failure both
ways - all pre-existing in this environment). php-cs-fixer and phpstan clean on both files.

## Deliberately not changed

`getModulePath()` still returns the folder - it is public and used elsewhere, so the file mtime is
computed in a private helper instead. The folder mtime is kept in the `max()` rather than replaced, so
adding or removing files in the module root keeps invalidating the entry exactly as before.
