### PR TITLE
Keep a custom feature value that another product still uses

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2463,6 +2463,25 @@ class ProductCore extends ObjectModel
         foreach ($features as $tab) {
             // Delete product custom features
             if ($tab['custom']) {
+                // A custom value is meant to belong to one product, but nothing enforces that:
+                // setWsProductFeatures() inserts whichever id_feature_value the webservice sends, so an
+                // integration that copies features between products makes several of them share one.
+                // Deleting it unconditionally here then emptied the feature on every other product still
+                // pointing at it, and left their feature_product rows referencing a row that is gone.
+                // Only drop the value once nothing else uses it -- the same rule the migrated back office
+                // path already applies in ProductFeatureValueUpdater::cleanOrphanCustomFeatureValues().
+                // This product's own rows are still present at this point, hence the id_product exclusion.
+                $usedByAnotherProduct = (bool) Db::getInstance()->getValue(
+                    'SELECT 1
+                    FROM `' . _DB_PREFIX_ . 'feature_product`
+                    WHERE `id_feature_value` = ' . (int) $tab['id_feature_value'] . '
+                    AND `id_product` != ' . (int) $this->id
+                );
+
+                if ($usedByAnotherProduct) {
+                    continue;
+                }
+
                 Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'feature_value` WHERE `id_feature_value` = ' . (int) $tab['id_feature_value']);
                 Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'feature_value_lang` WHERE `id_feature_value` = ' . (int) $tab['id_feature_value']);
             }

