### PR TITLE
Preserve pagination in product listing hreflang URLs

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -52,6 +52,24 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
     }
 
     /**
+     * Returns alternative language URLs for the current page of the product listing.
+     *
+     * @return array
+     */
+    protected function getAlternativeLangsUrl()
+    {
+        // Get the available language URLs for the current listing.
+        $alternativeLangs = parent::getAlternativeLangsUrl();
+
+        // Apply the same pagination rules as the canonical URL to each language.
+        foreach ($alternativeLangs as $languageCode => $url) {
+            $alternativeLangs[$languageCode] = $this->buildPaginatedUrl($url);
+        }
+
+        return $alternativeLangs;
+    }
+
+    /**
      * Takes an associative array with at least the "id_product" key
      * and returns an array containing all information necessary for
      * rendering the product in the template.


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On paginated categories, hreflang URLs point to page 1 while the canonical URL points to the current page. This PR applies buildPaginatedUrl() to alternative language URLs in ProductListingFrontController, just like the canonical URL creation code does.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable at least two languages and open page 3 of a category with enough products. Inspect the page source: canonical and every hreflang URL must contain page=3, including the current language. Follow the language alternatives and check reciprocal links. Check the first page, both without page and with page=1: hreflang URLs must omit page=1. Repeat for manufacturer and supplier product listings and with friendly URLs disabled. A shop with one active language must still omit hreflang links.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/34362109682
| Fixed issue or discussion?     |
| Related PRs       |
| Sponsor company   | TRENDO s.r.o.

**Before**

```html
<link rel="canonical" href="https://www.artikstudio.com/64-ceramic-kilns-kittec-nabertherm?page=3">
<link rel="alternate" href="https://www.artikstudio.com/cs/64-keramicke-pece-kittec-nabertherm" hreflang="cs-CZ">
<link rel="alternate" href="https://www.artikstudio.com/sk/64-keramicke-pece-kittec-nabertherm" hreflang="sk-SK">
<link rel="alternate" href="https://www.artikstudio.com/64-ceramic-kilns-kittec-nabertherm" hreflang="en-US">
```

**After**

```html
<link rel="canonical" href="https://www.artikstudio.com/64-ceramic-kilns-kittec-nabertherm?page=3">
<link rel="alternate" href="https://www.artikstudio.com/cs/64-keramicke-pece-kittec-nabertherm?page=3" hreflang="cs-CZ">
<link rel="alternate" href="https://www.artikstudio.com/sk/64-keramicke-pece-kittec-nabertherm?page=3" hreflang="sk-SK">
<link rel="alternate" href="https://www.artikstudio.com/64-ceramic-kilns-kittec-nabertherm?page=3" hreflang="en-US">
```
