### PR TITLE
Count what the cart already holds when pricing a product page

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5498,11 +5498,16 @@ class ProductCore extends ObjectModel
         /*
          * Now, to get proper prices, we need to calculate them for a specific quantity, because
          * there can be quantity discount. The variable to use is different for different contexts.
+         * If the caller resolved the quantity to price for itself, we use it. A product page does
+         * this: its quantity input says how many MORE to add, so the quantity that decides the price
+         * is the one the cart line will end up with, not the number in the box.
          * If a specific quantity_wanted is set, we use it. Usually a product page.
          * If cart_quantity is defined, we use it. Usually cart context.
          * Otherwise, we use minimal_quantity, if nothing was passed - on listings.
          */
-        if (isset($row['quantity_wanted'])) {
+        if (isset($row['quantity_to_price'])) {
+            $quantityToUseForPriceCalculations = max((int) $row['minimal_quantity'], (int) $row['quantity_to_price']);
+        } elseif (isset($row['quantity_wanted'])) {
             $quantityToUseForPriceCalculations = max((int) $row['minimal_quantity'], (int) $row['quantity_wanted']);
         } elseif (isset($row['cart_quantity'])) {
             $quantityToUseForPriceCalculations = max((int) $row['minimal_quantity'], (int) $row['cart_quantity']);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1253,6 +1253,13 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         // @todo - a centralized version of this method is implemented in ProductLazyArray - migrate to it when migrating this code
         $product['quantity_required'] = $this->getRequiredQuantity($product);
 
+        // Quantity the price must be computed for. The input above is incremental - it says how many
+        // more to add - so what decides the price is the quantity the cart line will hold once they
+        // are added, which is also the quantity the cart itself prices against. getRequiredQuantity()
+        // already reads the input this way when it subtracts what the cart holds from the minimum.
+        // Kept separate from quantity_wanted, which is the value shown in the input.
+        $product['quantity_to_price'] = (int) $product['quantity_wanted'] + (int) $product['cart_quantity'];
+
         // Render hook displayProductExtraContent
         $product['extraContent'] = (new ProductExtraContentFinder())->addParams(['product' => $this->product])->present();
         $product['ecotax_tax_inc'] = $this->product->getEcotax(null, true, true);

--- a/tests/Integration/Classes/ProductQuantityToPriceTest.php
+++ b/tests/Integration/Classes/ProductQuantityToPriceTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Context;
+use Currency;
+use Customer;
+use PHPUnit\Framework\TestCase;
+use Product;
+use ProductAssembler;
+use SpecificPrice;
+
+/**
+ * A quantity discount is matched against a quantity, and which quantity that is depends on who is
+ * asking. A cart line asks about the quantity it holds. A product page asks about a quantity the
+ * customer is about to ADD, so the quantity that decides the price is that plus what the cart already
+ * holds - otherwise the page quotes a price the cart immediately contradicts.
+ */
+class ProductQuantityToPriceTest extends TestCase
+{
+    private const DISCOUNT_FROM_QUANTITY = 5;
+    private const DISCOUNT_PERCENTAGE = 0.2;
+
+    private int $productId;
+    private int $specificPriceId;
+    private float $priceWithoutDiscount;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The CLI context carries neither a currency nor a visitor. Pricing needs the first to know its
+        // rounding precision, and ProductSearchContext reads the id off the second.
+        $context = Context::getContext();
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        if (!$context->customer) {
+            $context->customer = new Customer();
+        }
+
+        $product = new Product();
+        $product->name = [(int) Configuration::get('PS_LANG_DEFAULT') => 'Quantity discount fixture'];
+        $product->link_rewrite = [(int) Configuration::get('PS_LANG_DEFAULT') => 'quantity-discount-fixture'];
+        $product->price = 100.0;
+        $product->id_category_default = (int) Configuration::get('PS_HOME_CATEGORY');
+        $product->minimal_quantity = 1;
+        $product->active = true;
+        $product->add();
+        $this->productId = (int) $product->id;
+
+        $specificPrice = new SpecificPrice();
+        $specificPrice->id_product = $this->productId;
+        $specificPrice->id_shop = 0;
+        $specificPrice->id_shop_group = 0;
+        $specificPrice->id_currency = 0;
+        $specificPrice->id_country = 0;
+        $specificPrice->id_group = 0;
+        $specificPrice->id_customer = 0;
+        $specificPrice->id_product_attribute = 0;
+        $specificPrice->price = -1.0;
+        $specificPrice->from_quantity = self::DISCOUNT_FROM_QUANTITY;
+        $specificPrice->reduction = self::DISCOUNT_PERCENTAGE;
+        $specificPrice->reduction_tax = 1;
+        $specificPrice->reduction_type = 'percentage';
+        $specificPrice->from = '0000-00-00 00:00:00';
+        $specificPrice->to = '0000-00-00 00:00:00';
+        $specificPrice->add();
+        $this->specificPriceId = (int) $specificPrice->id;
+
+        SpecificPrice::flushCache();
+        $this->priceWithoutDiscount = $this->presentedPrice(['quantity_wanted' => 1]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!empty($this->specificPriceId)) {
+            (new SpecificPrice($this->specificPriceId))->delete();
+        }
+        if (!empty($this->productId)) {
+            (new Product($this->productId))->delete();
+        }
+        SpecificPrice::flushCache();
+
+        parent::tearDown();
+    }
+
+    /**
+     * The reported case: the cart already holds the threshold quantity and charges the discount, while
+     * the product page is still asked about the single unit in its input.
+     */
+    public function testAProductPagePricesForTheQuantityTheCartLineWillHold(): void
+    {
+        $priceWhenAddingOneToACartOfFive = $this->presentedPrice([
+            'quantity_wanted' => 1,
+            'cart_quantity' => 5,
+            'quantity_to_price' => 6,
+        ]);
+
+        $this->assertSame($this->discounted(), $priceWhenAddingOneToACartOfFive);
+        $this->assertNotSame($this->priceWithoutDiscount, $priceWhenAddingOneToACartOfFive);
+    }
+
+    /**
+     * The threshold is reached by the sum, not by either side on its own - three in the cart and two in
+     * the input is five, and five is what the cart line will be priced as.
+     */
+    public function testTheQuantityInTheCartAndTheQuantityBeingAddedCountTogether(): void
+    {
+        $this->assertSame(
+            $this->discounted(),
+            $this->presentedPrice(['quantity_wanted' => 2, 'cart_quantity' => 3, 'quantity_to_price' => 5])
+        );
+        $this->assertSame(
+            $this->priceWithoutDiscount,
+            $this->presentedPrice(['quantity_wanted' => 1, 'cart_quantity' => 3, 'quantity_to_price' => 4])
+        );
+    }
+
+    /**
+     * The cart asks a different question and must keep getting the same answer: it prices the line it
+     * holds, and it never sets quantity_to_price.
+     */
+    public function testACartLineStillPricesForTheQuantityItHolds(): void
+    {
+        $this->assertSame($this->discounted(), $this->presentedPrice(['cart_quantity' => 5]));
+        $this->assertSame($this->discounted(), $this->presentedPrice(['quantity_wanted' => 5, 'cart_quantity' => 5]));
+        $this->assertSame($this->priceWithoutDiscount, $this->presentedPrice(['quantity_wanted' => 1, 'cart_quantity' => 1]));
+    }
+
+    /**
+     * A listing sets neither, and must stay independent of whatever the visitor happens to have in
+     * their cart.
+     */
+    public function testAListingIsUnaffected(): void
+    {
+        $this->assertSame($this->priceWithoutDiscount, $this->presentedPrice([]));
+    }
+
+    private function discounted(): float
+    {
+        return round($this->priceWithoutDiscount * (1 - self::DISCOUNT_PERCENTAGE), 2);
+    }
+
+    /**
+     * @param array<string, int> $quantities
+     */
+    private function presentedPrice(array $quantities): float
+    {
+        // getProductProperties keys its result cache on the product, not on the quantity it was priced
+        // for, so a second call in the same process would return the first call's prices.
+        Product::resetStaticCache();
+        SpecificPrice::flushCache();
+
+        $assembler = new ProductAssembler(Context::getContext());
+        $presented = $assembler->assembleProduct(array_merge(['id_product' => $this->productId], $quantities));
+
+        return round((float) $presented['price'], 2);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A quantity discount is matched against a quantity, and the product page was asking about the wrong one. Its quantity input is incremental - it says how many MORE to add - so the quantity that decides the price is what the cart already holds plus what is being added. Pricing on the input alone showed a customer the full price on the product page while their cart charged the discounted one for the same unit, in the same session. `getRequiredQuantity()` already reads the input this way when it subtracts the cart's quantity from the product's minimum, so the page was the only place that did not.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Give a product a quantity discount from 5. With an empty cart the product page shows the discount from a quantity of 5, unchanged. Add 5 to the cart and return to the product page: before, it shows the full price while the cart line shows the discounted one; after, both show the discounted price. With 3 in the cart the discount appears once the input reaches 2, because that is the line the cart will hold. Listing and cart prices are unchanged.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #39668
| Related PRs       |
| Sponsor company   |

### Measured on 9.2.x with Hummingbird

Product at 11.90 tax excl, -20% from quantity 5, read from the endpoint the quantity input calls
(`?quantity_wanted=N&ajax=1&action=refresh`).

| cart holds | `quantity_wanted` | before | after |
| --- | --- | --- | --- |
| 5 | 1 | 14.28 | 11.42 |
| 3 | 1 | 14.28 | 14.28 |
| 3 | 2 | 14.28 | 11.42 |
| 0 | 4 | 14.28 | 14.28 |
| 0 | 5 | 11.42 | 11.42 |

Cart page unchanged at 11.42 throughout.

### Why a separate row key

`quantity_wanted` is the value rendered in the quantity input by the theme, and `CartLazyArray` sets it to
the cart line's quantity "for proper price calculation". Adding the cart's quantity to it would have shown
the wrong number in the input and priced every cart line for twice what it holds. The resolved quantity is
therefore passed as `quantity_to_price`, read by one new branch in `getProductProperties()`'s existing
documented dispatch, and set in one place.

### Why the sum and not the larger of the two

With 3 in the cart and a threshold of 5, adding 2 produces a line of 5 and the cart charges the discount.
Only the sum says so; `max()` would keep quoting the full price for a purchase that is about to be
discounted.

### Verification

- `tests/Integration/Classes/ProductQuantityToPriceTest.php` is new: 4 tests, 8 assertions. **2 fail on
  upstream `9.2.x`** with `Failed asserting that 100.0 is identical to 80.0`; all 4 pass with the change.
  The revert was verified by grepping both source files for `quantity_to_price` (0 before the RED run,
  1 and 2 after restoring) before the run was trusted.
- The other 2 tests are the guards: a cart line still prices for the quantity it holds, and a listing that
  sets neither key is unaffected. They pass both ways by design.
- End to end over HTTP on a 9.2 shop, table above, with the cart page re-read after each change.
- The mechanism was instrumented rather than inferred: on a product-page request with 5 in the cart,
  `getProductProperties` logged `wanted=1 cart_qty=5 minimal=1 -> qty=1`, and
  `SpecificPrice::getSpecificPrice` logged `quantity=1 id_cart=0 real_quantity=0 -> from_quantity<=1`.
- The two values the new line sums are assigned on adjacent lines of `ProductController` and were
  re-read on `upstream/9.2.x` itself, not only on the shop's pinned commit: `cart_quantity` from
  `$this->context->cart->getProductQuantity(...)` and `quantity_wanted` from `getWantedQuantity()`,
  immediately before the `getProductProperties()` call.
- php-cs-fixer: 0 of 3 files to fix. PHPStan: `[OK] No errors`.
- UI tests: not run. A campaign can be launched on request.

### Notes for reviewers

- The issue is labelled `Major` `Verified` `Ready`, and ibahloul-ps confirmed it on the thread: "It's
  definitely a bug, the quantity of products in the cart should be taken into account". He expected the
  fix in "a future version of the Hummingbird theme"; it is not a theme change - the number comes from
  core's pricing and the theme only prints it. Worth saying so in the PR conversation.
- The reporter's point 3 (with 5 in the cart the discount appears only at 6) does NOT reproduce on 9.2.x -
  measured, the empty-cart and 5-in-cart columns are identical. Only points 1 and 2 are fixed here.
- Comment posted 2026-09-07 with both measurements:
  https://github.com/PrestaShop/PrestaShop/issues/39668#issuecomment-5566112395

