### PR TITLE
Prevent empty query strings in product URLs

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -1031,7 +1031,7 @@ class DispatcherCore
      * @param array $params
      * @param bool $force_routes
      * @param string $anchor Optional anchor to add at the end of this url
-     * @param null $id_shop
+     * @param int|null $id_shop
      *
      * @return string
      *
@@ -1090,7 +1090,10 @@ class DispatcherCore
 
             foreach ($params as $key => $value) {
                 if (!isset($routeDefinition['keywords'][$key])) {
-                    $add_param[$key] = $value;
+                    // Only pass parameters that are not keywords of the default route
+                    if (!isset($this->default_routes[$routeName]['keywords'][$key])) {
+                        $add_param[$key] = $value;
+                    }
                 } else {
                     if ($params[$key]) {
                         $parameter = $params[$key];
@@ -1110,14 +1113,18 @@ class DispatcherCore
                 }
             }
             $url = preg_replace('#\{([^{}]*:)?[a-z0-9_]+?(:[^{}]*)?\}#', '', $url);
-            if (count($add_param)) {
-                $url .= '?' . http_build_query($add_param, '', '&');
+
+            // Only append a query string if parameters remain after encoding
+            $query = http_build_query($add_param, '', '&');
+            if ($query !== '') {
+                $url .= '?' . $query;
             }
         } else {
             // Build a classic url index.php?controller=foo&...
             $add_params = [];
             foreach ($params as $key => $value) {
-                if (!isset($routeDefinition['keywords'][$key])) {
+                // Only pass parameters that are not keywords of either route definition
+                if (!isset($routeDefinition['keywords'][$key]) && !isset($this->default_routes[$routeName]['keywords'][$key])) {
                     $add_params[$key] = $value;
                 }
             }

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -1090,10 +1090,7 @@ class DispatcherCore
 
             foreach ($params as $key => $value) {
                 if (!isset($routeDefinition['keywords'][$key])) {
-                    // Only pass parameters that are not keywords of the default route
-                    if (!isset($this->default_routes[$routeName]['keywords'][$key])) {
-                        $add_param[$key] = $value;
-                    }
+                    $add_param[$key] = $value;
                 } else {
                     if ($params[$key]) {
                         $parameter = $params[$key];
@@ -1123,8 +1120,7 @@ class DispatcherCore
             // Build a classic url index.php?controller=foo&...
             $add_params = [];
             foreach ($params as $key => $value) {
-                // Only pass parameters that are not keywords of either route definition
-                if (!isset($routeDefinition['keywords'][$key]) && !isset($this->default_routes[$routeName]['keywords'][$key])) {
+                if (!isset($routeDefinition['keywords'][$key])) {
                     $add_params[$key] = $value;
                 }
             }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -175,7 +175,12 @@ class LinkCore
         if (empty($idProductAttribute)) {
             $idProductAttribute = null;
         }
-        $params['id_product_attribute'] = $idProductAttribute;
+
+        // Only pass the combination parameter when the active product route uses it
+        if ($dispatcher->hasKeyword('product_rule', $idLang, 'id_product_attribute', $idShop)) {
+            $params['id_product_attribute'] = $idProductAttribute;
+        }
+
         if (!$alias) {
             $product = $this->getProductObject($product, $idLang, $idShop);
         }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -186,37 +186,45 @@ class LinkCore
         }
         $params['rewrite'] = (!$alias) ? $product->getFieldByLang('link_rewrite') : $alias;
 
+        // Only pass the ean13 parameter when the active route uses it
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'ean13', $idShop)) {
             if (!$ean13) {
                 $product = $this->getProductObject($product, $idLang, $idShop);
             }
             $params['ean13'] = (!$ean13) ? $product->ean13 : $ean13;
         }
+
+        // Only pass the meta title parameter when the active route uses it
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'meta_title', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['meta_title'] = Tools::str2url($product->getFieldByLang('meta_title'));
         }
 
+        // Only pass the manufacturer parameter when the active route uses it
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'manufacturer', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['manufacturer'] = Tools::str2url($product->isFullyLoaded ? $product->manufacturer_name : Manufacturer::getNameById($product->id_manufacturer));
         }
 
+        // Only pass the supplier parameter when the active route uses it
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'supplier', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['supplier'] = Tools::str2url($product->isFullyLoaded ? $product->supplier_name : Supplier::getNameById($product->id_supplier));
         }
 
+        // Only pass the price parameter when the active route uses it
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'price', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['price'] = $product->isFullyLoaded ? $product->price : Product::getPriceStatic($product->id, false, null, 6, null, false, true, 1, false, null, null, null, $product->specificPrice);
         }
 
