### PR TITLE
Add actionBackOfficeLoginCheck to let a module refuse a back office login attempt

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4788,6 +4788,11 @@
       <title>Modify back office login options form content</title>
       <description>This hook allows to modify back office login options form FormBuilder</description>
     </hook>
+    <hook id="actionBackOfficeLoginCheck">
+      <name>actionBackOfficeLoginCheck</name>
+      <title>Check a back office login attempt before the employee is authenticated</title>
+      <description>This hook allows to refuse a back office login attempt, for instance after checking a captcha added through actionBackOfficeLoginForm. Return false to refuse the attempt; returning anything else, including null, lets it continue.</description>
+    </hook>
     <hook id="actionEmployeeRequestPasswordResetForm">
       <name>actionEmployeeRequestPasswordResetForm</name>
       <title>Modify employee request password reset options form content</title>

--- a/src/Adapter/Hook/HookResultsProvider.php
+++ b/src/Adapter/Hook/HookResultsProvider.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Hook;
+
+use Hook;
+use PrestaShop\PrestaShop\Core\Hook\HookResultsProviderInterface;
+
+final class HookResultsProvider implements HookResultsProviderInterface
+{
+    public function getResults(string $hookName, array $parameters = []): array
+    {
+        /*
+         * WHY the legacy Hook::exec rather than HookManager: HookManager only forwards $array_return
+         * when Symfony is not booted; under the kernel it goes through
+         * HookDispatcher::dispatchRendering(), which flattens every return with
+         * `empty($partialContent) ? '' : current($partialContent)` and so turns a false into an empty
+         * string. This is the adapter that keeps the values intact.
+         *
+         * WHY nothing is caught here: HookManager swallows a module exception and returns nothing, which
+         * for a hook that answers "may this happen?" means the answer silently becomes yes. Letting it
+         * bubble keeps a broken module visible instead of quietly permissive.
+         */
+        $results = Hook::exec($hookName, $parameters, null, true);
+
+        return is_array($results) ? $results : [];
+    }
+}

--- a/src/Core/Hook/HookResultsProviderInterface.php
+++ b/src/Core/Hook/HookResultsProviderInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Hook;
+
+/**
+ * Executes a hook and hands back what every listening module returned.
+ *
+ * HookDispatcherInterface renders hooks: it flattens each module return into a string, so a hook whose
+ * contract is a decision rather than a display - "may this happen?" - cannot be dispatched through it.
+ * This interface exists for that second kind of hook.
+ */
+interface HookResultsProviderInterface
+{
+    /**
+     * @param array<string, mixed> $parameters
+     *
+     * @return array<string, mixed> the value each module returned, keyed by module name
+     */
+    public function getResults(string $hookName, array $parameters = []): array;
+}

--- a/src/PrestaShopBundle/Controller/Admin/LoginController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LoginController.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Throwable;
@@ -69,7 +70,29 @@ class LoginController extends PrestaShopAdminController
         $loginForm = $loginFormHandler->getForm();
         $requestPasswordResetForm = $requestResetPasswordFormHandler->getForm();
 
