### PR TITLE
Let a module add its own message to the update confirmation

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/module-update-message.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/module-update-message.ts
@@ -1,0 +1,30 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * A module supplies its update confirmation as plain text, while the confirm modal
+ * renders its message as HTML, so the text has to be escaped on the way in.
+ */
+export const escapeHtml = (value: string): string => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;');
+
+/**
+ * Joins the core update advice with the messages the modules being updated supplied.
+ * Empty parts are dropped so a module without a message changes nothing.
+ */
+export const buildUpdateConfirmMessage = (...parts: string[]): string => parts
+  .filter((part: string) => part !== '')
+  .join('<br><br>');
+
+/**
+ * Formats one module's message for a list covering several modules at once.
+ */
+export const formatModuleUpdateMessage = (
+  moduleName: string,
+  message: string,
+): string => escapeHtml(`${moduleName}: ${message}`);

--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -4,6 +4,10 @@
  */
 import {EventEmitter} from 'events';
 import ConfirmModal from '@components/modal';
+import {
+  buildUpdateConfirmMessage,
+  escapeHtml,
+} from '@app/utils/module-update-message';
 import ComponentsMap from './components-map';
 
 const ModuleCardMap = ComponentsMap.moduleCard;
@@ -160,6 +164,7 @@ export default class ModuleCard {
       event.preventDefault();
       const modal = $(`#${$(this).data('confirm_modal')}`);
       const isMaintenanceMode = window.isShopMaintenance;
+      const moduleMessage = <string>$(this).data('confirm-message') || '';
 
       if (modal.length !== 1) {
         // Modal body element
@@ -180,9 +185,12 @@ export default class ModuleCard {
             confirmButtonClass: isMaintenanceMode
               ? 'btn-primary'
               : 'btn-secondary',
-            confirmMessage: isMaintenanceMode
-              ? ''
-              : window.moduleTranslations.moduleModalUpdateConfirmMessage,
+            confirmMessage: buildUpdateConfirmMessage(
+              isMaintenanceMode
+                ? ''
+                : window.moduleTranslations.moduleModalUpdateConfirmMessage,
+              escapeHtml(moduleMessage),
+            ),
             closable: true,
             customButtons: isMaintenanceMode ? [] : [maintenanceLink],
           },

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -4,6 +4,10 @@
  */
 
 import ConfirmModal from '@components/modal';
+import {
+  buildUpdateConfirmMessage,
+  formatModuleUpdateMessage,
+} from '@app/utils/module-update-message';
 
 const {$} = window;
 
@@ -876,7 +880,10 @@ class AdminModuleController {
             ? window.moduleTranslations.moduleModalUpdateUpgrade
             : window.moduleTranslations.upgradeAnywayButtonText,
           confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
-          confirmMessage: isMaintenanceMode ? '' : window.moduleTranslations.moduleModalUpdateConfirmMessage,
+          confirmMessage: buildUpdateConfirmMessage(
+            isMaintenanceMode ? '' : window.moduleTranslations.moduleModalUpdateConfirmMessage,
+            self.collectModuleUpdateMessages(),
+          ),
           closable: true,
           customButtons: isMaintenanceMode ? [] : [maintenanceLink],
         },
@@ -979,6 +986,28 @@ class AdminModuleController {
       // eslint-disable-next-line
       $(this.addonItemListSelector).toggle(modulesCount !== this.modulesList.length / 2);
     }
+  }
+
+  /**
+   * Collects the confirmation messages the modules about to be updated attached to their
+   * update button, so "Update all" warns about the same things a single update does.
+   */
+  collectModuleUpdateMessages() {
+    return $(this.upgradeAllTargets)
+      .map(function moduleUpdateMessage() {
+        const message = $(this).data('confirm-message');
+
+        if (!message) {
+          return null;
+        }
+
+        return formatModuleUpdateMessage(
+          $(this).closest('.module-item-list').data('name'),
+          message,
+        );
+      })
+      .get()
+      .join('<br>');
   }
 
   isModulesPage() {

--- a/admin-dev/themes/new-theme/tests/utils/module-update-message.spec.js
+++ b/admin-dev/themes/new-theme/tests/utils/module-update-message.spec.js
@@ -1,0 +1,62 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+import {expect} from 'chai';
+import {
+  buildUpdateConfirmMessage,
+  escapeHtml,
+  formatModuleUpdateMessage,
+} from '../../js/app/utils/module-update-message';
+
+describe('ModuleUpdateMessage', () => {
+  describe('escapeHtml', () => {
+    it('leaves plain text alone', () => {
+      expect(escapeHtml('Your settings will be reset.')).to.equal('Your settings will be reset.');
+    });
+
+    it('neutralises markup supplied by a module', () => {
+      expect(escapeHtml('<img src=x onerror="alert(1)">')).to.equal(
+        '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;',
+      );
+    });
+
+    it('escapes the ampersand before the entities it introduces', () => {
+      expect(escapeHtml('&lt;')).to.equal('&amp;lt;');
+    });
+  });
+
+  describe('buildUpdateConfirmMessage', () => {
+    it('keeps the core advice on its own when no module said anything', () => {
+      expect(buildUpdateConfirmMessage('Use maintenance mode.', '')).to.equal('Use maintenance mode.');
+    });
+
+    it('keeps the module message on its own in maintenance mode', () => {
+      expect(buildUpdateConfirmMessage('', 'Settings will be reset.')).to.equal('Settings will be reset.');
+    });
+
+    it('separates the two with a blank line', () => {
+      expect(buildUpdateConfirmMessage('Use maintenance mode.', 'Settings will be reset.')).to.equal(
+        'Use maintenance mode.<br><br>Settings will be reset.',
+      );
+    });
+
+    it('drops every empty part', () => {
+      expect(buildUpdateConfirmMessage('', '')).to.equal('');
+    });
+  });
+
+  describe('formatModuleUpdateMessage', () => {
+    it('prefixes the message with the module name', () => {
+      expect(formatModuleUpdateMessage('Dummy payment', 'Settings will be reset.')).to.equal(
+        'Dummy payment: Settings will be reset.',
+      );
+    });
+
+    it('escapes the module name as well as the message', () => {
+      expect(formatModuleUpdateMessage('<b>Dummy</b>', '<i>reset</i>')).to.equal(
+        '&lt;b&gt;Dummy&lt;/b&gt;: &lt;i&gt;reset&lt;/i&gt;',
+      );
+    });
+  });
+});

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -59,6 +59,11 @@ abstract class ModuleCore implements ModuleInterface
      */
     public $confirmUninstall = '';
 
+    /**
+     * @var string Text to display when ask for confirmation on update action
+     */
+    public $confirmUpgrade = '';
+
     /** @var string author of the module */
     public $author;
 

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -95,6 +95,7 @@ class Module implements ModuleInterface
         'nbRates' => 0,
         'fullDescription' => '',
         'confirmUninstall' => '',
+        'confirmUpgrade' => '',
     ];
 
     /**

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -35,6 +35,7 @@ class ModuleRepository implements ModuleRepositoryInterface
         'limited_countries',
         'need_instance',
         'confirmUninstall',
+        'confirmUpgrade',
     ];
 
     /** @var ModuleDataProvider */

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
@@ -10,7 +10,7 @@
 {% else %}
   {# For the 'upgrade' action, if an upload_url is provided, it is added as a data-upload-url attribute to allow file upload during module upgrade via JavaScript #}
   <form class="{{ classes_form|default() }}" method="post" action="{{ url }}" {% if action == 'upgrade' and upload_url is not empty %}data-upload-url="{{ upload_url }}"{% endif %}>
-    <button type="submit" class="{{ classes }} module_action_menu_{{ action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ action }}">
+    <button type="submit" class="{{ classes }} module_action_menu_{{ action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ action }}"{% if action == 'upgrade' and confirm_message is defined and confirm_message is not empty %} data-confirm-message="{{ confirm_message }}"{% endif %}>
       {{ label }}
     </button>
   </form>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -12,7 +12,8 @@
         url: module.attributes.urls[module.attributes.url_active],
         action: module.attributes.url_active,
         label: module.attributes.urls_labels[module.attributes.url_active],
-        upload_url: module.attributes.upload_url|default(null)},
+        upload_url: module.attributes.upload_url|default(null),
+        confirm_message: module.attributes.confirmUpgrade|default('')},
     ) }}
     {% if (module.attributes.urls|length > 1) %}
         <input type="hidden" class="btn" />
