### PR TITLE
Treat an offline product as an ineligible free gift

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -931,6 +931,14 @@ class CartRuleCore extends ObjectModel
                 return (!$display_error) ? false : $this->trans('The gift product does not exist.', [], 'Shop.Notifications.Error');
             }
 
+            // An offline product is as unusable as a deleted one: the front office refuses to sell it, so a
+            // discount that offers it cannot be honoured. Read from the product's shop row, exactly like
+            // available_for_order below - both are 'shop' => true, so a product taken offline in one shop
+            // only stops the discount in that shop and nowhere else.
+            if (!(int) $giftProduct->active) {
+                return (!$display_error) ? false : $this->trans('The gift product is no longer available.', [], 'Shop.Notifications.Error');
+            }
+
             if (!(int) $giftProduct->available_for_order) {
                 return (!$display_error) ? false : $this->trans('The gift product is not available for order.', [], 'Shop.Notifications.Error');
             }

--- a/src/Adapter/Product/QueryHandler/SearchProductsForFreeGiftHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsForFreeGiftHandler.php
@@ -81,6 +81,10 @@ class SearchProductsForFreeGiftHandler implements SearchProductsForFreeGiftHandl
      */
     private function checkEligibility(array $product): array
     {
+        if (empty($product['active'])) {
+            return [true, $this->translator->trans('This product is disabled.', [], 'Admin.Catalog.Notification')];
+        }
+
         if (empty($product['available_for_order'])) {
             return [true, $this->translator->trans('This product is not available for order.', [], 'Admin.Catalog.Notification')];
         }

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -860,7 +860,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
         );
         $qb
             ->addSelect('p.id_product, pl.name, p.reference, i.id_image, p.product_type')
-            ->addSelect('ps.available_for_order, ps.minimal_quantity, ps.customizable')
+            ->addSelect('ps.active, ps.available_for_order, ps.minimal_quantity, ps.customizable')
             ->addSelect('sa.quantity as stock_quantity, sa.out_of_stock')
             ->leftJoin('p', $this->dbPrefix . 'stock_available', 'sa', 'sa.id_product = p.id_product AND sa.id_shop = :shopId AND sa.id_product_attribute = 0')
             ->addGroupBy('p.id_product')

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/FO/free_gift_discount_offline_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/FO/free_gift_discount_offline_product.feature
@@ -1,0 +1,49 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s discount --tags free-gift-discount-offline-product
+@restore-all-tables-before-feature
+@restore-languages-after-feature
+@free-gift-discount-offline-product
+Feature: Free gift discount with an offline product
+  PrestaShop refuses a free gift discount whose gift product is no longer sold
+  As a customer
+  I must not receive a gift the shop has taken offline
+
+  Background:
+    Given there is a customer named "testCustomer" whose email is "pub2@prestashop.com"
+    And language with iso code "en" is the default one
+    Given shop "shop1" with name "test_shop" exists
+    And there is a currency named "usd" with iso code "USD" and exchange rate of 0.92
+    And currency "usd" is the default one
+    And I enable feature flag "discount"
+
+  Scenario: A gift product that is still online can be offered
+    Given there is a product in the catalog named "bought-online" with a price of 20.0 and 100 items in stock
+    And there is a product in the catalog named "gift-online" with a price of 10.0 and 100 items in stock
+    When I create a "free_gift" discount "online_gift_discount" with following properties:
+      | name[en-US]  | Online gift         |
+      | active       | true                |
+      | valid_from   | 2025-01-01 00:00:00 |
+      | valid_to     | 2036-12-31 00:00:00 |
+      | code         | ONLINEGIFT          |
+      | gift_product | gift-online         |
+    And I create an empty cart "online_gift_cart" for customer "testCustomer"
+    And I add 1 product "bought-online" to the cart "online_gift_cart"
+    And I use a voucher "online_gift_discount" on the cart "online_gift_cart"
+    Then cart "online_gift_cart" should contain gift product "gift-online"
+
+  Scenario: A gift product taken offline cannot be offered
+    Given there is a product in the catalog named "bought-offline" with a price of 20.0 and 100 items in stock
+    And there is a product in the catalog named "gift-offline" with a price of 10.0 and 100 items in stock
+    When I create a "free_gift" discount "offline_gift_discount" with following properties:
+      | name[en-US]  | Offline gift        |
+      | active       | true                |
+      | valid_from   | 2025-01-01 00:00:00 |
+      | valid_to     | 2036-12-31 00:00:00 |
+      | code         | OFFLINEGIFT         |
+      | gift_product | gift-offline        |
+    And I create an empty cart "offline_gift_cart" for customer "testCustomer"
+    And I add 1 product "bought-offline" to the cart "offline_gift_cart"
+    And I update product "gift-offline" with following values:
+      | active | false |
+    And I use a voucher "offline_gift_discount" on the cart "offline_gift_cart"
+    Then I should get an error that the discount is invalid
+    And cart "offline_gift_cart" should not contain product "gift-offline"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A disabled product cannot be sold, so a discount that offers it as a free gift cannot be honoured either. `CartRule::checkValidity()` already refuses a gift product that does not exist, is not available for order, has a minimum quantity above one, requires customization or is out of stock, and the back office gift-product selector flags the same four - neither looks at the product's `active` flag. The result is the one boherm measured on this issue: applying the discount adds the offline product to the cart with no error at all, and the customer only finds out at checkout, where the front office says "This product is no longer available" and blocks the order while the discount still shows in the summary. "Offline products" is the first item of the ineligibility list the maintainers agreed on in this thread on 2025-10-24, and it is the only one of the four that nothing checks.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the `discount` feature flag. Create a free gift discount with a code, offering any active product. Add something to a front office cart and enter the code: the gift is added. Now disable the gift product in the catalogue and repeat with a fresh cart. Before: the discount is accepted and the disabled product lands in the cart, and checkout is blocked with no explanation of why. After: the discount is refused with "The gift product is no longer available." and the cart is untouched. Re-enable the product and the discount works again.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | #38517
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/42627 also touches `ProductRepository`, 52 lines away in a different method - no hunk overlap.
| Sponsor company   |

