### PR TITLE
Say so when the file integrity check could not run

### DIFF
--- a/src/Adapter/Requirement/CheckMissingOrUpdatedFiles.php
+++ b/src/Adapter/Requirement/CheckMissingOrUpdatedFiles.php
@@ -7,6 +7,8 @@
 namespace PrestaShop\PrestaShop\Adapter\Requirement;
 
 use PrestaShop\PrestaShop\Core\Version;
+use SimpleXMLElement;
+use Tools;
 
 /**
  * Part of requirements for a PrestaShop website
@@ -15,26 +17,69 @@ use PrestaShop\PrestaShop\Core\Version;
 class CheckMissingOrUpdatedFiles
 {
     /**
-     * @param string|null $dir
+     * Seconds to wait for the checksum list. The list weighs a few megabytes, so this is
+     * generous, but it is bounded: without it the download inherits default_socket_timeout
+     * and a stalled connection holds the request open far longer than the page can survive.
+     */
+    private const CHECKSUM_LIST_TIMEOUT = 30;
+
+    /**
+     * @param SimpleXMLElement|null $dir
      * @param string $path
      *
-     * @return array
+     * @return array{missing: string[], updated: string[], error: bool} `error` is true when the
+     *                                                                  checksum list could not be
+     *                                                                  read, which means nothing
+     *                                                                  was verified
      */
     public function getListOfUpdatedFiles($dir = null, $path = '')
+    {
+        if (null === $dir) {
+            $dir = $this->loadChecksumList();
+
+            if (null === $dir) {
+                // Reporting an empty list here would tell the merchant that every file matches,
+                // when in fact not a single one was compared.
+                return ['missing' => [], 'updated' => [], 'error' => true];
+            }
+        }
+
+        return $this->compareWithChecksumList($dir, $path) + ['error' => false];
+    }
+
+    /**
+     * @return SimpleXMLElement|null null when the list is unreachable or malformed
+     */
+    protected function loadChecksumList()
+    {
+        $url = _PS_API_URL_ . '/xml/md5-' . Version::MAJOR_VERSION . '/' . Version::VERSION . '.xml';
+        $body = Tools::file_get_contents($url, false, null, self::CHECKSUM_LIST_TIMEOUT);
+
+        if (!is_string($body) || '' === $body) {
+            return null;
+        }
+
+        $xml = @simplexml_load_string($body);
+
+        if (false === $xml || !isset($xml->ps_root_dir[0])) {
+            return null;
+        }
+
+        return $xml->ps_root_dir[0];
+    }
+
+    /**
+     * @param SimpleXMLElement $dir
+     * @param string $path
+     *
+     * @return array{missing: string[], updated: string[]}
+     */
+    private function compareWithChecksumList(SimpleXMLElement $dir, string $path): array
     {
         $fileList = [
             'missing' => [],
             'updated' => [],
         ];
-
-        if (null === $dir) {
-            $xml = @simplexml_load_file(_PS_API_URL_ . '/xml/md5-' . Version::MAJOR_VERSION . '/' . Version::VERSION . '.xml');
-            if (!$xml) {
-                return $fileList;
-            }
-
-            $dir = $xml->ps_root_dir[0];
-        }
 
         $excludeRegexp = '(install(-dev|-new)?|themes|tools|cache|docs|download|img|localization|log|mails|translations|upload|modules|override/(:?.*)index.php$)';
         $adminDir = basename(_PS_ADMIN_DIR_);
@@ -53,7 +98,10 @@ class CheckMissingOrUpdatedFiles
         }
 
         foreach ($dir->dir as $subdir) {
-            $fileList = array_merge_recursive($fileList, $this->getListOfUpdatedFiles($subdir, $path . $subdir['name'] . '/'));
+            $fileList = array_merge_recursive(
+                $fileList,
+                $this->compareWithChecksumList($subdir, $path . $subdir['name'] . '/')
+            );
         }
 
         return $fileList;

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -240,7 +240,12 @@
       missing: '{{ 'Missing files'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}',
       updated: '{{ 'Updated files'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}',
       changesDetected: '{{ 'Changed/missing files have been detected.'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}',
