### PR TITLE
Let a settings form keep the fields a module added to it

### DIFF
--- a/src/Adapter/Configuration/DatabaseLogsConfiguration.php
+++ b/src/Adapter/Configuration/DatabaseLogsConfiguration.php
@@ -49,6 +49,10 @@ class DatabaseLogsConfiguration implements DataConfigurationInterface
     {
         $resolver = new OptionsResolver();
         $resolver
+            // WHY: the Logs form dispatches actionDatabaseLogsForm, so a module can add its own fields
+            // to it and they arrive here alongside the core ones. They belong to the module, which
+            // reads them from actionDatabaseLogsSave, so they are left to it instead of being rejected.
+            ->setIgnoreUndefined(true)
             ->setRequired(['database_min_logger_level'])
             ->resolve($configuration);
 

--- a/src/Adapter/Configuration/LogsConfiguration.php
+++ b/src/Adapter/Configuration/LogsConfiguration.php
@@ -102,6 +102,10 @@ class LogsConfiguration implements DataConfigurationInterface
     {
         $resolver = new OptionsResolver();
         $resolver
+            // WHY: the Logs form dispatches actionLogsPageForm, so a module can add its own fields to
+            // it and they arrive here alongside the core ones. They belong to the module, which reads
+            // them from actionLogsPageSave, so they are left to it instead of being rejected.
+            ->setIgnoreUndefined(true)
             ->setRequired(['logs_by_email', 'logs_email_receivers'])
             ->resolve($configuration);
 

--- a/src/Core/Configuration/AbstractMultistoreConfiguration.php
+++ b/src/Core/Configuration/AbstractMultistoreConfiguration.php
@@ -112,6 +112,20 @@ abstract class AbstractMultistoreConfiguration implements DataConfigurationInter
             $resolver->setRequired($definedOptions);
         }
 
+        /*
+         * WHY: the settings forms these classes back dispatch an action<Name>PageForm hook that hands
+         * the form builder to modules so they can add their own fields, and the submitted values then
+         * arrive here as part of the same array. Those keys belong to the module, which reads them
+         * from the matching action<Name>PageSave hook, so refusing them made the core reject input it
+         * had itself invited: the page answered a save with an UndefinedOptionsException instead of
+         * saving. Undefined keys are now left to their owner rather than being treated as an error.
+         *
+         * This does not loosen anything the configuration owns. Required options are still enforced -
+         * that check compares the required list against what was given, independently of this - and
+         * every defined option is still type checked.
+         */
+        $resolver->setIgnoreUndefined(true);
+
         $resolver->resolve($configurationInputValues);
 
         return true;

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -19,7 +19,7 @@ use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
 use Shop;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\Resources\DatabaseDump;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
@@ -113,19 +113,39 @@ class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
      *
      * @param ShopConstraint $shopConstraint
      */
-    public function testUndefinedOptionsException(ShopConstraint $shopConstraint): void
+    public function testIncompleteConfiguration(ShopConstraint $shopConstraint): void
     {
         $isAllShopContext = ($shopConstraint->getShopGroupId() === null && $shopConstraint->getShopId() === null);
         $testedObject = $this->getDummyMultistoreConfiguration($shopConstraint);
-        $this->expectException(UndefinedOptionsException::class);
 
         if ($isAllShopContext) {
-            // in all shop context, multistore field are not expected
+            // in all shop context every field is required, and the multistore field is not one of them
+            $this->expectException(MissingOptionsException::class);
             $testedObject->updateConfiguration(['test_conf_1' => true, MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . 'test_conf_1' => true]);
         } else {
-            // test in other shop contexts with an undefined field
-            $testedObject->updateConfiguration(['undefined_element' => true]);
+            // in the other shop contexts fields may be left out, so there is nothing to reject here
+            $this->assertTrue($testedObject->validateConfiguration(['test_conf_1' => true]));
         }
+    }
+
+    /**
+     * The forms these classes back let a module add its own fields through the action<Name>Form hook,
+     * and the values arrive here with the core ones. They belong to the module, which reads them from
+     * the matching action<Name>Save hook, so they must not be rejected.
+     *
+     * @dataProvider provideShopConstraints
+     *
+     * @param ShopConstraint $shopConstraint
+     */
+    public function testItAcceptsFieldsAModuleAddedToTheForm(ShopConstraint $shopConstraint): void
+    {
+        $testedObject = $this->getDummyMultistoreConfiguration($shopConstraint);
+
+        $this->assertTrue($testedObject->validateConfiguration([
+            'test_conf_1' => true,
+            'test_conf_2' => 'a value',
+            'a_module_field' => 'contributed through the form hook',
+        ]));
     }
 
     /**

--- a/tests/Unit/Adapter/Carrier/CarrierOptionsConfigurationTest.php
+++ b/tests/Unit/Adapter/Carrier/CarrierOptionsConfigurationTest.php
@@ -12,7 +12,7 @@ use Carrier;
 use PrestaShop\PrestaShop\Adapter\Carrier\CarrierOptionsConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class CarrierOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -73,7 +73,9 @@ class CarrierOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['default_carrier' => true, 'carrier_default_order_by' => Carrier::SORT_BY_POSITION, 'carrier_default_order_way' => Carrier::SORT_BY_DESC]],
             [InvalidOptionsException::class, ['default_carrier' => 25, 'carrier_default_order_by' => true, 'carrier_default_order_way' => Carrier::SORT_BY_DESC]],
             [InvalidOptionsException::class, ['default_carrier' => 25, 'carrier_default_order_by' => Carrier::SORT_BY_POSITION, 'carrier_default_order_way' => true]],

--- a/tests/Unit/Adapter/Carrier/HandlingConfigurationTest.php
+++ b/tests/Unit/Adapter/Carrier/HandlingConfigurationTest.php
@@ -11,7 +11,7 @@ namespace Tests\Unit\Adapter\Carrier;
 use PrestaShop\PrestaShop\Adapter\Carrier\HandlingConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class HandlingConfigurationTest extends AbstractConfigurationTestCase
@@ -72,7 +72,9 @@ class HandlingConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['shipping_handling_charges' => 'wrong_value', 'free_shipping_price' => 10.5, 'free_shipping_weight' => 10.5]],
             [InvalidOptionsException::class, ['shipping_handling_charges' => 10.5, 'free_shipping_price' => 'wrong_value', 'free_shipping_weight' => 10.5]],
             [InvalidOptionsException::class, ['shipping_handling_charges' => 10.5, 'free_shipping_price' => 10.5, 'free_shipping_weight' => 'wrong_value']],

--- a/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
+++ b/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
@@ -11,7 +11,7 @@ namespace Tests\Unit\Adapter\Customer;
 use PrestaShop\PrestaShop\Adapter\Customer\CustomerConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class CustomerConfigurationTest extends AbstractConfigurationTestCase
@@ -85,7 +85,9 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['redisplay_cart_at_login' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['send_email_after_registration' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['password_reset_delay' => 'wrong_type'])],
@@ -93,6 +95,26 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['ask_for_birthday' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_offers' => 'wrong_type'])],
         ];
+    }
+
+    /**
+     * The Customer Settings form dispatches actionCustomerPreferencesPageForm, so a module can add its
+     * own field to it; the value then arrives here with the core ones and must not be rejected. The
+     * module reads it back from actionCustomerPreferencesPageSave.
+     */
+    public function testItAcceptsAFieldAModuleAddedToTheForm(): void
+    {
+        $customerConfiguration = new CustomerConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
+
+        $result = $customerConfiguration->updateConfiguration(
+            array_merge(self::VALID_CONFIGURATION, ['a_module_field' => 'added through the form hook'])
+        );
+
+        $this->assertSame([], $result);
     }
 
     public function testSuccessfulUpdate(): void

--- a/tests/Unit/Adapter/Invoice/InvoiceOptionsConfigurationTest.php
+++ b/tests/Unit/Adapter/Invoice/InvoiceOptionsConfigurationTest.php
@@ -13,7 +13,7 @@ use PrestaShop\PrestaShop\Adapter\Invoice\InvoiceOptionsConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class InvoiceOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -86,7 +86,9 @@ class InvoiceOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_invoices' => 'invalid_value_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_tax_breakdown' => 'invalid_value_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_product_images' => 'invalid_value_type'])],

--- a/tests/Unit/Adapter/Meta/SEOOptionsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SEOOptionsDataConfigurationTest.php
@@ -11,7 +11,7 @@ namespace Tests\Unit\Adapter\Preferences;
 use PrestaShop\PrestaShop\Adapter\Meta\SEOOptionsDataConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class SEOOptionsDataConfigurationTest extends AbstractConfigurationTestCase
@@ -68,7 +68,9 @@ class SEOOptionsDataConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['product_attributes_in_title' => 'wrong_type']],
         ];
     }

