### PR TITLE
Offer the search results that start with what was typed first

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-select2-ranking.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/init-select2-ranking.ts
@@ -1,0 +1,45 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+import {sortPrefixMatchesFirst, Select2Result} from '@app/utils/select2-prefix-first';
+
+interface Select2Namespace {
+  defaults?: {
+    defaults?: Record<string, unknown>;
+    set: (key: string, value: unknown) => void;
+  };
+}
+
+const {$} = window;
+
+/**
+ * Wires prefix-first ranking into every select2 of the back office.
+ *
+ * WHY it wraps the matcher instead of replacing it: select2 hands the search term to the matcher but
+ * not to the sorter, so the term has to be captured on the way past. The original matcher keeps doing
+ * the matching, including its diacritics handling, so which options appear is unchanged - only the
+ * order they appear in.
+ *
+ * WHY it has to run before DOM ready: the UI kit builds its select2 instances inside its own ready
+ * handler, and an instance resolves its options from the defaults when it is constructed.
+ */
+export default function initSelect2PrefixFirstRanking(): void {
+  const {select2} = $.fn as unknown as {select2?: Select2Namespace};
+  const defaults = select2?.defaults;
+  const originalMatcher = defaults?.defaults?.matcher;
+
+  if (!defaults || typeof originalMatcher !== 'function') {
+    return;
+  }
+
+  let lastTerm = '';
+
+  defaults.set('matcher', (params: {term?: string}, data: Select2Result) => {
+    lastTerm = params?.term ?? '';
+
+    return originalMatcher(params, data);
+  });
+  defaults.set('sorter', (data: Select2Result[]) => sortPrefixMatchesFirst(lastTerm, data));
+}

--- a/admin-dev/themes/new-theme/js/app/utils/select2-prefix-first.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/select2-prefix-first.ts
@@ -1,0 +1,56 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * select2 filters the options of a dropdown with a plain substring test and then leaves them in the
+ * order they were declared. Typing "s" in the order status selector therefore offers "Processing",
+ * "Payment accepted" and "Shipped" in that order, and the one the merchant meant is rarely first.
+ *
+ * This ranks the options that BEGIN with what was typed above the ones that merely contain it, which
+ * is what makes the first result the likely one, and select2 already highlights the first result and
+ * selects it on Enter.
+ */
+export interface Select2Result {
+  text?: string;
+  children?: Select2Result[];
+  [key: string]: unknown;
+}
+
+function startsWithTerm(result: Select2Result, upperTerm: string): boolean {
+  return typeof result.text === 'string' && result.text.toUpperCase().indexOf(upperTerm) === 0;
+}
+
+/**
+ * Groups keep their own position: a group is a merchant-defined section, and promoting one because its
+ * label happens to begin with the letter would move every option under it. Only the options inside a
+ * group are ranked.
+ */
+export const sortPrefixMatchesFirst = (
+  term: string,
+  results: Select2Result[],
+): Select2Result[] => {
+  if (!Array.isArray(results)) {
+    return results;
+  }
+
+  const upperTerm = (term ?? '').trim().toUpperCase();
+
+  if (upperTerm === '') {
+    return results;
+  }
+
+  const ranked = results.map((result) => (Array.isArray(result.children)
+    ? {...result, children: sortPrefixMatchesFirst(term, result.children)}
+    : result));
+
+  if (ranked.some((result) => Array.isArray(result.children))) {
+    return ranked;
+  }
+
+  // Array.prototype.sort is stable, so options of equal rank keep the order the shop declared them in.
+  return ranked.sort(
+    (a, b) => Number(startsWithTerm(b, upperTerm)) - Number(startsWithTerm(a, upperTerm)),
+  );
+};

--- a/admin-dev/themes/new-theme/js/theme.ts
+++ b/admin-dev/themes/new-theme/js/theme.ts
@@ -35,12 +35,17 @@ import initEmailFields from '@js/app/utils/email-idn';
 import initNumberCommaTransformer from '@js/app/utils/number-comma-transformer';
 import initPrestashopComponents from '@app/utils/init-components';
 import watchSymfonyDebugBar from '@app/utils/watch-symfony-debug-bar';
