### PR TITLE
Give the extra property definition routes a permission subject

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/extra_property_definition.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/extra_property_definition.yml
@@ -3,12 +3,14 @@ admin_extra_property_definitions_index:
   methods: GET
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::indexAction'
+    _legacy_controller: AdminExtraPropertyDefinitions
 
 admin_extra_property_definitions_search:
   path: /
   methods: POST
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
+    _legacy_controller: AdminExtraPropertyDefinitions
     gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.extra_property_definition
     redirectRoute: admin_extra_property_definitions_index
 
@@ -17,6 +19,7 @@ admin_extra_property_definitions_form_fields:
   methods: GET
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::formFieldsAction'
+    _legacy_controller: AdminExtraPropertyDefinitions
   requirements:
     formId: '[A-Za-z0-9_]+'
 
@@ -25,6 +28,7 @@ admin_extra_property_definitions_create:
   methods: [ GET, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::createAction'
+    _legacy_controller: AdminExtraPropertyDefinitions
     _parent: admin_extra_property_definitions_index
 
 admin_extra_property_definitions_edit:
@@ -32,6 +36,7 @@ admin_extra_property_definitions_edit:
   methods: [ GET, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::editAction'
+    _legacy_controller: AdminExtraPropertyDefinitions
     _parent: admin_extra_property_definitions_index
   requirements:
     extraPropertyDefinitionId: \d+
@@ -41,6 +46,7 @@ admin_extra_property_definitions_view:
   methods: GET
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::viewAction'
+    _legacy_controller: AdminExtraPropertyDefinitions
   requirements:
     extraPropertyDefinitionId: \d+
 
@@ -49,6 +55,7 @@ admin_extra_property_definitions_delete:
   methods: [ DELETE, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::deleteAction'
+    _legacy_controller: AdminExtraPropertyDefinitions
   requirements:
     extraPropertyDefinitionId: \d+
 
@@ -57,6 +64,7 @@ admin_extra_property_definitions_delete_drop_column:
   methods: [ DELETE, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::deleteDropColumnAction'
+    _legacy_controller: AdminExtraPropertyDefinitions
   requirements:
     extraPropertyDefinitionId: \d+
 
@@ -65,9 +73,11 @@ admin_extra_property_definitions_bulk_delete:
   methods: POST
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::bulkDeleteAction'
+    _legacy_controller: AdminExtraPropertyDefinitions
 
 admin_extra_property_definitions_bulk_delete_drop_column:
   path: /bulk-delete-drop-column
   methods: POST
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\ExtraPropertyDefinitionController::bulkDeleteDropColumnAction'
+    _legacy_controller: AdminExtraPropertyDefinitions


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The ten routes of `extra_property_definition.yml` reach the back office through controllers guarded on `request.get('_legacy_controller')`, and on `develop` none of them declares it - filtering the Extra property definitions grid answers 500 with `The slug ROLE_MOD_TAB__READ is invalid`. `9.2.x` already declares it on all ten; this brings `develop` in line. The two `_parent` defaults are untouched: they drive the tab and toolbar hierarchy, not the permission subject.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On `develop`, go to `/configure/advanced/extra-property-definitions/`, type anything in a filter field and submit. Before this change the request answers 500; after, the filter applies.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42436
| Related PRs       | The 9.2.x half, which fixes `admin_cms_pages_search_cms_category` and adds the routing test that guards the whole class, is prepared as `fix/search-grid-routes-permission-subject-42436`.
| Sponsor company   |

## Why develop only

All ten routes carry `_legacy_controller: AdminExtraPropertyDefinitions` on `9.2.x`, added 2026-07-02.
`develop`'s copy of the file has ten routes and zero of them, which is why the report says the bug
happens on `dev`. `develop` separately gained `_parent` on two routes on 2026-07-22; that is a different
mechanism (6 uses across the routing tree, tab/toolbar hierarchy) from `_legacy_controller` (701 uses,
read by the security expression), so both belong.

## Verification

`Symfony\Component\Yaml` parses the edited file to 10 routes with none missing `_legacy_controller` and
the 2 `_parent` defaults preserved. The routing test shipped in the 9.2.x half passes against this
branch too.
