### PR TITLE
Do not give a split shipment the previous carrier's shipping cost

### DIFF
--- a/src/Adapter/Shipment/ShipmentSplitter.php
+++ b/src/Adapter/Shipment/ShipmentSplitter.php
@@ -36,8 +36,17 @@ class ShipmentSplitter implements ShipmentSplitterInterface
         $newShipment->setOrderId($source->getOrderId());
         $newShipment->setTrackingNumber(null);
         $newShipment->setAddressId($source->getAddressId());
-        $newShipment->setShippingCostTaxExcluded($source->getShippingCostTaxExcluded());
-        $newShipment->setShippingCostTaxIncluded($source->getShippingCostTaxIncluded());
+        /*
+         * WHY not the source's cost: this shipment is being created for a DIFFERENT carrier, so what the
+         * previous one costs says nothing about what this one does. Copying it showed the merchant a price
+         * the new carrier never quoted, and it only ever went unnoticed because SplitShipmentHandler
+         * recomputes every shipment of the order straight afterwards when PS_ORDER_RECALCULATE_SHIPPING is
+         * on. With that setting off nothing recomputes it, and the copied value is what the merchant sees.
+         * A merchant who turns recalculation off sets shipping by hand, so an empty cost is the honest
+         * starting point; an inherited one is not.
+         */
+        $newShipment->setShippingCostTaxExcluded(0.0);
+        $newShipment->setShippingCostTaxIncluded(0.0);
 
         foreach ($productsToMove as $productToMove) {
             $orderDetailId = $productToMove->getOrderDetailId();

--- a/tests/Unit/Adapter/Shipment/ShipmentSplitterTest.php
+++ b/tests/Unit/Adapter/Shipment/ShipmentSplitterTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Shipment;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Shipment\ShipmentSplitter;
+use PrestaShopBundle\Entity\Shipment;
+use PrestaShopBundle\Entity\ShipmentProduct;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ShipmentSplitterTest extends TestCase
+{
+    private const SOURCE_CARRIER_ID = 2;
+    private const TARGET_CARRIER_ID = 3;
+    private const ORDER_ID = 17;
+    private const ADDRESS_ID = 42;
+    private const ORDER_DETAIL_ID = 90023;
+
+    /**
+     * The shipment the splitter returns is for a carrier of the caller's choosing, so the cost of the
+     * carrier it was split away from says nothing about it. It starts unset, exactly as the shipment
+     * CreateShipmentHandler and ShipmentProductAssigner build does, and is filled in afterwards by
+     * ShipmentShippingCostUpdater when PS_ORDER_RECALCULATE_SHIPPING allows it.
+     */
+    public function testSplitDoesNotCarryTheSourceCarriersShippingCostOver(): void
+    {
+        $source = $this->createSourceShipment(5.0, 6.0);
+
+        $newShipment = $this->createSplitter()->split($source, self::TARGET_CARRIER_ID, [
+            $this->shipmentProduct(self::ORDER_DETAIL_ID, 1),
+        ]);
+
+        $this->assertSame(0.0, $newShipment->getShippingCostTaxExcluded());
+        $this->assertSame(0.0, $newShipment->getShippingCostTaxIncluded());
+        $this->assertNotSame($source->getShippingCostTaxExcluded(), $newShipment->getShippingCostTaxExcluded());
+        $this->assertNotSame($source->getShippingCostTaxIncluded(), $newShipment->getShippingCostTaxIncluded());
+        $this->assertSame(5.0, $source->getShippingCostTaxExcluded(), 'the source keeps what it was charged');
+        $this->assertSame(6.0, $source->getShippingCostTaxIncluded(), 'the source keeps what it was charged');
+    }
+
+    /**
+     * Same carrier on both sides is the case where inheriting the cost looks harmless. It is not: the
+     * order would end up billed for that carrier twice.
+     */
+    public function testSplitOntoTheSameCarrierDoesNotDuplicateTheShippingCostEither(): void
+    {
+        $source = $this->createSourceShipment(5.0, 6.0);
+
+        $newShipment = $this->createSplitter()->split($source, self::SOURCE_CARRIER_ID, [
+            $this->shipmentProduct(self::ORDER_DETAIL_ID, 1),
+        ]);
+
+        $this->assertSame(0.0, $newShipment->getShippingCostTaxExcluded());
+        $this->assertSame(0.0, $newShipment->getShippingCostTaxIncluded());
+    }
+
+    /**
+     * Everything else the new shipment needs still comes from the source - the cost is the only thing
+     * that does not travel with it.
+     */
+    public function testSplitStillTakesTheOrderAddressAndProductsFromTheSource(): void
+    {
+        $source = $this->createSourceShipment(5.0, 6.0);
+
+        $newShipment = $this->createSplitter()->split($source, self::TARGET_CARRIER_ID, [
+            $this->shipmentProduct(self::ORDER_DETAIL_ID, 1),
+        ]);
+
+        $this->assertSame(self::TARGET_CARRIER_ID, $newShipment->getCarrierId());
+        $this->assertSame(self::ORDER_ID, $newShipment->getOrderId());
+        $this->assertSame(self::ADDRESS_ID, $newShipment->getAddressId());
+        $this->assertNull($newShipment->getTrackingNumber());
+        $this->assertCount(1, $newShipment->getProducts());
+        $this->assertSame(1, $newShipment->getProducts()->first()->getQuantity());
+        $this->assertSame(1, $source->getProducts()->first()->getQuantity(), 'the moved quantity left the source');
+    }
+
+    private function createSplitter(): ShipmentSplitter
+    {
+        return new ShipmentSplitter($this->createMock(TranslatorInterface::class));
+    }
+
+    private function createSourceShipment(float $costTaxExcluded, float $costTaxIncluded): Shipment
+    {
+        $source = new Shipment();
+        $source->setOrderId(self::ORDER_ID);
+        $source->setCarrierId(self::SOURCE_CARRIER_ID);
+        $source->setAddressId(self::ADDRESS_ID);
+        $source->setTrackingNumber(null);
+        $source->setShippingCostTaxExcluded($costTaxExcluded);
+        $source->setShippingCostTaxIncluded($costTaxIncluded);
+        $source->addShipmentProduct($this->shipmentProduct(self::ORDER_DETAIL_ID, 2));
+
+        return $source;
+    }
+
+    private function shipmentProduct(int $orderDetailId, int $quantity): ShipmentProduct
+    {
+        return (new ShipmentProduct())
+            ->setOrderDetailId($orderDetailId)
+            ->setQuantity($quantity);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ShipmentSplitter::split()` seeded the new shipment with the shipping cost of the shipment it was split away from, so a shipment created for carrier B was stored carrying carrier A's price. `SplitShipmentHandler` hides that whenever `PS_ORDER_RECALCULATE_SHIPPING` is on, because it recomputes every shipment of the order straight afterwards; with the setting off nothing recomputes it and the copied value is what the merchant sees, while the order's own shipping total is left alone - so the shipment rows and the order total disagree. The new shipment now starts with no cost, which is what the three other places that build a `Shipment` already do.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the `improved_shipment` feature flag and turn **Recalculate shipping costs after editing the order** off in Shop Parameters > Order Settings. Place an order with a carrier priced at 5.00, then split the shipment onto a second carrier with a different tariff. Before: the new shipment shows 5.00, the first carrier's price, and the shipment rows sum to 10.00 against an order total of 5.00. After: the new shipment shows 0.00 for the merchant to fill in, and the rows sum back to 5.00. With the setting on, both before and after produce the second carrier's own price - that path was already fixed by the recalculation added in May 2026.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #40459
| Related PRs       |
| Sponsor company   |

### Measured on 9.2.x

One order, one product line of 2, source shipment on carrier A (flat 5.00), split onto carrier B.
Everything held constant; only the setting and the splitter code varied.

| `PS_ORDER_RECALCULATE_SHIPPING` | 9.2.x today | with this change |
| --- | --- | --- |
| 1 (installed default) | 9.00 / 10.80 - carrier B's own tariff | 9.00 / 10.80, unchanged |
| 0 | 5.00 / 5.00 - carrier A's cost, verbatim | 0.00 / 0.00 |

```
9.2.x today:  SUM(ps_shipment.shipping_cost_tax_excl) = 10.00   ps_orders.total_shipping = 5.00
with the fix: SUM(ps_shipment.shipping_cost_tax_excl) =  5.00   ps_orders.total_shipping = 5.00
```

### Why 0.00 and not "compute carrier B's price in the splitter"

The three other `new Shipment()` sites already answer this. `CreateShipmentHandler`,
`ShipmentProductAssigner` and `OrderShipmentCreator` all seed `0.00` and let the recalculation decide
whether to fill it in; `CreateShipmentHandler` does it explicitly, with the same
`PS_ORDER_RECALCULATE_SHIPPING` conditional. `ShipmentSplitter` was the only site seeding from another
shipment, and that shipment belongs to a different carrier.

Computing the price in the splitter regardless of the setting was the alternative and is worse: it
re-prices the order behind a merchant who has explicitly asked for that not to happen, and it duplicates
`ShipmentShippingCostUpdater`, which `SplitShipmentHandler` calls one line later. The setting's own help
text is the tie-breaker - "If you disable this option, make sure to review the shipping costs whenever
you make changes to an order." An empty cost is something to review; an inherited one looks settled.

### Verification

- `tests/Unit/Adapter/Shipment/ShipmentSplitterTest.php` is new: 3 tests, 15 assertions.
  **2 of the 3 fail on current `9.2.x`** with `Failed asserting that 5.0 is identical to 0.0`; all 3 pass
  with the change. The revert was verified in the container (`git checkout upstream/9.2.x -- <file>`,
  then the copy lines re-read from the file) before the RED run was trusted.
- The third test is the mutation guard: order id, address id, tracking number and the moved products must
  still come from the source. It passes both ways by design.
- End to end on a 9.2 shop with the `improved_shipment` flag on, both values of
  `PS_ORDER_RECALCULATE_SHIPPING`, table above.
- php-cs-fixer: 0 of 2 files to fix. PHPStan: `[OK] No errors`.
- UI tests: not run. A campaign can be launched on request.

### Notes for reviewers

- The issue has no labels and no linked PR. Comment posted 2026-09-07 with the measured table.
- `ShipmentShippingCostUpdater` first appears on `9.2.x` on 2026-05-11 (`25d2883ae`), four months after
  this issue was filed, which is why the reporter saw the wrong cost on the default configuration and we
  no longer do. Worth saying in the PR conversation if a reviewer asks why the video does not reproduce.

