### PR TITLE
Add the AI context for the Payment component

### DIFF
--- a/.ai/CONTEXT.md
+++ b/.ai/CONTEXT.md
@@ -94,9 +94,9 @@ Domains: Address, Alias, ApiClient, Attachment, AttributeGroup, Carrier, Cart, C
 
 ## Component contexts
 
-All 28 shared infrastructure components have a context file at `Component/{ComponentName}/CONTEXT.md`.
+All 30 shared infrastructure components have a context file at `Component/{ComponentName}/CONTEXT.md`.
 
-Components: AdminAPI, BackOfficeHelp, Behat, Configuration, Console, Context, ContextStateManager, Controller, Cookie, CQRS, Database, Export, ExtraProperty, FacetedSearch, Forms, Grid, Hook, Import, Javascript, Link, Locale, MailTemplate, Migration, Playwright, PositionUpdater, Router, Smarty, TinyMCE, Twig
+Components: AdminAPI, BackOfficeHelp, Behat, Configuration, Console, Context, ContextStateManager, Controller, Cookie, CQRS, Database, Export, ExtraProperty, FacetedSearch, Forms, Grid, Hook, Import, Javascript, Link, Locale, MailTemplate, Migration, Payment, Playwright, PositionUpdater, Router, Smarty, TinyMCE, Twig
 
 ## Generated indexes
 

--- a/.ai/Component/Payment/CONTEXT.md
+++ b/.ai/Component/Payment/CONTEXT.md
@@ -1,0 +1,64 @@
+# Payment Component
+
+## Purpose
+
+Everything the core provides so that a payment module can offer itself at checkout and turn a validated
+cart into an order: the `PaymentOption` value object modules return from the payment hooks, the finder
+that collects those options, the legacy `PaymentModule` base class whose `validateOrder()` creates the
+order, and the back-office screens that decide which module is offered to whom. It implements no payment
+method of its own - every actual method is a module - and it does not own the order lifecycle after the
+order exists.
+
+## Layers
+
+| Layer | Path |
+|-------|------|
+| Payment option value object + form decorator | `src/Core/Payment/PaymentOption.php`, `src/Core/Payment/PaymentOptionFormDecorator.php` |
+| Back-office preferences configuration | `src/Core/Payment/PaymentModulePreferencesConfiguration.php` |
+| Checkout collection and rendering of options | `classes/checkout/PaymentOptionsFinder.php`, `classes/checkout/CheckoutPaymentStep.php` |
+| Legacy payment module base — `validateOrder()` lives here | `classes/PaymentModule.php` |
+| Free-order pseudo module | `classes/PaymentFree.php` |
+| Payments recorded against an order | `classes/order/OrderPayment.php`, `src/Adapter/Order/CommandHandler/AddPaymentHandler.php` |
+| Back-office controllers and forms | `src/PrestaShopBundle/Controller/Admin/Improve/Payment/`, `src/PrestaShopBundle/Form/Admin/Improve/Payment/` |
+| Module lists and presentation | `src/Adapter/Module/PaymentModuleListProvider.php`, `src/Adapter/Presenter/Module/PaymentModulesPresenter.php` |
+
+## Non-obvious patterns
+
+- A payment option can arrive through **three** hooks and `PaymentOptionsFinder::find()` reads all of them,
+  in order: `displayPaymentEU` (deprecated - each entry is passed through
+  `PaymentOption::convertLegacyOption()`), `advancedPaymentOptions`, then `paymentOptions`. Only the last
+  is type-checked, via `HookFinder::$expectedInstanceClasses`, which **throws** when a module returns
+  something that is not a `PaymentOption`. The first two are trusted.
+- `paymentOptions` is special-cased inside `Hook::getHookModuleExecList()`: its module list is **never
+  cached**, and every other hook's query explicitly excludes it (`h.name != "paymentOptions"`). On the
+  front office that same query then filters payment modules by the context country, currency and customer
+  group through `ps_module_country`, `ps_module_currency` and `ps_module_group`. A payment module can
+  therefore be installed, active and correctly hooked and still appear nowhere, because of a missing row
+  in one of those three tables.
+- Those rows are written from two unrelated places: `PaymentModule::addCheckboxCurrencyRestrictionsForModule()`
+  and its country/carrier siblings, called by the module at install time, and the back-office Payment
+  preferences form. A payment module that installs without calling them restricts itself to nothing.
+- `PaymentModule::validateOrder()` is the single entry point that turns a cart into an order, and it is
+  roughly 640 lines of `classes/PaymentModule.php` - it creates the order and its details, applies cart
+  rules, decrements stock, sends the confirmation mail and dispatches the payment hooks. New work belongs
+  in the Order domain's CQRS handlers; this method is called by modules and cannot change shape.
+- A free order does not go through a module. `PaymentOptionsFinder::findFree()` synthesises a
+  `PaymentOption` for `free_order`, and `classes/PaymentFree.php` is a `PaymentModule` subclass carrying
+  nothing but that name and `active = true`.
+- `PaymentOption` implements `HookContentClassInterface`, which is what lets a hook return an object
+  rather than a rendered string; the decision of how it renders belongs to `PaymentOptionFormDecorator`.
+
+## Canonical examples
+
+- `src/Core/Payment/PaymentOption.php` — what a module builds and returns from `paymentOptions`
+- `classes/checkout/PaymentOptionsFinder.php` — the three-hook collection and the free-order case
+- `classes/PaymentModule.php` — the base class every payment module extends
+- `src/Core/Payment/PaymentModulePreferencesConfiguration.php` — how the back office writes the restrictions
+
+## Related
+
+- [Hook Component](../Hook/CONTEXT.md) — `HookFinder`, and the `paymentOptions` special case described above
+- [Order Domain](../../Domain/Order/CONTEXT.md) — owns everything after `validateOrder()` has run
+- [Cart Domain](../../Domain/Cart/CONTEXT.md) — supplies the cart that `validateOrder()` consumes
+- [Module Domain](../../Domain/Module/CONTEXT.md) — installation, and the module lists the back office shows
+- [Forms Component](../Forms/CONTEXT.md) — the Payment preferences form types


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Payment was the one entry of the AI context batch that never landed. #41205 wrote a `CONTEXT.md` for every domain under `src/Core/Domain/`, and there is no `src/Core/Domain/Payment`, so Payment got neither a domain nor a component file while Cart, Order, Product and Discount did. This adds `.ai/Component/Payment/CONTEXT.md` and the index row for it. Component rather than Domain, because `.ai/STRUCTURE.md` maps `Domain/` to `src/Core/Domain/` and `Component/` to shared infrastructure, and that is what the payment code is: `src/Core/Payment/`, the legacy `classes/PaymentModule.php` base, `classes/checkout/PaymentOptionsFinder.php` and the back office screens under `Improve/Payment/`. The component index also said 28 while listing 29; it now says 30 and lists 30.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Read `.ai/Component/Payment/CONTEXT.md`. Every path in it exists on `9.2.x` and every relative link in Related resolves. The claims about hook collection and filtering can be checked against `classes/checkout/PaymentOptionsFinder.php:19-45` and `classes/Hook.php:800` / `:1297-1460`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41162
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41205
| Sponsor company   |

