### PR TITLE
Keep the conditions of a catalog price rule when it is edited

### DIFF
--- a/src/Adapter/CatalogPriceRule/CommandHandler/EditCatalogPriceRuleHandler.php
+++ b/src/Adapter/CatalogPriceRule/CommandHandler/EditCatalogPriceRuleHandler.php
@@ -39,7 +39,12 @@ final class EditCatalogPriceRuleHandler extends AbstractCatalogPriceRuleHandler 
             if (false === $specificPriceRule->update()) {
                 throw new CannotUpdateCatalogPriceRuleException(sprintf('Failed to update specific price rule with id %s', $specificPriceRule->id));
             }
-            $specificPriceRule->deleteConditions();
+            /*
+             * WHY the conditions are not touched: EditCatalogPriceRuleCommand carries no conditions, so
+             * a caller has no way to ask for them to be removed. Deleting them here dropped the scope of
+             * every rule the moment anything else about it was saved, and apply() then rebuilt the
+             * specific prices for the whole catalogue instead of the products the rule was aimed at.
+             */
             $specificPriceRule->apply();
         } catch (PrestaShopException $e) {
             throw new CatalogPriceRuleException(sprintf('An unexpected error occurred when editing specific price rule with id %s', $command->getCatalogPriceRuleId()->getValue()), 0, $e);

--- a/tests/Integration/Behaviour/Features/Context/Domain/CatalogPriceRuleContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CatalogPriceRuleContext.php
@@ -17,6 +17,8 @@ use Language;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\AddCatalogPriceRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\DeleteCatalogPriceRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\EditCatalogPriceRuleCommand;
 use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Exception\CatalogPriceRuleException;
 use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Query\GetCatalogPriceRuleForEditing;
 use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Query\GetCatalogPriceRuleListForProduct;
@@ -53,6 +55,53 @@ class CatalogPriceRuleContext extends AbstractDomainFeatureContext
 
             $this->getSharedStorage()->set($catalogPriceRuleReference, $catalogPriceRuleId->getValue());
         } catch (CatalogPriceRuleException|DomainConstraintException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I edit catalog price rule :catalogPriceRuleReference with following details:
+     *
+     * @param string $catalogPriceRuleReference
+     * @param TableNode $tableNode
+     */
+    public function editCatalogPriceRule(string $catalogPriceRuleReference, TableNode $tableNode): void
+    {
+        $command = new EditCatalogPriceRuleCommand($this->getSharedStorage()->get($catalogPriceRuleReference));
+        $data = $tableNode->getRowsHash();
+
+        if (isset($data['name'])) {
+            $command->setName($data['name']);
+        }
+        if (isset($data['from quantity'])) {
+            $command->setFromQuantity((int) $data['from quantity']);
+        }
+        if (isset($data['price'])) {
+            $command->setPrice((float) $data['price']);
+        }
+        if (isset($data['reduction type'], $data['reduction value'])) {
+            $command->setReduction($data['reduction type'], $data['reduction value']);
+        }
+
+        try {
+            $this->getCommandBus()->handle($command);
+        } catch (CatalogPriceRuleException|DomainConstraintException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I delete catalog price rule :catalogPriceRuleReference
+     *
+     * @param string $catalogPriceRuleReference
+     */
+    public function deleteCatalogPriceRule(string $catalogPriceRuleReference): void
+    {
+        try {
+            $this->getCommandBus()->handle(
+                new DeleteCatalogPriceRuleCommand($this->getSharedStorage()->get($catalogPriceRuleReference))
+            );
+        } catch (CatalogPriceRuleException $e) {
             $this->setLastException($e);
         }
     }

--- a/tests/Integration/Behaviour/Features/Scenario/CatalogPriceRule/catalog_price_rule_conditions_survive_edit.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CatalogPriceRule/catalog_price_rule_conditions_survive_edit.feature
@@ -1,0 +1,56 @@
+#./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s catalog_price_rule --tags catalog-price-rule-edit-conditions
+@restore-all-tables-before-feature
+@restore-products-before-feature
+@clear-cache-before-feature
+@catalog-price-rule
+@catalog-price-rule-edit-conditions
+
+Feature: Keep the conditions of a catalog price rule when it is edited in Back Office (BO)
+  As an employee
+  I need a catalog price rule to stay scoped to what I scoped it to when I edit anything else about it
+
+  Background:
+    Given language with iso code "en" is the default one
+    And shop "testShop" with name "test_shop" exists
+    And there is a currency named "usd" with iso code "USD" and exchange rate of 0.92
+    And country "UnitedStates" with iso code "US" exists
+    And group "visitor" named "Visitor" exists
+    And category "home" in default language named "Home" exists
+    And category "home" is the default one
+    And category "women" in default language named "Women" exists
+
+  Scenario: Renaming a rule does not widen it to the whole catalogue
+    Given I add product "inWomen" with following information:
+      | name[en-US] | dress    |
+      | type        | standard |
+    And I add product "outsideWomen" with following information:
+      | name[en-US] | mug      |
+      | type        | standard |
+    And I add catalog price rule "scopedRule" with following details:
+      | name            | scoped rule  |
+      | currency        | usd          |
+      | country         | UnitedStates |
+      | group           | visitor      |
+      | from quantity   | 1            |
+      | reduction type  | amount       |
+      | reduction value | 10           |
+      | shop            | testShop     |
+      | includes tax    | true         |
+      | price           | 50           |
+    And I add following conditions to catalog price rule "scopedRule":
+      | type     | value |
+      | category | women |
+    And I assign product inWomen to following categories:
+      | categories       | [home, women] |
+      | default category | women         |
+    Then I should be able to see following list of catalog price rules with language "en" with limit 50 offset 0 and total 1 and product "inWomen":
+      | name        | currency | country      | group   | from quantity | reduction type | reduction value | shop     | includes tax | price | from                | to                  |
+      | scoped rule | usd      | UnitedStates | visitor | 1             | amount         | 10              | testShop | true         | 50    | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+    And "outsideWomen" should have no catalog price rules with language "en"
+    When I edit catalog price rule "scopedRule" with following details:
+      | name | scoped rule renamed |
+    Then I should be able to see following list of catalog price rules with language "en" with limit 50 offset 0 and total 1 and product "inWomen":
+      | name                | currency | country      | group   | from quantity | reduction type | reduction value | shop     | includes tax | price | from                | to                  |
+      | scoped rule renamed | usd      | UnitedStates | visitor | 1             | amount         | 10              | testShop | true         | 50    | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+    And "outsideWomen" should have no catalog price rules with language "en"
+    And I delete catalog price rule "scopedRule"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `EditCatalogPriceRuleHandler::handle()` calls `$specificPriceRule->deleteConditions()` on every edit. `EditCatalogPriceRuleCommand` carries no conditions, so nothing in the request asks for that, and `apply()` then rebuilds the specific prices for the whole catalogue instead of the products the rule was scoped to. A rule restricted to one category, manufacturer, supplier, attribute or feature loses that restriction the first time a merchant saves anything about it - changing only the name is enough - and starts discounting the entire shop. The conditions are only reachable through the legacy screen, which `_legacy_link` redirects away, so a shop upgraded from 1.7 or 8 carries rules the migrated form cannot show and silently widens.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop upgraded from 1.7 or 8 that has a catalog price rule with a condition group, or after inserting one with `SpecificPriceRule::addConditions()`, check which products the rule prices (`ps_specific_price` rows with that `id_specific_price_rule`). Open the rule in Catalog > Discounts > Catalog price rules, change only its name and save. Before: the condition groups are gone from `ps_specific_price_rule_condition_group` and the rule now prices every product. After: the conditions are untouched and the rule still prices only the products it was scoped to.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | #36813
| Related PRs       |
| Sponsor company   |

### Why the cell is a bare `#36813` and not `Fixes #36813`

#36813 is the EPIC for migrating the catalog price rule screens, and its remaining scope in the #33135
checklist is "Add/Edit catalog price rule - Condition Group", i.e. building the conditions block in the
Symfony form. This branch does not do that. It stops the data loss the missing block causes.

### How this was found

The epic is an empty placeholder, so the scope came from the parent checklist #33135. Measuring what is
actually missing on `9.2.x`:

- `CatalogPriceRuleType` builds name, currency, country, group, from quantity, price, leave initial price,
  date range, reduction and shop. No conditions.
- `AdminSpecificPriceRuleController` still parses `condition_group_N` and calls
  `SpecificPriceRule::addConditions()`, but `routing/admin/sell/catalog/catalog_price_rule.yml` maps
  **every** legacy action away - `addspecific_price_rule`, `updatespecific_price_rule`,
  `deletespecific_price_rule`, the filter and the bulk delete. The legacy form is unreachable.
- The engine is intact: `SpecificPriceRule::getConditions()` and `apply()` still filter by category,
  manufacturer, supplier, attribute and feature. Only the write path throws the scope away.

### Verification

- `tests/Integration/Behaviour/Features/Scenario/CatalogPriceRule/catalog_price_rule_conditions_survive_edit.feature`
  is new. A rule scoped to the "Women" category prices a product in that category and not one outside it;
  after an edit that changes only the name, the outside product is priced too.
  **Fails on upstream `9.2.x`** with `Failed asserting that 1 matches expected 0` on
  `"outsideWomen" should have no catalog price rules`.
- Revert verified: `git checkout upstream/9.2.x -- <handler>` puts the `deleteConditions` grep count back
  to 1, and the RED run was taken in that state; `git checkout HEAD -- <handler>` returned it to 0.
- Whole `catalog_price_rule` suite: **9 scenarios, 172 steps, all green** with the fix; on base the same
  run is 8 passed / 1 failed, so the eight pre-existing scenarios are unaffected either way.
- php-cs-fixer: 0 of 2 files to fix. PHPStan: `[OK] No errors`.

### Two Behat steps added, because the edit handler had no test at all

`EditCatalogPriceRuleCommand` appears nowhere under `tests/` on `9.2.x`. The branch adds
`I edit catalog price rule :ref with following details:` and `I delete catalog price rule :ref` to
`CatalogPriceRuleContext`. The delete step is what keeps the new feature from leaking a rule into the
listing feature's absolute counts.

### Local environment note, not part of the diff

The `catalog_price_rule` suite could not run in this environment before this work: the Behat database had
no demo categories, so `category "women" ... exists` failed on all eight existing scenarios. It was
rebuilt from the live 9.2 database, with the shop renamed to `test_shop` and the employee to
`test@prestashop.com`, which is what the suite's `BeforeSuite` hook expects.

### Notes for reviewers

- A standalone bug report would be the natural home for this, since the data loss is independent of the
  migration epic. Filing one is held with the rest of the issue hold; until then the finding lives in the
  comment https://github.com/PrestaShop/PrestaShop/issues/36813#issuecomment-5571592639

