### PR TITLE
Answer a missing module with its message instead of a fatal

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -112,11 +112,16 @@ class ModuleController extends ModuleAbstractController
                 ['%modulename%' => $module_name],
                 'Admin.Modules.Notification'
             ));
-            $layoutSubTitle = null;
-        } else {
-            $this->saveModuleHistory($module);
-            $layoutSubTitle = $module->getInstance()->displayName;
+
+            // The branch that reports the module as missing used to fall through into
+            // method_exists($module->getInstance(), 'getContent'), which is a TypeError on PHP 8 - so the
+            // message was never seen and the page answered with a fatal instead. There is nothing to
+            // configure, so go back to where the message can be read.
+            return $this->redirectToRoute('admin_module_manage');
         }
+
+        $this->saveModuleHistory($module);
+        $layoutSubTitle = $module->getInstance()->displayName;
 
         // This controller is not purely migrated, in the sense that it still relies on the legacy layout because module implementing
         // getContent need the default theme to be working as expected


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ModuleController::configureModuleAction()` adds a flash message saying the module cannot be found, sets `$layoutSubTitle = null`, and then falls through to `method_exists($module->getInstance(), 'getContent')`. On that branch `getInstance()` is exactly what returned null, and `method_exists()` with null is a `TypeError` on PHP 8, so the page written to report the problem politely ends in a fatal and the message is never read. Returning to the module manager shows the flash, which is what the branch was written to do.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open `/index.php/improve/modules/manage/action/configure/<name>` with a `<name>` that is not an installed module (an uninstalled or misspelled one). Before: HTTP 500, `TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given`. After: a redirect to the module manager with "The module "<name>" cannot be found".
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | #32211
| Related PRs       |
| Sponsor company   |

Split out of #42667, which implemented the other half of @jolelievre's checklist on #32211 - blocking the
configuration page of a disabled module - and was rejected by @Hlavtox because a merchant has to be able
to configure a module before enabling it. That is a fair objection and #42667 is closed; this part is
independent of it and is a plain fatal.

The `TypeError` was measured on the runtime core supports:

```
php -r 'method_exists(null, "getContent");'
TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given
```

php-cs-fixer: 0 of 1 files to fix. PHPStan: `[OK] No errors`.