--- a/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
@@ -12,7 +12,7 @@ use PrestaShop\PrestaShop\Adapter\File\HtaccessFileGenerator;
 use PrestaShop\PrestaShop\Adapter\Meta\SetUpUrlsDataConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
@@ -135,7 +135,9 @@ class SetUpUrlsDataConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['friendly_url' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['default_language_url_prefix' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['accented_url' => 'wrong_type'])],

--- a/tests/Unit/Adapter/Meta/UrlSchemaDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/UrlSchemaDataConfigurationTest.php
@@ -12,7 +12,7 @@ use PrestaShop\PrestaShop\Adapter\Meta\UrlSchemaDataConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
@@ -273,7 +273,9 @@ class UrlSchemaDataConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['category_rule' => false])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['supplier_rule' => false])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['manufacturer_rule' => false])],

--- a/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
+++ b/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
@@ -11,7 +11,7 @@ namespace Tests\Unit\Adapter\Order;
 use PrestaShop\PrestaShop\Adapter\Order\GeneralConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class GeneralConfigurationTest extends AbstractConfigurationTestCase
@@ -91,7 +91,9 @@ class GeneralConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_final_summary' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_guest_checkout' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['disable_reordering_option' => 'wrong_type'])],

--- a/tests/Unit/Adapter/Order/GiftOptionsConfigurationTest.php
+++ b/tests/Unit/Adapter/Order/GiftOptionsConfigurationTest.php
@@ -11,7 +11,7 @@ namespace Tests\Unit\Adapter\Order;
 use PrestaShop\PrestaShop\Adapter\Order\GiftOptionsConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -81,7 +81,9 @@ class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_gift_wrapping' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['gift_wrapping_price' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['gift_wrapping_tax_rules_group' => 'wrong_type'])],

