### PR TITLE
Name the columns that share an import type

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/duplicate-import-columns.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/duplicate-import-columns.ts
@@ -1,0 +1,57 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+export interface ImportColumnSelection {
+  /**
+   * 1 based position of the column in the imported file, as the merchant sees it.
+   */
+  column: number;
+
+  /**
+   * Value of the selected option, which is what makes two columns duplicates.
+   */
+  value: string;
+
+  /**
+   * Label of the selected option, which is what the merchant recognises.
+   */
+  label: string;
+}
+
+/**
+ * Groups the column selections that share the same value, keeping the order in which the
+ * values first appear so the message reads left to right like the table above it.
+ */
+export const findDuplicateImportColumns = (
+  selections: ImportColumnSelection[],
+): ImportColumnSelection[][] => {
+  const byValue = new Map<string, ImportColumnSelection[]>();
+
+  selections.forEach((selection: ImportColumnSelection) => {
+    const group = byValue.get(selection.value);
+
+    if (group) {
+      group.push(selection);
+    } else {
+      byValue.set(selection.value, [selection]);
+    }
+  });
+
+  return Array.from(byValue.values()).filter(
+    (group: ImportColumnSelection[]) => group.length > 1,
+  );
+};
+
+/**
+ * Renders the duplicates as "Label (3, 7); Other label (2, 9)". The shape carries no prose,
+ * so it needs no translation of its own: the sentence next to it already says what it means.
+ */
+export const describeDuplicateImportColumns = (
+  selections: ImportColumnSelection[],
+): string => findDuplicateImportColumns(selections)
+  .map((group: ImportColumnSelection[]) => `${group[0].label} (${group
+    .map((selection: ImportColumnSelection) => selection.column)
+    .join(', ')})`)
+  .join('; ');