+        // Only pass the tags parameter when the active route uses it
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'tags', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['tags'] = Tools::str2url($product->getTags($idLang));
         }
 
+        // Only pass the category parameter when the active route uses it
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'category', $idShop)) {
             if (!$category) {
                 $product = $this->getProductObject($product, $idLang, $idShop);
@@ -224,11 +232,13 @@ class LinkCore
             $params['category'] = (!$category) ? $product->category : $category;
         }
 
+        // Only pass the reference parameter when the active route uses it
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'reference', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['reference'] = Tools::str2url($product->reference);
         }
 
+        // Only pass the categories parameter when the active route uses it
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'categories', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['category'] = (!$category) ? $product->category : $category;
@@ -460,10 +470,14 @@ class LinkCore
             $category = $this->getCategoryObject($category, $idLang);
         }
         $params['rewrite'] = (!$alias) ? $category->link_rewrite : $alias;
+
+        // Only pass the meta title parameter when the active route uses it
         if ($dispatcher->hasKeyword($rule, $idLang, 'meta_title', $idShop)) {
             $category = $this->getCategoryObject($category, $idLang);
             $params['meta_title'] = Tools::str2url($category->getFieldByLang('meta_title'));
         }
+
+        // Only pass the categories parameter when the active route uses it
         if ($dispatcher->hasKeyword($rule, $idLang, 'categories', $idShop)) {
             $category = $this->getCategoryObject($category, $idLang);
             $cats = [];
@@ -507,6 +521,7 @@ class LinkCore
 
         $dispatcher = Dispatcher::getInstance();
         if (!is_object($cmsCategory)) {
+            // Use the supplied alias without loading the object when the active route does not need its meta title
             if ($alias !== null && !$dispatcher->hasKeyword('cms_category_rule', $idLang, 'meta_title', $idShop)) {
                 return $url . $dispatcher->createUrl('cms_category_rule', $idLang, ['id' => (int) $cmsCategory, 'rewrite' => (string) $alias], $this->allow, '', $idShop);
             }
@@ -524,6 +539,7 @@ class LinkCore
         $params['id'] = $cmsCategory->id;
         $params['rewrite'] = (!$alias) ? $cmsCategory->link_rewrite : $alias;
 
+        // Only pass the meta title parameter when the active route uses it
         if ($dispatcher->hasKeyword('cms_category_rule', $idLang, 'meta_title', $idShop)) {
             $params['meta_title'] = Tools::str2url($cmsCategory->meta_title);
         }
@@ -559,6 +575,7 @@ class LinkCore
 
         $dispatcher = Dispatcher::getInstance();
         if (!is_object($cms)) {
+            // Use the supplied alias without loading the object when the active route does not need its meta title
             if ($alias !== null && !$dispatcher->hasKeyword('cms_rule', $idLang, 'meta_title', $idShop)) {
                 return $url . $dispatcher->createUrl('cms_rule', $idLang, ['id' => (int) $cms, 'rewrite' => (string) $alias], $this->allow, '', $idShop);
             }
@@ -570,6 +587,7 @@ class LinkCore
         $params['id'] = $cms->id;
         $params['rewrite'] = (!$alias) ? (is_array($cms->link_rewrite) ? $cms->link_rewrite[(int) $idLang] : $cms->link_rewrite) : $alias;
 
+        // Only pass the meta title parameter when the active route uses it
         if ($dispatcher->hasKeyword('cms_rule', $idLang, 'meta_title', $idShop)) {
             $params['meta_title'] = is_array($cms->meta_title) ? Tools::str2url($cms->meta_title[(int) $idLang]) : Tools::str2url($cms->meta_title);
         }
@@ -603,6 +621,7 @@ class LinkCore
 
         $dispatcher = Dispatcher::getInstance();
         if (!is_object($supplier)) {
+            // Use the supplied alias without loading the object when the active route does not need its meta title
             if ($alias !== null
                 && !$dispatcher->hasKeyword('supplier_rule', $idLang, 'meta_title', $idShop)
             ) {
@@ -623,6 +642,7 @@ class LinkCore
         $params['id'] = $supplier->id;
         $params['rewrite'] = (!$alias) ? $supplier->link_rewrite : $alias;
 
+        // Only pass the meta title parameter when the active route uses it
         if ($dispatcher->hasKeyword('supplier_rule', $idLang, 'meta_title', $idShop)) {
             $params['meta_title'] = Tools::str2url($supplier->meta_title);
         }
@@ -656,6 +676,7 @@ class LinkCore
 
         $dispatcher = Dispatcher::getInstance();
         if (!is_object($manufacturer)) {
+            // Use the supplied alias without loading the object when the active route does not need its meta title
             if ($alias !== null && !$dispatcher->hasKeyword('manufacturer_rule', $idLang, 'meta_title', $idShop)) {
                 return $url . $dispatcher->createUrl('manufacturer_rule', $idLang, ['id' => (int) $manufacturer, 'rewrite' => (string) $alias], $this->allow, '', $idShop);
             }
@@ -667,6 +688,7 @@ class LinkCore
         $params['id'] = $manufacturer->id;
         $params['rewrite'] = (!$alias) ? $manufacturer->link_rewrite : $alias;
 
+        // Only pass the meta title parameter when the active route uses it
         if ($dispatcher->hasKeyword('manufacturer_rule', $idLang, 'meta_title', $idShop)) {
             $params['meta_title'] = Tools::str2url($manufacturer->meta_title);
         }
@@ -1274,6 +1296,7 @@ class LinkCore
 
         $dispatcher = Dispatcher::getInstance();
         if (!is_object($attachment)) {
+            // Use the supplied alias without loading the object when the active route does not need its meta title
             if ($alias !== null && !$dispatcher->hasKeyword('attachment_rule', $idLang, 'meta_title', $idShop)) {
                 return $url . $dispatcher->createUrl('attachment_rule', $idLang, ['id' => (int) $attachment, 'rewrite' => (string) $alias], $this->allow, '', $idShop);
             }

--- a/tests/Unit/Classes/DispatcherTest.php
+++ b/tests/Unit/Classes/DispatcherTest.php
@@ -43,24 +43,24 @@ class DispatcherTest extends TestCase
     public static function createUrlProvider(): array
     {
         return [
-            // Keywords omitted from custom rules must not become query parameters
+            // Parameters absent from the active rule remain query parameters
             'omitted product ID' => [
-                'product_rule', '{rewrite}', ['id' => 3, 'rewrite' => 'item'], true, 'item',
+                'product_rule', '{rewrite}', ['id' => 3, 'rewrite' => 'item'], true, 'item?id=3',
             ],
             'omitted null combination' => [
                 'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'id_product_attribute' => null], true, 'item-p-3',
             ],
             'omitted non-null combination' => [
-                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'id_product_attribute' => 7], true, 'item-p-3',
+                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'id_product_attribute' => 7], true, 'item-p-3?id_product_attribute=7',
             ],
             'omitted optional keyword' => [
-                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'ean13' => '1234567890123'], true, 'item-p-3',
+                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'ean13' => '1234567890123'], true, 'item-p-3?ean13=1234567890123',
             ],
 
-            // Required keywords still populate classic URLs while unused keywords are excluded
+            // Classic URLs retain required keywords and additional parameters
             'classic URL' => [
                 'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'id_product_attribute' => 7, 'page' => 2], false,
-                'index.php?page=2&rewrite=item&id_product=3&controller=product',
+                'index.php?id_product_attribute=7&page=2&rewrite=item&id_product=3&controller=product',
             ],
 
             // Encoding empty extra parameters must not append a question mark

--- a/tests/Unit/Classes/DispatcherTest.php
+++ b/tests/Unit/Classes/DispatcherTest.php
@@ -16,6 +16,79 @@ use ReflectionClass;
 class DispatcherTest extends TestCase
 {
     /**
+     * @dataProvider createUrlProvider
+     */
+    public function testCreateUrl(string $routeName, string $rule, array $params, bool $useRoutes, string $expectedUrl): void
+    {
+        // Create an isolated dispatcher without loading shop configuration
+        $reflection = new ReflectionClass(DispatcherCore::class);
+        $dispatcher = $reflection->newInstanceWithoutConstructor();
+        $property = $reflection->getProperty('use_routes');
+        $property->setAccessible(true);
+        $property->setValue($dispatcher, $useRoutes);
+
+        // Compile the supplied rule with product keywords, including for a module route
+        $route = $dispatcher->computeRoute($rule, 'product', $dispatcher->default_routes['product_rule']['keywords']);
+        $property = $reflection->getProperty('routes');
+        $property->setAccessible(true);
+        $property->setValue($dispatcher, [1 => [1 => [$routeName => $route]]]);
+
+        // Preserve the anchor after the path and any encoded query parameters
+        $this->assertSame($expectedUrl . '#details', $dispatcher->createUrl($routeName, 1, $params, false, '#details', 1));
+    }
+
+    /**
+     * Provide native and module routes with omitted keywords and extra parameters.
+     */
+    public static function createUrlProvider(): array
+    {
+        return [
+            // Keywords omitted from custom rules must not become query parameters
+            'omitted product ID' => [
+                'product_rule', '{rewrite}', ['id' => 3, 'rewrite' => 'item'], true, 'item',
+            ],
+            'omitted null combination' => [
+                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'id_product_attribute' => null], true, 'item-p-3',
+            ],
+            'omitted non-null combination' => [
+                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'id_product_attribute' => 7], true, 'item-p-3',
+            ],
+            'omitted optional keyword' => [
+                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'ean13' => '1234567890123'], true, 'item-p-3',
+            ],
+
+            // Required keywords still populate classic URLs while unused keywords are excluded
+            'classic URL' => [
+                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'id_product_attribute' => 7, 'page' => 2], false,
+                'index.php?page=2&rewrite=item&id_product=3&controller=product',
+            ],
+
+            // Encoding empty extra parameters must not append a question mark
+            'null extra parameter' => [
+                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'extra' => null], true, 'item-p-3',
+            ],
+            'empty array extra parameter' => [
+                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'extra' => []], true, 'item-p-3',
+            ],
+
+            // Valid extra parameters, including zero, false and empty strings, retain their meaning
+            'mixed extra parameters' => [
+                'product_rule', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'extra' => null, 'page' => 0, 'flag' => false, 'search' => ''], true,
+                'item-p-3?page=0&flag=0&search=',
+            ],
+
+            // A module route without a default definition keeps its additional parameters
+            'module extra parameter' => [
+                'module-custom-product', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'id_product_attribute' => 7], true,
+                'item-p-3?id_product_attribute=7',
+            ],
+            'module null parameter' => [
+                'module-custom-product', '{rewrite}-p-{id}', ['id' => 3, 'rewrite' => 'item', 'extra' => null], true, 'item-p-3',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider validateRouteProvider
      */
     public function testValidateRoute($routeId, $rule, $defaultRoutes, $expectedResult, $expectedErrors)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Prevent a trailing `?` in generated friendly URLs by appending the query delimiter only when the encoded query string is non-empty. In `Link::getProductLink()`, pass `id_product_attribute` only when the active product route contains that keyword. This prevents an unused combination parameter from reaching the dispatcher while preserving required parameters on the standard route.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |
| UI Tests          | https://github.com/Codencode/ga.tests.ui.pr/actions/runs/34340658575
| Fixed issue or discussion?     | Fixes #42426
| Related PRs       | #42448 by @boo-code addresses the related default-route keyword issue #42440. This change uses the active route and does not filter parameters against default routes.
| Sponsor company   | TRENDO s.r.o.

Null values and empty arrays cannot produce a dangling query delimiter. Valid additional parameters, including zero, false and empty strings, retain their encoding. Anchors remain after the query string.
