### PR TITLE
Update matthiasmullie/minify to 1.3.75

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3456,16 +3456,16 @@
         },
         {
             "name": "matthiasmullie/minify",
-            "version": "1.3.73",
+            "version": "1.3.75",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matthiasmullie/minify.git",
-                "reference": "cb7a9297b4ab070909cefade30ee95054d4ae87a"
+                "reference": "76ba4a5f555fd7bf4aa408af608e991569076671"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matthiasmullie/minify/zipball/cb7a9297b4ab070909cefade30ee95054d4ae87a",
-                "reference": "cb7a9297b4ab070909cefade30ee95054d4ae87a",
+                "url": "https://api.github.com/repos/matthiasmullie/minify/zipball/76ba4a5f555fd7bf4aa408af608e991569076671",
+                "reference": "76ba4a5f555fd7bf4aa408af608e991569076671",
                 "shasum": ""
             },
             "require": {
@@ -3476,8 +3476,7 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": ">=2.0",
                 "matthiasmullie/scrapbook": ">=1.3",
-                "phpunit/phpunit": ">=4.8",
-                "squizlabs/php_codesniffer": ">=3.0"
+                "phpunit/phpunit": ">=4.8"
             },
             "suggest": {
                 "psr/cache-implementation": "Cache implementation to use with Minify::cache"
@@ -3515,7 +3514,7 @@
             ],
             "support": {
                 "issues": "https://github.com/matthiasmullie/minify/issues",
-                "source": "https://github.com/matthiasmullie/minify/tree/1.3.73"
+                "source": "https://github.com/matthiasmullie/minify/tree/1.3.75"
             },
             "funding": [
                 {
@@ -3523,7 +3522,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-15T10:27:10+00:00"
+            "time": "2025-06-25T09:56:19+00:00"
         },
         {
             "name": "matthiasmullie/path-converter",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `composer.json` already allows this - the constraint is `~1.3.0` and only `composer.lock` was pinned to 1.3.73, released 2024-03-15, while 1.3.74 and 1.3.75 have been available since June 2025. The releases carry a PCRE backtrack-limit fix in the comment handling that the asset pipeline runs over every stylesheet, plus decimal handling in the modern colour cleanup. Minified output is byte for byte identical on the theme assets checked, so nothing that ships changes shape.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Rebuild the CCC assets, or minify a stylesheet and a script through `CssMinifier` / `JsMinifier`, and compare the output with the previous version. It should be unchanged. The behaviour that does change is failure handling: a pattern that previously hit the PCRE backtrack limit now raises `MatthiasMullie\Minify\Exceptions\PatternMatchException` instead of silently returning a corrupted result.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | None
| Related PRs       |
| Sponsor company   |

### Scope

The lock diff touches the `matthiasmullie/minify` entry and nothing else - no other package name appears
in it. It was produced with `composer update matthiasmullie/minify --no-install`, so no unrelated
dependency was resolved along the way.

### Why it is worth doing

The 1.3.74 release adds `PatternMatchException` and reworks the comment-preservation pattern. That is a
fail-loud replacement for a PCRE backtrack-limit failure, which is the failure mode that silently
produces broken CSS rather than an error - the kind of defect that surfaces as an unexplained rendering
bug much later.

### Evidence it is safe

Minified output compared before and after on seven real theme assets - two `theme.js`, `theme.css` and
four `error*.css`. All seven md5 sums are identical, and the input/output byte counts match. So the
upgrade is output-neutral on what the project actually ships.

### What it does not fix

Not #42537. `src/JS.php` changes only two docblock lines between 1.3.73 and 1.3.75, `extractRegex()` is
untouched, and running that issue's reproducer on 1.3.75 still truncates. That fix has to land in
matthiasmullie/minify#455 first.
