### PR TITLE
Declare the HTML5 elements to HTML Purifier so CMS content keeps its structure

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4129,6 +4129,41 @@ exit;
                         'src' => 'URI',
                         'type' => 'Text',
                     ]);
+                    $def->addElement('audio', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', [
+                        'src' => 'URI',
+                        'type' => 'Text',
+                        'preload' => 'Enum#auto,metadata,none',
+                        'controls' => 'Bool',
+                        'autoplay' => 'Bool',
+                        'loop' => 'Bool',
+                        'muted' => 'Bool',
+                    ]);
+                    $def->addElement('picture', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common');
+                    $def->addElement('track', 'Block', 'Empty', 'Common', [
+                        'src' => 'URI',
+                        'kind' => 'Enum#subtitles,captions,descriptions,chapters,metadata',
+                        'srclang' => 'Text',
+                        'label' => 'Text',
+                        'default' => 'Bool',
+                    ]);
+
+                    // HTML Purifier ships an XHTML 1.0 definition, so every HTML5 element is unknown to it and
+                    // its tags are dropped on save -- the content survives but the structure does not. These are
+                    // the sectioning, grouping and text-level elements, which carry no scripting or embedding
+                    // surface of their own: they are declared here rather than left to each merchant, because the
+                    // markup above already extends the same definition for the media elements.
+                    foreach (['section', 'article', 'aside', 'nav', 'header', 'footer', 'main', 'figure', 'figcaption'] as $sectioningElement) {
+                        $def->addElement($sectioningElement, 'Block', 'Flow', 'Common');
+                    }
+                    foreach (['mark', 'bdi'] as $textLevelElement) {
+                        $def->addElement($textLevelElement, 'Inline', 'Inline', 'Common');
+                    }
+                    $def->addElement('time', 'Inline', 'Inline', 'Common', ['datetime' => 'Text']);
+                    $def->addElement('data', 'Inline', 'Inline', 'Common', ['value' => 'Text']);
+                    $def->addElement('wbr', 'Inline', 'Empty', 'Common');
+                    $def->addElement('details', 'Block', 'Flow', 'Common', ['open' => 'Bool']);
+                    $def->addElement('summary', 'Block', 'Flow', 'Common');
+
                     if ($allow_style) {
                         $def->addElement('style', 'Block', 'Flow', 'Common', ['type' => 'Text']);
                     }

--- a/tests/Integration/Classes/ToolsPurifyHtml5Test.php
+++ b/tests/Integration/Classes/ToolsPurifyHtml5Test.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use PHPUnit\Framework\TestCase;
+use Tools;
+
+class ToolsPurifyHtml5Test extends TestCase
+{
+    /**
+     * Tools::purifyHTML() returns its input untouched when the purifier is switched off, which would make
+     * every assertion below pass without the purifier ever running. Fail loudly instead of vacuously.
+     *
+     * Note purifyHTML() caches both the flag and the purifier in statics, so this reads the value that the
+     * rest of the process will use, not merely the current configuration row.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!Configuration::get('PS_USE_HTMLPURIFIER')) {
+            $this->fail('PS_USE_HTMLPURIFIER is off, so Tools::purifyHTML() is a passthrough and this test would assert nothing.');
+        }
+    }
+
+    /**
+     * @dataProvider provideHtml5Elements
+     */
+    public function testHtml5ElementsSurvivePurification(string $tag, string $html): void
+    {
+        $purified = Tools::purifyHTML($html);
+
+        $this->assertStringContainsString(
+            '<' . $tag,
+            $purified,
+            sprintf('The <%s> element was dropped by HTML Purifier. Purified output: %s', $tag, $purified)
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public function provideHtml5Elements(): iterable
+    {
+        // Sectioning and grouping content.
+        yield 'section' => ['section', '<section class="intro"><p>text</p></section>'];
+        yield 'article' => ['article', '<article class="post"><p>text</p></article>'];
+        yield 'aside' => ['aside', '<aside><p>text</p></aside>'];
+        yield 'nav' => ['nav', '<nav><a href="/page">link</a></nav>'];
+        yield 'header' => ['header', '<header><h1>title</h1></header>'];
+        yield 'footer' => ['footer', '<footer><p>text</p></footer>'];
+        yield 'main' => ['main', '<main><p>text</p></main>'];
+        yield 'figure' => ['figure', '<figure><img src="/img/a.png" alt="a" /></figure>'];
+        yield 'figcaption' => ['figcaption', '<figure><figcaption>caption</figcaption></figure>'];
+
+        // Text-level semantics.
+        yield 'mark' => ['mark', '<p><mark>highlighted</mark></p>'];
+        yield 'bdi' => ['bdi', '<p><bdi>name</bdi></p>'];
+        yield 'time' => ['time', '<p><time datetime="2026-01-01">January</time></p>'];
+        yield 'data' => ['data', '<p><data value="42">forty two</data></p>'];
+        yield 'wbr' => ['wbr', '<p>long<wbr />word</p>'];
+
+        // Interactive content.
+        yield 'details' => ['details', '<details open="open"><summary>more</summary><p>text</p></details>'];
+        yield 'summary' => ['summary', '<details><summary>more</summary><p>text</p></details>'];
+
+        // Media, completing the video/source pair the definition already carried.
+        yield 'audio' => ['audio', '<audio src="/media/a.mp3" controls="controls"></audio>'];
+        yield 'picture' => ['picture', '<picture><img src="/img/a.png" alt="a" /></picture>'];
+        yield 'track' => ['track', '<video src="/media/a.mp4"><track src="/media/a.vtt" kind="captions" /></video>'];
+    }
+
+    /**
+     * Declaring the elements above must not widen what may be put ON them. Without this, a regression that
+     * relaxed attribute handling would still leave every assertion above green.
+     *
+     * @dataProvider provideMarkupThatMustBeSanitized
+     */
+    public function testDeclaringHtml5ElementsDoesNotAllowScriptingAttributes(string $needle, string $html): void
+    {
+        $purified = Tools::purifyHTML($html);
+
+        $this->assertStringNotContainsString(
+            $needle,
+            $purified,
+            sprintf('"%s" survived purification. Purified output: %s', $needle, $purified)
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public function provideMarkupThatMustBeSanitized(): iterable
+    {
+        yield 'onclick on a new sectioning element' => ['onclick', '<section onclick="alert(1)">text</section>'];
+        yield 'onerror on a new sectioning element' => ['onerror', '<article onerror="alert(1)">text</article>'];
+        yield 'onmouseover on a new inline element' => ['onmouseover', '<mark onmouseover="alert(1)">text</mark>'];
+        yield 'javascript: href inside a new element' => ['javascript:', '<nav><a href="javascript:alert(1)">link</a></nav>'];
+        yield 'javascript: source on a new media element' => ['javascript:', '<audio src="javascript:alert(1)"></audio>'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | HTML Purifier ships an XHTML 1.0 element definition, so every HTML5 element is unknown to it and `Tools::purifyHTML()` drops the tag on save while keeping its contents. A CMS page written with `<section>`, `<article>`, `<aside>`, `<nav>`, `<header>`, `<footer>`, `<main>`, `<figure>` or `<figcaption>` loses all of its structure the moment it is saved, and `<audio>` loses its content entirely while its sibling `<video>` survives, because only the media elements had ever been declared. This declares the sectioning, grouping, text-level and interactive elements next to the existing `video`/`source` definitions, and completes the media set with `audio`, `picture` and `track`.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Design > Pages, edit a CMS page, switch the editor to source view and save `<section class="intro"><p>text</p></section>`. Before: the page saves as `<p>text</p>`, the `<section>` is gone. After: the element survives. `tests/Integration/Classes/ToolsPurifyHtml5Test.php` covers all 19 elements plus the sanitisation controls; it fails 19 of 24 on `9.2.x` and passes fully with the change.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #42371
| Related PRs       |
| Sponsor company   |

### Why the elements are declared in core rather than left to the hook

`actionModifyHtmlPurifierConfig` exists and a module can indeed add these itself, which is what the issue
thread suggests. But the same block already declares `video`, `source` and (conditionally) `style` for
exactly this reason, so the HTML5 gap is core's to close, not each merchant's. The new declarations run
**before** the hook, so a module can still override or remove any of them.

`#37967` is the precedent: missing attributes on the `video` element were treated as a bug in
`Tools::purifyHTML()` and fixed by extending the same definition.

### Measured on 9.2.0 with PS_USE_HTMLPURIFIER on

Every HTML5 element tested was stripped before the change - the tag removed, the contents kept:

    section article aside nav header footer main figure figcaption
    mark bdi time data wbr details summary
    audio picture track

`<audio src="/a.mp3" controls>` was the worst case: it purified to the **empty string**, so an embedded
audio player disappeared completely, while the identical `<video>` markup survived.

### Security

Attribute handling is untouched. Declaring an element with `Common` says which tag may appear, not what
may be put on it, so event handlers and `javascript:` URLs are removed exactly as before. Five of the
test's cases are negative controls that assert this - `onclick`, `onerror` and `onmouseover` on the new
elements, plus `javascript:` in an `href` and in an `<audio src>`. **Those 5 pass on the base branch as
well as on the branch**, which is what makes them controls rather than artefacts of the change.

Nothing with a scripting or embedding surface was added: no `script`, `iframe`, `object`, `embed`,
`canvas`, `svg`, `template` or `slot`. Form-associated elements (`progress`, `meter`, `output`) and
`ruby` were left out too - they are a different class and none of them is what the issue reports.

### Verification

- New test RED to GREEN on the real purifier: **19 failures of 24 on `9.2.x`**, 0 with the change.
  The revert was verified in the container both ways before trusting either run.
- The test fails loudly rather than vacuously if `PS_USE_HTMLPURIFIER` is off, since `purifyHTML()` is a
  passthrough in that case and every assertion would otherwise pass without the purifier ever running.
- php-cs-fixer clean; PHPStan `[OK] No errors` on both files.
- UI tests: not run. A campaign can be launched on request.

### Notes for reviewers

- The issue raises three separate things. Only the HTML5-element one is a defect. `onclick` being
  rejected is deliberate (`Validate.php`, `CleanHtmlValidator`) and must stay; the `<a>` wrapping `<div>`
  reflow is TinyMCE's schema, not the purifier. hugo-fasone already answered all three correctly on the
  thread - do not restate that, only add the fix.
- No competing PR: no open core PR touches `purifyHTML`, and of my own 395 open PRs the 3 that touch
  `classes/Tools.php` (#42685, #42698, #42712) have their highest hunk at line 2725, far from ~4075.

