### PR TITLE
Adapt CI to push Nightly reports in production and preproduction as well

### DIFF
--- a/.github/workflows/cron_nightly_tests_reports.yml
+++ b/.github/workflows/cron_nightly_tests_reports.yml
@@ -4,13 +4,12 @@ name: Nightly tests (Report)
 
 on:
   schedule:
-    - cron: '0 7 * * *'
+    - cron: "0 7 * * *"
   workflow_dispatch:
 
 jobs:
-  # Add pushed reports to GCP on nightly
   push-nightly-reports:
-    name: Push reports to nightly.prestashop-project.org
+    name: Push reports to nightly boards
     runs-on: ubuntu-latest
 
     strategy:
@@ -30,7 +29,27 @@ jobs:
             database: mariadb
 
     steps:
-      - name: Push reports
+      - name: Push report to production
+        env:
+          API_URL: https://api-nightly.prestashop-project.org
+          API_TOKEN: ${{ secrets.NIGHTLY_TOKEN }}
+          DATABASE: ${{ matrix.database }}
+          BRANCH: ${{ matrix.branch }}
         run: |
-          REPORT_NAME="$(date +%Y-%m-%d)-${{ matrix.branch }}-${{matrix.database}}"
-          curl -v "https://api-nightly.prestashop-project.org/hook/reports/import?token=${{ secrets.NIGHTLY_TOKEN }}&filename=${REPORT_NAME}.json&database=${{matrix.database}}"
+          REPORT_NAME="$(date +%Y-%m-%d)-${BRANCH}-${DATABASE}"
+          curl -v "${API_URL}/hook/reports/import?token=${API_TOKEN}&filename=${REPORT_NAME}.json&database=${DATABASE}"
+
+      - name: Push report to preproduction
+        continue-on-error: true
+        env:
+          API_URL: ${{ vars.NIGHTLY_PREPROD_API_URL }}
+          API_TOKEN: ${{ secrets.NIGHTLY_PREPROD_TOKEN }}
+          DATABASE: ${{ matrix.database }}
+          BRANCH: ${{ matrix.branch }}
+        run: |
+          if [ -z "$API_URL" ] || [ -z "$API_TOKEN" ]; then
+            echo "::warning::Preproduction target not configured, skipping"
+            exit 0
+          fi
+          REPORT_NAME="$(date +%Y-%m-%d)-${BRANCH}-${DATABASE}"
+          curl -v "${API_URL}/hook/reports/import?token=${API_TOKEN}&filename=${REPORT_NAME}.json&database=${DATABASE}"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The nightly reports import step currently pushes reports only to the production nightly board API. This PR makes it push each report to both the production and the preproduction boards, so that the preproduction environment of the nightly board can be tested against real data without waiting for a manual import. The preproduction call is isolated (`continue-on-error`) and skipped when its configuration is absent, so it can never break the production import. 
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run Nightly tests (Report) via Run workflow on develop
| UI Tests          | N/A — this PR only changes a GitHub Actions workflow used to import nightly reports into the board. It touches no application, theme or test code, so UI tests campaigns are not relevant here.
| Fixed issue or discussion?     | -
| Related PRs       | None.
| Sponsor company   | PrestaShop SA