### PR TITLE
Make the translator interface the contract the core actually uses

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -101,7 +101,7 @@ class ContextCore
     /** @var float */
     public $virtualTotalTaxIncluded = 0;
 
-    /** @var Translator */
+    /** @var TranslatorInterface */
     protected $translator = null;
 
     /** @var int */
@@ -407,7 +407,7 @@ class ContextCore
      *
      * @param bool $isInstaller Set to true if the method is called by the installer
      *
-     * @return Translator
+     * @return TranslatorInterface
      */
     public function getTranslator($isInstaller = false)
     {

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -15,7 +15,7 @@ use PrestaShop\PrestaShop\Core\ExtraProperty\Validation\ExtraPropertyValidatorIn
 use PrestaShop\PrestaShop\Core\ExtraProperty\Value\ExtraPropertiesBag;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Value\ExtraPropertyWriterInterface;
 use PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -109,7 +109,7 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
     /** @var string file type of image files. */
     protected $image_format = 'jpg';
 
-    /** @var TranslatorComponent */
+    /** @var TranslatorInterface */
     protected $translator;
 
     /**
@@ -184,7 +184,7 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
      * @param int|null $id if specified, loads and existing object from DB (optional)
      * @param int|null $id_lang required if object is multilingual (optional)
      * @param int|null $id_shop ID shop for objects with multishop tables
-     * @param TranslatorComponent|null $translator
+     * @param TranslatorInterface|null $translator
      *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -5,7 +5,7 @@
  */
 
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -127,7 +127,7 @@ abstract class ControllerCore
     public $php_self;
 
     /**
-     * @var TranslatorComponent
+     * @var TranslatorInterface
      */
     protected $translator;
 

--- a/classes/tree/Tree.php
+++ b/classes/tree/Tree.php
@@ -4,7 +4,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
-use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 
 class TreeCore
 {
@@ -33,7 +33,7 @@ class TreeCore
     /** @var TreeToolbar|ITreeToolbarCore|null */
     private $_toolbar;
 
-    /** @var TranslatorComponent */
+    /** @var TranslatorInterface */
     public $translator;
 
     public function __construct($id, $data = null)

--- a/install-dev/classes/controllerConsole.php
+++ b/install-dev/classes/controllerConsole.php
@@ -6,7 +6,7 @@
 
 use PrestaShopBundle\Install\AbstractInstall;
 use PrestaShopBundle\Install\LanguageList;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 
 abstract class InstallControllerConsole
 {
@@ -55,7 +55,7 @@ abstract class InstallControllerConsole
     public $datas;
 
     /**
-     * @var TranslatorComponent|null
+     * @var TranslatorInterface
      */
     public $translator;
 

--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -47,7 +47,7 @@ class InstallControllerHttp
     public $language;
 
     /**
-     * @var \Symfony\Component\Translation\Translator
+     * @var \PrestaShopBundle\Translation\TranslatorInterface
      */
     public $translator;
 

--- a/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
@@ -17,7 +17,7 @@ use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShopBundle\Entity\Repository\ShipmentRepository;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use PrestaShopException;
 use Tools;
 
@@ -39,7 +39,7 @@ class OrderDetailLazyArray extends AbstractLazyArray
     private $context;
 
     /**
-     * @var TranslatorComponent
+     * @var TranslatorInterface
      */
     private $translator;
 

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -29,7 +29,7 @@ use PrestaShop\PrestaShop\Adapter\Shipment\ShipmentTotalsCalculatorInterface;
 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
 use PrestaShopBundle\Entity\Repository\ShipmentRepository;
 use PrestaShopBundle\Entity\ShipmentProduct;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use PrestaShopException;
 use ProductDownload;
 use ReflectionException;
@@ -47,7 +47,7 @@ class OrderLazyArray extends AbstractLazyArray
     /** @var PriceFormatter */
     private $priceFormatter;
 
-    /** @var TranslatorComponent */
+    /** @var TranslatorInterface */
     private $translator;
 
     /** @var TaxConfiguration */

--- a/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
@@ -14,7 +14,7 @@ use Order;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use TaxConfiguration;
 
 class OrderSubtotalLazyArray extends AbstractLazyArray
@@ -31,7 +31,7 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
     /** @var bool */
     private $includeTaxes;
 
-    /** @var TranslatorComponent */
+    /** @var TranslatorInterface */
     private $translator;
 
     /**

--- a/src/PrestaShopBundle/Translation/TranslatorInterface.php
+++ b/src/PrestaShopBundle/Translation/TranslatorInterface.php
@@ -7,12 +7,20 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Translation;
 
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface as SymfonyTranslatorInterface;
 
 /**
- * Interface for PrestaShop translators
+ * Interface for PrestaShop translators.
+ *
+ * The core fetches its translator from the container by this interface and the debug environment
+ * decorates it, so the concrete class differs between environments. Everything the core actually
+ * calls on a translator therefore has to be declared here: setting the locale and reading the
+ * catalogue are part of that, and both come from Symfony's own contracts, which every translator
+ * built on the framework already satisfies.
  */
-interface TranslatorInterface extends SymfonyTranslatorInterface
+interface TranslatorInterface extends SymfonyTranslatorInterface, LocaleAwareInterface, TranslatorBagInterface
 {
     /**
      * Performs a reverse search in the catalogue and returns the translation key if found.

--- a/tests/Unit/PrestaShopBundle/Translation/TranslatorInterfaceContractTest.php
+++ b/tests/Unit/PrestaShopBundle/Translation/TranslatorInterfaceContractTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Translation;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Translation\DataCollectorTranslator;
+use PrestaShopBundle\Translation\Translator;
+use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
+use ReflectionClass;
+
+class TranslatorInterfaceContractTest extends TestCase
+{
+    /**
+     * The container is asked for TranslatorInterface and the debug environment decorates the
+     * result, so the concrete class a caller receives is not fixed. Anything the core calls on a
+     * translator has to be on the interface, or the only way to type a translator is to name one
+     * implementation - which then breaks in the environment that returns another.
+     *
+     * @dataProvider provideMethodsTheCoreCallsOnATranslator
+     */
+    public function testTheInterfaceDeclaresWhatTheCoreCalls(string $method): void
+    {
+        $this->assertTrue(
+            method_exists(TranslatorInterface::class, $method),
+            sprintf('%s is called on translators fetched by interface, so it must be declared on it.', $method)
+        );
+    }
+
+    public function provideMethodsTheCoreCallsOnATranslator(): iterable
+    {
+        // trans:        everywhere
+        // setLocale:    Context::getTranslator, PaymentModule, OrderHistory, ContextStateManager
+        // getCatalogue: Module::isUsingNewTranslationSystem
+        yield 'trans' => ['trans'];
+        yield 'getLocale' => ['getLocale'];
+        yield 'setLocale' => ['setLocale'];
+        yield 'getCatalogue' => ['getCatalogue'];
+    }
+
+    /**
+     * @dataProvider provideTranslatorsTheContainerCanReturn
+     */
+    public function testEveryTranslatorTheContainerCanReturnSatisfiesTheInterface(string $class): void
+    {
+        $this->assertTrue(
+            is_a($class, TranslatorInterface::class, true),
+            sprintf('%s can be returned by the container, so it must satisfy the interface.', $class)
+        );
+    }
+
+    public function provideTranslatorsTheContainerCanReturn(): iterable
+    {
+        yield 'component' => [TranslatorComponent::class];
+        yield 'debug decorator' => [DataCollectorTranslator::class];
+        yield 'translator' => [Translator::class];
+    }
+
+    /**
+     * The three implementations do not share a parent, which is why naming one of them in a
+     * signature is what broke: a DataCollectorTranslator is not a TranslatorComponent.
+     */
+    public function testTheImplementationsDoNotShareAConcreteParent(): void
+    {
+        $this->assertNotInstanceOf(TranslatorComponent::class, $this->reflectWithoutConstructor(DataCollectorTranslator::class));
+        $this->assertNotInstanceOf(DataCollectorTranslator::class, $this->reflectWithoutConstructor(TranslatorComponent::class));
+    }
+
+    private function reflectWithoutConstructor(string $class): object
+    {
+        return (new ReflectionClass($class))->newInstanceWithoutConstructor();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The container is asked for `PrestaShopBundle\Translation\TranslatorInterface` and the debug environment decorates the result, so the concrete class a caller receives is not fixed - and the three implementations do not share a concrete parent. The core nonetheless annotated translators as `TranslatorComponent` everywhere, and `Context::getTranslator()` was documented as returning it while returning whatever the container holds. Following those annotations is what makes a class work with debug off and throw with it on, which is what #34138 reports. The interface could not simply be used instead, because it did not declare what the core calls on a translator: `setLocale()` in six places and `getCatalogue()` in one, on values fetched by interface. Both come from Symfony's own contracts, so `TranslatorInterface` now extends `LocaleAwareInterface` and `TranslatorBagInterface` - which all three implementations already satisfy - and the annotations name the interface.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `vendor/bin/phpstan analyse -c phpstan.neon.dist classes/ src/ controllers/` reports the same 629 errors before and after. Reverting only `src/PrestaShopBundle/Translation/TranslatorInterface.php` to the base makes `tests/Unit/PrestaShopBundle/Translation/TranslatorInterfaceContractTest.php` fail on exactly the `setLocale` and `getCatalogue` data sets. For the reported symptom, write a class taking `TranslatorInterface` in its constructor, pass `$this->getTranslator()` from a module, and load a page with `_PS_MODE_DEV_` on and off - the concrete class differs, the interface does not.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34138
| Related PRs       | The documentation example this issue quotes is fixed separately in `PrestaShop/docs` (branch `fix/module-translator-type-hint-34138`). `fix/checkout-process-translator-type` is the same defect class in `CheckoutProcessProviderResolver`, found independently.
| Sponsor company   |

## Why the interface changed rather than the annotations alone

Annotating `Context::getTranslator()` truthfully is a two-line change, and on its own it makes PHPStan
report **13 errors** across `classes/` and `src/`:

```
setLocale()     Context::getTranslator, PaymentModule x2, OrderHistory x2, ContextStateManager x2
getCatalogue()  Module::isUsingNewTranslationSystem
@var            ObjectModel, Controller, Tree, OrderDetailLazyArray, OrderLazyArray, OrderSubtotalLazyArray
```

Those are not annotation noise. Seven of them are the core calling methods that were never on the
contract it fetched by, and the six properties are annotated as one implementation while holding
another whenever debug is on - the reported bug, inside the core, in six places. Patching the
annotations one at a time leaves the interface unusable, which is exactly why the documentation
recommended naming a concrete class.

## On backward compatibility

Consumers are unaffected: every existing type hint on `TranslatorInterface` keeps working, and the
interface gains methods rather than losing any. Only an implementation could be affected, and the
three in the core - `TranslatorComponent`, `DataCollectorTranslator`, `Translator` - each extend a
Symfony translator and already have both methods. The interface carries no `@internal` or `@api`
marking. This targets `develop` rather than `9.2.x` because an implementation that does not extend a
Symfony translator would have to add them.

## Evidence

PHPStan over `classes/ src/ controllers/`: **629 errors on `upstream/develop`, 629 with this branch**,
with the base measured by reverting `classes/` and `src/` and confirming they were byte-identical to
`upstream/develop`, then restoring and confirming they matched the commit.

Test: `tests/Unit/PrestaShopBundle/Translation/TranslatorInterfaceContractTest.php`, 8 cases. Reverting
only the interface fails exactly the `setLocale` and `getCatalogue` data sets and leaves the other six
green, so the cases that pin the change are separable from the ones that pin the implementations. The
last case asserts the two implementations are not instances of one another, which is the property that
makes a concrete type hint unsafe in the first place.

`php-cs-fixer` and `phpstan` clean on all nine files.