--- a/admin-dev/themes/new-theme/js/pages/import-data/EntityFieldsValidator.ts
+++ b/admin-dev/themes/new-theme/js/pages/import-data/EntityFieldsValidator.ts
@@ -3,6 +3,11 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
+import {
+  describeDuplicateImportColumns,
+  ImportColumnSelection,
+} from '@app/utils/duplicate-import-columns';
+
 const {$} = window;
 
 export default class EntityFieldsValidator {
@@ -24,26 +29,33 @@ export default class EntityFieldsValidator {
    * @private
    */
   checkDuplicateSelectedValues(): boolean {
-    const uniqueFields: Array<string | number | string[] | undefined> = [];
-    let valid = true;
+    const selections: ImportColumnSelection[] = [];
 
-    $('.js-entity-field select').each(function () {
+    $('.js-entity-field select').each(function (index: number) {
       const value = $(this).val();
 
-      if (value === 'no') {
+      if (value === undefined || value === 'no') {
         return;
       }
 
-      if ($.inArray(value, uniqueFields) !== -1) {
-        valid = false;
-        $('.js-duplicate-columns-warning').removeClass('d-none');
-        return;
-      }
-
-      uniqueFields.push(value);
+      selections.push({
+        // The merchant counts the columns of the file from one, left to right.
+        column: index + 1,
+        value: String(value),
+        label: $(this).find('option:selected').text().trim(),
+      });
     });
 
-    return valid;
+    const duplicates = describeDuplicateImportColumns(selections);
+
+    if (duplicates === '') {
+      return true;
+    }
+
+    $('.js-duplicate-columns-warning').removeClass('d-none');
+    $('.js-duplicate-columns').text(duplicates);
+
+    return false;
   }
 
   /**

--- a/admin-dev/themes/new-theme/tests/utils/duplicate-import-columns.spec.js
+++ b/admin-dev/themes/new-theme/tests/utils/duplicate-import-columns.spec.js
@@ -1,0 +1,80 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+import {expect} from 'chai';
+import {
+  describeDuplicateImportColumns,
+  findDuplicateImportColumns,
+} from '../../js/app/utils/duplicate-import-columns';
+
+const column = (position, value, label) => ({column: position, value, label});
+
+describe('DuplicateImportColumns', () => {
+  describe('findDuplicateImportColumns', () => {
+    it('finds nothing when every column has its own type', () => {
+      expect(findDuplicateImportColumns([
+        column(1, 'id', 'ID'),
+        column(2, 'name', 'Name'),
+      ])).to.deep.equal([]);
+    });
+
+    it('groups the columns sharing a type', () => {
+      const groups = findDuplicateImportColumns([
+        column(1, 'id', 'ID'),
+        column(2, 'price', 'Price'),
+        column(3, 'price', 'Price'),
+      ]);
+
+      expect(groups).to.have.lengthOf(1);
+      expect(groups[0].map((selection) => selection.column)).to.deep.equal([2, 3]);
+    });
+
+    it('reports every group, not just the first', () => {
+      const groups = findDuplicateImportColumns([
+        column(1, 'price', 'Price'),
+        column(2, 'reference', 'Reference'),
+        column(3, 'price', 'Price'),
+        column(4, 'reference', 'Reference'),
+      ]);
+
+      expect(groups).to.have.lengthOf(2);
+    });
+
+    it('keeps a group of three together instead of splitting it in pairs', () => {
+      const groups = findDuplicateImportColumns([
+        column(1, 'price', 'Price'),
+        column(2, 'price', 'Price'),
+        column(3, 'price', 'Price'),
+      ]);
+
+      expect(groups).to.have.lengthOf(1);
+      expect(groups[0].map((selection) => selection.column)).to.deep.equal([1, 2, 3]);
+    });
+  });
+
+  describe('describeDuplicateImportColumns', () => {
+    it('says nothing when there is nothing to say', () => {
+      expect(describeDuplicateImportColumns([
+        column(1, 'id', 'ID'),
+      ])).to.equal('');
+    });
+
+    it('names the type and every column it was chosen for', () => {
+      expect(describeDuplicateImportColumns([
+        column(1, 'id', 'ID'),
+        column(2, 'price', 'Price tax excluded'),
+        column(7, 'price', 'Price tax excluded'),
+      ])).to.equal('Price tax excluded (2, 7)');
+    });
+
+    it('separates several duplicated types', () => {
+      expect(describeDuplicateImportColumns([
+        column(2, 'price', 'Price'),
+        column(3, 'reference', 'Reference'),
+        column(7, 'price', 'Price'),
+        column(9, 'reference', 'Reference'),
+      ])).to.equal('Price (2, 7); Reference (3, 9)');
+    });
+  });
+});

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/ImportDataConfiguration/Blocks/import_data_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/ImportDataConfiguration/Blocks/import_data_configuration.html.twig
@@ -73,6 +73,7 @@
       <div class="alert alert-warning js-validation-error js-duplicate-columns-warning d-none" role="alert">
         <p class="alert-text">
           {{ 'Two columns cannot have the same type of values'|trans({}, 'Admin.Advparameters.Feature') }}
+          <span class="js-duplicate-columns">&nbsp;</span>
         </p>
       </div>
       <div class="alert alert-warning js-validation-error js-missing-column-warning d-none" role="alert">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Advanced Parameters > Import` refuses to run when two columns are mapped to the same type, and says only "Two columns cannot have the same type of values". On a file with dozens of columns, most of them scrolled out of view, finding the pair is left entirely to the merchant. The warning now names the type and every column position it was chosen for, and reports every duplicated type rather than stopping at the first one found.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. `Advanced Parameters > Import`, pick any entity and upload a file with several columns. 2. Map two distant columns to the same type, for instance columns 2 and 7 both to `Price tax excluded`, and press `Next step`. 3. The warning now reads `Two columns cannot have the same type of values Price tax excluded (2, 7)`. 4. Add a second clash, for instance columns 3 and 9 both to `Reference`: both are listed, separated by a semicolon. 5. Fix the mapping and the import proceeds as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29949
| Related PRs       | None
| Sponsor company   | None

### Why no new wording

The neighbouring "This column must be set:" warning already fills a `js-missing-column` span from JavaScript, so the same shape is used here: the existing sentence is followed by a `js-duplicate-columns` span. What the span contains is a label and a list of numbers, `Price tax excluded (2, 7)`, with no prose of its own, so the change adds nothing to translate.

### Structure

The grouping and the formatting are a pure function in `admin-dev/themes/new-theme/js/app/utils/duplicate-import-columns.ts`, so they can be tested without a DOM. `EntityFieldsValidator` keeps the DOM reading: it collects the selected value, the selected option label and the one-based column position of each select, and hands the list over.

The previous implementation returned as soon as it saw the second occurrence of a value, which is why it could not name anything and why a file with two separate clashes only ever revealed one of them.

### Test

`admin-dev/themes/new-theme/tests/utils/duplicate-import-columns.spec.js`, seven cases including three columns sharing one type and two independent clashes. Two mutations were checked: reporting only the first group fails two cases, and dropping the column numbers from the message fails two.