-        if ($authenticationUtils->getLastAuthenticationError() instanceof AuthenticationException) {
+        $lastAuthenticationError = $authenticationUtils->getLastAuthenticationError();
+        if ($lastAuthenticationError instanceof CustomUserMessageAuthenticationException) {
+            /*
+             * WHY this branch: nothing in core throws this exception, so the only thing that reaches it
+             * is a module deliberately refusing the attempt through actionBackOfficeLoginCheck. Such a
+             * refusal has a reason of its own - a failed captcha, a blocked IP - and answering it with
+             * the credentials message would tell the employee their password is wrong when it is not.
+             * Every other authentication failure keeps the generic message, so a real credentials error
+             * still reveals nothing about whether the employee exists.
+             */
+            $this->addFlash('error', $this->trans(
+                $lastAuthenticationError->getMessageKey(),
+                /*
+                 * WHY the filter: the message data comes from a module and reaches the translator, which
+                 * interpolates it with strtr. A non-scalar value there raises "Array to string
+                 * conversion" or "Object of class X could not be converted to string" while the login
+                 * page renders, so a module mistake would turn a refused attempt into a 500 on the login
+                 * screen. Dropping those leaves the placeholder untouched in the message instead.
+                 */
+                array_filter($lastAuthenticationError->getMessageData(), 'is_scalar'),
+                'Admin.Login.Notification'
+            ));
+        } elseif ($lastAuthenticationError instanceof AuthenticationException) {
             $this->addFlash('error', $this->trans('The employee does not exist, or the password provided is incorrect.', [], 'Admin.Login.Notification'));
         }
 

--- a/src/PrestaShopBundle/EventSubscriber/BackOfficeLoginCheckSubscriber.php
+++ b/src/PrestaShopBundle/EventSubscriber/BackOfficeLoginCheckSubscriber.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\EventSubscriber;
+
+use PrestaShop\PrestaShop\Core\Hook\HookResultsProviderInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+
+/**
+ * Lets a module refuse a back office login attempt, which is what a captcha or an IP filter needs and
+ * what the front office has had for years through validateCustomerFormFields and
+ * actionSubmitAccountBefore. The employee side lost its equivalent when the legacy login controller and
+ * its actionAdminLoginControllerLoginBefore hook were removed in 9.0.
+ *
+ * The form itself is already extensible - the login form handler dispatches actionBackOfficeLoginForm
+ * when it builds the form, so a module can add its own field. What was missing is the other half:
+ * somewhere to check that field before the employee is authenticated.
+ */
+class BackOfficeLoginCheckSubscriber implements EventSubscriberInterface
+{
+    public const HOOK_NAME = 'actionBackOfficeLoginCheck';
+
+    /**
+     * WHY this exact number: the listeners already registered on the firewall dispatcher for this event
+     * are UserProviderListener (2048 and 1024), CsrfProtectionListener (512), UserCheckerListener (256)
+     * and CheckCredentialsListener (0). Running above all of them means the hook is consulted on every
+     * attempt - including one whose email matches no employee, which is precisely the case a captcha
+     * has to cover - and that no password is ever compared for an attempt a module refuses. Sharing a
+     * priority with a core listener would leave the order to registration order, so this deliberately
+     * does not reuse 2048.
+     */
+    private const PRIORITY = 4096;
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly HookResultsProviderInterface $hookResultsProvider,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CheckPassportEvent::class => ['onCheckPassport', self::PRIORITY],
+        ];
+    }
+
+    public function onCheckPassport(CheckPassportEvent $event): void
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return;
+        }
+
+        $results = $this->hookResultsProvider->getResults(self::HOOK_NAME, [
+            /*
+             * WHY no password: a module deciding whether an attempt may proceed has no business reading
+             * it, and the removed actionAdminLoginControllerLoginBefore handing it to every listening
+             * module was a liability, not a feature to restore.
+             */
+            'email' => $event->getPassport()->getBadge(UserBadge::class)?->getUserIdentifier() ?? '',
+            'request' => $request,
+        ]);
+
+        foreach ($results as $result) {
+            /*
+             * WHY only an explicit false: a module listening in order to observe returns null, and
+             * treating that as a veto would lock every employee out the moment such a module is
+             * installed.
+             */
+            if (false === $result) {
+                throw new CustomUserMessageAuthenticationException(
+                    'Your login attempt was refused. Please try again.'
+                );
+            }
+        }
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/hook.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/hook.yml
@@ -26,6 +26,11 @@ services:
     autowire: true
     autoconfigure: true
 
+  PrestaShop\PrestaShop\Adapter\Hook\HookResultsProvider: ~
+
+  PrestaShop\PrestaShop\Core\Hook\HookResultsProviderInterface:
+    alias: PrestaShop\PrestaShop\Adapter\Hook\HookResultsProvider
+
   PrestaShop\PrestaShop\Adapter\HookManager: ~
 
   prestashop.adapter.hook.manager:

