### PR TITLE
Let the currency feed URL follow the define on both code paths

### DIFF
--- a/src/Core/Currency/ExchangeRateProvider.php
+++ b/src/Core/Currency/ExchangeRateProvider.php
@@ -21,9 +21,10 @@ use Symfony\Component\Cache\Adapter\AdapterInterface as CacheInterface;
 class ExchangeRateProvider
 {
     /**
-     * This url was set in the _PS_CURRENCY_FEED_URL_ const but it is not accessible in every
-     * context because it is weirdly defined in defines_uri.inc.php So it is safer to define
-     * it properly here.
+     * Default value of the _PS_CURRENCY_FEED_URL_ define, which defines_uri.inc.php builds from
+     * _PS_API_URL_ and which this service is given. A shop that redefines either of them in
+     * config/defines_custom.inc.php is followed by this provider and by
+     * Currency::refreshCurrencies() alike.
      */
     public const CURRENCY_FEED_URL = 'http://api.prestashop.com/xml/currencies.xml';
 

--- a/src/PrestaShopBundle/Resources/config/services/core/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/currency.yml
@@ -28,7 +28,7 @@ services:
   prestashop.core.exchange_rate.provider:
     class: PrestaShop\PrestaShop\Core\Currency\ExchangeRateProvider
     arguments:
-      - !php/const \PrestaShop\PrestaShop\Core\Currency\ExchangeRateProvider::CURRENCY_FEED_URL
+      - '@=constant("_PS_CURRENCY_FEED_URL_")'
       - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrencyIsoCode()'
       - '@prestashop.core.currency.exchange_rate.circuit_breaker'
       - '@cache.app'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The currency feed URL has one documented knob, `_PS_CURRENCY_FEED_URL_`, which `config/defines_uri.inc.php` builds from `_PS_API_URL_` and which a shop can redefine in `config/defines_custom.inc.php`. Two code paths fetch that feed and only one obeys it. `Currency::refreshCurrencies()`, behind `cron_currency_rates.php`, reads the define. `ExchangeRateProvider`, behind the back office and the `GetCurrencyExchangeRate` query, is handed `ExchangeRateProvider::CURRENCY_FEED_URL` by `src/PrestaShopBundle/Resources/config/services/core/currency.yml`, a class constant holding the same literal, so it keeps requesting `api.prestashop.com` whatever the shop configured. The service argument now resolves the define instead.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create `config/defines_custom.inc.php` with `<?php define('_PS_CURRENCY_FEED_URL_', 'http://example.test/feed.xml');`. 2. Clear `var/cache`. 3. Boot the container and read the first constructor argument of `prestashop.core.exchange_rate.provider`, for instance with a reflection read of its `currencyFeedUrl` property. Before this change it is `http://api.prestashop.com/xml/currencies.xml`; after it is the URL from the file. 4. `Currency::refreshCurrencies()` already used the file's URL both before and after. 5. With no `defines_custom.inc.php` present, both paths use `http://api.prestashop.com/xml/currencies.xml` as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Relates to #29467
| Related PRs       | None
| Sponsor company   | None

### Behaviour change

With no override present, nothing changes: `_PS_CURRENCY_FEED_URL_` resolves to the same string the constant held. The only shops that see a difference are those already carrying a `_PS_CURRENCY_FEED_URL_` or `_PS_API_DOMAIN_` override, for which the back office path starts obeying an override it was silently ignoring. That is the whole surface of the change, and it is the behaviour the override was always documented to have.

### Why the expression resolves the constant directly

`PrestaShop\PrestaShop\Adapter\Configuration::get()` does return defines, and `RemoteLocalizationPackLoader` reaches `_PS_API_URL_` that way, so `'@=service("prestashop.adapter.legacy.configuration").get("_PS_CURRENCY_FEED_URL_")'` would also work. It calls `buildShopConstraintFromContext()` before the `defined()` short-circuit, though, which attaches a shop-context dependency to the instantiation of a service that only needs a string. `'@=constant("_PS_CURRENCY_FEED_URL_")'` reads the define and nothing else.

### Measured

On a 9.2 shop with `config/defines_custom.inc.php` defining `_PS_CURRENCY_FEED_URL_` to a URL distinct from the default, reading `currencyFeedUrl` off the instantiated service:

| kernel | before | after |
| ------ | ------ | ----- |
| AdminKernel | `http://api.prestashop.com/xml/currencies.xml` | the overridden URL |
| FrontKernel | `http://api.prestashop.com/xml/currencies.xml` | the overridden URL |
| AdminAPIKernel | `http://api.prestashop.com/xml/currencies.xml` | the overridden URL |

Restoring only the service argument, with the override still in place, brings the old value back in every kernel. The front office answers 200 with a cold and a warm cache either way, and `tests/Unit/Core/Currency/ExchangeRateProviderTest` is unaffected since it constructs the provider directly.

### No automated test

A test cannot distinguish the two wirings. With no override the define and the constant hold the same string, so any assertion comparing the service to `_PS_CURRENCY_FEED_URL_` passes with the constant wiring too, and a test process cannot redefine a constant that `config/config.inc.php` has already set during bootstrap. The check is the two-value comparison above, which is reproducible from the How to test steps.

### On the rest of the issue

The other half of the request, pointing the feed at a `prestashop-project.org` endpoint under #28771, is not code. `https://api.prestashop-project.org/xml/currencies.xml` answers 404 for that path, and `http://api.prestashop.com/xml/currencies.xml` still answers 200. When the feed is served elsewhere it becomes one line in `config/defines_uri.inc.php`, and this change means that line then governs both code paths rather than one.