### What the file says that is not obvious from the directory

Written from the code rather than from the template, so the "Non-obvious patterns" section carries the
three things that actually cost a payment-module author time:

- `PaymentOptionsFinder::find()` reads **three** hooks in order - `displayPaymentEU` (deprecated, each
  entry converted by `PaymentOption::convertLegacyOption()`), `advancedPaymentOptions`, then
  `paymentOptions` - and only the last is type-checked through `HookFinder::$expectedInstanceClasses`,
  which throws when a module returns something that is not a `PaymentOption`.
- `paymentOptions` is special-cased in `Hook::getHookModuleExecList()`: never cached, excluded from every
  other hook's query, and on the front office filtered by context country, currency and customer group
  via `ps_module_country`, `ps_module_currency`, `ps_module_group`. An installed, active, correctly
  hooked payment module can therefore be invisible because of a missing row.
- Those rows come from two unrelated places - `PaymentModule::addCheckbox*RestrictionsForModule()` at
  install time and the back office preferences form - so a module that skips them offers itself nowhere.

Also recorded: `validateOrder()` is ~640 of the 1410 lines of `classes/PaymentModule.php` and is the
single cart-to-order entry point modules call, and the free order path bypasses modules entirely
(`PaymentOptionsFinder::findFree()` plus `classes/PaymentFree.php`).

### Conventions followed

- The shipped 29 component files carry no `> **Status:** Draft` banner even though
  `component-context-generator`'s template shows one; this file matches the 29 rather than the template,
  since it was written from the code and not generated.
- Paths, not class inventories, per `.ai/STRUCTURE.md`'s writing guidelines.
- No pointer files added: `.ai/STRUCTURE.md` lists `.cursor/rules/*.mdc` and
  `.github/instructions/*.instructions.md` as optional and only for new domains.

### Verification

- Every path named in the file exists on `9.2.x`; every relative link in `## Related` resolves
  (`../Hook/`, `../Forms/`, `../../Domain/{Order,Cart,Module}/`), checked by opening them.
- Every factual claim was read this session: `classes/PaymentModule.php` is 1410 lines and
  `validateOrder()` starts at 194 with the next method at 831; `Hook::getHookModuleExecList()` is at
  `classes/Hook.php:800` and delegates to `getAllHookRegistrations()` at `:1297`, which holds the
  no-cache list and the country/currency/group filtering; `HookFinder::$expectedInstanceClasses` throws
  at `src/PrestaShopBundle/Service/Hook/HookFinder.php:66`.
- Index arithmetic checked both ways: 30 names listed, 30 directories under `.ai/Component/`.
- **The domain line in the same file was checked and deliberately left alone**: it claims 58, lists 58
  names, and `.ai/Domain/` holds 58 directories, with no name missing on either side. Only the component
  sentence was wrong, so only that one is touched. Worth saying in the PR, because #41205's own body
  says "57 business domains and 22 shared components" - three different component counts exist across
  the two artifacts, and a reviewer who starts counting should find the domain side already settled.

### Notes for reviewers

- Say in the body that this closes the last of the five (#41158, #41159, #41160, #41161 are already
  satisfied by #41205 and only need closing) - it makes the batch legible to whoever triages it.
- The `Type?` is `improvement` and the base `9.2.x` because it is a docs/tooling addition, not a product
  feature. #41205 went to `develop`, but that was in April when `9.1.x` was the patch branch.
- **`Category?` deliberately differs from the precedent.** #41205 used `IN`; this uses `CO`. `IN` is the
  installer and `.ai/` is neither installer nor front/back office, so `CO` (core) is the closest true
  value - but both are valid template values, ps-jarvis parses either fine, and the deviation is worth
  one line in the PR body offering to switch to `IN` for consistency with the parent PR if a maintainer
  prefers the series to match. Checked #41205's cells directly rather than assuming: `Type? improvement`,
  `Category? IN`, `Branch? develop`, `UI Tests` filled with "N/A - documentation/tooling only".

