### PR TITLE
Offer every installed language in the cart rule form

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -729,7 +729,12 @@ class AdminCartRulesControllerCore extends AdminController
 
         $attribute_groups = AttributeGroup::getAttributesGroups($this->context->language->id);
         $currencies = Currency::getCurrencies(false, true, true);
-        $languages = Language::getLanguages();
+        // Every other back office form builds its translatable fields from AdminController::getLanguages(),
+        // which lists all installed languages. Calling Language::getLanguages() here listed only the active
+        // ones, so a language that is installed but disabled got no tab and its name could never be entered
+        // -- while the list and the compatibility selector still read the name in the employee's language,
+        // which may be exactly that disabled one, and showed it blank.
+        $languages = $this->getLanguages();
         $countries = $current_object->getAssociatedRestrictions('country', true, true);
         $groups = $current_object->getAssociatedRestrictions('group', false, true);
         $shops = $current_object->getAssociatedRestrictions('shop', false, false);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `AdminCartRulesController::renderForm()` built the translatable Name field from `Language::getLanguages()`, which returns only the **active** languages. Every other back office form goes through `AdminController::getLanguages()`, which calls `Language::getLanguages(false)` and lists **all installed** languages. A language that is installed but disabled therefore got no tab in the cart rule form and its name could never be entered, while the cart rule list and the "compatible with other cart rules" selector join the lang table on the employee's own language - which may be exactly that disabled one - and showed a blank name.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install two languages, keep the shop on one and disable the other, and set an employee's back office language to the disabled one. Open Catalog > Discounts > Cart Rules and add or edit a rule. Before: the Name field offers only the active language, and after saving the rule's name is blank in the list and in the compatibility selector. After: the form offers a tab for both languages, so the name can be entered for the disabled one and the list shows it.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42361
| Related PRs       |
| Sponsor company   |

### Why the inherited accessor rather than flipping the flag

The reporter's suggestion, `Language::getLanguages(false)`, produces the right list. Using
`$this->getLanguages()` produces the same list and also removes the reason the two could disagree:
`AdminController::getLanguages()` **is** the call to `Language::getLanguages(false)`, plus the
`default_form_language` bookkeeping. The controller had duplicated that lookup and then drifted from it,
so calling the accessor is what stops it drifting again.

`AdminCartRulesController` is the only multilang back office form that bypassed the accessor. The three
other controllers calling `Language::getLanguages()` directly are a different concern and were left
alone: `AdminCustomerThreadsController` builds a filter over languages customers actually shop in,
`AdminStatsController` reports translation coverage of the live shop, and
`AdminTranslationsController::copyMailFilesForAllLanguages()` copies mail templates. None of them is a
translatable form field.

Note `parent::renderForm()` does call `getLanguages()`, but only at the end of this method - the cart
rule template is fetched before that - so the controller has to make the call itself.

### Measured on 9.2 with a second language installed and disabled

Instantiating the real controller and reading the variable handed to the template:

| | `languages` passed to the form |
| --- | --- |
| base | `[en]` |
| this branch | `[en, fr]` |

and the two accessors side by side, same shop state:

    Language::getLanguages()      : [en]      <- AdminCartRulesController::renderForm():732
    Language::getLanguages(false) : [en, fr]  <- AdminController::getLanguages():3494

With both languages active the two agree, which is why this only shows up once a language is disabled.

### Verification

- The existing harness already covers this controller: `AdminControllerTest::getControllersClasses()`
  lists `AdminCartRulesController`, and `tests/Integration/Classes/controller` is **28 tests / 42
  assertions, 0 failures, identical before and after**.
- php-cs-fixer clean; PHPStan `[OK] No errors`.
- UI tests: not run. A campaign can be launched on request.

### No automated test, and why

I got a render harness working (define `_PS_ADMIN_DIR_`, mock the employee and cookie, call
`renderForm()`, read the `languages` template variable) and it does produce a clean red/green - that is
where the table above comes from. I did not ship it as a test:

`AdminControllerTest.php:183` already does `define('_PS_ADMIN_DIR_', '')` in the same suite, and 28
places in `classes/` and `src/` branch on `defined('_PS_ADMIN_DIR_')`, including `Context`, `Dispatcher`,
`Cart`, `Employee` and `Language`. A test needing the constant to hold the real admin path would pass or
fail depending on which test ran first, and defining it would change behaviour for everything after it in
the process. An order-dependent test is worse than none. Making this testable properly needs a back
office render harness that owns that constant, which is a larger change than this fix and belongs in a
separate PR.

### Notes for reviewers

- Remaining data caveat worth stating on the thread if asked: rules saved while the language was disabled
  keep an empty name row, so they still list blank until re-saved through the fixed form. The fix removes
  the cause, it does not backfill existing rows.
- No competing PR: no open core PR touches `AdminCartRulesController.php` (#42485, #41663 and my own
  #42609 matched only on text, not on files), and of my 395 open PRs the 3 touching
  `classes/controller/AdminController.php` have hunks at lines 3/476/837/2185/2816, far from
  `getLanguages()` at ~3485.

