### PR TITLE
Keep the query error when a schema update rolls back

### DIFF
--- a/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
@@ -52,6 +52,34 @@ class UpdateSchemaCommand extends Command
     }
 
     /**
+     * Rolls the schema update back after a query failed, without letting that get in the way of the
+     * error that caused it.
+     *
+     * WHY: the statements being run are DDL, and MySQL commits the open transaction implicitly as soon
+     * as it executes one. By the time a later statement fails there is usually nothing left to roll
+     * back, so rolling back unconditionally threw "There is no active transaction" - and threw it from
+     * inside the catch block, so it replaced the query error on its way out and the caller was told
+     * nothing about what had actually gone wrong. The same check already guards the rollback at the end
+     * of the run; this is the one place that was missing it.
+     *
+     * The rollback is attempted rather than assumed, so a driver that reports no transaction while
+     * holding one still gets one, and a failure to roll back still cannot replace the original error.
+     */
+    private function rollBackWithoutHidingTheError(Connection $connection): void
+    {
+        $nativeConnection = $connection->getNativeConnection();
+        if ($nativeConnection instanceof PDO && !$nativeConnection->inTransaction()) {
+            return;
+        }
+
+        try {
+            $connection->rollBack();
+        } catch (Exception $rollBackFailure) {
+            // Deliberately swallowed: the caller needs the query error that started this, not this one.
+        }
+    }
+
+    /**
      * @param InputInterface $input
      * @param OutputInterface $output
      */
@@ -88,7 +116,7 @@ class UpdateSchemaCommand extends Command
             try {
                 $this->executeUpdateQuery($connection, $sql);
             } catch (Exception $e) {
-                $connection->rollBack();
+                $this->rollBackWithoutHidingTheError($connection);
 
                 throw $e;
             }

--- a/tests/Unit/PrestaShopBundle/Command/UpdateSchemaCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/Command/UpdateSchemaCommandTest.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 namespace Tests\Unit\PrestaShopBundle\Command;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Result;
 use Doctrine\ORM\EntityManager;
+use PDO;
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Command\UpdateSchemaCommand;
+use ReflectionMethod;
 
 class UpdateSchemaCommandTest extends TestCase
 {
@@ -32,6 +35,60 @@ class UpdateSchemaCommandTest extends TestCase
             'ps',
             $manager
         );
+    }
+
+    /**
+     * The statements this command runs are DDL, and MySQL commits the open transaction implicitly as
+     * soon as it executes one. By the time a later statement fails there is nothing left to roll back,
+     * and asking anyway threw "There is no active transaction" from inside the catch block - replacing
+     * the query error that the caller actually needed.
+     */
+    public function testItDoesNotRollBackWhenTheTransactionIsAlreadyGone(): void
+    {
+        $nativeConnection = $this->createMock(PDO::class);
+        $nativeConnection->method('inTransaction')->willReturn(false);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getNativeConnection')->willReturn($nativeConnection);
+        $connection->expects($this->never())->method('rollBack');
+
+        $this->rollBack($connection);
+    }
+
+    public function testItRollsBackWhileATransactionIsStillOpen(): void
+    {
+        $nativeConnection = $this->createMock(PDO::class);
+        $nativeConnection->method('inTransaction')->willReturn(true);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getNativeConnection')->willReturn($nativeConnection);
+        $connection->expects($this->once())->method('rollBack');
+
+        $this->rollBack($connection);
+    }
+
+    /**
+     * Whatever the rollback does, it must not become the error the caller sees.
+     */
+    public function testItKeepsTheQueryErrorWhenTheRollBackItselfFails(): void
+    {
+        $nativeConnection = $this->createMock(PDO::class);
+        $nativeConnection->method('inTransaction')->willReturn(true);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getNativeConnection')->willReturn($nativeConnection);
+        $connection->method('rollBack')->willThrowException(new DBALException('There is no active transaction'));
+
+        $this->rollBack($connection);
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function rollBack(Connection $connection): void
+    {
+        $method = new ReflectionMethod($this->command, 'rollBackWithoutHidingTheError');
+        $method->setAccessible(true);
+        $method->invoke($this->command, $connection);
     }
 
     public function testRemoveDropTables(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The statements `UpdateSchemaCommand` runs are DDL, and MySQL commits the open transaction implicitly as soon as it executes one. By the time a later statement fails there is nothing left to roll back, so the rollback in the catch block threw `There is no active transaction` - and threw it on the way out of that block, so it replaced the query error and the `throw $e` below it was never reached. Installing or upgrading a shop then reported a message that says nothing about what failed. The rollback now skips the case where the transaction is already gone, and cannot replace the original error even if it fails for another reason.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33337
| Related PRs       | The triggers behind the reports were fixed elsewhere - #33641 in psgdpr, #33874 in autoupgrade. This is the masking, which is independent of them and still present.
| Sponsor company   |

## How to test

Make any statement in the schema update fail after at least one DDL statement has run. Before, the
console reports `There is no active transaction`; after, it reports what the database objected to.

Measured on 9.2.x against MySQL 8.4.10:

```
after beginTransaction()   inTransaction = true
after a CREATE TABLE       inTransaction = false     <- committed implicitly
failing statement          SQLSTATE[42000] ... Key column 'nonexistent_column' doesn't exist
rollBack()                 Doctrine\DBAL\Driver\PDO\PDOException: There is no active transaction
```

The second exception is the one that reached the console, which is why the issue thread has many
environments and no common cause: every reporter was reading the same replacement message.

## Scope, deliberately

This does not change **what** fails - a shop that hits a bad `ALTER TABLE` still stops there. It
changes an error nobody can act on into the database's own message. That is the whole value: #33337
ran for months across four repositories because the actual cause was invisible, and the individual
causes (#33641 psgdpr, #33874 autoupgrade) were each found only by someone reading the statement
printed above the error.

The identical check already guards the commit/rollback at the end of the run
(`!$connection->getNativeConnection() instanceof PDO || ...->inTransaction()`). The catch block was
the one place missing it, so this is bringing one line into line with its own file.

The rollback is attempted rather than assumed - a driver that reports no transaction while holding one
still gets one - and it is wrapped so a failure for any other reason cannot replace the original error
either.

## Test

`tests/Unit/PrestaShopBundle/Command/UpdateSchemaCommandTest.php`, 3 new cases (18 total, was 15),
reaching the private helper by reflection rather than widening the command's API. Two surgical
mutations, each failing exactly one case and leaving the rest green:

- guard removed, method kept -> only `testItDoesNotRollBackWhenTheTransactionIsAlreadyGone` fails
- try/catch removed          -> only `testItKeepsTheQueryErrorWhenTheRollBackItselfFails` fails

php-cs-fixer exit 0, PHPStan "No errors".
