### PR TITLE
Keep an order editable once its combination was deleted

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -361,6 +361,12 @@ class OrderCore extends ObjectModel
         $cart_base_product_quantity = [];
         $products = $this->getProducts();
         foreach ($products as &$product) {
+            // Order detail rows are presented as cart rows. `id_product` is read from the product
+            // table, which getProductsDetail() reaches through a LEFT JOIN, so it is null once the
+            // product has been deleted from the catalogue - while the order detail still knows which
+            // product the line was for. Map it like the two fields below, otherwise the line is
+            // dropped from the list and every consumer prices it as product 0.
+            $product['id_product'] = $product['product_id'];
             $product['id_product_attribute'] = $product['product_attribute_id'];
             $product['cart_quantity'] = $product['product_quantity'];
             $product_id_list[] = $this->id_address_delivery . '_'

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -13,6 +13,7 @@ use Cache;
 use Carrier;
 use Cart;
 use CartRule;
+use Combination;
 use Currency;
 use Customer;
 use Order;
@@ -352,11 +353,14 @@ class OrderAmountUpdater
         foreach ($order->getCartProducts() as $orderProduct) {
             $orderDetail = new OrderDetail($orderProduct['id_order_detail'], null, $this->contextStateManager->getContext());
 
-            // A product deleted from the catalogue is gone from the cart as well, so there is no
-            // current price to sync this line to. Its order detail keeps the amounts it was invoiced
-            // at, which are the only meaningful ones left. Any other absence is still a desync and
-            // is reported by getProductFromCart() below.
-            if (!Product::existsInDatabase((int) $orderDetail->product_id)) {
+            // A product or a combination deleted from the catalogue is gone from the cart as well,
+            // so there is no current price to sync this line to. Its order detail keeps the amounts
+            // it was invoiced at, which are the only meaningful ones left. Any other absence is
+            // still a desync and is reported by getProductFromCart() below.
+            if (!Product::existsInDatabase((int) $orderDetail->product_id)
+                || (0 !== (int) $orderDetail->product_attribute_id
+                    && !Combination::existsInDatabase((int) $orderDetail->product_attribute_id))
+            ) {
                 continue;
             }
 

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -351,6 +351,15 @@ class OrderAmountUpdater
         $cartProducts = $cart->getProducts(true, false, null, true, $this->keepOrderPrices);
         foreach ($order->getCartProducts() as $orderProduct) {
             $orderDetail = new OrderDetail($orderProduct['id_order_detail'], null, $this->contextStateManager->getContext());
+
+            // A product deleted from the catalogue is gone from the cart as well, so there is no
+            // current price to sync this line to. Its order detail keeps the amounts it was invoiced
+            // at, which are the only meaningful ones left. Any other absence is still a desync and
+            // is reported by getProductFromCart() below.
+            if (!Product::existsInDatabase((int) $orderDetail->product_id)) {
+                continue;
+            }
+
             $cartProduct = $this->getProductFromCart($cartProducts, (int) $orderDetail->product_id, (int) $orderDetail->product_attribute_id, (int) $orderDetail->id_customization);
 
             $this->orderDetailUpdater->updateOrderDetail(

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -13,6 +13,7 @@ use AdminController;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Cart;
+use Combination;
 use Configuration;
 use Context;
 use Currency;
@@ -1858,6 +1859,28 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
         $foundProduct = $this->getProductByName($productReference);
         $product = new Product($foundProduct->getProductId());
         $product->delete();
+    }
+
+    /**
+     * @When I delete combination :combinationReference of product :productReference from catalogue
+     *
+     * @param string $combinationReference
+     * @param string $productReference
+     */
+    public function removeCombinationFromCatalogue(string $combinationReference, string $productReference)
+    {
+        $foundProduct = $this->getProductByName($productReference);
+        $product = new Product($foundProduct->getProductId());
+
+        foreach ($product->getAttributeCombinations() as $attributeCombination) {
+            if ($attributeCombination['reference'] === $combinationReference) {
+                (new Combination((int) $attributeCombination['id_product_attribute']))->delete();
+
+                return;
+            }
+        }
+
+        throw new RuntimeException(sprintf('Combination "%s" of product "%s" was not found', $combinationReference, $productReference));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_combination.feature
@@ -1,0 +1,77 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-deleted-combination
+@restore-all-tables-before-feature
+@reboot-kernel-before-feature
+@clear-cache-before-feature
+@order-deleted-combination
+Feature: Edit an order whose combination was removed from the catalogue
+  In order to keep invoiced amounts stable
+  As a BO user
+  I need to still be able to edit an order that contains a combination deleted from the catalogue
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And there is a product in the catalog named "Deleted Combination Product" with a price of 10.0 and 100 items in stock
+    And product "Deleted Combination Product" has combinations with following details:
+      | reference    | quantity | price | attributes |
+      | combination1 | 100      | 0.0   | Size:L     |
+      | combination2 | 100      | 0.0   | Size:M     |
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 2 items of combination "combination1" of the product "Deleted Combination Product" to the cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart       |
+      | message             | test             |
+      | payment module name | dummy_payment    |
+      | status              | Payment accepted |
+
+  # The pair is the point: deleting the ordered combination from the catalogue has to leave the order
+  # with exactly the amounts the control keeps when the combination is left in place.
+  Scenario: CONTROL changing the shipping address of an order whose combination still exists
+    Given order "bo_order1" should have following details:
+      | total_products | 20.00 |
+    And I create customer "controlCombinationCustomer" with following details:
+      | firstName | testFirstName                     |
+      | lastName  | testLastName                      |
+      | email     | control-combination@mailexample.eu |
+      | password  | secret                            |
+    And I add new address to customer "controlCombinationCustomer" with following details:
+      | Address alias | control-combination-address |
+      | First name    | testFirstName               |
+      | Last name     | testLastName                |
+      | Address       | Work address st. 1234567890 |
+      | City          | Birmingham                  |
+      | Country       | United States               |
+      | State         | Alabama                     |
+      | Postal code   | 12345                       |
+    When I change order "bo_order1" shipping address to "control-combination-address"
+    Then order "bo_order1" should have following details:
+      | total_products | 20.00 |
+
+  Scenario: Changing the shipping address still works once the ordered combination is deleted
+    Given order "bo_order1" should have following details:
+      | total_products | 20.00 |
+    And I create customer "deletedCombinationCustomer" with following details:
+      | firstName | testFirstName                      |
+      | lastName  | testLastName                       |
+      | email     | deleted-combination@mailexample.eu |
+      | password  | secret                             |
+    And I add new address to customer "deletedCombinationCustomer" with following details:
+      | Address alias | deleted-combination-address |
+      | First name    | testFirstName               |
+      | Last name     | testLastName                |
+      | Address       | Work address st. 1234567890 |
+      | City          | Birmingham                  |
+      | Country       | United States               |
+      | State         | Alabama                     |
+      | Postal code   | 12345                       |
+    When I delete combination "combination1" of product "Deleted Combination Product" from catalogue
+    And I change order "bo_order1" shipping address to "deleted-combination-address"
+    Then order "bo_order1" should have following details:
+      | total_products | 20.00 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_product.feature
@@ -1,0 +1,76 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-deleted-product
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@order-deleted-product
+Feature: Edit an order whose product was removed from the catalogue
+  In order to keep invoiced amounts stable
+  As a BO user
+  I need order totals to survive editing an order that contains a product deleted from the catalogue
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart       |
+      | message             | test             |
+      | payment module name | dummy_payment    |
+      | status              | Payment accepted |
+
+  # Changing the shipping address moves the tax address, so the tax included totals below are the
+  # ones the new address produces - the point of the pair is that deleting the product from the
+  # catalogue must leave the order with exactly the same amounts as leaving it in place.
+  Scenario: CONTROL changing the shipping address of an order whose products all still exist
+    Given order "bo_order1" should have following details:
+      | total_products    | 23.80 |
+      | total_products_wt | 25.23 |
+    And I create customer "controlCustomer" with following details:
+      | firstName | testFirstName          |
+      | lastName  | testLastName           |
+      | email     | control@mailexample.eu |
+      | password  | secret                 |
+    And I add new address to customer "controlCustomer" with following details:
+      | Address alias | control-address                          |
+      | First name    | testFirstName               |
+      | Last name     | testLastName                |
+      | Address       | Work address st. 1234567890 |
+      | City          | Birmingham                  |
+      | Country       | United States               |
+      | State         | Alabama                     |
+      | Postal code   | 12345                       |
+    When I change order "bo_order1" shipping address to "control-address"
+    Then order "bo_order1" should have following details:
+      | total_products    | 23.80 |
+      | total_products_wt | 23.80 |
+
+  Scenario: Changing the shipping address does not zero the totals of an order whose product is gone
+    Given order "bo_order1" should have following details:
+      | total_products    | 23.80 |
+      | total_products_wt | 25.23 |
+    And I create customer "deletedCustomer" with following details:
+      | firstName | testFirstName          |
+      | lastName  | testLastName           |
+      | email     | deleted@mailexample.eu |
+      | password  | secret                 |
+    And I add new address to customer "deletedCustomer" with following details:
+      | Address alias | deleted-address                          |
+      | First name    | testFirstName               |
+      | Last name     | testLastName                |
+      | Address       | Work address st. 1234567890 |
+      | City          | Birmingham                  |
+      | Country       | United States               |
+      | State         | Alabama                     |
+      | Postal code   | 12345                       |
+    When I delete product "Mug The best is yet to come" from catalogue
+    And I change order "bo_order1" shipping address to "deleted-address"
+    Then order "bo_order1" should have following details:
+      | total_products    | 23.80 |
+      | total_products_wt | 23.80 |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Deleting a combination removes it from every cart, including those behind past orders, and `Cart::getProducts()` cannot return a combination that no longer exists. The guard added for deleted products only checked the product, so an order line whose combination was deleted still aborted the whole order update - leaving the order permanently uneditable, including changing its status. The line's order detail already holds the amounts it was invoiced at, so it is skipped like a deleted product. A combination still in the catalogue but missing from the cart remains a reported desync.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Order a product combination, then delete that combination from the catalogue and edit the order - changing the shipping address is enough. Before this change the edit fails with "Could not find the product in cart, meaning Order and Cart are out of sync"; after it the order is editable and keeps its invoiced amounts. Automated: `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-deleted-combination`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28888
| Related PRs       | Sits on top of #42608, which fixes the deleted-*product* half of the same defect.
| Sponsor company   |

## Why the root cause cannot be fixed instead

`Product::deleteCartProducts()` (`classes/Product.php:1549-1551`) and `Combination::delete()`
(`classes/Combination.php:300,303`) delete `cart_product` rows for every cart, ordered ones included.
Keeping those rows would not help: `Cart::getProducts()` inner-joins `product_shop` and filters
`p.id_product IS NOT NULL` (`classes/Cart.php:734,758`), so a deleted product or combination can never
be returned by the cart. Tolerating the missing line is the only option, which is why this follows
#42608's approach rather than protecting the cart rows.

## Measured on 9.2.0

Driving `OrderAmountUpdater::update()` on a real order, three states:

```
cart intact                                          -> OK
ordered combination deleted from the catalogue       -> OK        (was: OrderException)
combination still exists, cart row missing           -> OrderException, as before
```

The third state is the point of the guard being conditional: a genuine desync is still reported.

With #42608 applied but without this change, the second state still threw - #42608's
`Product::existsInDatabase()` check passes because the product itself is untouched.

## Tests

`tests/Integration/Behaviour/Features/Scenario/Order/order_deleted_combination.feature`, 2 scenarios
(39 steps), paired the same way as #42608's: a control that leaves the combination in place and the
deletion case, both asserting the same totals. Needs one new step,
`I delete combination :combinationReference of product :productReference from catalogue`, added next to
the existing `I delete product :productReference from catalogue` in `OrderFeatureContext` because the
`order` Behat suite registers no combination context.

Mutation: dropping the combination half of the guard fails exactly the deletion scenario with
`Could not find the product in cart, meaning Order and Cart are out of sync` and leaves the control
green. #42608's own feature still passes (2 scenarios, 35 steps). php-cs-fixer and phpstan clean.
