### PR TITLE
Apply the shop's timezone when the shop context changes

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1015,6 +1015,41 @@ class ShopCore extends ObjectModel
         }
         static::$context_shop_group = null;
         self::$context = $type;
+
+        self::applyContextTimezone();
+    }
+
+    /**
+     * Applies the timezone configured for the shop context that was just set.
+     *
+     * WHY: the timezone is bound once during bootstrap (config/config.inc.php), where the only shop
+     * known is the one resolved from the URL. Every other shop context is decided later - the
+     * employee's shop selector in the back office, the order's shop when a status changes or an
+     * invoice is rendered, the requested shop in the webservice - so without this the process keeps
+     * running in the URL shop's timezone and every date written while working on another shop is off
+     * by the offset between the two.
+     *
+     * The comparison against the current timezone keeps this free for the common case: a shop
+     * context switch only costs a configuration read, and the session query is issued exclusively
+     * when the timezone genuinely changes.
+     */
+    private static function applyContextTimezone(): void
+    {
+        $timezone = Configuration::get('PS_TIMEZONE');
+
+        // Empty while installing, before the configuration table holds the value.
+        if (empty($timezone) || $timezone === date_default_timezone_get()) {
+            return;
+        }
+
+        // Same suppression as bootstrap: an identifier that is no longer valid must not warn, and
+        // leaves PHP - and therefore the database session - on the timezone already in place.
+        if (!@date_default_timezone_set($timezone)) {
+            return;
+        }
+
+        // Keep the database session offset aligned with PHP, as bootstrap does (see issue #30828).
+        Db::getInstance()->setTimeZone();
     }
 
     /**

--- a/tests/Integration/Classes/ShopContextTimezoneTest.php
+++ b/tests/Integration/Classes/ShopContextTimezoneTest.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Customer;
+use DateTime;
+use DateTimeZone;
+use Db;
+use PrestaShop\PrestaShop\Core\Multistore\MultistoreConfig;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\Resetter\ShopResetter;
+use Tools;
+
+/**
+ * The timezone is bound once during bootstrap, from the shop resolved out of the URL. Every other
+ * shop context - the back office shop selector, the order's shop when an invoice is rendered, the
+ * webservice's requested shop - is decided afterwards, so Shop::setContext() has to re-apply it.
+ *
+ * The two clocks asserted here are the ones every write actually uses: PHP's date(), which is what
+ * ObjectModel::add() stores into date_add (classes/ObjectModel.php:529), and the database session
+ * offset, which is what NOW() resolves against.
+ */
+class ShopContextTimezoneTest extends KernelTestCase
+{
+    private const DEFAULT_SHOP_ID = 1;
+    private const SHOP_TIMEZONE = 'Europe/Paris';
+    /** +14:00, so it can never coincide with the shop or the runner's timezone. */
+    private const OTHER_SHOP_TIMEZONE = 'Pacific/Kiritimati';
+
+    private static int $secondShopId;
+    private static string $initialTimezone;
+    private static ?int $initialContext;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::bootKernel();
+        // Global var read by legacy code resolving the container (SymfonyContainer::getInstance).
+        global $kernel;
+        $kernel = self::$kernel;
+
+        self::$initialTimezone = date_default_timezone_get();
+        self::$initialContext = Shop::getContext();
+
+        ShopResetter::resetShops();
+        Configuration::updateGlobalValue(MultistoreConfig::FEATURE_STATUS, 1);
+
+        $secondShop = new Shop();
+        $secondShop->name = 'Shop Context Timezone Shop 2';
+        $secondShop->id_shop_group = (int) Shop::getGroupFromShop(self::DEFAULT_SHOP_ID, true);
+        $secondShop->id_category = 2;
+        $secondShop->active = true;
+        $secondShop->save();
+        self::$secondShopId = (int) $secondShop->id;
+
+        Shop::resetStaticCache();
+        Shop::resetContext();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::removeShopTimezone(self::$secondShopId);
+        ShopResetter::resetShops();
+
+        // Restore the process globals this test moves on purpose, or every later date assertion in
+        // the same PHPUnit process inherits them.
+        date_default_timezone_set(self::$initialTimezone);
+        Db::getInstance()->setTimeZone();
+        if (null !== self::$initialContext) {
+            Shop::setContext(self::$initialContext, self::DEFAULT_SHOP_ID);
+        }
+
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Configuration::updateGlobalValue('PS_TIMEZONE', self::SHOP_TIMEZONE);
+        self::removeShopTimezone(self::$secondShopId);
+        Configuration::clearConfigurationCacheForTesting();
+        Configuration::loadConfiguration();
+
+        date_default_timezone_set(self::SHOP_TIMEZONE);
+        Db::getInstance()->setTimeZone();
+    }
+
+    public function testSwitchingToAShopWithItsOwnTimezoneMovesTheProcessClock(): void
+    {
+        $this->setShopTimezone(self::$secondShopId, self::OTHER_SHOP_TIMEZONE);
+
+        Shop::setContext(Shop::CONTEXT_SHOP, self::DEFAULT_SHOP_ID);
+        $this->assertSame(self::SHOP_TIMEZONE, date_default_timezone_get());
+
+        Shop::setContext(Shop::CONTEXT_SHOP, self::$secondShopId);
+        $this->assertSame(self::OTHER_SHOP_TIMEZONE, date_default_timezone_get());
+
+        Shop::setContext(Shop::CONTEXT_SHOP, self::DEFAULT_SHOP_ID);
+        $this->assertSame(self::SHOP_TIMEZONE, date_default_timezone_get());
+    }
+
+    public function testAllShopsContextFallsBackToTheGlobalTimezone(): void
+    {
+        $this->setShopTimezone(self::$secondShopId, self::OTHER_SHOP_TIMEZONE);
+
+        Shop::setContext(Shop::CONTEXT_SHOP, self::$secondShopId);
+        $this->assertSame(self::OTHER_SHOP_TIMEZONE, date_default_timezone_get());
+
+        Shop::setContext(Shop::CONTEXT_ALL);
+        $this->assertSame(self::SHOP_TIMEZONE, date_default_timezone_get());
+    }
+
+    public function testAShopWithoutItsOwnTimezoneKeepsTheGlobalOne(): void
+    {
+        Shop::setContext(Shop::CONTEXT_SHOP, self::$secondShopId);
+
+        $this->assertSame(self::SHOP_TIMEZONE, date_default_timezone_get());
+    }
+
+    public function testTheDatabaseSessionOffsetFollowsTheShopTimezone(): void
+    {
+        $this->setShopTimezone(self::$secondShopId, self::OTHER_SHOP_TIMEZONE);
+
+        Shop::setContext(Shop::CONTEXT_SHOP, self::DEFAULT_SHOP_ID);
+        $this->assertSame($this->offsetOf(self::SHOP_TIMEZONE), $this->databaseSessionOffset());
+
+        Shop::setContext(Shop::CONTEXT_SHOP, self::$secondShopId);
+        $this->assertSame($this->offsetOf(self::OTHER_SHOP_TIMEZONE), $this->databaseSessionOffset());
+    }
+
+    public function testAnUnusableTimezoneLeavesTheProcessOnTheOneAlreadyInPlace(): void
+    {
+        $this->setShopTimezone(self::$secondShopId, 'Not/AZone');
+
+        Shop::setContext(Shop::CONTEXT_SHOP, self::$secondShopId);
+
+        $this->assertSame(self::SHOP_TIMEZONE, date_default_timezone_get());
+        $this->assertSame($this->offsetOf(self::SHOP_TIMEZONE), $this->databaseSessionOffset());
+    }
+
+    /**
+     * The last hop: what a row written under that shop context is actually stamped with.
+     */
+    public function testARowWrittenUnderAShopContextCarriesThatShopsWallClock(): void
+    {
+        $this->setShopTimezone(self::$secondShopId, self::OTHER_SHOP_TIMEZONE);
+        Shop::setContext(Shop::CONTEXT_SHOP, self::$secondShopId);
+
+        $customer = new Customer();
+        $customer->firstname = 'Shop';
+        $customer->lastname = 'Timezone';
+        $customer->email = 'shop-timezone-' . uniqid() . '@prestashop.test';
+        $customer->passwd = Tools::hash('Pr3st4Sh0P');
+        $customer->add();
+
+        $writtenAt = $this->asWallClock($customer->date_add);
+        $customer->delete();
+
+        $this->assertLessThan(
+            60,
+            abs($writtenAt->getTimestamp() - $this->wallClockOf(self::OTHER_SHOP_TIMEZONE)->getTimestamp()),
+            'date_add should carry the wall clock of the shop the row was written under'
+        );
+        // And it is genuinely that shop's clock, not the global one it used to be stamped with.
+        $this->assertGreaterThan(
+            60,
+            abs($writtenAt->getTimestamp() - $this->wallClockOf(self::SHOP_TIMEZONE)->getTimestamp()),
+            'the two timezones must be far enough apart for the assertion above to mean anything'
+        );
+    }
+
+    /**
+     * date_add is a naive wall-clock string. Anchoring it and the expected clocks to the same
+     * fixed zone is what makes them comparable - reading it back in the current default timezone
+     * would compare instants, which are equal whatever timezone produced them.
+     */
+    private function asWallClock(string $naiveDateTime): DateTime
+    {
+        return new DateTime($naiveDateTime, new DateTimeZone('UTC'));
+    }
+
+    private function wallClockOf(string $timezone): DateTime
+    {
+        return $this->asWallClock((new DateTime('now', new DateTimeZone($timezone)))->format('Y-m-d H:i:s'));
+    }
+
+    private function setShopTimezone(int $shopId, string $timezone): void
+    {
+        Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . "configuration (name, id_shop_group, id_shop, value, date_add, date_upd)
+             VALUES ('PS_TIMEZONE', NULL, " . $shopId . ", '" . pSQL($timezone) . "', NOW(), NOW())"
+        );
+        Configuration::clearConfigurationCacheForTesting();
+        Configuration::loadConfiguration();
+    }
+
+    private static function removeShopTimezone(int $shopId): void
+    {
+        Db::getInstance()->execute(
+            'DELETE FROM ' . _DB_PREFIX_ . "configuration WHERE name = 'PS_TIMEZONE' AND id_shop = " . $shopId
+        );
+        Configuration::clearConfigurationCacheForTesting();
+        Configuration::loadConfiguration();
+    }
+
+    private function databaseSessionOffset(): string
+    {
+        return (string) Db::getInstance()->getValue('SELECT @@session.time_zone');
+    }
+
+    private function offsetOf(string $timezone): string
+    {
+        return (new DateTime('now', new DateTimeZone($timezone)))->format('P');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The timezone is bound once during bootstrap (`config/config.inc.php:139`), from the shop resolved out of the URL. Every other shop context is decided afterwards - the employee's shop selector in the back office, the order's shop when a status changes or an invoice is rendered, the requested shop in the webservice - so the process kept running in the URL shop's timezone and every date written while working on another shop was off by the offset between the two. `Shop::setContext()` now re-applies the timezone configured for the context it just set and realigns the database session offset with it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a multistore install give two shops different timezones (Shop parameters > ... > Localization saves `PS_TIMEZONE` against the shop context you are in). Switch the back office shop selector between them and write something - place or edit an order, add a customer. Before this change every `date_add` used the timezone of the shop in the address bar, whichever shop was selected; after, it uses the selected shop's. `tests/Integration/Classes/ShopContextTimezoneTest.php` covers it end to end.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | N/A
| Related PRs       | #42580 also touches `classes/shop/Shop.php` (`findShopByHost` visibility, line ~1358) - 343 lines from this hunk, no conflict.
| Sponsor company   |

There is no issue for this yet. The defect is described in full above and was found while
reading the surrounding code rather than reported; a tracking issue can be opened on request.

## Why `Shop::setContext()` and not the back office entry points

The back office settles its shop context in two different places - `AdminController::initShopContext()`
for legacy pages and the ADR-0024 `ShopContextBuilder::buildLegacyContext()` for migrated ones - and
neither is the last word for the other. Both route through `Shop::setContext()`, and so does every
other context switch, so that is where the timezone belongs. `ContextStateManager::restoreShopContext()`
calls it too, which means save/restore of the timezone comes for free with no extra code.

Placing it there also fixes three cases outside the back office that have the same shape:
`classes/pdf/HTMLTemplate.php:230` (invoice PDF dates), `classes/order/OrderHistory.php:239` (order
status changes) and `classes/webservice/WebserviceRequest.php:876/881/911` (the requested shop).

`classes/` is also the only layer allowed to make these calls: `phpstan-disallowed-calls.neon` forbids
legacy calls in `src/Core/*` and `src/PrestaShopBundle/*`.

## Cost

`applyContextTimezone()` returns after one configuration read (in-memory cache) and a string compare
whenever the timezone does not actually change, which is every single-shop install and every multistore
whose shops share a timezone. The `SET SESSION time_zone` query is issued only when it genuinely
differs. That matters because `Shop::setContext()` is called in loops - `classes/Hook.php:981/1195`
dispatches per shop, `classes/Product.php:4860/4888` switches per shop.

An identifier that is no longer valid is suppressed exactly as bootstrap suppresses it, and leaves both
PHP and the database session on the timezone already in place rather than half-applying.

## Evidence

Measured on 9.2, multistore, shop 1 `Europe/Paris` and shop 2 `Europe/Sofia`, replaying a back office
request on the main domain and then applying the shop selector exactly as
`AdminController::initShopContext()` does for a cookie of `s-2`:

```
                                      Context shop   PS_TIMEZONE     PHP tz          MySQL offset
  after bootstrap (URL = shop 1)          1          Europe/Paris    Europe/Paris    +02:00
  after switching BO context to shop 2    2          Europe/Sofia    Europe/Paris    +02:00

  PHP date()        2026-09-06 19:29:43
  MySQL NOW()       2026-09-06 19:29:43
  shop 2 wall clock 2026-09-06 20:29:43
```

Test: `tests/Integration/Classes/ShopContextTimezoneTest.php`, 6 cases, 12 assertions. Mutation proof -
reverting `classes/shop/Shop.php` to the base branch fails 4 of the 6, including the row-write case,
whose customer `date_add` lands 43200 seconds (12 hours, Paris against Pacific/Kiritimati) from the
shop it was written under. The 2 that stay green are the deliberate controls: a shop with no timezone
of its own, and an unusable identifier - both assert that nothing moves.

Full unit suite 5484 tests / 12716 assertions, byte-identical with and without the change (20 errors,
1 failure, all pre-existing in this environment). `ContextStateManagerTest`, `ContextTest` and
`ExtraPropertyMultiShopTest` likewise identical against the base branch. cs-fixer and phpstan clean.

