### PR TITLE
Document Hook::exec $id_module as an ID, not a name

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -872,7 +872,8 @@ class HookCore extends ObjectModel
      *
      * @param string $hook_name Hook Name
      * @param array $hook_args Parameters for the functions
-     * @param string|int|null $id_module Execute hook for this module only
+     * @param int|null $id_module Execute hook for this module only. This is a module ID, not a module
+     *                            name - resolve a name with Module::getModuleIdByName() first
      * @param bool $array_return If specified, the result will be provided in an array [module_name => module_output]
      * @param bool $check_exceptions Check if this function should respect hook controller exceptions configured in backoffice
      * @param bool $use_push Force change to be refreshed on Dashboard widgets (unused)

--- a/tests/Integration/Classes/HookTest.php
+++ b/tests/Integration/Classes/HookTest.php
@@ -8,6 +8,7 @@ namespace Tests\Integration\Classes;
 
 use Hook;
 use PHPUnit\Framework\TestCase;
+use PrestaShopException;
 
 class HookTest extends TestCase
 {
@@ -24,5 +25,37 @@ class HookTest extends TestCase
     public function testIsDisplayHookNameHeaderIsNotADisplayHook(): void
     {
         $this->assertFalse(Hook::isDisplayHookName('header'));
+    }
+
+    /**
+     * $id_module is a module ID: exec() compares it to the registration's id_module. A module name has
+     * been rejected here since the argument check was introduced, so the PHPDoc offering string was wrong.
+     */
+    public function testExecRejectsAModuleNameAsIdModule(): void
+    {
+        $this->expectException(PrestaShopException::class);
+
+        Hook::exec('displayHeader', [], 'ps_mymodule');
+    }
+
+    /**
+     * Control for the test above: the check is about being an ID, not about the PHP type, so a numeric
+     * string passes it just like an int does.
+     */
+    public function testExecAcceptsAModuleIdAsIntOrNumericString(): void
+    {
+        foreach ([1, '1'] as $idModule) {
+            try {
+                Hook::exec('displayHeader', [], $idModule);
+            } catch (PrestaShopException $e) {
+                $this->fail(sprintf(
+                    'A module ID (%s) must be accepted, got: %s',
+                    var_export($idModule, true),
+                    $e->getMessage()
+                ));
+            }
+        }
+
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/Integration/Classes/HookTest.php
+++ b/tests/Integration/Classes/HookTest.php
@@ -35,6 +35,8 @@ class HookTest extends TestCase
     {
         $this->expectException(PrestaShopException::class);
 
+        // Passing a module name is the defect under test; the documented signature makes it a static error.
+        // @phpstan-ignore-next-line
         Hook::exec('displayHeader', [], 'ps_mymodule');
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The PHPDoc offered `string\|int\|null` for `Hook::exec()`'s `$id_module`, but passing a module name throws `Invalid id_module or hook_name` - the argument check requires a numeric value, and the only later use of `$id_module` compares it to the hook registration's `id_module`, which is an ID. The annotation is the wrong half: it read `int\|null` from 2012, when the check was introduced, until a PHPStan pass widened it to `string\|int\|null` in 2021 without touching the check. This restores it and says explicitly that a name must be resolved with `Module::getModuleIdByName()` first, which is what core already does before calling. Tests pin the contract so the two cannot drift apart again.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `Hook::exec('displayHeader', [], 'ps_somemodule')` throws `PrestaShopException`; the same call with `1` or `'1'` does not. `tests/Integration/Classes/HookTest.php` covers both. No runtime change - the only production edit is a docblock.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #33872
| Related PRs       |
| Sponsor company   |

## Which of the reporter's options this takes, and why

@Hlavtox offered "fix the PHPDoc" or "resolve the name to an ID", then asked a third question nobody
answered: was it *meant* to accept a string? The history says no, and that is what settles it:

- `3e98ba04d8b` / `d9e0f26e7c8` (2012, "Refactoring of Hook class") introduce `Invalid id_module or hook_name`.
- `6f447538fff` (2021, "PHPStan (Level 4) on classes/") changes the annotation only:
  `- @param int|null` -> `+ @param string|int|null`, leaving the check alone.

So the `string` is an annotation error from a static-analysis pass, not a design intent that was never
implemented. @kpodemski's "fixing the doc is ok" is the right call and this is the evidence for it.

Resolving the name inside `exec()` was rejected deliberately: `Hook::exec()` is one of the hottest paths in
the application, so a name lookup is a query on every call, and it would duplicate an idiom callers already
apply explicitly. `src/Adapter/Shipment/DeliveryOptionsProvider.php` is the only core caller that passes a
non-null `$id_module`, and it calls `Module::getModuleIdByName()` first. Every other core caller passes
`null`, so nothing in core is broken today - this is a contract defect, not a live failure.

## The annotation can be narrowed safely

Worth stating, because the `string` came from a PHPStan run and narrowing it could plausibly reintroduce
whatever that run was silencing: with `int|null` restored, **PHPStan level 5 is clean over `classes` and
`src`** (verified with a positive control - an injected `strlen(12345, 6789)` was reported, so the analysis
was really running).

## Evidence

The production change is a docblock, so there is no RED/GREEN for it. The tests pin the *check* instead, and
they bite: replacing the `($id_module && !is_numeric($id_module))` term with `(false)` fails exactly
`testExecRejectsAModuleNameAsIdModule` and leaves the other four green. Restored, 5 tests / 5 assertions OK.

`Hook::exec()` cannot be reached in a unit test - `getHookStatusByName()` queries the DB before the check -
so the tests are integration tests, in the existing `tests/Integration/Classes/HookTest.php`.

cs-fixer exit 0 on both files.
