### PR TITLE
Roll back a module installation that failed

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -915,6 +915,40 @@ abstract class ModuleCore implements ModuleInterface
             return false;
         }
 
+        if ($this->uninstallCoreRegistration()) {
+            PrestaShopLogger::addLog(
+                Context::getContext()->getTranslator()->trans(
+                    'Module uninstalled successfully: %s v%s',
+                    [$this->name, $this->version],
+                    'Admin.Modules.Notification'
+                ),
+                PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE,
+                null,
+                'Module',
+                null,
+                true
+            );
+            Hook::exec('actionModuleUninstallAfter', ['object' => $this]);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Removes everything the core registered for this module: its hooks and hook exceptions, the meta
+     * of its front controllers, its association to every shop, its permissions, its customer group
+     * restrictions, and the module row itself. It does not touch anything the module created for
+     * itself, and it does not emit the uninstall log or hooks - uninstall() does that around it.
+     *
+     * Every step removes rows if they are there and is a no-op if they are not, so this can be called
+     * on a module that is only partially registered.
+     *
+     * @return bool whether the module row could be deleted
+     */
+    public function uninstallCoreRegistration(): bool
+    {
         // Retrieve hooks used by the module
         $sql = 'SELECT DISTINCT(`id_hook`) FROM `' . _DB_PREFIX_ . 'hook_module` WHERE `id_module` = ' . (int) $this->id;
         $result = Db::getInstance()->executeS($sql);
@@ -959,19 +993,6 @@ abstract class ModuleCore implements ModuleInterface
         if (Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'module` WHERE `id_module` = ' . (int) $this->id)) {
             Cache::clean('Module::isInstalled' . $this->name);
             Cache::clean('Module::getModuleIdByName_' . pSQL($this->name));
-            PrestaShopLogger::addLog(
-                Context::getContext()->getTranslator()->trans(
-                    'Module uninstalled successfully: %s v%s',
-                    [$this->name, $this->version],
-                    'Admin.Modules.Notification'
-                ),
-                PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE,
-                null,
-                'Module',
-                null,
-                true
-            );
-            Hook::exec('actionModuleUninstallAfter', ['object' => $this]);
 
             return true;
         }

--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -97,14 +97,60 @@ class ModuleManager implements ModuleManagerInterface
         $module = $this->moduleRepository->getModule($name);
         $this->dispatchPreAction($module);
 
-        $installed = $module->onInstall();
+        try {
+            $installed = $module->onInstall();
+        } catch (Throwable $throwable) {
+            // WHY: a module's install() reports failure by returning false, but it can also simply
+            // throw - registerHook() does exactly that for a hook the module never implements, which
+            // is one of the shapes reported. The registration has to be undone either way, and the
+            // error itself still belongs to the caller, so it is rethrown untouched.
+            $this->rollBackFailedInstallation($module);
+
+            throw $throwable;
+        }
+
         if ($installed) {
             // Only trigger install event if install has succeeded otherwise it could automatically add tabs linked to a
             // module not installed (@see ModuleTabManagementSubscriber) or other unwanted automatic actions.
             $this->dispatch(ModuleManagementEvent::INSTALL, $module);
+        } else {
+            $this->rollBackFailedInstallation($module);
         }
 
         return $installed;
+    }
+
+    /**
+     * Undoes the registration the core performed for a module whose installation then failed.
+     *
+     * WHY: install() registers the module - the module row, its shop association, its permissions and
+     * its customer group restrictions - before handing over to the module's own install(), and nothing
+     * removed that again when the module's part failed. The module was left registered and active, so
+     * the next attempt matched the isInstalled() branch at the top of install() and was answered by
+     * upgrade() instead: the module's install() never ran a second time, yet the merchant was told the
+     * installation had succeeded, on a shop where the module is half installed.
+     *
+     * This can only ever run on a fresh installation. install() returns through upgrade() before
+     * reaching onInstall() whenever the module is already installed, so reaching this point means
+     * isInstalled() was false and every registration being removed here was made by the attempt that
+     * has just failed.
+     *
+     * Only what the core registered is undone. A module that failed part way through its own install()
+     * is in a state only it can describe, so its uninstall() is deliberately not called and anything it
+     * created for itself is left alone - an orphaned module table is a far smaller problem than a
+     * module the shop believes is installed and enabled.
+     */
+    private function rollBackFailedInstallation(ModuleInterface $module): void
+    {
+        $instance = $module->getInstance();
+        if ($instance === null) {
+            return;
+        }
+
+        // Safe to call unconditionally: it returns early when the module ships no override directory,
+        // and only ever removes overrides this module is the author of.
+        $instance->uninstallOverrides();
+        $instance->uninstallCoreRegistration();
     }
 
     public function postInstall(string $name): bool

