### PR TITLE
Collect bulk failures per call instead of on the handler

### DIFF
--- a/src/Core/Domain/AbstractBulkCommandHandler.php
+++ b/src/Core/Domain/AbstractBulkCommandHandler.php
@@ -14,11 +14,6 @@ use Throwable;
 abstract class AbstractBulkCommandHandler
 {
     /**
-     * @var Throwable[]
-     */
-    protected $exceptions;
-
-    /**
      * @param array $ids
      * @param string $exceptionToCatch when cought this exception will allow the loop to continue
      *                                 and show bulk error at the end of the loop, instead of breaking it on first error.
@@ -28,6 +23,12 @@ abstract class AbstractBulkCommandHandler
      */
     protected function handleBulkAction(array $ids, string $exceptionToCatch, mixed $command = null): void
     {
+        // WHY local and not a property: handlers are registered as services and are reused for every
+        // dispatch in the process, so a property outlived the call that filled it - a later bulk action
+        // that failed on nothing still threw, replaying the earlier call's failures. Nothing outside
+        // this method ever read it, so the state does not need to exist rather than needing a reset.
+        $exceptions = [];
+
         foreach ($ids as $id) {
             try {
                 if (!$this->supports($id)) {
@@ -41,12 +42,12 @@ abstract class AbstractBulkCommandHandler
                     throw $e;
                 }
 
-                $this->exceptions[] = $e;
+                $exceptions[] = $e;
             }
         }
 
-        if (!empty($this->exceptions)) {
-            throw $this->buildBulkException($this->exceptions);
+        if (!empty($exceptions)) {
+            throw $this->buildBulkException($exceptions);
         }
     }
 

--- a/tests/Unit/Core/Domain/AbstractBulkCommandHandlerTest.php
+++ b/tests/Unit/Core/Domain/AbstractBulkCommandHandlerTest.php
@@ -93,6 +93,51 @@ class AbstractBulkCommandHandlerTest extends TestCase
 
         $this->assertInstanceOf(TestCommand::class, $handler->getCommand());
     }
+
+    /**
+     * Handlers are services, so one instance serves every dispatch in a long running process (Behat,
+     * a CLI command, a Messenger consumer). What one call collects must not still be there for the next.
+     */
+    public function testEachCallReportsOnlyItsOwnFailures(): void
+    {
+        $firstFailure = new FailingId(1, new FeatureException('first'));
+        $secondFailure = new FailingId(2, new FeatureException('second'));
+        $handler = new TestAbstractBulkCommandHandler([$firstFailure, $secondFailure], IdInterface::class);
+
+        try {
+            $handler->handle([$firstFailure, new ExampleId(10)], FeatureException::class);
+            Assert::fail('the failing id should have produced a bulk exception');
+        } catch (BulkCommandExceptionInterface $e) {
+            Assert::assertCount(1, $e->getExceptions());
+        }
+
+        try {
+            $handler->handle([$secondFailure, new ExampleId(11)], FeatureException::class);
+            Assert::fail('the failing id should have produced a bulk exception');
+        } catch (BulkCommandExceptionInterface $e) {
+            Assert::assertCount(
+                1,
+                $e->getExceptions(),
+                'the second call reported the first call failures as well'
+            );
+        }
+    }
+
+    public function testACallThatFailsOnNothingDoesNotThrow(): void
+    {
+        $failingId = new FailingId(1, new FeatureException('first'));
+        $handler = new TestAbstractBulkCommandHandler([$failingId], IdInterface::class);
+
+        try {
+            $handler->handle([$failingId], FeatureException::class);
+        } catch (BulkCommandExceptionInterface $e) {
+            // expected; this call is only here to leave a failure behind
+        }
+
+        // Every id below succeeds, so reaching the end without an exception is the assertion.
+        $handler->handle([new ExampleId(2), new ExampleId(3)], FeatureException::class);
+        $this->addToAssertionCount(1);
+    }
 }
 
 class TestAbstractBulkCommandHandler extends AbstractBulkCommandHandler


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `AbstractBulkCommandHandler::$exceptions` was a property that was never initialised and never reset. Bulk command handlers are registered as services, so one instance serves every dispatch in the process and the property outlived the call that filled it: failures accumulated across calls, and a bulk action that failed on nothing still threw, replaying an earlier call's exceptions. A caller deriving a count from the list could reach a negative figure. No subclass reads the property, so the collection becomes a local variable and the shared state stops existing rather than needing a reset.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In one PHP process (Behat, a CLI command, a Messenger consumer) dispatch a bulk command that fails on at least one id, then dispatch a second bulk command that succeeds on every id. Before this change the second call throws a bulk exception carrying the first call's failures; after, it returns. Covered by two cases added to `tests/Unit/Core/Domain/AbstractBulkCommandHandlerTest.php`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42506
| Related PRs       |
| Sponsor company   |

## Why a local variable and not the reset the report suggests

Resetting the property at the top of `handleBulkAction()` and typing it
`protected array $exceptions = []` works, but it keeps mutable state on a shared service for no
benefit and leaves the same defect one forgotten line away. The collection is an implementation
detail of a single method: all 14 subclasses were checked and none references `$this->exceptions`,
and the other `->exceptions` matches in the tree belong to the bulk exception and command classes,
which declare their own property. A local variable removes the failure mode by construction.

## Evidence

Reverting `src/Core/Domain/AbstractBulkCommandHandler.php` fails exactly the two added cases -
`testEachCallReportsOnlyItsOwnFailures` on "the second call reported the first call failures as well",
and `testACallThatFailsOnNothingDoesNotThrow` - and leaves the four pre-existing cases in that file
green. 6 tests / 12 assertions with the fix. `php-cs-fixer` and `phpstan` clean.

The tests were added to the existing file and reuse its `TestAbstractBulkCommandHandler` /
`ExampleId` / `FailingId` harness rather than introducing a parallel one.

## Not a duplicate

No open PR touches `src/Core/Domain/AbstractBulkCommandHandler.php`. #41714 (GautierBoudeweel) matches
a text search for the class name but its file list does not include it. Of my own 366 open core PRs,
none touches the file.
