### PR TITLE
Read PS_LANG_DEFAULT for the shop that was asked for

### DIFF
--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -300,11 +300,11 @@ class CMSCore extends ObjectModel
      */
     public static function getCMSContent($idCms, $idLang = null, $idShop = null)
     {
-        if (null === $idLang) {
-            $idLang = (int) Configuration::get('PS_LANG_DEFAULT');
-        }
         if (null === $idShop) {
             $idShop = (int) Configuration::get('PS_SHOP_DEFAULT');
+        }
+        if (null === $idLang) {
+            $idLang = (int) Configuration::get('PS_LANG_DEFAULT', null, null, $idShop);
         }
 
         $sql = '

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1425,7 +1425,7 @@ class LinkCore
 
         // If the language is our default language, no prefix needed
         if (
-            $idLang == Configuration::get('PS_LANG_DEFAULT')
+            $idLang == Configuration::get('PS_LANG_DEFAULT', null, null, $idShop)
             && (bool) Configuration::get('PS_DEFAULT_LANGUAGE_URL_PREFIX', null, null, $idShop) === false
         ) {
             return '';

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -395,7 +395,7 @@ class MailCore extends ObjectModel
             if ($iso) {
                 $isoArray[] = $iso;
             }
-            $isoDefault = Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT'));
+            $isoDefault = Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT', null, null, $idShop));
             if ($isoDefault && $iso !== $isoDefault) {
                 $isoArray[] = $isoDefault;
             }

--- a/tests/Integration/Classes/CMSTest.php
+++ b/tests/Integration/Classes/CMSTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use CMS;
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Shop;
+
+class CMSTest extends TestCase
+{
+    private const CMS_ID = 1;
+    private const OTHER_SHOP_ID = 2;
+    private const OTHER_SHOP_LANG_ID = 2;
+    private const CONTENT_IN_LANG_1 = 'other shop, language 1';
+    private const CONTENT_IN_LANG_2 = 'other shop, language 2';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->removeFixtures();
+
+        $db = Db::getInstance();
+
+        // Configuration::get() only honours an explicitly requested shop while the multistore
+        // feature is on, and that in turn needs more than one shop to exist.
+        $db->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'shop` (`id_shop`, `id_shop_group`, `name`, `color`, `id_category`, `theme_name`, `active`, `deleted`)
+             VALUES (' . self::OTHER_SHOP_ID . ", 1, 'other shop', '', 2, 'hummingbird', 1, 0)"
+        );
+        $db->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . "configuration` (`name`, `value`, `id_shop`, `date_add`, `date_upd`)
+             VALUES ('PS_MULTISHOP_FEATURE_ACTIVE', '1', NULL, NOW(), NOW())"
+        );
+
+        // The other shop keeps a default language of its own, different from the one in context.
+        $db->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . "configuration` (`name`, `value`, `id_shop`, `date_add`, `date_upd`)
+             VALUES ('PS_LANG_DEFAULT', '" . self::OTHER_SHOP_LANG_ID . "', " . self::OTHER_SHOP_ID . ', NOW(), NOW())'
+        );
+
+        foreach ([1 => self::CONTENT_IN_LANG_1, self::OTHER_SHOP_LANG_ID => self::CONTENT_IN_LANG_2] as $idLang => $content) {
+            $db->execute(
+                'INSERT INTO `' . _DB_PREFIX_ . 'cms_lang` (`id_cms`, `id_lang`, `id_shop`, `meta_title`, `head_seo_title`, `meta_description`, `content`, `link_rewrite`)
+                 VALUES (' . self::CMS_ID . ', ' . (int) $idLang . ', ' . self::OTHER_SHOP_ID . ", 'title', 'title', '', '" . pSQL($content) . "', 'link-" . (int) $idLang . "')"
+            );
+        }
+
+        $this->refreshCaches();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeFixtures();
+        $this->refreshCaches();
+        parent::tearDown();
+    }
+
+    private function removeFixtures(): void
+    {
+        $db = Db::getInstance();
+        $db->execute('DELETE FROM `' . _DB_PREFIX_ . 'cms_lang` WHERE `id_cms` = ' . self::CMS_ID . ' AND `id_shop` = ' . self::OTHER_SHOP_ID);
+        $db->execute('DELETE FROM `' . _DB_PREFIX_ . "configuration` WHERE `name` = 'PS_LANG_DEFAULT' AND `id_shop` = " . self::OTHER_SHOP_ID);
+        $db->execute('DELETE FROM `' . _DB_PREFIX_ . "configuration` WHERE `name` = 'PS_MULTISHOP_FEATURE_ACTIVE'");
+        $db->execute('DELETE FROM `' . _DB_PREFIX_ . 'shop` WHERE `id_shop` = ' . self::OTHER_SHOP_ID);
+    }
+
+    private function refreshCaches(): void
+    {
+        Shop::resetStaticCache();
+        Configuration::loadConfiguration();
+    }
+
+    /**
+     * Asking for another shop's content without naming a language has to fall back to the default
+     * language of that shop, not to the one of the shop currently in context.
+     */
+    public function testItFallsBackToTheDefaultLanguageOfTheRequestedShop(): void
+    {
+        self::assertTrue(Shop::isFeatureActive(), 'the fixture must have multistore on, or the requested shop is ignored');
+        self::assertSame(self::OTHER_SHOP_LANG_ID, (int) Configuration::get('PS_LANG_DEFAULT', null, null, self::OTHER_SHOP_ID));
+
+        $row = CMS::getCMSContent(self::CMS_ID, null, self::OTHER_SHOP_ID);
+
+        self::assertSame(self::CONTENT_IN_LANG_2, $row['content']);
+    }
+
+    /**
+     * A language given explicitly still wins over the shop's default.
+     */
+    public function testItKeepsAnExplicitlyRequestedLanguage(): void
+    {
+        $row = CMS::getCMSContent(self::CMS_ID, 1, self::OTHER_SHOP_ID);
+
+        self::assertSame(self::CONTENT_IN_LANG_1, $row['content']);
+    }
+
+    /**
+     * The other shop's default language must not leak into a call that names no shop.
+     */
+    public function testItLeavesTheShopInContextAlone(): void
+    {
+        $expected = Db::getInstance()->getValue(
+            'SELECT `content` FROM `' . _DB_PREFIX_ . 'cms_lang` WHERE `id_cms` = ' . self::CMS_ID
+            . ' AND `id_lang` = ' . (int) Configuration::get('PS_LANG_DEFAULT')
+            . ' AND `id_shop` = ' . (int) Configuration::get('PS_SHOP_DEFAULT')
+        );
+
+        $row = CMS::getCMSContent(self::CMS_ID);
+
+        self::assertSame($expected, $row['content']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Three methods accept a shop id and then resolve the default language without passing it, so they answer with the default language of the shop in context rather than the one requested. `CMS::getCMSContent($id, null, $otherShop)` is the reported case: it returned the other shop's page in the current shop's language. The shop is now resolved before the language so it can be handed on. The same shape is fixed in `Mail::send()`, whose own comment calls the value "Default language of the shop", and in `Link::getLangLink()`, which compares against it on the line directly above a `PS_DEFAULT_LANGUAGE_URL_PREFIX` lookup already scoped to that shop.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Needs multistore on and a second shop with a default language of its own. Give the second shop CMS content in both languages, then call `CMS::getCMSContent($idCms, null, $secondShopId)`: before this change it returns the content in the first shop's default language, after it returns the second shop's. `tests/Integration/Classes/CMSTest.php` builds that fixture and asserts it.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29519
| Related PRs       |
| Sponsor company   |

## Scope

Surveyed every method in `classes/` that takes a shop id and reads `PS_LANG_DEFAULT` without it. Five
matches, three of which are this defect:

| site | why it is the same defect |
| ---- | ------------------------- |
| `CMS::getCMSContent()` | the reported case |
| `Mail::send()` | the comment above it reads "Default language of the shop", and the same file already scopes `PS_LOGO_MAIL` with `$idShop` |
| `Link::getLangLink()` | the next line reads `PS_DEFAULT_LANGUAGE_URL_PREFIX` scoped to `$idShop`, and lines above pass `$idShop` to `PS_REWRITING_SETTINGS` and `isMultiLanguageActivated()` |

Left alone deliberately: `Employee::__construct()` and `ObjectModel::__construct()`. Both read the value
as a fallback for an *invalid* `$id_lang` rather than to answer for a given shop, and in `ObjectModel`
the shop is applied afterwards. Changing the base model constructor for that is a different question.

## Reproduction, measured on 9.2.0

A second shop whose default language is French, holding the page in both languages:

```
PS_LANG_DEFAULT for shop 1 = 1
PS_LANG_DEFAULT for shop 2 = 2
PS_LANG_DEFAULT unscoped   = 1        <- what the method read

CMS::getCMSContent(1, null, 2)  before = 'QA-SHOP2-ENGLISH'
CMS::getCMSContent(1, null, 2)  after  = 'QA-SHOP2-FRENCH'
```

Controls, unchanged either way: `getCMSContent(1)`, `getCMSContent(1, 2)`, `getCMSContent(1, 1, 2)` and
`getCMSContent(1, 2, 2)`.

## Blast radius

`Configuration::get()` discards a requested shop id unless the multistore feature is on
(`classes/Configuration.php:217`), so on a single-shop installation these three calls resolve exactly as
before. The change can only alter behaviour where multistore is active and the requested shop differs
from the one in context - which is the reported situation.

## Tests

`tests/Integration/Classes/CMSTest.php`, 3 cases: the fallback, an explicitly requested language still
winning, and the shop in context being unaffected. It creates the second shop and turns multistore on
because `Configuration::get()` ignores the shop id otherwise, and removes both in `tearDown` (verified:
the test database is left with one shop and no leftover rows).

Mutation: reverting only `classes/CMS.php` to base fails
`testItFallsBackToTheDefaultLanguageOfTheRequestedShop` and leaves the other two green.
`tests/Integration/Classes/LinkTest.php` is identical before and after this branch (6 tests, 8
assertions). php-cs-fixer and phpstan clean on all four files.
