### PR TITLE
Answer 404 when a product redirect names no target

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -203,6 +203,22 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $this->product->redirect_type = RedirectType::TYPE_NOT_FOUND;
             }
 
+            // A redirect that names no target cannot be performed. Both Link::getProductLink() and
+            // Link::getCategoryLink() throw on an empty id, which surfaced as a 500 on an ordinary product
+            // page. The state is reachable without anything exotic: the webservice accepts a redirect type
+            // without a target, and deleting the target product leaves one behind. It also covers a
+            // category redirect whose fallback above found no default category. Answer "not found", which
+            // is what a redirect to nowhere means and what the same branch already does when a product
+            // redirects to itself.
+            if (!$this->product->id_type_redirected && in_array($this->product->redirect_type, [
+                RedirectType::TYPE_PRODUCT_PERMANENT,
+                RedirectType::TYPE_PRODUCT_TEMPORARY,
+                RedirectType::TYPE_CATEGORY_PERMANENT,
+                RedirectType::TYPE_CATEGORY_TEMPORARY,
+            ])) {
+                $this->product->redirect_type = RedirectType::TYPE_NOT_FOUND;
+            }
+
             $redirect_type = $this->product->redirect_type;
             // If product has no specified redirect settings, we get default from configuration
             if (empty($redirect_type) || $redirect_type == RedirectType::TYPE_DEFAULT) {

--- a/tests/Unit/Classes/controller/ProductControllerRedirectWithoutTargetTest.php
+++ b/tests/Unit/Classes/controller/ProductControllerRedirectWithoutTargetTest.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Controller;
+
+use Context;
+use Link;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
+use Product;
+use ProductControllerCore;
+use RuntimeException;
+
+/**
+ * A disabled product carrying a redirect that names no target used to reach
+ * Link::getProductLink(0) or Link::getCategoryLink(0), both of which throw, so an ordinary product page
+ * answered 500 instead of 404.
+ *
+ * The state needs nothing exotic: the webservice accepts a redirect type without a target, and deleting
+ * the product a redirect pointed at leaves one behind.
+ */
+class ProductControllerRedirectWithoutTargetTest extends TestCase
+{
+    /**
+     * @dataProvider provideRedirectTypesWithoutTarget
+     */
+    public function testRedirectWithoutATargetAnswersNotFound(string $redirectType, int $defaultCategoryId): void
+    {
+        $controller = new RedirectTestProductController();
+        $controller->setProductUnderTest($this->disabledProduct($redirectType, $defaultCategoryId));
+        // With the recorder in place, any attempt to build a redirect link throws instead of returning,
+        // so reaching the redirect branch at all is what fails the test rather than a missing stub.
+        $controller->installLinkRecorder();
+
+        $controller->checkPermissionsToViewProduct();
+
+        $this->assertSame(
+            RedirectType::TYPE_NOT_FOUND,
+            $controller->getProductUnderTest()->redirect_type,
+            sprintf('"%s" without a target should fall back to a 404.', $redirectType)
+        );
+        $this->assertContains('errors/404', $controller->templatesSet);
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public function provideRedirectTypesWithoutTarget(): iterable
+    {
+        yield '301-product with no target' => [RedirectType::TYPE_PRODUCT_PERMANENT, 0];
+        yield '302-product with no target' => [RedirectType::TYPE_PRODUCT_TEMPORARY, 0];
+        // The category branch fills the target from the default category, so it only breaks when that
+        // is missing too - which is the second case the report describes.
+        yield '301-category with no default category' => [RedirectType::TYPE_CATEGORY_PERMANENT, 0];
+        yield '302-category with no default category' => [RedirectType::TYPE_CATEGORY_TEMPORARY, 0];
+    }
+
+    /**
+     * A category redirect that does have a default category must still redirect, so the guard cannot be
+     * a blanket "category redirects are 404". This is the control: it must keep its redirect type.
+     */
+    public function testCategoryRedirectStillUsesTheDefaultCategory(): void
+    {
+        $controller = new RedirectTestProductController();
+        $controller->setProductUnderTest($this->disabledProduct(RedirectType::TYPE_CATEGORY_PERMANENT, 7));
+        $controller->installLinkRecorder();
+
+        // The redirect branch ends in exit(), so the recorder throws instead of returning a link. That
+        // is what makes the redirect observable from a test at all.
+        try {
+            $controller->checkPermissionsToViewProduct();
+            $this->fail('The category redirect was never performed.');
+        } catch (RedirectLinkRequested $requested) {
+            $this->assertSame('category', $requested->kind);
+            $this->assertSame(7, $requested->targetId, 'The redirect did not target the default category.');
+        }
+
+        $this->assertSame(RedirectType::TYPE_CATEGORY_PERMANENT, $controller->getProductUnderTest()->redirect_type);
+        $this->assertNotContains('errors/404', $controller->templatesSet);
+    }
+
+    private function disabledProduct(string $redirectType, int $defaultCategoryId): Product
+    {
+        $product = new RedirectTestProduct();
+        $product->id = 42;
+        $product->active = false;
+        $product->redirect_type = $redirectType;
+        $product->id_type_redirected = 0;
+        $product->id_category_default = $defaultCategoryId;
+
+        return $product;
+    }
+}
+
+/**
+ * Both methods this overrides query the database; nothing here needs their real answers.
+ */
+class RedirectTestProduct extends Product
+{
+    public function __construct()
+    {
+    }
+
+    public function isAssociatedToShop($id_shop = null)
+    {
+        return true;
+    }
+
+    public function checkAccess($id_customer)
+    {
+        return true;
+    }
+}
+
+/**
+ * Renders nothing and translates nothing: the decision under test is which redirect type and which
+ * template the controller settles on, not how either is produced.
+ */
+class RedirectTestProductController extends ProductControllerCore
+{
+    /**
+     * @var string[]
+     */
+    public $templatesSet = [];
+
+    public function __construct()
+    {
+    }
+
+    public function setProductUnderTest(Product $product): void
+    {
+        $this->product = $product;
+    }
+
+    public function getProductUnderTest(): Product
+    {
+        return $this->product;
+    }
+
+    /**
+     * Gives the controller a context whose link builder records the category it was asked for and
+     * throws, so the redirect can be observed without running into the exit() that follows it.
+     */
+    public function installLinkRecorder(): void
+    {
+        $context = new Context();
+        $context->link = new RecordingLink();
+
+        $this->context = $context;
+    }
+
+    public function setTemplate($template, $params = [], $locale = null)
+    {
+        $this->templatesSet[] = $template;
+    }
+
+    protected function trans($id, array $parameters = [], $domain = null, $locale = null)
+    {
+        return $id;
+    }
+}
+
+/**
+ * Signals that the controller tried to build a redirect link, and for which target. In production that
+ * call is what throws when the target is 0, which is how the 500 was produced.
+ */
+class RedirectLinkRequested extends RuntimeException
+{
+    /**
+     * @var string
+     */
+    public $kind;
+
+    /**
+     * @var int
+     */
+    public $targetId;
+
+    public function __construct(string $kind, int $targetId)
+    {
+        parent::__construct(sprintf('A %s redirect link was requested for id %d.', $kind, $targetId));
+        $this->kind = $kind;
+        $this->targetId = $targetId;
+    }
+}
+
+/**
+ * Records which category a link was requested for. It throws rather than returning, because the
+ * controller calls exit() straight after building the redirect location.
+ */
+class RecordingLink extends Link
+{
+    public function __construct()
+    {
+    }
+
+    public function getCategoryLink($category, $alias = null, $idLang = null, $selectedFilters = null, $idShop = null, $relativeProtocol = false)
+    {
+        throw new RedirectLinkRequested('category', (int) $category);
+    }
+
+    public function getProductLink($product, $alias = null, $category = null, $ean13 = null, $idLang = null, $idShop = null, $idProductAttribute = null, $force_routes = false, $relativeProtocol = false, $withIdInAnchor = false, $extraParams = [], bool $addAnchor = true)
+    {
+        throw new RedirectLinkRequested('product', (int) $product);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A disabled product whose `redirect_type` is `301-product` or `302-product` but whose `id_type_redirected` is `0` reached `Link::getProductLink(0)`, which throws `Invalid product vars`, so an ordinary product page answered **HTTP 500 instead of 404**. The same happened to `301-category` / `302-category` when `id_category_default` was missing too, because the existing fallback then set the target to `0` and `Link::getCategoryLink(0)` throws in the same way. A redirect that names no target is now treated as not found, which is what it means and what the surrounding branch already does when a product redirects to itself.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Disable a product, set its redirect to "Permanent redirection to a product (301)" and leave the target empty - reachable through the webservice, or by deleting the product the redirect pointed at. Visit the product URL. Before: HTTP 500, `PrestaShopException: Invalid product vars` in the log. After: HTTP 404 with the 404 page. Repeat with a category redirect on a product that has no default category. A category redirect that *does* have a default category must still redirect - that case is covered by a test.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42288
| Related PRs       | Supersedes #42287, which was closed automatically when `9.1.x` was deleted
| Sponsor company   |

### Credit

@Sasni reported this and opened #42287 with the same approach for the product case. That pull request
was **not rejected**: its timeline shows `base_ref_deleted` followed by `closed`, both by jolelievre on
2026-08-20, when `9.1.x` was removed. It carried the `Bug fix` label and a milestone. This is that fix,
rebuilt on `9.2.x`, with the category case added and a test.

### What this adds over #42287

#42287 guarded the two product redirect types. The report also names a second case, and it fails the
same way: for `301-category` / `302-category` the existing code fills the target from
`id_category_default`, so when the product has no default category the target is still `0` and
`Link::getCategoryLink(0)` throws `Invalid category vars`.

Rather than a second `elseif`, the guard is a single check after the existing fallback has had its
chance, covering all four redirect types. That way the category fallback keeps working and only a
redirect that still has no target after it is turned into a 404.

### Verified on 9.2.x

- `controllers/front/ProductController.php:198-204` - only the category types get a fallback; the product
  types fall through with `id_type_redirected` still `0`.
- `classes/Link.php:154` throws `Invalid product vars` and `classes/Link.php:401` throws
  `Invalid category vars` when the id is empty.
- `RedirectType::TYPE_NOT_FOUND` is `'404'`, and the switch handles it in `case TYPE_NOT_FOUND: default:`
  by sending `404 Not Found` and the `errors/404` template, so setting it produces a real 404 rather than
  falling through to something else.

### Test

`tests/Unit/Classes/controller/ProductControllerRedirectWithoutTargetTest.php`, a unit test with no
database: the product double answers `isAssociatedToShop()` and `checkAccess()` itself, and the
controller double records templates instead of rendering.

The link builder is stubbed to **throw** rather than return, for two reasons: the redirect branch ends in
`exit()`, which would kill the test process, and it makes the failure say what actually went wrong. On
`9.2.x` the four cases fail with `A product redirect link was requested for id 0.` and
`A category redirect link was requested for id 0.` - which is the call that throws in production - rather
than with an incidental error from a missing stub.

- **4 of 5 fail on `9.2.x`; all 5 pass with the change.**
- The fifth is a control: a category redirect that *does* have a default category must still redirect,
  and it asserts the link was requested for that category. It passes on both sides, so it catches a fix
  that over-triggers and turns working redirects into 404s.
- `tests/Unit/Classes`: **724 tests, 0 errors** with the change; reverting only the controller change
  leaves the same 724 tests with exactly those 4 errors. The single pre-existing warning is on both sides.
- php-cs-fixer clean; PHPStan `[OK] No errors`.
- UI tests: not run. A campaign can be launched on request.

### Notes for reviewers

- Say plainly that #42287 was closed by branch deletion rather than on merit, and credit @Sasni in the
  body, not only in the commit.
- No competing PR: nothing open touches `checkPermissionsToViewProduct` or `id_type_redirected`, and of
  my 395 open PRs the 6 touching `controllers/front/ProductController.php` have their nearest hunk at
  line 335, against a target region of 181-270.