@@ -30,7 +31,8 @@
                         url: module_url,
                         action: module_action,
                         label: module.attributes.urls_labels[module_action],
-                        upload_url: module.attributes.upload_url|default(null)},
+                        upload_url: module.attributes.upload_url|default(null),
+                        confirm_message: module.attributes.confirmUpgrade|default('')},
                     ) }}
                 </li>
             {% endif %}

--- a/tests/Integration/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Integration/Core/Module/ModuleRepositoryTest.php
@@ -29,7 +29,17 @@ class ModuleRepositoryTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->moduleRepository = $this->buildModuleRepository(false);
+    }
+
+    /**
+     * @param bool $mainClassIsValid whether the module main classes can be instantiated, which is
+     *                               what decides if the repository reads the modules' own attributes
+     */
+    private function buildModuleRepository(bool $mainClassIsValid): ModuleRepository
+    {
         $mockModuleDataProvider = $this->createMock(ModuleDataProvider::class);
+        $mockModuleDataProvider->method('isModuleMainClassValid')->willReturn($mainClassIsValid);
         $mockModuleDataProvider->method('findByName')->willReturn([
             'installed' => 0,
             'active' => true,
@@ -76,7 +86,7 @@ class ModuleRepositoryTest extends TestCase
         /** @var CacheProvider $cacheProvider */
         $cacheProvider = DoctrineProvider::wrap(new ArrayAdapter());
 
-        $this->moduleRepository = new ModuleRepository(
+        return new ModuleRepository(
             $mockModuleDataProvider,
             $this->createMock(AdminModuleDataProvider::class),
             $cacheProvider,
@@ -116,5 +126,22 @@ class ModuleRepositoryTest extends TestCase
 
         $this->assertEquals('overridden full description', $dummy_module->get('fullDescription'));
         $this->assertEquals('added value', $dummy_module->get('testAttribute'));
+    }
+
+    public function testModuleAttributesCarryTheUpdateConfirmationMessage(): void
+    {
+        $moduleRepository = $this->buildModuleRepository(true);
+
+        $this->assertEquals(
+            'Your dummy payment settings will be reset by this update.',
+            $moduleRepository->getModule('dummy_payment')->get('confirmUpgrade')
+        );
+    }
+
+    public function testUpdateConfirmationMessageIsEmptyForAModuleThatSetsNone(): void
+    {
+        $moduleRepository = $this->buildModuleRepository(true);
+
+        $this->assertSame('', $moduleRepository->getModule('bankwire')->get('confirmUpgrade'));
     }
 }

--- a/tests/Resources/modules/dummy_payment/dummy_payment.php
+++ b/tests/Resources/modules/dummy_payment/dummy_payment.php
@@ -35,6 +35,7 @@ class Dummy_Payment extends PaymentModule
         parent::__construct();
 
         $this->displayName = 'Dummy payment';
+        $this->confirmUpgrade = 'Your dummy payment settings will be reset by this update.';
 
         $this->active = true;
     }

--- a/tests/Unit/PrestaShopBundle/Twig/Module/ActionButtonTemplateTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Module/ActionButtonTemplateTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig\Module;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+/**
+ * The update button carries the message its module attached to the update confirmation.
+ * The attribute has to stay out of the markup when the module supplied nothing, otherwise
+ * the front end cannot tell "no message" from "empty message".
+ */
+class ActionButtonTemplateTest extends TestCase
+{
+    private const TEMPLATE = 'action_button.html.twig';
+
+    private Environment $twig;
+
+    protected function setUp(): void
+    {
+        $this->twig = new Environment(new FilesystemLoader(
+            dirname(__DIR__, 5) . '/src/PrestaShopBundle/Resources/views/Admin/Module/Includes'
+        ));
+    }
+
+    public function testTheUpdateButtonCarriesTheModuleMessage(): void
+    {
+        $markup = $this->render('upgrade', 'Your settings will be reset.');
+
+        $this->assertStringContainsString(
+            'data-confirm-message="Your settings will be reset."',
+            $markup
+        );
+    }
+
+    public function testTheAttributeIsAbsentWhenTheModuleSuppliedNoMessage(): void
+    {
+        $this->assertStringNotContainsString('data-confirm-message', $this->render('upgrade', ''));
+    }
+
+    public function testTheAttributeIsAbsentWhenTheParameterIsNotPassedAtAll(): void
+    {
+        $markup = $this->twig->render(self::TEMPLATE, [
+            'action' => 'upgrade',
+            'name' => 'dummy_payment',
+            'url' => '/upgrade',
+            'label' => 'Update',
+            'classes' => 'btn',
+        ]);
+
+        $this->assertStringNotContainsString('data-confirm-message', $markup);
+    }
+
+    public function testOtherActionsNeverCarryTheAttribute(): void
+    {
+        foreach (['install', 'enable', 'disable', 'reset', 'uninstall'] as $action) {
+            $this->assertStringNotContainsString(
+                'data-confirm-message',
+                $this->render($action, 'Your settings will be reset.'),
+                sprintf('The "%s" action must not carry the update message.', $action)
+            );
+        }
+    }
+
+    public function testTheMessageIsEscapedIntoTheAttribute(): void
+    {
+        $markup = $this->render('upgrade', 'Read "the docs" & <b>stop</b>');
+
+        $this->assertStringContainsString(
+            'data-confirm-message="Read &quot;the docs&quot; &amp; &lt;b&gt;stop&lt;/b&gt;"',
+            $markup
+        );
+    }
+
+    private function render(string $action, string $confirmMessage): string
+    {
+        return $this->twig->render(self::TEMPLATE, [
+            'action' => $action,
+            'name' => 'dummy_payment',
+            'url' => '/module-action',
+            'label' => 'Action',
+            'classes' => 'btn',
+            'confirm_message' => $confirmMessage,
+        ]);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A module cannot warn the merchant before its own files are replaced. This adds `$confirmUpgrade`, the update counterpart of the `$confirmUninstall` property modules can already set, and shows it in the confirmation the Module Manager already displays before an update. Covers item 1 of the issue; item 2, the checksum verification, is not included, see below.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. In any module's constructor add `$this->confirmUpgrade = 'Your customisations to this module will be lost.';` and make an update available for it. 2. Module Manager, `Updates` tab, click `Update` on that module: the confirmation now shows the core advice and the module's sentence below it. 3. Click `Update all`: the same sentence appears, prefixed with the module's display name, alongside the messages of any other module being updated. 4. Repeat with a module that sets nothing: the confirmation is unchanged from before this PR, and its update button carries no `data-confirm-message` attribute at all.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #30628
| Related PRs       | None
| Sponsor company   | None

### How it is wired

The route already exists for the uninstall confirmation, so this reuses it rather than inventing one:

| Step | Uninstall (already shipped) | Update (this PR) |
| ---- | --------------------------- | ---------------- |
| module property | `Module::$confirmUninstall` | `Module::$confirmUpgrade` |
| copied off the instance | `ModuleRepository::MODULE_ATTRIBUTES` | same list |
| default in the attributes bag | `Adapter\Module\Module` | same array |
| reaches the page | rendered in `modal_confirm.html.twig` | `data-confirm-message` on the update button |

`ModuleRepository::getModuleAttributes()` reads the instantiated module rather than the cached `config.xml`, so no `config.xml` schema change is needed.

The confirmation itself is built in TypeScript, not Twig: `js/components/module-card.ts` for a single module and `js/pages/module/controller.js` for `Update all`. Both now append the module text to the core advice. A module that sets nothing produces no attribute, the join drops the empty part, and the modal is byte-for-byte what it was before.

`Update all` collects the messages of the modules it is about to update and prefixes each with the module name, so the warning cannot be skipped by using the bulk action instead of the per-module one.

### Escaping

Modules supply plain text, matching `$confirmUninstall`, but `ConfirmModal` assigns its message with `innerHTML`. The text is therefore escaped before being joined, in `js/app/utils/module-update-message.ts`, and the module name is escaped with it.

### What is not in this PR

Item 2 of the issue, verifying a checksum before updating, is left out on purpose. It needs a manifest format, tooling to produce it at release time, a decision on which files are in scope (vendor, translations, generated assets), and a policy for what a mismatch does. None of that is settled, whereas item 1 only had to fill a hole in a mechanism that already ships. Splitting them keeps this reviewable.

### Tests

- `tests/Unit/PrestaShopBundle/Twig/Module/ActionButtonTemplateTest.php` renders the button template directly: the attribute appears for `upgrade` with a message, is absent with an empty message, absent when the parameter is not passed, absent for every other action, and the message is escaped into the attribute. Removing the gate fails 3 of the 5.
- `tests/Integration/Core/Module/ModuleRepositoryTest.php` asserts the property reaches the module attributes, and that a module setting none reports an empty string. Both are RED on `develop`.
- `admin-dev/themes/new-theme/tests/utils/module-update-message.spec.js` covers the escaping and the joining, including the case where a module supplies markup. Dropping one replacement from the escaper fails 2 of the 9.
