### PR TITLE
Read each logo scope with shop parameters instead of switching the shop context

### DIFF
--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -166,27 +166,37 @@ class LogoUploader
         return false;
     }
 
+    /**
+     * Deletes the previous file when the logo of this scope is its own rather than one inherited from
+     * the group or from all shops.
+     *
+     * Each scope is read with the shop parameters of Configuration::get() instead of by switching the
+     * global shop context. Switching it here was doing real damage: Shop::setContext() was called three
+     * times and never restored, so anything that failed in between left the rest of the request holding
+     * a context that no longer described the shop being edited. The last of those calls also passed the
+     * context shop id straight to Shop::setContext(), which forwards it unchanged to the int-typed
+     * Shop::getGroupIdFromShopId(); with no shop in context that is a TypeError, and the request then
+     * died a second time inside the error page, because every Adapter\Configuration::get() there builds
+     * a ShopConstraint from the context this method had left at group id 0. The merchant saw "Shop group
+     * id 0 is invalid" - a message about the aborted cleanup rather than about their logo.
+     */
     private function updateInMultiShopContext(&$idShop, &$idShopGroup, $fieldName)
     {
         if (Shop::getContext() == Shop::CONTEXT_SHOP) {
             $idShop = Shop::getContextShopID();
             $idShopGroup = Shop::getContextShopGroupID();
-            Shop::setContext(Shop::CONTEXT_ALL);
-            $logoAll = Configuration::get($fieldName);
-            Shop::setContext(Shop::CONTEXT_GROUP, $idShopGroup);
-            $logoGroup = Configuration::get($fieldName);
-            Shop::setContext(Shop::CONTEXT_SHOP, $idShop);
-            $logoShop = Configuration::get($fieldName);
+            $logoAll = Configuration::getGlobalValue($fieldName);
+            $logoGroup = Configuration::get($fieldName, null, $idShopGroup, 0);
+            $logoShop = Configuration::get($fieldName, null, $idShopGroup, $idShop);
             if ($logoAll != $logoShop && $logoGroup != $logoShop && $logoShop != false) {
-                @unlink($this->imageDirection . Configuration::get($fieldName));
+                @unlink($this->imageDirection . $logoShop);
             }
         } elseif (Shop::getContext() == Shop::CONTEXT_GROUP) {
             $idShopGroup = Shop::getContextShopGroupID();
-            Shop::setContext(Shop::CONTEXT_ALL);
-            $logoAll = Configuration::get($fieldName);
-            Shop::setContext(Shop::CONTEXT_GROUP, $idShopGroup);
-            if ($logoAll != Configuration::get($fieldName)) {
-                @unlink($this->imageDirection . Configuration::get($fieldName));
+            $logoAll = Configuration::getGlobalValue($fieldName);
+            $logoGroup = Configuration::get($fieldName, null, $idShopGroup, 0);
+            if ($logoAll != $logoGroup) {
+                @unlink($this->imageDirection . $logoGroup);
             }
         }
     }

--- a/tests/Integration/Core/Shop/LogoUploaderContextTest.php
+++ b/tests/Integration/Core/Shop/LogoUploaderContextTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Shop;
+
+use Configuration;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Image\ImageFormatConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Shop\LogoUploader;
+use ReflectionClass;
+use ReflectionMethod;
+use Shop;
+
+/**
+ * updateInMultiShopContext() reads the logo of three shop scopes. It used to do that by switching the
+ * global shop context three times and never restoring it, which had two consequences:
+ *
+ *  - the last switch handed the context shop id straight to the int-typed Shop::getGroupIdFromShopId(),
+ *    so with no shop in context the whole request died with a TypeError;
+ *  - because the method never restored what it changed, everything after it ran with a context that no
+ *    longer described the shop being edited, and Adapter\Configuration::get() then threw
+ *    "Shop group id 0 is invalid" from the error page - hiding the original failure.
+ *
+ * Reading each scope through Configuration::get()'s shop parameters removes both.
+ */
+class LogoUploaderContextTest extends TestCase
+{
+    /**
+     * @var array{0: mixed, 1: mixed, 2: mixed}
+     */
+    private $savedContext;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->savedContext = [
+            self::readShopStatic('context'),
+            self::readShopStatic('context_id_shop'),
+            self::readShopStatic('context_id_shop_group'),
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        // Shop's context lives in statics, so it outlives the test unless it is put back by hand.
+        self::writeShopStatic('context', $this->savedContext[0]);
+        self::writeShopStatic('context_id_shop', $this->savedContext[1]);
+        self::writeShopStatic('context_id_shop_group', $this->savedContext[2]);
+
+        parent::tearDown();
+    }
+
+    /**
+     * The reported state: a shop context whose shop id never got resolved, which is what a merchant hit
+     * when saving a logo for a newly added shop.
+     */
+    public function testItSurvivesSaveWithAnUnresolvedShopContext(): void
+    {
+        // Built while the context is still healthy, as it is in a real request: constructing a Shop
+        // itself reads configuration, which is not possible once the context shop id is gone.
+        $uploader = $this->buildUploader();
+
+        self::writeShopStatic('context', Shop::CONTEXT_SHOP);
+        self::writeShopStatic('context_id_shop', null);
+        self::writeShopStatic('context_id_shop_group', null);
+
+        $idShop = null;
+        $idShopGroup = null;
+        $this->invokeUpdateInMultiShopContext($uploader, $idShop, $idShopGroup);
+
+        // Reaching here at all is the assertion: this used to raise
+        // "getGroupIdFromShopId(): Argument #1 ($shopId) must be of type int, null given".
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Whatever happens inside, the shop context the rest of the request depends on has to come out of
+     * the call exactly as it went in. Without that, an aborted logo save leaves every later
+     * Configuration::get() building a ShopConstraint from a context that no longer makes sense.
+     */
+    public function testItLeavesTheGlobalShopContextUntouched(): void
+    {
+        $uploader = $this->buildUploader();
+
+        self::writeShopStatic('context', Shop::CONTEXT_SHOP);
+        self::writeShopStatic('context_id_shop', null);
+        self::writeShopStatic('context_id_shop_group', null);
+
+        $idShop = null;
+        $idShopGroup = null;
+        $this->invokeUpdateInMultiShopContext($uploader, $idShop, $idShopGroup);
+
+        $this->assertSame(Shop::CONTEXT_SHOP, self::readShopStatic('context'), 'The shop context type was changed.');
+        $this->assertNull(self::readShopStatic('context_id_shop'), 'The context shop id was changed.');
+        $this->assertNull(self::readShopStatic('context_id_shop_group'), 'The context shop group id was changed.');
+    }
+
+    private function invokeUpdateInMultiShopContext(LogoUploader $uploader, &$idShop, &$idShopGroup): void
+    {
+        $method = new ReflectionMethod($uploader, 'updateInMultiShopContext');
+        $method->setAccessible(true);
+        $arguments = [&$idShop, &$idShopGroup, 'PS_LOGO'];
+        $method->invokeArgs($uploader, $arguments);
+    }
+
+    private function buildUploader(): LogoUploader
+    {
+        return new LogoUploader(
+            new Shop((int) Configuration::get('PS_SHOP_DEFAULT')),
+            $this->createMock(ImageFormatConfigurationInterface::class),
+            _PS_IMG_DIR_
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    private static function readShopStatic(string $property)
+    {
+        $reflected = (new ReflectionClass(Shop::class))->getProperty($property);
+        $reflected->setAccessible(true);
+
+        return $reflected->getValue();
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function writeShopStatic(string $property, $value): void
+    {
+        $reflected = (new ReflectionClass(Shop::class))->getProperty($property);
+        $reflected->setAccessible(true);
+        $reflected->setValue(null, $value);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `LogoUploader::updateInMultiShopContext()` read the logo of three shop scopes by calling `Shop::setContext()` three times and never restoring it. The last of those calls hands the context shop id to `Shop::setContext()`, which forwards it unchanged to the int-typed `Shop::getGroupIdFromShopId()`, so with no shop resolved in the context the save died with a `TypeError`. Worse, because nothing was restored, the rest of the request ran with a half-switched context and every `Adapter\Configuration::get()` then built a `ShopConstraint` from a group id of `0` and threw again from inside the error page - so the merchant was shown "Shop group id 0 is invalid" instead of anything about their logo. `Configuration::get()` already accepts the shop group and shop to read, so the context switching is removed entirely.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a multistore install, Design > Theme and logo, select a shop and save a header logo, mail logo or favicon. Before: on a shop whose context id is not resolved the request fails and the message names a shop group id of 0. After: the save completes and the global shop context is the same after the call as before it. `tests/Integration/Core/Shop/LogoUploaderContextTest.php` covers both halves and errors twice on `9.2.x`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41247
| Related PRs       |
| Sponsor company   |

### The chain, reproduced on 9.2.x

The reporter attached a trace, and it is a `[1/2]` / `[2/2]` pair - the second exception replaced the
first while the error page was being rendered. Both links reproduce on `9.2.x`:

```
[1/2] TypeError: ShopCore::getGroupIdFromShopId(): Argument #1 ($shopId) must be of type int, null given
        at LogoUploader.php:178  Shop::setContext(Shop::CONTEXT_SHOP, $idShop)

[2/2] ShopException: Shop group id 0 is invalid.
        at Adapter/Configuration.php:412  ShopConstraint::shopGroup(Shop::getContextShopGroupID())
        at EmployeeSessionSubscriber.php:140  Configuration::get('PS_COOKIE_CHECKIP')
```

Measured directly rather than inferred: `Shop::setContext(Shop::CONTEXT_SHOP, null)` raises exactly the
first message, and with the context left at group `0` a single `Adapter\Configuration::get()` raises
exactly the second, from `ShopGroupId.php:48`. So `[2/2]` is a consequence of `[1/2]` aborting the method
half way through its context switching, not an independent fault.

`Shop::setContext()` is the reason the first one is a fatal rather than a no-op: it casts for its own
property (`self::$context_id_shop = (int) $id;`) and then passes the same `$id` **uncast** to the
int-typed `getGroupIdFromShopId()` on the next line.

### Why read with parameters instead of restoring the context

Wrapping the switches in a `try`/`finally` would stop the corruption but keep a read path that mutates
global state, and would still leave the `TypeError`. `Configuration::get($key, $idLang, $idShopGroup,
$idShop)` already expresses the scope directly, so the three reads become three calls and the context is
never touched. Both failure modes disappear rather than being contained.

The values compared are the same as before: the old code read each scope immediately after switching to
it, so `getGlobalValue()` matches the `CONTEXT_ALL` read, `get($k, null, $group, 0)` the `CONTEXT_GROUP`
read, and `get($k, null, $group, $shop)` the `CONTEXT_SHOP` read. The `unlink` now uses the value already
read instead of asking `Configuration` a fourth time, which only happened to be right because the last
switch left the context on the scope being deleted.

### What this does not fix

Why the context shop id is unresolved when a merchant saves a logo for a newly added shop is **not**
established here, and it needs a multistore back office session to chase. This PR makes that failure
visible and harmless instead of fatal-and-mislabelled; it does not remove the underlying cause. Two
places worth looking at, both found while tracing this:

- `Adapter\Configuration::buildShopConstraintFromContext()` (`src/Adapter/Configuration.php:409-412`)
  throws whenever the context ids are missing, so *any* error page rendered in that state is replaced by
  a shop-constraint exception. That is what made this report hard to read, and it is reachable from
  something as ordinary as `new Shop($id)` - `ThemeRepository` calls configuration during construction,
  which is how the first version of the test blew up before it reached the method under test.
- `Shop::setContext()`'s uncast forward described above.

Neither is changed here: they are separate decisions about whether a missing context should be a hard
error, and both belong in their own PR rather than bundled into a logo fix.

### Verification

- `tests/Integration/Core/Shop/LogoUploaderContextTest.php` is new. **Both tests error on `9.2.x` with
  the reporter's `TypeError`; both pass with the change.** The revert was verified in the container both
  ways (`getGlobalValue` count 0 then 2) before either run was trusted.
- One test asserts the reported state survives at all; the other asserts the global shop context comes
  out of the call byte-identical to how it went in, which is the invariant whose absence produced the
  masking exception. `Shop`'s context lives in statics, so the test saves and restores all three by
  reflection in `tearDown` rather than leaving them for the next test.
- `tests/Integration/Core/Shop`: 6 tests, 21 assertions, 0 failures.
- php-cs-fixer clean; PHPStan `[OK] No errors`.
- UI tests: not run. A campaign can be launched on request.

### Notes for reviewers

- The issue carries the `Autoupgrade` label but the reporter states it reproduces on 9.0.2 as well as
  9.1.0, so it is not upgrade-specific; the label is probably worth removing.

