### PR TITLE
Read the image from the request body on a webservice PUT

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -1036,12 +1036,132 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
      *
      * @throws WebserviceException
      */
+    /**
+     * Returns the image sent with a PUT request, in the $_FILES shape the rest of this class expects.
+     *
+     * PHP only parses a multipart body for POST requests, so $_FILES is empty on a PUT whatever the
+     * client sends. A PUT therefore carries its image as the raw request body, which is also what
+     * REST clients do for a binary resource. The multipart branch is kept for the servers and SAPIs
+     * that do populate $_FILES on a PUT.
+     *
+     * The body goes straight to a temporary file rather than to a string: $_FILES is capped by
+     * upload_max_filesize before any of this runs, but nothing caps a body read out of php://input,
+     * so the shop's own image limit has to be applied while reading rather than afterwards.
+     *
+     * @param int $maxBytes largest body this caller accepts, in bytes
+     *
+     * @return array{name: string, type: string, tmp_name: string, error: int, size: int, is_upload: bool}|null
+     *                                                                                                          null when the request carries no image at all
+     *
+     * @throws WebserviceException
+     */
+    protected function getPutImageFile($maxBytes)
+    {
+        if (isset($_FILES['image']['tmp_name']) && $_FILES['image']['tmp_name']) {
+            return $_FILES['image'] + ['is_upload' => true];
+        }
+
+        $tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS');
+
+        if ($tmpName === false) {
+            throw new WebserviceException('Error while copying image to the temporary directory', [75, 400]);
+        }
+
+        $size = $this->readRequestBody($tmpName, $maxBytes);
+
+        if ($size === 0) {
+            @unlink($tmpName);
+
+            return null;
+        }
+
+        return [
+            'name' => basename($tmpName),
+            'type' => $_SERVER['CONTENT_TYPE'] ?? '',
+            'tmp_name' => $tmpName,
+            'error' => UPLOAD_ERR_OK,
+            'size' => $size,
+            'is_upload' => false,
+        ];
+    }
+
+    /**
+     * The raw request body, as a stream. Isolated so it can be replaced in tests.
+     *
+     * @return resource|false
+     */
+    protected function openRequestBody()
+    {
+        return fopen('php://input', 'rb');
+    }
+
+    /**
+     * Copies the request body to $destination, reading at most one byte more than the caller
+     * accepts. The body is never held in memory as a whole, and an oversized one stops being read
+     * as soon as it is known to be oversized - that one extra byte is what tells the caller so.
+     *
+     * @param string $destination
+     * @param int $maxBytes
+     *
+     * @return int bytes written
+     *
+     * @throws WebserviceException
+     */
+    protected function readRequestBody($destination, $maxBytes)
+    {
+        $input = $this->openRequestBody();
+
+        if ($input === false) {
+            return 0;
+        }
+
+        $output = fopen($destination, 'wb');
+
+        if ($output === false) {
+            fclose($input);
+
+            throw new WebserviceException('Error while copying image to the temporary directory', [75, 400]);
+        }
+
+        $size = stream_copy_to_stream($input, $output, $maxBytes + 1);
+
+        fclose($input);
+        fclose($output);
+
+        return $size === false ? 0 : $size;
+    }
+
+    /**
+     * Moves a file returned by getPutImageFile() to its destination.
+     *
+     * move_uploaded_file() only accepts a file PHP itself received as an upload, so the raw body
+     * variant has to be renamed instead.
+     *
+     * @param array $file
+     * @param string $destination
+     *
+     * @return bool
+     */
+    protected function moveReceivedFile(array $file, $destination)
+    {
+        if (!empty($file['is_upload'])) {
+            return move_uploaded_file($file['tmp_name'], $destination);
+        }
+
+        return rename($file['tmp_name'], $destination);
+    }
+
     protected function writePostedImageOnDisk($reception_path, $dest_width = null, $dest_height = null, $image_types = null, $parent_path = null)
     {
         $imgMaxUploadSize = ((int) Configuration::get('PS_LIMIT_UPLOAD_IMAGE_VALUE')) * 1000 * 1000;
         if ($this->wsObject->method == 'PUT') {
-            if (isset($_FILES['image']['tmp_name']) && $_FILES['image']['tmp_name']) {
-                $file = $_FILES['image'];
+            $file = $this->getPutImageFile($imgMaxUploadSize);
+
+            if ($file === null) {
+                throw new WebserviceException('Please set an "image" parameter with image data for value', [76, 400]);
+            }
+
+            try {
                 if ($file['size'] > $imgMaxUploadSize) {
                     throw new WebserviceException(sprintf('The image size is too large (maximum allowed is %d KB)', $imgMaxUploadSize / 1000), [72, 400]);
                 }
@@ -1073,7 +1193,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 }
 
                 // Try to copy image file to a temporary file
-                if (!($tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !move_uploaded_file($_FILES['image']['tmp_name'], $tmp_name)) {
+                if (!($tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !$this->moveReceivedFile($file, $tmp_name)) {
                     throw new WebserviceException('Error while copying image to the temporary directory', [75, 400]);
                 } else {
                     // Try to copy image file to the image directory
@@ -1083,8 +1203,12 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 @unlink($tmp_name);
 
                 return $result;
-            } else {
-                throw new WebserviceException('Please set an "image" parameter with image data for value', [76, 400]);
+            } finally {
+                // A body received into a temporary file is ours to remove, on the way out of any of
+                // the checks above as much as on success; a real upload is PHP's to clean up.
+                if (empty($file['is_upload']) && file_exists($file['tmp_name'])) {
+                    @unlink($file['tmp_name']);
+                }
             }
         } elseif ($this->wsObject->method == 'POST') {
             if (isset($_FILES['image']['tmp_name']) && $_FILES['image']['tmp_name']) {

--- a/tests/Unit/Classes/Webservice/WebserviceImagePutBodyTest.php
+++ b/tests/Unit/Classes/Webservice/WebserviceImagePutBodyTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Webservice;
+
+use PHPUnit\Framework\TestCase;
+use WebserviceSpecificManagementImages;
+
+/**
+ * PHP only fills $_FILES for a POST multipart body, so a PUT has to take its image from the raw
+ * request body. These cases pin that, pin that a real upload still takes the upload path, and pin
+ * that the body is read under the shop's size limit instead of being buffered and measured after.
+ */
+class WebserviceImagePutBodyTest extends TestCase
+{
+    private const NO_LIMIT = 1048576;
+
+    /** @var string[] */
+    private array $temporaryFilesBefore = [];
+
+    protected function setUp(): void
+    {
+        $this->temporaryFilesBefore = $this->temporaryFiles();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_FILES['image']);
+
+        // A failing case throws before its own unlink, and these files land in a tracked directory.
+        foreach (array_diff($this->temporaryFiles(), $this->temporaryFilesBefore) as $leftOver) {
+            @unlink($leftOver);
+        }
+    }
+
+    public function testAPutWithoutABodyCarriesNoImage(): void
+    {
+        $this->assertNull($this->buildManager('')->readPutImageFile(self::NO_LIMIT));
+    }
+
+    public function testAPutWithoutABodyLeavesNoTemporaryFileBehind(): void
+    {
+        $before = $this->countTemporaryFiles();
+
+        $this->buildManager('')->readPutImageFile(self::NO_LIMIT);
+
+        $this->assertSame($before, $this->countTemporaryFiles());
+    }
+
+    public function testAPutBodyIsExposedAsAnUploadedFileWouldBe(): void
+    {
+        $body = 'not really a png, but the shape is what matters';
+        $file = $this->buildManager($body)->readPutImageFile(self::NO_LIMIT);
+
+        $this->assertIsArray($file);
+        $this->assertSame(strlen($body), $file['size']);
+        $this->assertSame(UPLOAD_ERR_OK, $file['error']);
+        $this->assertFalse($file['is_upload']);
+        $this->assertFileExists($file['tmp_name']);
+        $this->assertSame($body, file_get_contents($file['tmp_name']));
+
+        @unlink($file['tmp_name']);
+    }
+
+    public function testAnOversizedBodyStopsBeingReadOnceItIsKnownToBeOversized(): void
+    {
+        $limit = 10;
+        $file = $this->buildManager(str_repeat('x', 5000))->readPutImageFile($limit);
+
+        // One byte past the limit: enough for the caller's "> limit" check to fire, and the 4989
+        // bytes after it are never read, let alone held in memory.
+        $this->assertSame($limit + 1, $file['size']);
+        $this->assertSame($limit + 1, filesize($file['tmp_name']));
+        $this->assertGreaterThan($limit, $file['size']);
+
+        @unlink($file['tmp_name']);
+    }
+
+    public function testABodyExactlyOnTheLimitIsReadWhole(): void
+    {
+        $limit = 10;
+        $file = $this->buildManager(str_repeat('x', $limit))->readPutImageFile($limit);
+
+        $this->assertSame($limit, $file['size']);
+        $this->assertLessThanOrEqual($limit, $file['size']);
+
+        @unlink($file['tmp_name']);
+    }
+
+    public function testAMultipartUploadIsPreferredWhenTheServerProvidedOne(): void
+    {
+        $_FILES['image'] = [
+            'name' => 'photo.jpg',
+            'type' => 'image/jpeg',
+            'tmp_name' => '/tmp/php-upload-fixture',
+            'error' => UPLOAD_ERR_OK,
+            'size' => 1234,
+        ];
+
+        $file = $this->buildManager('a raw body that must be ignored')->readPutImageFile(self::NO_LIMIT);
+
+        $this->assertSame('/tmp/php-upload-fixture', $file['tmp_name']);
+        $this->assertTrue($file['is_upload']);
+    }
+
+    public function testARawBodyIsMovedWithoutGoingThroughMoveUploadedFile(): void
+    {
+        $manager = $this->buildManager('body');
+        $file = $manager->readPutImageFile(self::NO_LIMIT);
+        $destination = tempnam(sys_get_temp_dir(), 'ps-test-');
+
+        // move_uploaded_file() refuses a file PHP did not receive as an upload, so a raw body has
+        // to be renamed; if this ever goes back through move_uploaded_file() it returns false.
+        $this->assertTrue($manager->moveReceived($file, $destination));
+        $this->assertSame('body', file_get_contents($destination));
+
+        @unlink($destination);
+    }
+
+    private function countTemporaryFiles(): int
+    {
+        return count($this->temporaryFiles());
+    }
+
+    /**
+     * @return string[]
+     */
+    private function temporaryFiles(): array
+    {
+        return (array) glob(_PS_TMP_IMG_DIR_ . 'PS*');
+    }
+
+    /**
+     * Only the stream behind php://input is replaced, so the copy under test is the real one.
+     */
+    private function buildManager(string $body): object
+    {
+        return new class($body) extends WebserviceSpecificManagementImages {
+            private string $body;
+
+            public function __construct(string $body)
+            {
+                $this->body = $body;
+            }
+
+            public function readPutImageFile(int $maxBytes)
+            {
+                return $this->getPutImageFile($maxBytes);
+            }
+
+            public function moveReceived(array $file, string $destination): bool
+            {
+                return $this->moveReceivedFile($file, $destination);
+            }
+
+            protected function openRequestBody()
+            {
+                $stream = fopen('php://memory', 'r+b');
+                fwrite($stream, $this->body);
+                rewind($stream);
+
+                return $stream;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PUT /api/images/products/{product_id}/{image_id}` is documented in `WebserviceSpecificManagementImages` and implemented in `manageDeclinatedImagesCRUD()`, but it could never succeed: `writePostedImageOnDisk()` takes the file from `$_FILES`, and PHP populates `$_FILES` only for a POST multipart body. Every PUT answered `400`, error 76, "Please set an "image" parameter with image data for value", with a multipart body and with a raw one alike. A PUT now falls back to the raw request body, which is how a REST client sends a binary anyway.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable the webservice and create a key with `GET` and `PUT` on `images`. 2. `GET /api/images/products/1/1` and keep the bytes. 3. `curl -u KEY: -X PUT --data-binary @other.jpg -H "Content-Type: image/jpeg" .../api/images/products/1/1`. Before this change it answers 400 error 76; after it answers 200 and returns the new image. 4. `GET` the same URL again: the stored image has changed. 5. Send a rejected PUT, `--data-binary @some.txt -H "Content-Type: text/plain"`, a few times and list `img/tmp/PS*`: one file per call is left there without this change, none with it. 6. Multipart uploads on POST are untouched.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29653
| Related PRs       | None
| Sponsor company   | None

### Measured before and after

On a 9.2 shop, `PUT /api/images/products/1/1`:

| body | before | after |
| ---- | ------ | ----- |
| `-F image=@file.png` (multipart) | 400, error 76 | 400, error 76 on this server, since PHP still does not parse it |
| `--data-binary @file.png` (raw) | 400, error 76 | 200, and the stored image changes |

The multipart branch is kept rather than removed, for servers and SAPIs that do populate `$_FILES` on a PUT.

`move_uploaded_file()` refuses a file PHP did not receive as an upload, so the move to the temporary file follows the same split: an upload is moved with `move_uploaded_file()`, a raw body is renamed.

### On PATCH

The issue asks for PATCH as well. PATCH is already a first-class webservice method: it is in the `ps_webservice_permission` method enum and `WebserviceRequest` handles it, so with the permission granted a PATCH reaches the images manager and stops at its `default` branch with error 67. It is deliberately not added here. PATCH is defined as applying a described modification to a resource, and an image is an opaque binary with no partial form to describe, so PATCH would either be a synonym for PUT, which is misleading, or would need a patch format that does not exist. Replacing an image is exactly what PUT is for, and it now works.

### Reading the body under the size limit

`upload_max_filesize` bounds a multipart upload before any PHP code runs, and nothing plays that role for a body read out of `php://input` on a PUT. Measured on PHP 8.1 with `post_max_size = 20M`, a 25 MiB `PUT` body read with `file_get_contents('php://input')` returns all 26214400 bytes, at a 48 MiB peak allocation. `PS_LIMIT_UPLOAD_IMAGE_VALUE` is therefore the only bound on that read, and checking it after the read is too late.

The body is copied into the temporary file with `stream_copy_to_stream()`, capped at one byte past the limit. The extra byte is what lets the existing `> $imgMaxUploadSize` check still tell "at the limit" from "over it", and a body of any size above the limit stops being read there. A 30 MiB PUT against a 2 MB shop limit answers 400, error 72, in 0.115 s.

### Cleaning up the temporary file

A raw body has to be received into a temporary file, and that file is this class's to remove: on the way out of the size check, the mime allow-list and the upload-error branch, not only on success. The PUT branch is wrapped in `try`/`finally` for that. Measured on a 9.2 shop, three rejected PUTs with a `text/plain` body: three orphaned files in `img/tmp/` before this, none after, with the same 400 and the same message either way. A real upload is left to PHP, which cleans up its own temporary files.

### Test

`tests/Unit/Classes/Webservice/WebserviceImagePutBodyTest.php` covers a PUT with no body, a PUT with no body leaving no temporary file, a PUT whose body becomes the file, an oversized body stopping one byte past the limit, a body exactly on the limit being read whole, a real multipart upload taking precedence, and the move going through `rename()` rather than `move_uploaded_file()` for a raw body. Only the stream behind `php://input` is replaced in the fixture, so the copy under test is the real one, and a case that fails part way removes what it created rather than leaving it in `tests/Resources/img/tmp/`.

Four mutations were checked: removing the raw-body fallback fails two cases, moving every file with `move_uploaded_file()` fails one, dropping the length argument to `stream_copy_to_stream()` fails one, and keeping the temporary file when the body is empty fails one. The `finally` is not reachable from a unit test, so it is covered by the shop measurement above instead.