--- a/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
+++ b/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
@@ -11,7 +11,7 @@ namespace Tests\Unit\Adapter\Shop;
 use PrestaShop\PrestaShop\Adapter\Shop\MaintenanceConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
@@ -74,7 +74,9 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['enable_shop' => 'wrong_type', 'maintenance_allow_admins' => true, 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
             [InvalidOptionsException::class, ['enable_shop' => true, 'maintenance_allow_admins' => 'wrong_type', 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
             [InvalidOptionsException::class, ['enable_shop' => true, 'maintenance_allow_admins' => true, 'maintenance_ip' => ['wrong_type'], 'maintenance_text' => ['fr' => 'test string']]],

--- a/tests/Unit/Adapter/Webservice/WebserviceConfigurationTest.php
+++ b/tests/Unit/Adapter/Webservice/WebserviceConfigurationTest.php
@@ -11,7 +11,7 @@ namespace Tests\Unit\Adapter\Webservice;
 use PrestaShop\PrestaShop\Adapter\Webservice\WebserviceConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class WebserviceConfigurationTest extends AbstractConfigurationTestCase
@@ -71,7 +71,9 @@ class WebserviceConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, ['enable_webservice' => 'wrong_type', 'enable_cgi' => true]],
             [InvalidOptionsException::class, ['enable_webservice' => true, 'enable_cgi' => 'wrong_type']],
         ];

--- a/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -12,6 +12,8 @@ use PrestaShop\PrestaShop\Adapter\Shop\Context as ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\Resources\DummyMultistoreConfiguration;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
@@ -56,6 +58,51 @@ class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
             [false, 1, 2, false],
             [false, 5, 7, false],
         ];
