### PR TITLE
Assign the cart to the context before saving it in FrontController

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -430,6 +430,17 @@ class FrontControllerCore extends Controller
                     $cart->id_address_invoice = (int) Address::getFirstCustomerAddressId($cart->id_customer);
                 }
                 if ($to_update) {
+                    /*
+                     * Cart::update() fires actionCartSave, which is a front office hook: modules listening on it
+                     * expect the context to hold the cart being saved, exactly as they do everywhere else in the
+                     * front office. Without it, anything that asks for a price - Product::getPriceStatic(),
+                     * Cart::getProducts() - throws, because with no cart in the context and no employee there is
+                     * no address to resolve taxes and country scoped prices against.
+                     *
+                     * The cart update a few lines above already assigns the context before saving for the same
+                     * reason; this was the one place that did not.
+                     */
+                    $this->context->cart = $cart;
                     $cart->update();
                 }
             }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `FrontController::init()` allocates the customer's first address to a cart that has none and calls `Cart::update()`, which fires `actionCartSave` while the context still holds no cart - the context is only assigned twenty-seven lines further down. A module listening on that hook and asking for a price (`Product::getPriceStatic()`, `Cart::getProducts()`) therefore gets "If no employee is assigned in the context, cart ID must be provided to this method." and the front office dies with a fatal error, on an ordinary page request, for any customer whose cart addresses are still empty. The cart update twenty-four lines above already assigns the context before saving for exactly this reason; this was the one place that did not.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a module registered on `actionCartSave` whose handler calls `Product::getPriceStatic(1)` (source below). Log in on the front office, add a product to the cart, then set that cart's `id_address_delivery` and `id_address_invoice` to 0 - the state a cart is left in when the account is created before an address exists - and load any front office page. Before: the request dies with `PrestaShopException: If no employee is assigned in the context, cart ID must be provided to this method.` After: the page renders and the addresses are allocated as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41300
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/42496
| Sponsor company   |

### The chain, measured on 9.2.x

| step | location |
| --- | --- |
| address allocation saves the cart | `classes/controller/FrontController.php:433` |
| the save fires the front office hook | `classes/Cart.php:310` |
| the hook runs with `Context::getContext()->cart === null` | measured, see below |
| `getPriceStatic()` has no cart, no `$id_cart`, no employee | `classes/Product.php:3428` |
| and throws | `classes/Product.php:3435` |

On a front office request the only assignments to `Context::$cart` are `Context::updateCustomer()`,
which runs at login, and three lines in `FrontController::init()`: line 408, and lines 460 and 462 -
both of which run after the block that saves the cart.

### Why the guard in Product is not the thing to relax

`$cur_cart` is read at `classes/Product.php:3470` to resolve the tax address, which supplies the
country, state and postcode that `priceCalculation()` uses for the tax rate and for country scoped
specific prices. Removing the throw would not make the call correct, it would make it return a price
computed against the default country instead of the customer's - a silent wrong price in place of a
loud failure. The back office does not hit the throw because the same condition accepts an employee in
place of a cart.

### Verification

Reproduced and fixed through the real caller - an HTTP request to the front office, not a hand-built
call - with this module registered on `actionCartSave`:

```php
public function hookActionCartSave($params)
{
    $ctx = Context::getContext();
    $line = 'context_cart=' . (is_object($ctx->cart) ? 'obj#' . $ctx->cart->id : gettype($ctx->cart));
    try {
        $line .= ' getPriceStatic=OK(' . Product::getPriceStatic(1) . ')';
    } catch (\Throwable $e) {
        $line .= ' getPriceStatic=THROW ' . $e->getMessage();
    }
    try {
        $line .= ' getProducts=OK(' . count($params['cart']->getProducts()) . ')';
    } catch (\Throwable $e) {
        $line .= ' getProducts=THROW ' . $e->getMessage();
    }
    file_put_contents(_PS_ROOT_DIR_ . '/var/qa.log', $line . "\n", FILE_APPEND);
}
```

Before:

```
actionCartSave context_cart=NULL employee=unset param_cart=64
  getPriceStatic=THROW If no employee is assigned in the context, cart ID must be provided to this method.
  getProducts=THROW If no employee is assigned in the context, cart ID must be provided to this method.
```

After:

```
actionCartSave context_cart=obj#64 employee=unset param_cart=64
  getPriceStatic=OK(1823.04) getProducts=OK(1)
```

- Both directions checked: reverting the line restores both throws, and re-applying it clears them.
- Regression pass on the same build: front office home, product, cart, my account and order pages all
  return 200 in a logged-in session and in a guest session, and the cart ends with the same addresses
  allocated as before the change.
- php-cs-fixer clean, PHPStan `[OK] No errors`, `php -l` clean.
- No automated test. `FrontController::init()` is not reachable from the PHPUnit harness - there is no
  front office request fixture in `tests/`, and the existing `tests/Unit/Classes/controller/FrontControllerTest.php`
  reaches the controller only through a subclass that bypasses `init()` entirely. The reproduction above
  is deterministic and is the proof offered instead; a UI campaign can be run on request.

### Notes for reviewers

- **Three of my own open PRs touch `classes/controller/FrontController.php`**, checked against the full
  394-row open-PR list rather than a truncated one: **#42656** (lines 994/1407/1420) and **#42186**
  (lines 1821/2065) are far from line 433 and are only worth a mention; **#42496** is the one that
  matters.
- Overlaps my own **#42496** (fixes #34177), which restructures the same `if ($to_update)` statement to
  stop saving the cart when the customer has no address at all. The two are independent - #42496 does
  not touch the context, so on the reported path, where the customer *does* have an address, the save
  still runs and the fatal still occurs. Whichever lands second needs a one line rebase.
- Supersedes the closed **#41301** (Codencode), which carried this assignment plus the #34177 half.
  Credit it in the body. Its approach was disputed on the grounds that `Cart::update()` should not need
  a cart in the context; the answer is that the assignment is the front office's invariant rather than
  `update()`'s requirement, and that the sibling save at line 408 already maintains it.

