### PR TITLE
Escape and quote shop domains written into .htaccess

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2569,6 +2569,32 @@ class ToolsCore
         return $domains;
     }
 
+    /**
+     * Turns a shop or media server domain into a pattern safe to use as a RewriteCond
+     * argument in .htaccess.
+     *
+     * @param string $domain
+     *
+     * @return string
+     */
+    public static function getHtaccessDomainPattern($domain)
+    {
+        /*
+         * WHY: a domain is free text - ShopUrl validates it with isCleanHtml - but it ends up
+         * inside an Apache directive, where two character classes are dangerous:
+         *  - regex metacharacters, because a RewriteCond pattern is a regex: the unescaped dots
+         *    in "^10.0.1.34$" also match "10a0b1c34";
+         *  - whitespace, because Apache splits a directive into arguments on it. An unquoted
+         *    pattern holding a space becomes an extra argument, Apache stops parsing .htaccess
+         *    with "RewriteCond: bad flag delimiters" and answers HTTP 500 for every request -
+         *    the back office included, so the merchant can no longer correct the domain.
+         * preg_quote() handles the first and also escapes the brackets of an IPv6 literal, which
+         * is why the manual bracket escaping it replaced is no longer needed. Quoting the
+         * argument handles the second.
+         */
+        return '"^' . preg_quote($domain) . '$"';
+    }
+
     public static function generateHtaccess($path = null, $rewrite_settings = null, $cache_control = null, $specific = '', $disable_multiviews = null, $medias = false, $disable_modsec = null)
     {
         if (
@@ -2667,7 +2693,7 @@ class ToolsCore
         foreach ($medias as $media) {
             foreach ($media as $media_url) {
                 if ($media_url) {
-                    $media_domains .= 'RewriteCond %{HTTP_HOST} ^' . $media_url . '$ [OR]' . PHP_EOL;
+                    $media_domains .= 'RewriteCond %{HTTP_HOST} ' . self::getHtaccessDomainPattern($media_url) . ' [OR]' . PHP_EOL;
                 }
             }
         }
@@ -2682,14 +2708,11 @@ class ToolsCore
         fwrite($write_fd, "RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]\n\n");
 
         foreach ($domains as $domain => $list_uri) {
-            // As we use regex in the htaccess, ipv6 surrounded by brackets must be escaped
-            $domain = str_replace(['[', ']'], ['\[', '\]'], $domain);
-
             $domain_rewrite_cond = '';
             foreach ($list_uri as $uri) {
                 fwrite($write_fd, PHP_EOL . PHP_EOL . '#Domain: ' . $domain . PHP_EOL);
                 if (Shop::isFeatureActive()) {
-                    fwrite($write_fd, 'RewriteCond %{HTTP_HOST} ^' . $domain . '$' . PHP_EOL);
+                    fwrite($write_fd, 'RewriteCond %{HTTP_HOST} ' . self::getHtaccessDomainPattern($domain) . PHP_EOL);
                 }
                 fwrite($write_fd, 'RewriteRule . - [E=REWRITEBASE:' . $uri['physical'] . ']' . PHP_EOL);
 
@@ -2702,7 +2725,7 @@ class ToolsCore
                     $rewrite_settings = (int) Configuration::get('PS_REWRITING_SETTINGS', null, null, (int) $uri['id_shop']);
                 }
 
-                $domain_rewrite_cond = 'RewriteCond %{HTTP_HOST} ^' . $domain . '$' . PHP_EOL;
+                $domain_rewrite_cond = 'RewriteCond %{HTTP_HOST} ' . self::getHtaccessDomainPattern($domain) . PHP_EOL;
                 // Rewrite virtual multishop uri
                 if ($uri['virtual']) {
                     if (!$rewrite_settings) {

--- a/tests/Unit/Classes/ToolsTest.php
+++ b/tests/Unit/Classes/ToolsTest.php
@@ -1268,4 +1268,48 @@ class ToolsTest extends TestCase
         $this->assertTrue($method->isStatic());
         $this->assertSame(2, $method->getNumberOfParameters());
     }
+
+    /**
+     * @dataProvider providerHtaccessDomainPattern
+     */
+    public function testGetHtaccessDomainPatternMatchesOnlyThatDomain(string $domain, string $lookalike): void
+    {
+        $regex = $this->htaccessDomainPatternToRegex(Tools::getHtaccessDomainPattern($domain));
+
+        $this->assertSame(1, preg_match($regex, $domain), 'a domain must still match its own pattern');
+        $this->assertSame(0, preg_match($regex, $lookalike), 'the pattern must not match anything else');
+    }
+
+    public function providerHtaccessDomainPattern(): iterable
+    {
+        // An unescaped dot is "any character", so ^10.0.1.34$ also matched 10a0b1c34.
+        yield 'dots are literal' => ['10.0.1.34', '10a0b1c34'];
+        // Unescaped, ^[::1]$ is a character class matching one of : or 1 - never the address.
+        yield 'ipv6 brackets are escaped' => ['[::1]', '1'];
+        yield 'a regular domain is unaffected' => ['shop.example.com', 'shopxexample.com'];
+    }
+
+    public function testGetHtaccessDomainPatternIsQuotedSoWhitespaceCannotSplitTheDirective(): void
+    {
+        // A domain holding a space used to emit
+        //   RewriteCond %{HTTP_HOST} ^10.0.1.34 10.0.6.3$
+        // which Apache rejects with "RewriteCond: bad flag delimiters". That is a parse error
+        // on .htaccess, so every request - the back office included - answers HTTP 500 and the
+        // merchant can no longer correct the domain. Quoting keeps it a single argument.
+        $pattern = Tools::getHtaccessDomainPattern('10.0.1.34 10.0.6.3');
+
+        $this->assertStringStartsWith('"', $pattern);
+        $this->assertStringEndsWith('"', $pattern);
+        $this->assertStringNotContainsString(
+            '"',
+            substr($pattern, 1, -1),
+            'the quoted argument must not be terminated early'
+        );
+    }
+
+    private function htaccessDomainPatternToRegex(string $pattern): string
+    {
+        // preg_quote() escapes #, so it is safe as the delimiter here.
+        return '#' . trim($pattern, '"') . '#';
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Tools::generateHtaccess()` interpolated a shop domain straight into a `RewriteCond` pattern. A domain holding whitespace - which `ShopUrl` accepts, since it validates `domain` with `isCleanHtml` - emitted `RewriteCond %{HTTP_HOST} ^10.0.1.34 10.0.6.3$`. Apache splits a directive on whitespace, rejects the leftover argument with `RewriteCond: bad flag delimiters`, and answers HTTP 500 for every request, back office included, so the merchant could not correct the domain from the interface. The pattern was unescaped too, so `^10.0.1.34$` also matched `10a0b1c34`. Both are now handled at the one place a domain becomes a directive: `preg_quote()` escapes the metacharacters and the argument is quoted so whitespace cannot split it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set a shop URL domain to `10.0.1.34 10.0.6.3` (SEO & URLs, or directly in `ps_shop_url.domain`), regenerate `.htaccess`, and request any page. Before this change Apache answers HTTP 500 for every URL and logs `RewriteCond: bad flag delimiters`; after it, the file parses and the site responds normally. `tests/Unit/Classes/ToolsTest.php` covers the escaping and the quoting separately.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34027
| Related PRs       |
| Sponsor company   |

## Why the generator and not the validator

Tightening `ShopUrl`'s `isCleanHtml` to a hostname validator was considered and rejected.
It would reject domains existing shops already have stored, and it would not repair an
installation that is already down - the broken value is on disk in `.htaccess` and the back
office is unreachable, so the merchant cannot go and fix the field. The generator is the one
place where a domain becomes an Apache directive, so that is where the value gets neutralised.
Regenerating `.htaccess` repairs an affected install.

## Scope

Three sites build a `RewriteCond` from a domain and all three are changed: media servers at
`:2670` (which appends an `[OR]` flag after the argument - measured separately, since a quoted
argument followed by a flag is a different parse path), the multishop condition at `:2692`, and
`$domain_rewrite_cond` at `:2705`, which every later `fwrite` reuses. The manual
`str_replace(['[', ']'], ...)` IPv6 escaping is **removed** rather than kept, because
`preg_quote()` already escapes those brackets and running both would double-escape them.

One asymmetry this introduces, since it is visible in the diff: the `#Domain:` comment line above each
block still prints the domain as stored, while the directive below it now prints the escaped form. That is
deliberate. The comment exists to tell a reader which shop a block belongs to, so it should show the domain
the merchant actually configured; escaping is only meaningful for the value Apache parses as a pattern.
Before this change both were bracket-escaped, so an IPv6 block was labelled `#Domain: \[::1\]`, which named
no domain anyone had entered.

## Evidence

`generateHtaccess()` returns early when `_PS_IN_TEST_` is defined (`tests/Unit/bootstrap.php:8`
defines it), so a test that calls it asserts nothing - green with the fix and green without it.
The escaping therefore lives in a named helper and the test covers the helper.

RED/GREEN by mutating the helper, each mutation failing exactly the assertions it should:

```
drop preg_quote(), keep quoting  -> 3 failures (dots, ipv6, plain domain), quoting test passes
drop quoting, keep preg_quote()  -> 1 failure  (the quoting test), the other three pass
restored                         -> 4 tests, 9 assertions, OK
```

End to end against real Apache, on the file the generator actually produced, with only the
directive shape changed between requests:

```
A. as generated now (quoted + escaped)      HTTP 200
B. same file, directives as 9.2.x emits     HTTP 500   <- byte-identical to the reporter's line
C. restored to A                            HTTP 200
```

Escaped and quoted, these all still parse: space, tab, CR, backslash, underscore, IPv6 literal.
IPv6 still matches its own pattern, confirming the removed bracket escaping is not needed.

Full `ToolsTest` 407 passing. cs-fixer clean (0 of 2), PHPStan level 5 no errors.