### Where the gap is

PR #41050 (merged 2026-05-29, closing #39803) built the eligibility feature this issue asked for, at three
levels. `active` is missing from all three:

| criterion | write-time (`DiscountValidator`) | runtime (`CartRule::checkValidity()`) | BO selector (`SearchProductsForFreeGiftHandler`) |
| --- | --- | --- | --- |
| requires customization | rejects | rejects | flags |
| minimum quantity > 1 | rejects | rejects | flags |
| not available for order | allowed | rejects | flags |
| out of stock, orders denied | allowed | rejects | flags |
| deleted | - | rejects | - |
| **disabled** | **-** | **nothing** | **nothing** |

The change adds it to the two soft levels, next to `available_for_order`, and deliberately not to
`DiscountValidator`: the design there is two-tier, and #41050's own scenarios spell it out - "Creating a
discount with a product not available for order **succeeds**", "Creating a discount with an out-of-stock
product (orders denied) **succeeds**". Intrinsic properties that can never work are refused at write time;
volatile, reversible states are refused at application time. Being offline is the most reversible of them.

### Why not auto-disable the discount as well

`UpdateProductHandler` disables free gift discounts outright when the gift product gains a minimum
quantity, gains required customization or loses availability for order, and `ProductDeleter` does the same
on deletion. Adding `active` there was considered and rejected on two grounds. First, that disabling is
irreversible for the merchant: putting the product back online does not bring the discount back, and taking
a product offline is routinely temporary - restocking, a seasonal line - unlike deletion or a catalogue
decision about customization. Second, it would need the same call in `BulkUpdateProductStatusHandler`,
which writes `active` directly and calls no disabler, or the grid's "Disable selection" and the single
product toggle would behave differently on the same discount. The runtime check covers every route that
can set `active`, including those two, imports and modules, and it costs the merchant nothing to undo.

### Multishop

`active` and `available_for_order` are both declared `'shop' => true` in `Product::$definition`, and the
guard sits next to the existing one and reads the same loaded object, so a product taken offline in one
shop stops the discount in that shop and nowhere else - the same semantics the sibling check already has.

### Verification

- `tests/Integration/Behaviour/Features/Scenario/Discount/FO/free_gift_discount_offline_product.feature`
  is new: 2 scenarios, 28 steps. The offline one **fails on upstream `9.2.x`** with
  `Last error should be "CartRuleValidityException", but got "null"` - the discount is accepted and no
  error is raised at all. The online one is the control and passes on both.
- The revert was verified: after `git checkout upstream/9.2.x -- classes/CartRule.php` the file greps 0
  occurrences of the new message, and the RED run above was taken in that state.
- `--tags free-gift-discount-eligibility` (#41050's own 11 scenarios, 117 steps) stays green.
- Full `discount` suite: 98 failures on this branch and **98 on plain `upstream/9.2.x`**, scenarios
  212 -> 214 and passes 114 -> 116. The suite is not green on its base in a single pass; this change adds
  two passing scenarios and no failures.
- php-cs-fixer: 0 of 3 files to fix. PHPStan: `[OK] No errors`.
- UI tests: not run. A campaign can be launched on request.

### Not covered by a test, and why

The back office selector half has no test, because nothing in `SearchProductsForFreeGiftHandler::checkEligibility()`
has one - the other four criteria there are untested too, and there is no Behat step for that query. The
runtime block is in the same state: none of its five existing messages is asserted anywhere. The new
scenario is the first coverage that block has.

### Notes for reviewers

- The table cell carries a bare `#38517`, not `Fixes #38517`: an empty cell there trips ps-jarvis's table parser, and a `Fixes` would close the wrong thing. That issue is a specification covering eleven scenarios; this branch
  answers one of them. The others are either already implemented by #41050 or still being settled in the
  thread (the minimum-quantity gift question, option 2 vs option 3, has no decision yet).
- The comment posted on the issue maps all eleven items to what current `9.2.x` does.