-      noChangeDetected: '{{ 'No change has been detected in your files.'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}'
+      noChangeDetected: '{{ 'No change has been detected in your files.'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}',
+      checkFailed: '{{ 'Your files could not be checked. The list of official checksums could not be downloaded.'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}'
+    };
+
+    var displayCheckFailure = function() {
+      $('#changedFiles').html('<div class="alert alert-warning mb-0" role="alert"><p class="alert-text">' + translations.checkFailed + '</p></div>');
     };
 
     $.ajax({
@@ -254,6 +259,12 @@
           'missing': translations.missing,
           'updated': translations.updated,
         };
+
+        if (json.error) {
+          displayCheckFailure();
+
+          return;
+        }
 
         if (json.missing.length || json.updated.length) {
           $('#changedFiles').html('<div class="alert alert-warning" role="alert"><p class="alert-text">' + translations.changesDetected + '</p></div>');
@@ -272,7 +283,8 @@
               .append(html);
           }
         });
-      }
+      },
+      error: displayCheckFailure
     });
   });
 </script>

--- a/tests/Unit/Adapter/Requirement/CheckMissingOrUpdatedFilesTest.php
+++ b/tests/Unit/Adapter/Requirement/CheckMissingOrUpdatedFilesTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Requirement;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Requirement\CheckMissingOrUpdatedFiles;
+use SimpleXMLElement;
+
+class CheckMissingOrUpdatedFilesTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('_PS_ADMIN_DIR_')) {
+            define('_PS_ADMIN_DIR_', _PS_ROOT_DIR_ . '/admin-dev');
+        }
+    }
+
+    public function testAnUnreachableChecksumListIsReportedAsAnError(): void
+    {
+        $result = $this->buildChecker(null)->getListOfUpdatedFiles();
+
+        // Without this the page tells the merchant "No change has been detected in your files"
+        // after comparing nothing at all, which is the one answer it must never give.
+        $this->assertTrue($result['error']);
+        $this->assertSame([], $result['missing']);
+        $this->assertSame([], $result['updated']);
+    }
+
+    public function testAReadableChecksumListIsNotReportedAsAnError(): void
+    {
+        $result = $this->buildChecker($this->checksumList([
+            'composer.json' => md5_file(_PS_ROOT_DIR_ . '/composer.json'),
+        ]))->getListOfUpdatedFiles();
+
+        $this->assertFalse($result['error']);
+        $this->assertSame([], $result['missing']);
+        $this->assertSame([], $result['updated']);
+    }
+
+    public function testAFileAbsentFromTheInstallIsReportedAsMissing(): void
+    {
+        $result = $this->buildChecker($this->checksumList([
+            'this-file-is-not-part-of-the-install.php' => 'd41d8cd98f00b204e9800998ecf8427e',
+        ]))->getListOfUpdatedFiles();
+
+        $this->assertSame(['this-file-is-not-part-of-the-install.php'], $result['missing']);
+        $this->assertSame([], $result['updated']);
+        $this->assertFalse($result['error']);
+    }
+
+    public function testAFileWhoseContentDiffersIsReportedAsUpdated(): void
+    {
+        $result = $this->buildChecker($this->checksumList([
+            'composer.json' => 'd41d8cd98f00b204e9800998ecf8427e',
+        ]))->getListOfUpdatedFiles();
+
+        $this->assertSame(['composer.json'], $result['updated']);
+        $this->assertSame([], $result['missing']);
+        $this->assertFalse($result['error']);
+    }
+
+    public function testExcludedPathsAreStillSkipped(): void
+    {
+        $result = $this->buildChecker($this->checksumList([
+            'themes/this-theme-does-not-exist/config.yml' => 'd41d8cd98f00b204e9800998ecf8427e',
+            'img/this-image-does-not-exist.png' => 'd41d8cd98f00b204e9800998ecf8427e',
+        ]))->getListOfUpdatedFiles();
+
+        $this->assertSame([], $result['missing']);
+        $this->assertSame([], $result['updated']);
+    }
+
+    /**
+     * @param array<string, string> $files relative path => expected md5
+     */
+    private function checksumList(array $files): SimpleXMLElement
+    {
+        $xml = new SimpleXMLElement('<ps_root_dir version="test"/>');
+
+        foreach ($files as $path => $md5) {
+            $node = $xml;
+            $segments = explode('/', $path);
+            $name = array_pop($segments);
+
+            foreach ($segments as $segment) {
+                $node = $node->addChild('dir');
+                $node->addAttribute('name', $segment);
+            }
+
+            $file = $node->addChild('md5file', $md5);
+            $file->addAttribute('name', $name);
+        }
+
+        return $xml;
+    }
+
+    private function buildChecker(?SimpleXMLElement $checksumList): CheckMissingOrUpdatedFiles
+    {
+        return new class($checksumList) extends CheckMissingOrUpdatedFiles {
+            /**
+             * @var SimpleXMLElement|null
+             */
+            private $checksumList;
+
+            public function __construct(?SimpleXMLElement $checksumList)
+            {
+                $this->checksumList = $checksumList;
+            }
+
+            protected function loadChecksumList()
+            {
+                return $this->checksumList;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CheckMissingOrUpdatedFiles::getListOfUpdatedFiles()` returned an empty list both when every file matched and when the checksum list could not be downloaded, and `Advanced Parameters > Information` renders an empty list as "No change has been detected in your files". A shop that cannot reach the checksum service is therefore told its files are intact after comparing nothing. The result now carries an explicit error flag, the download is given an explicit timeout instead of inheriting `default_socket_timeout`, and the page gets the error branch it never had: the AJAX call had no `error` callback at all, so a failed or timed out request left the card on "Checking files..." indefinitely.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Block outgoing traffic to `api.prestashop.com` (add it to `/etc/hosts` as `127.0.0.1`, or drop the packets). 2. Open `Advanced Parameters > Information`. Before this change the "List of changed files" card ends on the green "No change has been detected in your files"; after it, it shows a warning saying the checksums could not be downloaded. 3. Restore access and reload: the card behaves as before, listing changed and missing files or reporting none. 4. To exercise the second half, make the endpoint fail (for instance by revoking the employee's read permission on the page while it loads): the card now shows the same warning instead of spinning forever.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29798
| Related PRs       | None
| Sponsor company   | None

### On the change requested in the issue

The issue proposes turning the exclusion list into an inclusion list of `admin, app, bin, classes, controllers, js, pdf, src, vendor, webservice`, on the grounds that unrelated folders in the shop root make the page hang. Measured against the published checksum list for 9.1.5:

| | files |
| --- | --- |
| entries in the checksum list | 37245 |
| after the current exclusion regex | 20036 |
| of which `vendor/` | 10769 |

The loop walks the checksum list, not the filesystem, so a merchant's own folders are never visited and cannot slow it down; and the proposed inclusion list keeps `vendor`, which is 54 per cent of the work, so it would leave the cost essentially unchanged. Hashing that set takes about 3 seconds on a warm local SSD, which is not by itself a hang.

What can hang it is the part this PR changes: `simplexml_load_file()` on a several-megabyte list over plain HTTP with no timeout of its own, followed by a front end that had no failure path. Dropping `vendor` from the comparison would make the check faster by hiding exactly the tampering an integrity check exists to find, so the file set is deliberately left alone.

### Test

`tests/Unit/Adapter/Requirement/CheckMissingOrUpdatedFilesTest.php` covers the unreachable list, a readable one, a missing file, a modified file, and that excluded paths are still skipped. Two targeted mutations were checked: restoring the silent empty result fails the first case, and disabling the exclusion regex fails the last one.