+import initSelect2PrefixFirstRanking from '@app/utils/init-select2-ranking';
 import '@js/components/header/search-form';
 
 const {$} = window;
 
 // Theme Javascript
 window.Dropzone.autoDiscover = false;
+
+// Has to run before the UI kit builds its select2 instances on DOM ready, because an instance reads
+// the defaults when it is constructed.
+initSelect2PrefixFirstRanking();
 
 new NavBar();
 new Header();

--- a/admin-dev/themes/new-theme/tests/utils/select2-prefix-first.spec.js
+++ b/admin-dev/themes/new-theme/tests/utils/select2-prefix-first.spec.js
@@ -1,0 +1,95 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+import { expect } from 'chai';
+import { sortPrefixMatchesFirst } from '../../js/app/utils/select2-prefix-first';
+
+// The order statuses of a stock shop, in the order the shop declares them. Typing "s" matches five of
+// them with select2's substring filter, and only one of them starts with it.
+const orderStatuses = () => [
+  { text: 'Awaiting check payment' },
+  { text: 'Payment accepted' },
+  { text: 'Processing in progress' },
+  { text: 'Shipped' },
+  { text: 'Delivered' },
+  { text: 'Canceled' },
+  { text: 'Refunded' },
+  { text: 'Payment error' },
+  { text: 'On backorder (paid)' },
+];
+
+describe('sortPrefixMatchesFirst', () => {
+  it('puts the status that starts with the letter first', () => {
+    const sorted = sortPrefixMatchesFirst('s', orderStatuses());
+
+    expect(sorted[0].text).to.equal('Shipped');
+  });
+
+  it('keeps the declared order among the results that only contain the term', () => {
+    const sorted = sortPrefixMatchesFirst('s', orderStatuses()).map((result) => result.text);
+
+    expect(sorted).to.deep.equal([
+      'Shipped',
+      'Awaiting check payment',
+      'Payment accepted',
+      'Processing in progress',
+      'Delivered',
+      'Canceled',
+      'Refunded',
+      'Payment error',
+      'On backorder (paid)',
+    ]);
+  });
+
+  it('ignores the case of what was typed', () => {
+    expect(sortPrefixMatchesFirst('SHIP', orderStatuses())[0].text).to.equal('Shipped');
+    expect(sortPrefixMatchesFirst('ship', orderStatuses())[0].text).to.equal('Shipped');
+  });
+
+  it('changes nothing when nothing was typed', () => {
+    const original = orderStatuses().map((result) => result.text);
+
+    expect(sortPrefixMatchesFirst('', orderStatuses()).map((r) => r.text)).to.deep.equal(original);
+    expect(sortPrefixMatchesFirst('   ', orderStatuses()).map((r) => r.text)).to.deep.equal(original);
+  });
+
+  it('trims what was typed, because select2 does not', () => {
+    expect(sortPrefixMatchesFirst('  ship  ', orderStatuses())[0].text).to.equal('Shipped');
+  });
+
+  it('promotes several matches and keeps them in their declared order', () => {
+    const sorted = sortPrefixMatchesFirst('pay', orderStatuses()).map((r) => r.text);
+
+    expect(sorted.slice(0, 2)).to.deep.equal(['Payment accepted', 'Payment error']);
+  });
+
+  it('ranks inside a group without moving the group', () => {
+    const grouped = [
+      { text: 'Paid', children: [{ text: 'Awaiting payment' }, { text: 'Payment accepted' }] },
+      { text: 'Sent', children: [{ text: 'Processing in progress' }, { text: 'Shipped' }] },
+    ];
+
+    const sorted = sortPrefixMatchesFirst('s', grouped);
+
+    expect(sorted.map((group) => group.text)).to.deep.equal(['Paid', 'Sent']);
+    expect(sorted[1].children.map((child) => child.text)).to.deep.equal([
+      'Shipped',
+      'Processing in progress',
+    ]);
+  });
+
+  it('does not mutate what select2 passed in', () => {
+    const results = orderStatuses();
+
+    sortPrefixMatchesFirst('s', results);
+
+    expect(results.map((r) => r.text)).to.deep.equal(orderStatuses().map((r) => r.text));
+  });
+
+  it('leaves an entry with no text alone rather than throwing', () => {
+    const sorted = sortPrefixMatchesFirst('s', [{ id: 1 }, { text: 'Shipped' }]);
+
+    expect(sorted[0].text).to.equal('Shipped');
+  });
+});


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The searchable selects of the back office filter their options with a plain substring test and then leave them in the order the shop declared them, because select2's default matcher is `stripDiacritics(text).toUpperCase().indexOf(term.toUpperCase()) > -1` and its default sorter is the identity function. Typing `s` in the order status selector therefore highlights "Awaiting check payment" and pressing Enter picks it, while the merchant meant "Shipped". This ranks the options that begin with what was typed above the ones that merely contain it, through select2's own `sorter` default, so it covers every searchable select in the back office.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open any order in the back office and click the status selector at the top. Type `s`. Before: the list is filtered but keeps the shop's declared order, so the highlighted first entry is "Awaiting check payment" and Enter picks it. After: "Shipped" is first and highlighted, and Enter picks it. The same applies to every back office dropdown with a search field, for example the module selector under Design > Positions.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #37054
| Related PRs       |
| Sponsor company   |