--- a/tests/Unit/Core/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Module/ModuleManagerTest.php
@@ -47,11 +47,25 @@ class ModuleManagerTest extends TestCase
         $adminModuleDataProvider->method('isAllowedAccess')->willReturn(true);
 
         $this->module = $this->getModuleMock();
+        $this->moduleManager = $this->createModuleManagerFor($this->module);
+    }
+
+    /**
+     * Builds a ModuleManager whose repository serves the given module, so a test can install a module
+     * that fails without disturbing the shared one every other test relies on.
+     */
+    private function createModuleManagerFor(Module $module): ModuleManager
+    {
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock->method('trans')->willReturnArgument(0);
+
+        $adminModuleDataProvider = $this->createMock(AdminModuleDataProvider::class);
+        $adminModuleDataProvider->method('isAllowedAccess')->willReturn(true);
 
         $moduleRepository = $this->createMock(ModuleRepository::class);
-        $moduleRepository->method('getModule')->willReturn($this->module);
+        $moduleRepository->method('getModule')->willReturn($module);
 
-        $this->moduleManager = $this->getMockBuilder(ModuleManager::class)
+        $moduleManager = $this->getMockBuilder(ModuleManager::class)
             ->setConstructorArgs([
                 $moduleRepository,
                 $this->getModuleDataProviderMock(),
@@ -67,12 +81,56 @@ class ModuleManagerTest extends TestCase
             ->onlyMethods(['upgradeMigration'])
             ->getMock()
         ;
-        $this->moduleManager->method('upgradeMigration')->willReturn(true);
+        $moduleManager->method('upgradeMigration')->willReturn(true);
+
+        return $moduleManager;
     }
 
     public function testInstall(): void
     {
         $this->assertTrue($this->moduleManager->install(self::INSTALLED_MODULE_NAME));
+        $this->assertTrue($this->moduleManager->install(self::UNINSTALLED_MODULE_NAME));
+    }
+
+    /**
+     * A module that reports failure must not stay registered: leaving the registration behind made the
+     * next attempt match the isInstalled() branch of install(), which answers with upgrade() and
+     * reports success without ever running the module's install() again.
+     */
+    public function testAnInstallationThatReturnsFalseIsRolledBack(): void
+    {
+        [$module, $legacyModule] = $this->getFailingModuleMock(null);
+        $legacyModule->expects($this->once())->method('uninstallCoreRegistration');
+
+        $moduleManager = $this->createModuleManagerFor($module);
+
+        $this->assertFalse($moduleManager->install(self::UNINSTALLED_MODULE_NAME));
+    }
+
+    /**
+     * A module's install() can fail by throwing rather than by returning false - registerHook() does
+     * that for a hook the module never implements. The registration must be undone in that case too,
+     * and the error must still reach the caller.
+     */
+    public function testAnInstallationThatThrowsIsRolledBackAndKeepsTheError(): void
+    {
+        [$module, $legacyModule] = $this->getFailingModuleMock(new Exception('hook has no method'));
+        $legacyModule->expects($this->once())->method('uninstallCoreRegistration');
+
+        $moduleManager = $this->createModuleManagerFor($module);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('hook has no method');
+        $moduleManager->install(self::UNINSTALLED_MODULE_NAME);
+    }
+
+    /**
+     * The rollback deletes rows, so it must be unreachable for an installation that worked.
+     */
+    public function testASuccessfulInstallationIsNotRolledBack(): void
+    {
+        $this->legacyModule->expects($this->never())->method('uninstallCoreRegistration');
+
         $this->assertTrue($this->moduleManager->install(self::UNINSTALLED_MODULE_NAME));
     }
 
@@ -181,7 +239,7 @@ class ModuleManagerTest extends TestCase
             ->disableOriginalConstructor()
             ->enableOriginalClone()
             ->addMethods(['reset'])
-            ->onlyMethods(['getErrors'])
+            ->onlyMethods(['getErrors', 'uninstallOverrides', 'uninstallCoreRegistration'])
             ->getMock()
         ;
         $this->legacyModule->method('reset')->willReturn(true);
@@ -197,6 +255,40 @@ class ModuleManagerTest extends TestCase
         $module->method('getInstance')->willReturn($this->legacyModule);
 
         return $module;
+    }
+
+    /**
+     * @param Exception|null $throwable what the module's install() does instead of succeeding:
+     *                                  throw it, or return false when null
+     *
+     * @return array{0: Module&MockObject, 1: LegacyModule&MockObject}
+     */
+    private function getFailingModuleMock(?Exception $throwable): array
+    {
+        /** @var Module&MockObject $module */
+        $module = $this->getMockBuilder(Module::class)
+            ->disableOriginalConstructor()
+            ->enableOriginalClone()
+            ->getMock()
+        ;
+
+        /** @var LegacyModule&MockObject $legacyModule */
+        $legacyModule = $this->getMockBuilder(LegacyModule::class)
+            ->disableOriginalConstructor()
+            ->enableOriginalClone()
+            ->onlyMethods(['getErrors', 'uninstallOverrides', 'uninstallCoreRegistration'])
+            ->getMock()
+        ;
+
+        $module->method('get')->with('version')->willReturn('1.0.0');
+        $module->method('getInstance')->willReturn($legacyModule);
+        if ($throwable === null) {
+            $module->method('onInstall')->willReturn(false);
+        } else {
+            $module->method('onInstall')->willThrowException($throwable);
+        }
+
+        return [$module, $legacyModule];
     }
 
     private function getModuleDataProviderMock(): ModuleDataProvider


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Module::install()` registers a module - the module row, its shop association, its permissions and its customer group restrictions - before handing over to the module's own `install()`, and nothing removed that again when the module's part failed. The module was left registered and active, so the next attempt matched the `isInstalled()` branch at the top of `ModuleManager::install()` and was answered by `upgrade()`: the module's `install()` never ran a second time, yet the merchant was told the installation had succeeded, on a shop where the module is only half installed. A failed installation now undoes the registration the core made for it, whether the module reported the failure by returning false or by throwing, as `registerHook()` does for a hook the module never implements. Errors still reach the caller untouched.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33369
| Related PRs       | Touches `classes/module/Module.php`, as do open PRs #42509 (unregisterHook, lines 1232/1245), #42561 (getCacheId, line 2415) and #42551 (uninstallOverrides, lines 3019/3133). No overlap - the change here is in `uninstall()` at lines 890-980 and in `src/Core/Module/ModuleManager.php`, which none of them touch.
| Sponsor company   |

## How to test

A module whose `install()` is `parent::install() && $this->registerHook('displayHome') && false`
(with a `hookDisplayHome()` so the hook registers), installed three times in a row:

```
before   attempt #1 -> Cannot install   module=1 module_shop=1 hook_module=2 module_group=6 auth_role=4 module_access=4
         attempt #2 -> succeeded        (unchanged)
         attempt #3 -> succeeded        (unchanged)

after    attempt #1 -> Cannot install   module=0 module_shop=0 hook_module=0 module_group=0 auth_role=0 module_access=0
         attempt #2 -> Cannot install   all zero
         attempt #3 -> Cannot install   all zero
```

Those are the six tables named in the report. The module's own `install()` was instrumented to count
its calls: before the fix it ran **once** across all three attempts, so attempt #2 installed nothing
and reported success purely because `upgrade()` had nothing to do.

The second failure mode, and the one #33369's maintainers described: a hook registered without its
method makes `registerHook()` **throw**, which unwinds out of `onInstall()` and so needs handling
separately from a plain `false`. Same before/after result.

## Design notes

- The rollback is **state-based**, not a reverse list of steps: `uninstallCoreRegistration()` removes
  rows where they exist and no-ops where they do not, so it covers every partial state, including the
  one where `Module::install()` returns false from `enable()` after the module row was already
  inserted.
- **It cannot touch a working module.** `ModuleManager::install()` returns through `upgrade()`
  before reaching `onInstall()` whenever `isInstalled()`, so reaching the rollback means the module
  was not installed and every row removed was written by the attempt that just failed. Pinned by
  `testASuccessfulInstallationIsNotRolledBack`.
- **The module's own `uninstall()` is deliberately not called.** A module that failed part way
  through its `install()` is in a state only it can describe. Known limit: anything the module
  created for itself is left behind. An orphaned module table is a far smaller problem than a module
  the shop believes is installed and enabled.
- `onInstall()` has exactly one caller (`ModuleManager.php:100`), so this seam covers the module
  manager path completely. `LocalizationPack.php:479` calls `Module::install()` directly and keeps
  the current behaviour.

## Test

`tests/Unit/Core/Module/ModuleManagerTest.php`, 3 new cases (13 total, was 10). Mutation proof: with
`src/Core/Module/ModuleManager.php` reverted to `upstream/9.2.x` (revert verified by grep, 0
occurrences of `rollBackFailedInstallation`), exactly the two rollback cases fail with
"Method was expected to be called 1 time, actually called 0 times", while the success guard and all
10 pre-existing cases stay green. php-cs-fixer exit 0, PHPStan "No errors".
