### PR TITLE
Give every search-grid route a permission subject

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -99,6 +99,7 @@ admin_cms_pages_search_cms_category:
   methods: POST
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\CommonController::searchGridAction'
+    _legacy_controller: AdminCmsContent
     gridDefinitionFactoryService: prestashop.core.grid.definition.factory.cms_page_category
     redirectRoute: admin_cms_pages_index
     redirectQueryParamsToKeep:

--- a/tests/Unit/PrestaShopBundle/Routing/SearchGridRoutePermissionSubjectTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/SearchGridRoutePermissionSubjectTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Routing;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * CommonController::searchGridAction is guarded by
+ * `is_granted('read', request.get('_legacy_controller'))`. A route that reaches it without that
+ * default resolves an empty permission subject, and Access::isGranted() then rejects the slug it
+ * builds - the grid's filter form answers 500 instead of filtering.
+ *
+ * Nothing else catches this: app/config/config_test.yml swaps PageVoter for a test double whose
+ * voteOnAttribute() returns true unconditionally, so an integration test cannot see a broken
+ * security expression.
+ */
+class SearchGridRoutePermissionSubjectTest extends TestCase
+{
+    private const ROUTING_DIR = __DIR__ . '/../../../../src/PrestaShopBundle/Resources/config/routing';
+
+    private const GUARDED_ACTION = 'CommonController::searchGridAction';
+
+    public function testEverySearchGridRouteDeclaresItsPermissionSubject(): void
+    {
+        $routes = $this->getRoutesReaching(self::GUARDED_ACTION);
+
+        // Guards the assertion below against passing because the scan found nothing.
+        $this->assertGreaterThan(
+            30,
+            count($routes),
+            'the routing scan found almost no search-grid routes, so it is not looking where it should'
+        );
+
+        $withoutSubject = [];
+        foreach ($routes as $name => $file) {
+            if (!isset($this->routeDefaults($file, $name)['_legacy_controller'])) {
+                $withoutSubject[] = sprintf('%s (%s)', $name, $file);
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $withoutSubject,
+            "these routes reach searchGridAction without a _legacy_controller default, so filtering their grid answers 500:\n"
+            . implode("\n", $withoutSubject)
+        );
+    }
+
+    /**
+     * @return array<string, string> route name => routing file, relative to the routing directory
+     */
+    private function getRoutesReaching(string $action): array
+    {
+        $found = [];
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(self::ROUTING_DIR));
+        foreach ($files as $file) {
+            if ($file->isDir() || $file->getExtension() !== 'yml') {
+                continue;
+            }
+            $parsed = Yaml::parseFile($file->getPathname());
+            if (!is_array($parsed)) {
+                continue;
+            }
+            foreach ($parsed as $name => $definition) {
+                if (!is_array($definition) || !isset($definition['defaults']['_controller'])) {
+                    continue;
+                }
+                if (str_contains((string) $definition['defaults']['_controller'], $action)) {
+                    $found[$name] = $file->getPathname();
+                }
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function routeDefaults(string $file, string $routeName): array
+    {
+        $parsed = Yaml::parseFile($file);
+
+        return $parsed[$routeName]['defaults'] ?? [];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CommonController::searchGridAction` is guarded by `is_granted('read', request.get('_legacy_controller'))`. A route reaching it without that default resolves an empty permission subject, and `Access::isGranted()` rejects the `ROLE_MOD_TAB__READ` slug it builds, so the grid's filter form answers 500 instead of filtering. Of the 41 routes reaching that action, `admin_cms_pages_search_cms_category` was the only one missing it. The added unit test parses the routing files and asserts the default is present on all of them, because nothing else can: `app/config/config_test.yml` swaps `PageVoter` for a double whose `voteOnAttribute()` returns true unconditionally, so an integration test cannot see a broken security expression.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to Design > Pages, filter the categories grid and submit. Before this change the request answers 500 with `The slug ROLE_MOD_TAB__READ is invalid`; after, the filter applies. `tests/Unit/PrestaShopBundle/Routing/SearchGridRoutePermissionSubjectTest.php` covers the whole class of routes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42436
| Related PRs       | The other half of #42436 is develop-only and is prepared separately as `fix/extra-property-routes-legacy-controller-42436`.
| Sponsor company   |

## Scope

The reported route (`admin_extra_property_definitions_search`) is NOT broken on 9.2.x - all ten routes
of that file have carried `_legacy_controller` since 2026-07-02. Only `develop` lacks them, so that half
targets `develop`. Surveying every `searchGridAction` route surfaced the CMS one, which IS broken on both
branches, so it is fixed here at the lowest applicable branch. `AdminCmsContent` is not a guess - every
sibling route in `cms_pages.yml` already uses it.

## Evidence

Reverting the CMS route makes the test fail and name it:
`admin_cms_pages_search_cms_category (.../admin/improve/design/cms_pages.yml)`. The test also asserts it
found more than 30 search-grid routes, so it cannot pass by scanning nothing. `tests/Unit/PrestaShopBundle/Routing`
is green at 71 tests, `phpstan` clean, and `bin/console lint:yaml` accepts the touched file.