### Three of the four requests in the issue were already satisfied

Measured on `9.2.x` against select2 4.0.13, which is what actually renders this selector - `UpdateOrderStatusType` sets `'autocomplete' => true`, `PrestaShopBundle\Form\Extension\AutoCompleteExtension` turns that into `data-toggle="select2"` and `data-minimumResultsForSearch=7`, and the UI kit's `initSelect2` constructs the instance:

| Ask in the issue | State before this branch |
| --- | --- |
| Focus the search field when the dropdown opens | already done - `on("open")` calls `$search.trigger("focus")` |
| First result preselected so Enter picks it | already done - `Results.prototype.highlightFirstItem` triggers `mouseenter` on the first option |
| Arrow keys move through the list | already done - `select2/keys` defines `UP: 38, DOWN: 40`, bound by the results view |
| Rank options that START with the term | **missing** - this branch |

That is why the keyboard flow felt broken even though the keyboard handling works: the highlighted first result was the wrong one, so Enter selected the wrong status.

### Design decisions

- **Wraps the matcher, does not replace it.** select2 hands the search term to the matcher but not to the
  sorter, so the term is captured on the way past and the original matcher still decides which options
  match, diacritics handling included. Only the order changes.
- **Applied as a select2 default, not to one widget.** The UI kit already sets `theme` and `width` the same
  way (`jQuery.fn.select2.defaults.set(...)`), so this follows the mechanism the project already uses, and
  every searchable select benefits rather than the order status one alone.
- **Runs at module scope in `theme.ts`, not on DOM ready.** The UI kit builds its select2 instances inside
  its own ready handler and an instance resolves its options from the defaults at construction time, so a
  default set in a later ready handler would not reach them.
- **Groups keep their position.** Promoting a group because its label starts with the letter would drag
  every option under it along. Only the options inside a group are ranked. This was not obvious - the first
  implementation promoted the group and one of the tests caught it.
- **Split into a pure module and a wiring module.** `select2-prefix-first.ts` holds the sort with no jQuery
  reference so the mocha suite can exercise it; `init-select2-ranking.ts` holds the jQuery wiring.

### Verification

- `admin-dev/themes/new-theme/tests/utils/select2-prefix-first.spec.js` is new: 9 tests. The theme's own
  suite runs 130 passing, 0 failing (121 pre-existing plus these 9).
- Two mutations were checked and both are caught: turning the prefix test back into a substring test fails
  4 tests, removing the group guard fails 1.
- `npx eslint` clean on the three changed/added TypeScript files.
- The compiled bundle is not in the diff - `/admin-dev/themes/new-theme/public/*` is gitignored
  (`.gitignore:126`).

### Not verified, and why

The end-to-end keyboard flow in a real browser was not exercised: that needs a back office session, and the
UI test campaigns are paused. The three keyboard behaviours listed above were read from the bundled select2
source rather than clicked through, and the ranking itself is unit-tested.

### Notes for reviewers

- `Fixes #37054` is correct here: with the ranking in place all four points of the issue hold.
- The issue has carried `Waiting for PM` since 2024-10-23 and `NMI` since 2024-10-11. The product question
  asked at the time was whether the old behaviour should come back; this answers it differently, by making
  the current widget behave the way the reporter described wanting, which is also standard combobox
  behaviour rather than a product preference.

