### PR TITLE
Give the session handler a lifetime, not an expiry date

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -155,8 +155,13 @@ setlocale(LC_NUMERIC, 'en_US.UTF-8', 'en_US.utf8');
 
 /* Instantiate cookie */
 $cookie_lifetime = defined('_PS_ADMIN_DIR_') ? (int) Configuration::get('PS_COOKIE_LIFETIME_BO') : (int) Configuration::get('PS_COOKIE_LIFETIME_FO');
+// WHY two variables: Cookie takes the absolute moment the cookie expires, while
+// session_set_cookie_params() - which SessionHandler feeds - takes a DURATION in seconds. Handing the
+// absolute timestamp to both gave PHPSESSID a Max-Age of about 1.8 billion seconds, i.e. decades.
+$session_cookie_lifetime = 0;
 if ($cookie_lifetime > 0) {
-    $cookie_lifetime = time() + (max($cookie_lifetime, 1) * 3600);
+    $session_cookie_lifetime = max($cookie_lifetime, 1) * 3600;
+    $cookie_lifetime = time() + $session_cookie_lifetime;
 }
 
 $force_ssl = Configuration::get('PS_SSL_ENABLED');
@@ -177,7 +182,7 @@ if (defined('_PS_ADMIN_DIR_')) {
 
 if (PHP_SAPI !== 'cli') {
     $sessionHandler = new SessionHandler(
-        $cookie_lifetime,
+        $session_cookie_lifetime,
         $force_ssl,
         Configuration::get('PS_COOKIE_SAMESITE'),
         Context::getContext()->shop->physical_uri

--- a/tests/Unit/Core/Session/SessionCookieLifetimeIsADurationTest.php
+++ b/tests/Unit/Core/Session/SessionCookieLifetimeIsADurationTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Session;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * config.inc.php builds two different things out of the configured cookie lifetime: an absolute moment
+ * for Cookie, which is what its constructor takes, and a duration in seconds for SessionHandler, whose
+ * init() hands it to session_set_cookie_params(). Feeding the absolute timestamp to the second gave
+ * PHPSESSID a Max-Age of roughly 1.8 billion seconds.
+ *
+ * The wiring lives in procedural bootstrap that cannot be executed in isolation, so the guard is on the
+ * file itself: SessionHandler must not be constructed with the variable holding the absolute moment.
+ */
+class SessionCookieLifetimeIsADurationTest extends TestCase
+{
+    private const BOOTSTRAP = __DIR__ . '/../../../../config/config.inc.php';
+
+    private function getSessionHandlerConstruction(): string
+    {
+        $source = file_get_contents(self::BOOTSTRAP);
+        self::assertNotFalse($source, 'config.inc.php could not be read');
+
+        $start = strpos($source, 'new SessionHandler(');
+        self::assertNotFalse($start, 'config.inc.php no longer constructs a SessionHandler');
+
+        $end = strpos($source, ');', $start);
+        self::assertNotFalse($end);
+
+        return substr($source, $start, $end - $start);
+    }
+
+    public function testTheSessionHandlerIsNotGivenTheAbsoluteExpiry(): void
+    {
+        $construction = $this->getSessionHandlerConstruction();
+
+        $this->assertStringNotContainsString(
+            '$cookie_lifetime',
+            $construction,
+            'SessionHandler received the absolute expiry Cookie takes; session_set_cookie_params() wants a duration'
+        );
+        $this->assertStringContainsString('$session_cookie_lifetime', $construction);
+    }
+
+    public function testTheDurationIsNotBuiltFromTheCurrentTime(): void
+    {
+        $source = file_get_contents(self::BOOTSTRAP);
+        self::assertNotFalse($source);
+
+        // The assignment that produces the duration must be hours times seconds, with no clock in it.
+        $this->assertSame(
+            1,
+            preg_match('/\$session_cookie_lifetime = ([^;]+);/', $source, $matches),
+            'the duration is no longer assigned in one place, so this guard cannot see it'
+        );
+        $this->assertStringNotContainsString(
+            'time()',
+            $matches[1],
+            'the session lifetime was built from the clock, which makes it an absolute moment again'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `config/config.inc.php` turns the configured cookie lifetime into an absolute Unix timestamp, which is what `Cookie` takes, and then passes the same value to `SessionHandler`, whose `init()` gives it to `session_set_cookie_params()` as a duration in seconds. `PHPSESSID` came out with a `Max-Age` of roughly 1.8 billion seconds - an expiry decades away - while the `PrestaShop-*` cookies beside it expired on time. The duration now has its own variable and the absolute moment is derived from it, so both call sites keep their own meaning.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With a Front Office cookie lifetime configured (default 480 hours), load any front page and read the `Set-Cookie` header for `PHPSESSID`. Before this change its `Max-Age` is about 1.79e9 seconds; after, it is 1728000 (480 hours), matching the `PrestaShop-*` cookies. A configured `0` still yields a session cookie on both sides.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42432, Fixes #29312
| Related PRs       |
| Sponsor company   |

## The two meanings

- `Cookie::__construct()` takes the moment the cookie expires - used at `config.inc.php` lines 164, 168, 174.
- `SessionHandler::init()` passes its lifetime to `session_set_cookie_params(['lifetime' => ...])`
  (`src/Core/Session/SessionHandler.php:78-79`), which takes a duration in seconds.

The disabled case is preserved: a configured `0` leaves both values at `0`, which means a session cookie
to `Cookie` and to `session_set_cookie_params()` alike.

## On the test, honestly

The wiring is procedural bootstrap that cannot be executed in isolation, so
`tests/Unit/Core/Session/SessionCookieLifetimeIsADurationTest.php` guards the file rather than the
resulting header: `SessionHandler` must not be constructed with the variable holding the absolute
moment, and the duration must not be assigned from the clock. Reverting the argument fails it with
"SessionHandler received the absolute expiry Cookie takes". That pins the wiring, not the behaviour -
weaker than a behavioural test, and said as much on the issue.

## Same bug, reported twice

#29312 reported this in August 2022 ("PHPSESSID session cookie has a default expiration time set to 2075y") and Prestaworks named the cause on it in May 2026. #42432 is the 2026 report of the same defect. Both are closed by this change, so the keyword is repeated rather than chained, since `Fixes #A #B` binds only the first number.

## Not a duplicate

No open PR touches `config/config.inc.php` or `src/Core/Session/SessionHandler.php`, mine included.