--- a/tests/Integration/Classes/ProductCustomFeatureValueDeletionTest.php
+++ b/tests/Integration/Classes/ProductCustomFeatureValueDeletionTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Db;
+use Feature;
+use FeatureValue;
+use PHPUnit\Framework\TestCase;
+use Product;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+/**
+ * Product::deleteFeatures() used to drop a custom feature value from the whole catalogue, so deleting
+ * one product emptied the feature on every other product that shared the value and left their
+ * feature_product rows pointing at a row that no longer existed.
+ *
+ * Nothing stops several products sharing one custom value: Product::setWsProductFeatures() inserts
+ * whichever id_feature_value the webservice sends, without checking who owns it.
+ */
+class ProductCustomFeatureValueDeletionTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    /**
+     * @var int
+     */
+    private $featureId;
+
+    /**
+     * @var int[]
+     */
+    private $createdProductIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        $feature = new Feature();
+        $feature->name = [1 => 'Shared custom feature'];
+        $feature->add();
+        $this->featureId = (int) $feature->id;
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdProductIds as $productId) {
+            $product = new Product($productId);
+            if ($product->id) {
+                $product->delete();
+            }
+        }
+
+        $feature = new Feature($this->featureId);
+        if ($feature->id) {
+            // Removes the feature and every value still attached to it.
+            $feature->delete();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testDeletingOneProductKeepsACustomValueAnotherProductStillUses(): void
+    {
+        $customValueId = $this->createCustomFeatureValue('Shared value');
+        $firstProductId = $this->createProductWithFeatureValue('first-product', $customValueId);
+        $secondProductId = $this->createProductWithFeatureValue('second-product', $customValueId);
+
+        // Guard the fixture itself: without two live associations the test would pass vacuously.
+        $this->assertSame(2, $this->countAssociations($customValueId));
+
+        $firstProduct = new Product($firstProductId);
+        $this->assertTrue((bool) $firstProduct->delete());
+
+        $this->assertTrue(
+            $this->featureValueExists($customValueId),
+            'Deleting one product removed a custom feature value that another product still uses.'
+        );
+        $this->assertSame(
+            1,
+            $this->countAssociations($customValueId),
+            'The surviving product lost its association to the shared custom feature value.'
+        );
+        $this->assertSame(
+            [$secondProductId],
+            $this->associatedProductIds($customValueId),
+            'The association left behind belongs to the wrong product.'
+        );
+    }
+
+    /**
+     * The guard must not leak rows either: once the last product using the value is gone, the value
+     * itself has to go, exactly as it did before.
+     */
+    public function testDeletingTheLastProductStillRemovesTheCustomValue(): void
+    {
+        $customValueId = $this->createCustomFeatureValue('Only value');
+        $onlyProductId = $this->createProductWithFeatureValue('only-product', $customValueId);
+
+        $this->assertSame(1, $this->countAssociations($customValueId));
+
+        $onlyProduct = new Product($onlyProductId);
+        $this->assertTrue((bool) $onlyProduct->delete());
+
+        $this->assertFalse(
+            $this->featureValueExists($customValueId),
+            'A custom feature value survived the deletion of the only product using it.'
+        );
+    }
+
+    private function createCustomFeatureValue(string $value): int
+    {
+        $featureValue = new FeatureValue();
+        $featureValue->id_feature = $this->featureId;
+        $featureValue->custom = true;
+        $featureValue->value = [1 => $value];
+        $featureValue->add();
+
+        return (int) $featureValue->id;
+    }
+
+    private function createProductWithFeatureValue(string $slug, int $customValueId): int
+    {
+        $product = new Product(null, false, 1);
+        $product->name = [1 => $slug];
+        $product->link_rewrite = [1 => $slug];
+        $product->price = 10.0;
+        $product->add();
+
+        $productId = (int) $product->id;
+        $this->createdProductIds[] = $productId;
+
+        // Mirrors what setWsProductFeatures() does: the value id is inserted as given, with no check
+        // of whether it already belongs to another product.
+        $product->addFeaturesToDB($this->featureId, $customValueId);
+
+        return $productId;
+    }
+
+    private function featureValueExists(int $customValueId): bool
+    {
+        return (bool) Db::getInstance()->getValue(
+            'SELECT 1 FROM `' . _DB_PREFIX_ . 'feature_value` WHERE `id_feature_value` = ' . $customValueId
+        );
+    }
+
+    private function countAssociations(int $customValueId): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'feature_product` WHERE `id_feature_value` = ' . $customValueId
+        );
+    }
+
+    /**
+     * @return int[]
+     */
+    private function associatedProductIds(int $customValueId): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'feature_product` WHERE `id_feature_value` = ' . $customValueId
+        ) ?: [];
+
+        return array_map('intval', array_column($rows, 'id_product'));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Product::deleteFeatures()` removed every custom feature value of the product being deleted with an unconditional `DELETE` on `feature_value`, without checking whether another product referenced the same row. Nothing prevents that sharing: `Product::setWsProductFeatures()` inserts whichever `id_feature_value` the webservice sends and never checks who owns it. Deleting one such product emptied the feature on every other product sharing the value and left their `feature_product` rows pointing at a row that no longer exists, so the feature renders blank in the front office. The delete is now skipped while another product still references the value - the same rule the migrated back office path already applies in `ProductFeatureValueUpdater::cleanOrphanCustomFeatureValues()`.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a feature, give a product a custom value for it, and through the webservice `PUT` that same `id_feature_value` onto a second product (`associations/product_features`). Both now point at one row. Delete the first product. Before: the value is gone from `ps_feature_value` and the second product's feature renders blank while its `ps_feature_product` row still exists. After: the value survives and the second product is untouched. Deleting the second product afterwards still removes the value, so nothing is leaked. Both cases are covered by `tests/Integration/Classes/ProductCustomFeatureValueDeletionTest.php`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42347
| Related PRs       |
| Sponsor company   |

### One correction to the report, which changes the trigger but not the defect

The report's step 5 is "open product 1 in the back office and save it". On 9.2 that no longer reaches
this code. Saving a product in the back office goes through the CQRS path, and
`ProductFeatureValueUpdater::cleanOrphanCustomFeatureValues()` already does the right thing - it deletes
a custom value only when `feature_product` has no row left for it at all. The reporter measured on
8.2.1, where that guard was not on the save path.

What is still unguarded on 9.2 is `Product::deleteFeatures()`, whose only route is
`deleteProductFeatures()` (single caller, `Product.php:1287`) inside `Product::delete()`. So on a current
shop the damage is triggered by **deleting a product**, not by saving one. The data loss, the dangling
`feature_product` rows and the blank front-office feature are identical; only the trigger is narrower,
and the fix is the same. Verified by reading both paths on `9.2.x`, not inferred from the 8.2.1 report.

### Verified on 9.2.x

All three mechanisms the report names are present:

- `classes/Product.php:6692` - `setWsProductFeatures()` passes the received `id_feature_value` straight
  to `addFeaturesToDB()`, with no ownership or `custom` check.
- `classes/Product.php:6668` - `getWsProductFeatures()` does `unset($rows[$keyrow]['custom'])`.
- `classes/Product.php:2465` - `deleteFeatures()` deletes the value globally when `custom` is set.

### What this PR deliberately does not change

- **`setWsProductFeatures()` is left alone.** Preventing the sharing at write time means choosing a
  semantic - reject the call, or silently clone the value and return an id the caller did not send -
  and both are visible behaviour changes for existing integrations. Once the delete is guarded, sharing
  is no longer destructive, so that decision does not have to be rushed to stop the data loss. It is
  also the method my open #42217 already touches, so keeping them apart keeps both reviewable.
- **`getWsProductFeatures()` is left alone.** Re-exposing `custom` is not the one-line `unset` removal it
  looks like: the `product_features` association declares exactly `id` and `id_feature_value` in
  `webserviceParameters` (`classes/Product.php:625`), so the field would have to be added to the
  association schema, which changes the webservice contract and its synopsis output. That is a separate
  discussion from stopping the data loss.

### Verification

- `tests/Integration/Classes/ProductCustomFeatureValueDeletionTest.php` is new (`A` in git status, it
  does not touch the existing `ProductTest.php`). **1 of 2 tests fails on `9.2.x`, both pass with the
  change.** The revert was verified in the container both ways before either run was trusted.
- The second test - deleting the last product using a value still removes it - **passes on both sides**.
  It is a control against the guard leaking orphan rows, not a restatement of the fix.
- The first test also asserts the fixture itself has two live associations before deleting anything, so
  it cannot pass vacuously if the sharing setup ever stops working.
- php-cs-fixer clean; PHPStan `[OK] No errors`.
- UI tests: not run. A campaign can be launched on request.

### Notes for reviewers

- The reporter's production numbers (1,704 shared associations, 824 already unrecoverable) are from an
  8.2.1 shop. Do not repeat them as if measured on 9.2 - they are evidence that the sharing happens in
  the field, not that this trigger fires on 9.2.
- This PR does not repair existing damage. Rows already pointing at a deleted value stay dangling; a
  data repair would be a separate discussion.
- No competing PR. My own #42217 touches `deleteProductFeatures()` (~line 2299), `addFeaturesToDB()`
  (~4620) and `setWsProductFeatures()` (~6694); this change is inside `deleteFeatures()` at ~2465, so the
  nearest hunks are about 160 lines apart.

