### PR TITLE
Sort the Security sessions grids newest first by default

### DIFF
--- a/src/Core/Search/Filters/Security/Session/CustomerFilters.php
+++ b/src/Core/Search/Filters/Security/Session/CustomerFilters.php
@@ -30,7 +30,7 @@ class CustomerFilters extends Filters
             'limit' => 10,
             'offset' => 0,
             'orderBy' => 'id_customer_session',
-            'sortOrder' => 'asc',
+            'sortOrder' => 'desc',
             'filters' => [],
         ];
     }

--- a/src/Core/Search/Filters/Security/Session/EmployeeFilters.php
+++ b/src/Core/Search/Filters/Security/Session/EmployeeFilters.php
@@ -30,7 +30,7 @@ class EmployeeFilters extends Filters
             'limit' => 10,
             'offset' => 0,
             'orderBy' => 'id_employee_session',
-            'sortOrder' => 'asc',
+            'sortOrder' => 'desc',
             'filters' => [],
         ];
     }

--- a/tests/Unit/Core/Grid/Query/Security/Session/SessionGridDefaultSortingTest.php
+++ b/tests/Unit/Core/Grid/Query/Security/Session/SessionGridDefaultSortingTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Grid\Query\Security\Session;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicator;
+use PrestaShop\PrestaShop\Core\Grid\Query\Security\Session\CustomerQueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Query\Security\Session\EmployeeQueryBuilder;
+use PrestaShop\PrestaShop\Core\Search\Filters\Security\Session\CustomerFilters;
+use PrestaShop\PrestaShop\Core\Search\Filters\Security\Session\EmployeeFilters;
+
+/**
+ * Sessions are an append-only log: the most recent rows are the useful ones, so both
+ * session grids must land on the newest session first, like the Logs, E-mail logs and
+ * Orders grids already do.
+ */
+class SessionGridDefaultSortingTest extends TestCase
+{
+    private const DB_PREFIX = 'ps_';
+
+    public function testCustomerSessionGridIsSortedNewestFirstByDefault(): void
+    {
+        $queryBuilder = new CustomerQueryBuilder(
+            $this->getMockConnection(),
+            self::DB_PREFIX,
+            new DoctrineSearchCriteriaApplicator()
+        );
+
+        $qb = $queryBuilder->getSearchQueryBuilder(new CustomerFilters(CustomerFilters::getDefaults()));
+
+        $this->assertStringContainsString('ORDER BY id_customer_session desc', $qb->getSQL());
+    }
+
+    public function testEmployeeSessionGridIsSortedNewestFirstByDefault(): void
+    {
+        $queryBuilder = new EmployeeQueryBuilder(
+            $this->getMockConnection(),
+            self::DB_PREFIX,
+            new DoctrineSearchCriteriaApplicator()
+        );
+
+        $qb = $queryBuilder->getSearchQueryBuilder(new EmployeeFilters(EmployeeFilters::getDefaults()));
+
+        $this->assertStringContainsString('ORDER BY id_employee_session desc', $qb->getSQL());
+    }
+
+    private function getMockConnection(): Connection
+    {
+        $mock = $this->createMock(Connection::class);
+        $mock->method('getDatabasePlatform')->willReturn(new MySQLPlatform());
+        $mock->method('createQueryBuilder')->willReturnCallback(function () use (&$mock): QueryBuilder {
+            return new QueryBuilder($mock);
+        });
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Advanced Parameters > Security > Employee sessions` and `> Customer sessions` both default to their primary key **ascending**, so the page opens on the oldest sessions. On a shop with a few thousand rows those are the least useful ones, and the reporter has to re-sort on every visit. Both grids now default to the primary key descending, i.e. newest session first.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Have more than one row in `ps_employee_session` / `ps_customer_session` (log in from two browsers, or insert rows directly). 2. Go to `Advanced Parameters > Security`, open the `Employee sessions` tab, then the `Customer sessions` tab. 3. The highest ID is now on the first row instead of the last. 4. Clicking the `ID` or `Last update` column headers still re-sorts both ways. Note that a stored per-employee grid filter wins over the default, so an existing install that has already opened the page keeps its previous order until the filter is reset.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #30545
| Related PRs       | None
| Sponsor company   | None

### Why the primary key and not `date_upd`

`date_upd` carries no index on either table:

```
ps_customer_session: PRIMARY KEY (id_customer_session)                  -- no index on date_upd
ps_employee_session: PRIMARY KEY (id_employee_session), KEY (id_employee) -- no index on date_upd
```

The primary key is auto-increment, so it is monotonic with session creation and orders identically for this purpose, at no cost on a table the issue describes as holding several thousand rows. The `Last update` column stays sortable for anyone who wants recency-of-activity instead.

### Why this is an improvement rather than a new feature

The issue carries `Feature` / `Needs Specs` because it was reclassified on the day it was opened, on the grounds that the column is already clickable. This PR adds no option and no schema change: it only flips a default so the two session grids match the three sibling append-only grids that already ship this way.

| Grid | default `orderBy` | default `sortOrder` |
| ---- | ----------------- | ------------------- |
| `LogsFilters` | `id_log` | `desc` |
| `EmailLogsFilter` | `id_mail` | `desc` |
| `OrderFilters` | `id_order` | `DESC` |
| `Security\Session\EmployeeFilters` | `id_employee_session` | `asc` -> `desc` |
| `Security\Session\CustomerFilters` | `id_customer_session` | `asc` -> `desc` |

`CustomerThreadFilter` is deliberately left at `asc`: a support queue is worked oldest first.

### Test

`tests/Unit/Core/Grid/Query/Security/Session/SessionGridDefaultSortingTest.php` pushes the default filters through the real `DoctrineSearchCriteriaApplicator` and the two grid query builders and asserts the emitted SQL, so it fails if either the default or the applicator wiring regresses. Verified RED on `upstream/9.2.x` with the two filter classes reverted, GREEN with them.
