### PR TITLE
Keep product delete route paths clear of the CRS SQL pattern

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/product.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/product.yml
@@ -150,7 +150,7 @@ admin_products_download_virtual_product_file:
     virtualProductFileId: \d+
 
 admin_products_delete_from_all_shops:
-  path: /{productId}/delete-from-all-shops
+  path: /{productId}/remove-from-all-shops
   methods: [ POST, DELETE ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::deleteFromAllShopsAction
@@ -163,7 +163,7 @@ admin_products_delete_from_all_shops:
     productId: \d+
 
 admin_products_delete_from_shop_group:
-  path: /{productId}/delete-from-shop-group/{shopGroupId}
+  path: /{productId}/remove-from-shop-group/{shopGroupId}
   methods: [ POST, DELETE ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::deleteFromShopGroupAction
@@ -173,7 +173,7 @@ admin_products_delete_from_shop_group:
     shopGroupId: \d+
 
 admin_products_delete_from_shop:
-  path: /{productId}/delete-from-shop/{shopId}
+  path: /{productId}/remove-from-shop/{shopId}
   methods: [ POST, DELETE ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::deleteFromShopAction
@@ -430,7 +430,7 @@ admin_products_bulk_duplicate_shop_group:
     expose: true
 
 admin_products_bulk_delete_from_all_shops:
-  path: /bulk-delete-from-all-shops
+  path: /bulk-remove-from-all-shops
   methods: [ POST, DELETE ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::bulkDeleteFromAllShopsAction
@@ -445,7 +445,7 @@ admin_products_bulk_delete_from_all_shops:
     expose: true
 
 admin_products_bulk_delete_from_shop:
-  path: /bulk-delete-from-shop/{shopId}
+  path: /bulk-remove-from-shop/{shopId}
   methods: [ POST, DELETE ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::bulkDeleteFromShopAction
@@ -461,7 +461,7 @@ admin_products_bulk_delete_from_shop:
     expose: true
 
 admin_products_bulk_delete_from_shop_group:
-  path: /bulk-delete-from-shop-group/{shopGroupId}
+  path: /bulk-remove-from-shop-group/{shopGroupId}
   methods: [ POST, DELETE ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::bulkDeleteFromShopGroupAction

--- a/tests/Unit/PrestaShopBundle/Routing/RoutePathsAvoidWafSqlPatternTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/RoutePathsAvoidWafSqlPatternTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Routing;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * The OWASP Core Rule Set matches `\bdelete\b\W*?\bfrom\b` against REQUEST_FILENAME at paranoia level 1
+ * (rule 959075, "SQL Injection Attack"). A route path containing that shape is refused with a 403 by any
+ * ModSecurity install running the default rules, which merchants on managed hosting often cannot change.
+ * The path text carries no meaning of its own - route names are what the application generates URLs from
+ * - so it costs nothing to stay clear of it.
+ */
+class RoutePathsAvoidWafSqlPatternTest extends TestCase
+{
+    private const ROUTING_DIR = __DIR__ . '/../../../../src/PrestaShopBundle/Resources/config/routing';
+
+    /**
+     * The literal CRS 959075 pattern.
+     */
+    private const CRS_SQL_PATTERN = '/\bdelete\b\W*?\bfrom\b/i';
+
+    public function testNoRoutePathLooksLikeAnSqlDeleteStatement(): void
+    {
+        $paths = $this->getAllRoutePaths();
+
+        $this->assertGreaterThan(
+            200,
+            count($paths),
+            'the routing scan found almost no paths, so it is not looking where it should'
+        );
+
+        $offending = array_filter(
+            $paths,
+            fn (string $path): bool => preg_match(self::CRS_SQL_PATTERN, $path) === 1
+        );
+
+        $this->assertSame(
+            [],
+            $offending,
+            "these route paths match the OWASP CRS 959075 SQL-injection pattern and answer 403 behind default ModSecurity rules:\n"
+            . implode("\n", $offending)
+        );
+    }
+
+    /**
+     * @return array<string, string> route name => path
+     */
+    private function getAllRoutePaths(): array
+    {
+        $paths = [];
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(self::ROUTING_DIR));
+        foreach ($files as $file) {
+            if ($file->isDir() || $file->getExtension() !== 'yml') {
+                continue;
+            }
+            $parsed = Yaml::parseFile($file->getPathname());
+            if (!is_array($parsed)) {
+                continue;
+            }
+            foreach ($parsed as $name => $definition) {
+                if (is_array($definition) && isset($definition['path']) && is_string($definition['path'])) {
+                    $paths[(string) $name] = $definition['path'];
+                }
+            }
+        }
+
+        return $paths;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The OWASP Core Rule Set matches `\bdelete\b\W*?\bfrom\b` against `REQUEST_FILENAME` at paranoia level 1 (rule 959075, "SQL Injection Attack"), so the six product deletion routes whose path contained `delete-from` answer 403 behind any ModSecurity install running the default rules - a normal Delete button in the back office fails with no explanation, and merchants on managed hosting frequently cannot edit those rules. Only the path text changes, to `remove-from`. Route names, controllers, methods, permissions and requirements are untouched.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With ModSecurity and the default CRS in front of the shop, delete a product from a shop in the back office. Before this change the request answers 403 with rule 959075 in the log; after, it completes. Without a WAF nothing changes - the routes resolve exactly as before, since only the path text differs.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42420
| Related PRs       |
| Sponsor company   |

## Why this is safe

Nothing depends on the literal path. A grep of the tree finds **zero** occurrences of `delete-from`
outside `admin/sell/catalog/products/product.yml`, against **thirteen** references to the route names
(`admin_products_delete_from_*`, `admin_products_bulk_delete_from_*`), which are unchanged and are what
the application generates URLs from. All six routes are `methods: [POST, DELETE]`, so there are no links
or bookmarks to break.

## This is a judgement call, and the alternative is legitimate

It accommodates a third-party false positive in our own URLs. For: CRS 959075 is paranoia level 1 and on
by default, the affected merchants usually cannot change the rules, the symptom is an unexplained 403 on
a normal action, and the path text carries no meaning. Against: the principled fix is a documented WAF
exclusion, and PrestaShop cannot shape its URLs around every ruleset. Both were put on the issue so the
maintainers can pick; if the documentation route is preferred, drop the rename and keep the test.

## The guard is worth keeping either way

`tests/Unit/PrestaShopBundle/Routing/RoutePathsAvoidWafSqlPatternTest.php` parses every routing file and
asserts no path matches the literal rule-959075 pattern, with a >200-path floor so it cannot pass by
scanning nothing. Restoring one of the six paths fails it and names the route.
