### PR TITLE
Make the predefined order message dropdown searchable

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
@@ -55,6 +55,9 @@ class OrderMessageType extends AbstractType
             ->add('order_message', ChoiceType::class, [
                 'choices' => $this->orderMessageNameChoiceProvider->getChoices(),
                 'required' => false,
+                // A shop can define many predefined messages, so the list needs the same
+                // search box the other long dropdowns of the back office already have.
+                'autocomplete' => true,
             ])
             ->add('is_displayed_to_customer', CheckboxType::class, [
                 'required' => false,

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageTypeTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Sell\Order;
+
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Sell\Order\OrderMessageType;
+use PrestaShopBundle\Form\Extension\AutoCompleteExtension;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class OrderMessageTypeTest extends TypeTestCase
+{
+    use ValidatorExtensionTrait;
+
+    protected function getExtensions(): array
+    {
+        $nameChoiceProvider = $this->createMock(FormChoiceProviderInterface::class);
+        $nameChoiceProvider->method('getChoices')->willReturn([
+            'Delay' => 1,
+            'Out of stock' => 2,
+        ]);
+
+        $messageChoiceProvider = $this->createMock(ConfigurableFormChoiceProviderInterface::class);
+        $messageChoiceProvider->method('getChoices')->willReturn([
+            1 => 'We are sorry for the delay.',
+            2 => 'This product is out of stock.',
+        ]);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        return [
+            $this->getValidatorExtension(),
+            new PreloadedExtension(
+                [new OrderMessageType($nameChoiceProvider, $messageChoiceProvider, $translator)],
+                [ChoiceType::class => [new AutoCompleteExtension()]]
+            ),
+        ];
+    }
+
+    public function testThePredefinedMessageDropdownIsSearchable(): void
+    {
+        $attributes = $this->buildView()['order_message']->vars['attr'];
+
+        // The UI kit turns a select carrying this attribute into a select2, which is what
+        // gives the predefined messages a search box.
+        $this->assertSame('select2', $attributes['data-toggle']);
+    }
+
+    public function testTheSearchBoxOnlyAppearsOnceTheListIsLongEnough(): void
+    {
+        $attributes = $this->buildView()['order_message']->vars['attr'];
+
+        // Same threshold as every other autocompleted dropdown of the back office, so a shop
+        // with a handful of messages is not given a search box it does not need.
+        $this->assertSame(7, $attributes['data-minimumResultsForSearch']);
+    }
+
+    public function testTheOtherFieldsAreLeftAlone(): void
+    {
+        $view = $this->buildView();
+
+        $this->assertArrayNotHasKey('data-toggle', $view['message']->vars['attr']);
+        $this->assertArrayNotHasKey('data-toggle', $view['is_displayed_to_customer']->vars['attr']);
+    }
+
+    private function buildView(): \Symfony\Component\Form\FormView
+    {
+        return $this->factory->create(OrderMessageType::class)->createView();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The `Choose your order message` dropdown on the order view is a plain select, so a shop with a long list of predefined messages has to scroll it. Every other long dropdown in the back office opts into `ChoiceType`'s `autocomplete` option, which `AutoCompleteExtension` turns into `data-toggle="select2"` and the UI kit turns into a select2 with a search box. This field never opted in; it does now.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. `Sell > Customer Service > Order Messages`, create at least seven predefined messages. 2. Open any order and expand the `Messages` block. 3. `Choose your order message` now opens with a search field and filters as you type; picking a message still fills the textarea and still asks before overwriting an edited one. 4. With fewer than seven messages the dropdown is unchanged, which is the shared threshold, not a special case for this field.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #30471
| Related PRs       | None
| Sponsor company   | None

### The change

```php
->add('order_message', ChoiceType::class, [
    'choices' => $this->orderMessageNameChoiceProvider->getChoices(),
    'required' => false,
    'autocomplete' => true,
])
```

`PrestaShopBundle\Form\Extension\AutoCompleteExtension` normalises that into `data-toggle="select2"` plus `data-minimumResultsForSearch`, defaulting to 7, and `prestashop-ui-kit`'s `initSelect2()` picks the attribute up. The same option is already set on the carrier dropdown of the shipping modal (`UpdateOrderShippingType`), the order status dropdown (`UpdateOrderStatusType`), the cart summary, supplier, manufacturer and address forms.

The existing behaviour in `js/pages/order/message/order-view-page-messages-handler.ts` is untouched: it listens for `change` delegated on `document`, and select2 dispatches a native `change` on the underlying select.

### Why an improvement rather than a new feature

The issue is labelled `Feature` because it was reclassified in 2022 after a check against 1.7.5.2 and 1.7.6.9. This adds no new mechanism: it sets an existing option on one existing field, which is also the direction given on the issue ("Input needs to be changed to select2"). No new service, no new template, no schema change.

### Test

`tests/Unit/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageTypeTest.php` builds the form through `TypeTestCase` with `AutoCompleteExtension` registered, and asserts the rendered attributes of the dropdown plus that the message textarea and the checkbox are left alone. Two of its three cases are red on `9.2.x`.