--- a/tests/Unit/PrestaShopBundle/EventSubscriber/BackOfficeLoginCheckSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventSubscriber/BackOfficeLoginCheckSubscriberTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Hook\HookResultsProviderInterface;
+use PrestaShopBundle\EventSubscriber\BackOfficeLoginCheckSubscriber;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+
+class BackOfficeLoginCheckSubscriberTest extends TestCase
+{
+    public function testItListensOnTheEventThatPrecedesTheCredentialCheck(): void
+    {
+        $events = BackOfficeLoginCheckSubscriber::getSubscribedEvents();
+
+        $this->assertArrayHasKey(CheckPassportEvent::class, $events);
+        $this->assertSame('onCheckPassport', $events[CheckPassportEvent::class][0]);
+    }
+
+    public function testItOutranksEveryCoreListenerOfThatEvent(): void
+    {
+        // Measured on the admin firewall dispatcher: UserProviderListener 2048 and 1024,
+        // CsrfProtectionListener 512, UserCheckerListener 256, CheckCredentialsListener 0. Running above
+        // all of them is what makes the hook reachable for an email matching no employee, which is the
+        // case a captcha has to cover, and what keeps a refused attempt from reaching the password
+        // comparison.
+        $priority = BackOfficeLoginCheckSubscriber::getSubscribedEvents()[CheckPassportEvent::class][1];
+
+        $this->assertGreaterThan(2048, $priority);
+    }
+
+    public function testAModuleReturningFalseRefusesTheAttempt(): void
+    {
+        $subscriber = $this->createSubscriber(['securitymodule' => false]);
+
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+
+        $subscriber->onCheckPassport($this->createEvent());
+    }
+
+    public function testOneModuleRefusingIsEnoughEvenWhenTheOthersAgree(): void
+    {
+        $subscriber = $this->createSubscriber([
+            'observer' => null,
+            'securitymodule' => false,
+            'another' => true,
+        ]);
+
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+
+        $subscriber->onCheckPassport($this->createEvent());
+    }
+
+    /**
+     * @dataProvider provideResultsThatDoNotRefuse
+     */
+    public function testOnlyAnExplicitFalseRefuses(mixed $moduleResult): void
+    {
+        // A module listening in order to observe returns null, and the legacy hook layer answers with an
+        // empty string for a module that returns nothing. Treating any of those as a veto would lock
+        // every employee out the moment such a module is installed.
+        $subscriber = $this->createSubscriber(['observer' => $moduleResult]);
+
+        $subscriber->onCheckPassport($this->createEvent());
+
+        $this->addToAssertionCount(1);
+    }
+
+    public static function provideResultsThatDoNotRefuse(): iterable
+    {
+        yield 'a module that only observes' => [null];
+        yield 'a module that explicitly agrees' => [true];
+        yield 'a module that rendered nothing' => [''];
+        yield 'a falsy value that is not false' => [0];
+        yield 'the string a template would produce' => ['0'];
+    }
+
+    public function testNoModuleListeningLetsTheLoginContinue(): void
+    {
+        $subscriber = $this->createSubscriber([]);
+
+        $subscriber->onCheckPassport($this->createEvent());
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testTheHookIsNotEvenRunOutsideARequest(): void
+    {
+        $provider = $this->createMock(HookResultsProviderInterface::class);
+        $provider->expects($this->never())->method('getResults');
+
+        $subscriber = new BackOfficeLoginCheckSubscriber(new RequestStack(), $provider);
+
+        $subscriber->onCheckPassport($this->createEvent());
+    }
+
+    public function testTheHookReceivesTheSubmittedEmailAndTheRequest(): void
+    {
+        $request = new Request();
+        $stack = new RequestStack();
+        $stack->push($request);
+
+        $provider = $this->createMock(HookResultsProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('getResults')
+            ->with(
+                BackOfficeLoginCheckSubscriber::HOOK_NAME,
+                // The password is deliberately absent: a module deciding whether an attempt may proceed
+                // has no business reading it.
+                ['email' => 'employee@example.com', 'request' => $request]
+            )
+            ->willReturn([]);
+
+        (new BackOfficeLoginCheckSubscriber($stack, $provider))->onCheckPassport($this->createEvent());
+    }
+
+    public function testTheHookIsDeclaredSoItAppearsInTheBackOfficeHookList(): void
+    {
+        $hookXml = (string) file_get_contents(__DIR__ . '/../../../../install-dev/data/xml/hook.xml');
+
+        $this->assertStringContainsString(
+            '<name>' . BackOfficeLoginCheckSubscriber::HOOK_NAME . '</name>',
+            $hookXml,
+            'an undeclared hook still works but never shows up in the back office hook list'
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $hookResults
+     */
+    private function createSubscriber(array $hookResults): BackOfficeLoginCheckSubscriber
+    {
+        $stack = new RequestStack();
+        $stack->push(new Request());
+
+        $provider = $this->createMock(HookResultsProviderInterface::class);
+        $provider->method('getResults')->willReturn($hookResults);
+
+        return new BackOfficeLoginCheckSubscriber($stack, $provider);
+    }
+
+    private function createEvent(): CheckPassportEvent
+    {
+        return new CheckPassportEvent(
+            $this->createMock(AuthenticatorInterface::class),
+            new SelfValidatingPassport(new UserBadge('employee@example.com'))
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The back office login form is already extensible - `prestashop.admin.login.form_handler` is a `Core\Form\Handler` built with the hook name `BackOfficeLogin`, so `Handler::getForm()` dispatches `actionBackOfficeLoginForm`, and `displayAdminLogin` renders in the login layout. A module can therefore add a captcha field today. What it cannot do is act on that field: `actionAdminLoginControllerLoginBefore` disappeared with the legacy login controllers in 5988bbb206e (2024-06-11), and `LoginController::loginAction()` only renders the page - Symfony Security owns the submission. This adds the missing half, a hook that can refuse an attempt before the employee is authenticated.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Write a throwaway module with `hookActionBackOfficeLoginCheck()` returning `false` and register it on `actionBackOfficeLoginCheck`. Submit the back office login form with any email and password. Before: the attempt proceeds normally. After: the attempt is refused, the page returns to the login screen with no session, and the alert reads the module's own message rather than the credentials error. Change the module to return `null` and the login behaves exactly as before the patch.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #36944
| Related PRs       |
| Sponsor company   |

### Why a new hook name and not the old one

`actionAdminLoginControllerLoginBefore` passed `['controller' => $this, 'password' => $passwd, 'email' => $email]`.
There is no controller to pass any more, so reusing the name would hand modules a hook that looks
compatible and is not. `actionBackOfficeLoginCheck` sits in the same family as the
`actionBackOfficeLoginForm` hook that already fires, which is where a module adds the field this hook
then checks.

The password is deliberately not among the parameters. A module deciding whether an attempt may proceed
has no business reading it, and handing it to every listening module was a liability of the old hook, not
a feature worth restoring. The parameters are `email` (the submitted identifier, taken from the passport's
`UserBadge`) and `request`.

### Why CheckPassportEvent, at priority 4096

Measured on the admin firewall dispatcher (`security.event_dispatcher.main`), the listeners on that event
are `UserProviderListener` 2048 and 1024, `CsrfProtectionListener` 512, `UserCheckerListener` 256 and
`CheckCredentialsListener` 0. Running above all of them buys two things:

- the hook is consulted even when the submitted email matches no employee, which is precisely the case a
  captcha has to cover - a lower priority would let `UserCheckerListener` resolve the user first and abort
  with `UserNotFoundException` before the module is ever asked;
- no password is compared for an attempt a module refuses.

4096 rather than 2048 so the position is not decided by registration order. The subscriber needs no
service configuration: `event_subscriber.yml` auto-registers
`src/PrestaShopBundle/EventSubscriber/*` with `autoconfigure: true`, and Symfony's
`RegisterGlobalSecurityEventListenersPass` copies a globally tagged listener of `CheckPassportEvent` onto
every firewall dispatcher (that event is in its `EVENT_BUBBLING_EVENTS` list). Confirmed with
`debug:event-dispatcher --dispatcher=security.event_dispatcher.main`: the subscriber is listener #1.

### Why a new HookResultsProviderInterface

The veto is carried by what the modules return, and those values cannot travel through
`HookDispatcherInterface`. `HookDispatcher::dispatchRendering()` flattens every module return with
`empty($partialContent) ? '' : current($partialContent)`, so a `false` arrives as `''`.
`Adapter\HookManager::exec()` forwards `$array_return` only when Symfony is not booted; under the kernel
it routes to that same rendering call, so it cannot carry a decision either. PHPStan additionally forbids
calling the legacy `Hook` class from inside `PrestaShopBundle` and tells you to add an interface and an
adapter, which is what this does: `Core\Hook\HookResultsProviderInterface` plus
`Adapter\Hook\HookResultsProvider`. The adapter deliberately does not swallow module exceptions the way
`HookManager` does - for a hook that answers "may this happen?", a swallowed error silently becomes a yes.

### Why only an explicit false refuses

`null`, `true`, `''` and `0` all let the attempt continue. A module that listens in order to observe
returns `null`, and treating that as a veto would lock every employee out of the back office the moment
such a module is installed.

### Why LoginController changed

`loginAction()` answered every `AuthenticationException` with "The employee does not exist, or the password
provided is incorrect.", so a veto's own message was swallowed and the merchant was told their password was
wrong when it was not. The controller now renders a `CustomUserMessageAuthenticationException` message as
written and keeps the generic message for everything else. Nothing else in core throws that exception -
grepped - so only a deliberate module veto reaches the new branch, and a real credentials failure still
reveals nothing about whether the employee exists. The message goes through `raw_purified` in the login
layout, the same channel as every other login flash.

The message data is filtered to scalars before it reaches the translator. Measured on the 9.2 shop:
`trans()` on a `CustomUserMessageAuthenticationException` carrying `['%x%' => ['a', 'b']]` raises
"Array to string conversion", and an object value raises "Object of class X could not be converted to
string" - while the login page is rendering, so one module mistake would turn a refused attempt into a 500
on the login screen. With `array_filter(..., 'is_scalar')` all five cases render: `%ip%` interpolates, and
a non-scalar leaves the placeholder literal.

A module that throws its own `AuthenticationException` instead of returning `false` still fails closed -
the attempt is refused and the browser goes back to the login page - but the exception takes the firewall
entry-point path rather than the failure handler, so its message is not shown. Measured. The contract is a
return value, and the hook description says so.

### Verification

Measured on the 9.2 shop with a throwaway module attached to the hook, before and after the refactor to
the adapter:

| module returns | POST to the login path | alert on the login page |
| --- | --- | --- |
| `false` | 302 back to login, no session | the module's own message |
| `null` | 302 back to login, no session | "The employee does not exist, or the password provided is incorrect." |

The hook fired for `nobody@example.invalid`, i.e. before the employee lookup, with `email` set and
`request` a real `Symfony\Component\HttpFoundation\Request`.

`tests/Unit/PrestaShopBundle/EventSubscriber/BackOfficeLoginCheckSubscriberTest.php` is new: 13 tests,
14 assertions, green. Two mutations were checked and both are caught:

- `false === $result` weakened to `!$result` - 4 errors (the observer, empty-string, `0` and `'0'` cases);
- priority lowered from 4096 to 0 - 1 failure.

php-cs-fixer: 0 of 5 files to fix. PHPStan on all four production files: `[OK] No errors`.
`lint:container` is red on this shop for an unrelated pre-existing reason (Monolog
`RotatingFileHandler::$maxFiles` receives a string), so registration was confirmed with `debug:container`
and `debug:event-dispatcher` instead.

### No upgrade script

Core adds new hooks to `install-dev/data/xml/hook.xml` only: #41824 did exactly that for `actionNotFound`,
and no file under `install-dev/upgrade/sql/` inserts into `PREFIX_hook` at all. On an already-installed
shop the row is created by `Hook::registerHook()` when a module attaches to a name that is not there yet -
verified here, the row appeared on the 9.2 shop the moment the test module registered. The XML entry is
what puts the hook in the back office hook list on a fresh install.

### Notes for reviewers

- Base is `9.2.x`, not `develop`: the issue is labelled `Improvement`, and #41824 added a new hook on
  `9.1.x`, a patch branch, so a new hook on the next minor's branch is well within precedent.
- Maintainer support on the thread: matks agreed with putting the hooks back, and Hlavtox asked on
  2025-12-02 what to implement. The answer was posted as
  https://github.com/PrestaShop/PrestaShop/issues/36944#issuecomment-5569587537.