+    }
+
+    /**
+     * The settings forms these classes back let a module add its own fields through the
+     * action<Name>Form hook, and those values then arrive here with the core ones. Rejecting them made
+     * the page answer a save with an UndefinedOptionsException instead of saving.
+     */
+    public function testItAcceptsFieldsAModuleAddedToTheForm(): void
+    {
+        $configuration = $this->getTestableClass(false, null);
+
+        $this->assertTrue($configuration->validateConfiguration([
+            'test_conf_1' => true,
+            'test_conf_2' => 'a value',
+            'a_module_field' => 'contributed through the form hook',
+        ]));
+    }
+
+    /**
+     * Accepting a module's fields must not stop the class enforcing its own: in all shop context every
+     * defined option is required.
+     */
+    public function testItStillRejectsAMissingRequiredField(): void
+    {
+        $configuration = $this->getTestableClass(true, null);
+
+        $this->expectException(MissingOptionsException::class);
+        $configuration->validateConfiguration([
+            'test_conf_1' => true,
+            'a_module_field' => 'contributed through the form hook',
+        ]);
+    }
+
+    /**
+     * Nor stop it type checking them.
+     */
+    public function testItStillRejectsAFieldOfTheWrongType(): void
+    {
+        $configuration = $this->getTestableClass(false, null);
+
+        $this->expectException(InvalidOptionsException::class);
+        $configuration->validateConfiguration([
+            'test_conf_1' => 'not a bool',
+            'a_module_field' => 'contributed through the form hook',
+        ]);
     }
 
     /**

--- a/tests/Unit/Core/OrderReturn/Configuration/OrderReturnOptionsConfigurationTest.php
+++ b/tests/Unit/Core/OrderReturn/Configuration/OrderReturnOptionsConfigurationTest.php
@@ -12,7 +12,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\OrderReturn\Configuration\OrderReturnOptionsConfiguration;
 use PrestaShopBundle\Form\Admin\Sell\CustomerService\OrderReturn\OrderReturnOptionsType;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class OrderReturnOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -98,8 +98,10 @@ class OrderReturnOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
             [
-                UndefinedOptionsException::class,
+                MissingOptionsException::class,
                 ['does_not_exist' => 'does_not_exist'],
             ],
             [

--- a/tests/Unit/Core/Tax/TaxOptionsConfigurationTest.php
+++ b/tests/Unit/Core/Tax/TaxOptionsConfigurationTest.php
@@ -12,7 +12,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Tax\Ecotax\ProductEcotaxResetterInterface;
 use PrestaShop\PrestaShop\Core\Tax\TaxOptionsConfiguration;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class TaxOptionsConfigurationTest extends AbstractConfigurationTestCase
@@ -103,7 +103,9 @@ class TaxOptionsConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            // An unknown key is now left to the module that owns it, so what makes this input
+            // invalid is that every field the class does own is missing.
+            [MissingOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, [
                 'enable_tax' => 'wrong_type',
                 'display_tax_in_cart' => true,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The settings forms dispatch an `action<Name>Form` hook that hands the form builder to modules so they can add their own fields, and the submitted values then arrive at the configuration class with the core ones. Those classes validate with an `OptionsResolver` that rejects any key it does not define, so saving such a form answered with an `UndefinedOptionsException` instead of saving: the core refused input it had itself invited, and the module never reached its own `action<Name>Save` hook. Undefined keys are now left to the module that owns them, via `OptionsResolver::setIgnoreUndefined()`.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33356
| Related PRs       | Regression introduced for this page by #27608 (Customer Settings made multistore compatible, first released 8.1.0, commit 70f979116f0).
| Sponsor company   |

## How to test

A module adding a field to Shop Parameters > Customer Settings through
`actionCustomerPreferencesPageForm`, then saving the form. Before: the page answers with
`UndefinedOptionsException: The option "..." does not exist.` After: the form saves and the module's
`actionCustomerPreferencesPageSave` hook receives its value.

Reproduced without a back office, at the level the exception is actually thrown - `setData()`
forwards straight to `updateConfiguration()`:

```
input   ['test_conf_1' => true, 'test_conf_2' => 'x', 'rgpd_title' => 'My module field']
before  UndefinedOptionsException: The option "rgpd_title" does not exist.
after   accepted
```

## Why not allow_extra_fields

That is what the report proposes and it is not the cause. The module adds its field to the form
BUILDER via the hook, so the form knows the field and Symfony's extra-fields check never fires. The
throw comes from `AbstractMultistoreConfiguration::validateConfiguration()`. Worth stating in the
thread, since anyone who tried the suggested fix would have concluded the report was wrong.

## Scope

62 settings form handlers dispatch an `action<Name>Form` / `action<Name>Save` pair. Affected are the
ones whose configuration validates through an `OptionsResolver`: the **21** classes extending
`AbstractMultistoreConfiguration` (none of which override `validateConfiguration()`, so the base class
is a single seam) plus `LogsConfiguration` and `DatabaseLogsConfiguration`, which resolve their own
options. The other 27 own-implementations validate with `isset()` or manual checks and were never
affected - verified by reading every one.

## What is deliberately not loosened

Required options and allowed types are still enforced. In Symfony's `resolve()`, `ignoreUndefined`
only skips copying undefined keys into the resolved set; the required check compares the required list
against what was given and is independent of it. Both are pinned by their own tests, each with a
module field present so they prove the guard holds in exactly the new situation.

The known trade: a core field renamed in the form type but not in the resolver no longer raises a loud
error. It would silently fail to save either way, because `updateConfigurationValue()` looks the field
up by name, and the hook contract makes unknown keys a supported input - so a supported input must not
crash the page.

## Changed assertions - read this before the diff

Eleven test classes carry a data set submitting only `['does_not_exist' => 'does_not_exist']` and
expecting `UndefinedOptionsException`. They now expect `MissingOptionsException`: the input is still
rejected, but by what actually makes it invalid, namely that every field the class owns is absent. The
integration test's `testUndefinedOptionsException` was likewise reworked - its all-shop branch still
asserts a rejection, and its other branch asserted precisely the behaviour this issue reports as a bug.

## Evidence

Full unit suite over `tests/Unit/Core`, `tests/Unit/Adapter`, `tests/Unit/PrestaShopBundle/Form`,
measured on both sides:

```
baseline (upstream/9.2.x)   Tests: 4170  Errors: 29  Failures: 1
with this branch            Tests: 4174  Errors: 29  Failures: 1
```

Identical pre-existing errors and failures, +4 new tests. Mutation proof: with the three source files
reverted to `upstream/9.2.x` (revert verified by grep, 0 occurrences of `setIgnoreUndefined`), the
four tests whose input carries a module-contributed field all fail, and the rest stay green.
php-cs-fixer exit 0 over all 18 files, PHPStan "No errors".
