### PR TITLE
Let an order be viewed when the shop rounds towards the next odd value

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -15,7 +15,6 @@ use OrderInvoice;
 use OrderReturn;
 use OrderSlip;
 use Pack;
-use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleHtmlAuthorizationChecker;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
@@ -33,6 +32,7 @@ use PrestaShopBundle\Entity\Repository\ShipmentRepository;
 use Product;
 use Shop;
 use StockAvailable;
+use Tools;
 
 /**
  * Handles GetOrderProductsForViewing query using legacy object models
@@ -146,10 +146,18 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 $product['unit_price_tax_incl']
             ;
 
-            // if rounding type is set to "per item" we must round the unit price now, otherwise values won't match
-            // the totals in the order summary
+            /*
+             * If rounding type is set to "per item" we must round the unit price now, otherwise values
+             * won't match the totals in the order summary.
+             *
+             * WHY Tools::ps_round and not DecimalNumber::round: the shop offers six rounding modes and
+             * the decimal library implements five of them - it has no half-odd - so asking the converter
+             * for the sixth threw "Cannot map round mode 5" and no order could be opened at all on a shop
+             * set to "Round towards the next odd value". ps_round reads PS_PRICE_ROUND_MODE itself, covers
+             * all six, and is what computed these amounts in the first place.
+             */
             if ((int) $order->round_type === Order::ROUND_ITEM) {
-                $unitPrice = (new DecimalNumber((string) $unitPrice))->round($precision, $this->getNumberRoundMode());
+                $unitPrice = Tools::ps_round((float) $unitPrice, $precision);
             }
 
             $totalPrice = $unitPrice * $product['product_quantity'];
@@ -229,8 +237,8 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 $totalPriceFormatted,
                 $product['current_stock'],
                 $imagePath,
-                (new DecimalNumber((string) $product['unit_price_tax_excl']))->round($precision, $this->getNumberRoundMode()),
-                (new DecimalNumber((string) $product['unit_price_tax_incl']))->round($precision, $this->getNumberRoundMode()),
+                (string) Tools::ps_round((float) $product['unit_price_tax_excl'], $precision),
+                (string) Tools::ps_round((float) $product['unit_price_tax_incl'], $precision),
                 (string) $product['tax_rate'],
                 $this->locale->formatPrice($product['amount_refunded'], $currency->iso_code),
                 $product['product_quantity_refunded'] + $product['product_quantity_return'],

--- a/tests/Integration/Adapter/Order/QueryHandler/GetOrderProductsForViewingRoundModeTest.php
+++ b/tests/Integration/Adapter/Order/QueryHandler/GetOrderProductsForViewingRoundModeTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Order\QueryHandler;
+
+use Configuration;
+use Context;
+use Currency;
+use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderProductsForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductsForViewing;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The back office offers six rounding modes; the decimal library implements five of them and has no
+ * half-odd. Mapping the shop's mode to one of the library's threw for the sixth, so a shop set to
+ * "Round towards the next odd value" could not open any order at all.
+ */
+class GetOrderProductsForViewingRoundModeTest extends KernelTestCase
+{
+    private const ORDER_ID = 1;
+
+    /** @var int */
+    private $originalRoundMode;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $context = Context::getContext();
+        $context->container = self::getContainer();
+        // Price computation reads the rounding precision off the context currency; without it
+        // ComputingPrecision::getPrecision() is handed null.
+        $context->currency = new Currency(Currency::getDefaultCurrencyId());
+
+        $this->originalRoundMode = (int) Configuration::get('PS_PRICE_ROUND_MODE');
+    }
+
+    protected function tearDown(): void
+    {
+        Configuration::updateValue('PS_PRICE_ROUND_MODE', $this->originalRoundMode);
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider provideEveryRoundModeOfferedInTheBackOffice
+     */
+    public function testAnOrderCanBeViewedWhateverRoundModeTheShopUses(int $roundMode, string $label): void
+    {
+        Configuration::updateValue('PS_PRICE_ROUND_MODE', $roundMode);
+
+        $products = self::getContainer()
+            ->get('prestashop.core.query_bus')
+            ->handle(GetOrderProductsForViewing::all(self::ORDER_ID));
+
+        $this->assertInstanceOf(
+            OrderProductsForViewing::class,
+            $products,
+            sprintf('an order must be viewable with the round mode "%s"', $label)
+        );
+    }
+
+    /**
+     * The six choices of PreferencesType::price_round_mode, in the order the back office lists them.
+     */
+    public static function provideEveryRoundModeOfferedInTheBackOffice(): iterable
+    {
+        yield 'R1 round up away from zero' => [PS_ROUND_HALF_UP, 'Round up away from zero, when it is half way there'];
+        yield 'R2 round down towards zero' => [PS_ROUND_HALF_DOWN, 'Round down towards zero, when it is half way there'];
+        yield 'R3 round towards the next even value' => [PS_ROUND_HALF_EVEN, 'Round towards the next even value'];
+        yield 'R4 round towards the next odd value' => [PS_ROUND_HALF_ODD, 'Round towards the next odd value'];
+        yield 'R5 round up to the nearest value' => [PS_ROUND_UP, 'Round up to the nearest value'];
+        yield 'R6 round down to the nearest value' => [PS_ROUND_DOWN, 'Round down to the nearest value'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The back office offers six rounding modes under Shop Parameters > General; `PrestaShop\Decimal`'s `Rounding` implements five of them and has no half-odd. `Adapter\Number\RoundModeConverter` omits `PS_ROUND_HALF_ODD` from its map and throws `CoreException: Cannot map round mode 5`, and `GetOrderProductsForViewingHandler` asks for that mapping unconditionally while building an order's product list. A shop set to "Round towards the next odd value" therefore cannot open any order at all. Rounding those prices with `Tools::ps_round()` covers all six modes and is what computed the amounts in the first place.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shop Parameters > General > Round mode, choose "Round towards the next odd value". Open any order in Orders. Before: the page fails with `Cannot map round mode 5`. After: the order opens and the unit prices are rounded half-odd. The other five modes are unchanged.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #30441, Fixes #32284
| Related PRs       |
| Sponsor company   |

### Verification

- `tests/Integration/Adapter/Order/QueryHandler/GetOrderProductsForViewingRoundModeTest.php` is new: one
  case per back office choice, six in total. **On upstream `9.2.x` exactly the R4 case errors** with
  `PrestaShop\PrestaShop\Adapter\CoreException: Cannot map round mode 5`; the other five pass either way,
  so they are the control that the change does not alter the modes that already worked.
- Revert verified: `git checkout upstream/9.2.x -- <handler>` puts the `Tools::ps_round` count back to 0
  and the RED run was taken in that state; restoring returns it to 4.
- php-cs-fixer clean, PHPStan `[OK] No errors`.

### Notes

- `AbstractOrderHandler::getNumberRoundMode()` now has no callers. Left in place rather than removed: it is
  `protected` on a class module code can extend, so deleting it belongs in a major.
- `Adapter/RoundingMapper` is dead code with the same blind spot - it maps half-odd to half-even with the
  comment "does not exist (never used)". Not touched here; worth deleting or fixing separately.
- The measured rounding tables for all six modes, and the mapping from the back office R numbering to the
  constants, are on #32284 and #32356.
