### PR TITLE
Tax an order line with the tax rules group it was sold under

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -459,12 +459,25 @@ class OrderDetailCore extends ObjectModel
     }
 
     /**
-     * Dynamically get the taxRulesGroupId instead of relying one the one saved in database
+     * Get the tax rules group this line was sold under.
      *
      * @return int
      */
     public function getTaxRulesGroupId(): int
     {
+        /*
+         * WHY: a placed order is a financial record, so the tax category it is recalculated with is
+         * the one stored on the line at checkout, not the product's current one - moving a product
+         * to another tax rules group afterwards must not re-tax orders that are already placed.
+         * This does not weaken the address-driven recalculation this method feeds: the address is a
+         * separate argument to TaxManagerFactory, which picks the rule that applies to the new
+         * address *within* this group. Lines that carry no group - orders imported or created
+         * before the column was written - keep the previous lookup on the product.
+         */
+        if ((int) $this->id_tax_rules_group > 0) {
+            return (int) $this->id_tax_rules_group;
+        }
+
         return (int) Product::getIdTaxRulesGroupByIdProduct((int) $this->product_id, $this->context);
     }
 

--- a/tests/Integration/Classes/Order/OrderDetailTaxRulesGroupTest.php
+++ b/tests/Integration/Classes/Order/OrderDetailTaxRulesGroupTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Order;
+
+use OrderDetail;
+use PHPUnit\Framework\TestCase;
+use Product;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+class OrderDetailTaxRulesGroupTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    private const PRODUCT_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+    }
+
+    /**
+     * An order is a financial record: once a line has been sold under a tax rules group, moving the
+     * product to another group must not change how that line is taxed when the order is recalculated
+     * (which is what editing an address in the back office does).
+     */
+    public function testItKeepsTheGroupTheLineWasSoldUnderWhenTheProductMovedToAnother(): void
+    {
+        $currentProductGroupId = (int) Product::getIdTaxRulesGroupByIdProduct(self::PRODUCT_ID);
+        $groupSoldUnder = $currentProductGroupId + 1;
+
+        $orderDetail = new OrderDetail();
+        $orderDetail->product_id = self::PRODUCT_ID;
+        $orderDetail->id_tax_rules_group = $groupSoldUnder;
+
+        $this->assertSame($groupSoldUnder, $orderDetail->getTaxRulesGroupId());
+    }
+
+    /**
+     * Lines that carry no group - imported orders, and orders created before the column was written
+     * - have nothing historical to honour, so they still resolve the product's current group.
+     */
+    public function testItFallsBackToTheProductWhenTheLineCarriesNoGroup(): void
+    {
+        $currentProductGroupId = (int) Product::getIdTaxRulesGroupByIdProduct(self::PRODUCT_ID);
+        $this->assertGreaterThan(
+            0,
+            $currentProductGroupId,
+            'the fixture product must belong to a tax rules group for this test to mean anything'
+        );
+
+        $orderDetail = new OrderDetail();
+        $orderDetail->product_id = self::PRODUCT_ID;
+        $orderDetail->id_tax_rules_group = 0;
+
+        $this->assertSame($currentProductGroupId, $orderDetail->getTaxRulesGroupId());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `OrderDetail::getTaxRulesGroupId()` resolved the product's current tax rules group instead of the one stored on the order line, so recalculating a placed order - which is what editing an address in the back office does - re-taxed it with whatever group the product had been moved to since. The line was left contradicting itself: `id_tax_rules_group` and `tax_rate` kept the sold-under values while `order_detail_tax` and `unit_price_tax_incl` carried the new ones. The stored group is now preferred, falling back to the product only for lines that carry none - imported orders, and rows written before the column was populated, which have nothing historical to honour and so keep the previous behaviour by design.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | N/A
| Related PRs       | Touches `classes/order/OrderDetail.php`, as does open PR #42654 (`getTaxCalculatorStatic()`, single hunk at line 350). No overlap - this hunk is at line 466.
| Sponsor company   |

There is no issue for this yet. The defect is described in full above and was found while
reading the surrounding code rather than reported; a tracking issue can be opened on request.

## Why the stored group, and why that does not undo #20903

The dynamic lookup was introduced in 931deea3c59 under #20903 ("Update Order amount when its
addresses are modified"), whose own linked issues (#21099, #21254) are about the ADDRESS changing,
not about the product's tax group changing. The address is a separate argument to
`TaxManagerFactory::getManager($address, $groupId)` and selects the rule that applies *within* the
group, so address-driven recalculation does not need the group itself to be dynamic. Measured
below.

## Evidence (9.2.0)

Order placed through real checkout while the product was on a two-tax group (10% + 5%,
one after another), then the product moved to the 20% group and the order recalculated:

```
before fix   1754.676000 -> 1823.040000   re-taxed with the product's new group
after fix    1823.040000 -> 1754.676000   restored to the group the line was sold under
```

with the product still sitting on the 20% group in both runs, so the product lookup is not what
produced the second figure.

Non-regression, same order, tax address moved between two countries the group rates differently:

```
address FR   1754.676000   expected 1519.20 x 1.10 x 1.05 = 1754.676000
address US   1595.160000   expected 1519.20 x 1.05        = 1595.160000
```

## Test

`tests/Integration/Classes/Order/OrderDetailTaxRulesGroupTest.php`, 2 cases. Mutation proof: with
`classes/order/OrderDetail.php` reverted to `upstream/9.2.x` (revert verified by grep, 0
occurrences of the guard), `testItKeepsTheGroupTheLineWasSoldUnderWhenTheProductMovedToAnother`
fails with "Failed asserting that 9 is identical to 10" and the fallback case stays green - so each
case pins its own branch. php-cs-fixer exit 0, PHPStan "No errors".

