### PR TITLE
Show the page header title when the employee's language has no row

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1621,7 +1621,7 @@ class AdminControllerCore extends Controller
                 if (Validate::isLoadedObject($obj) && isset($obj->{$this->identifier_name}) && !empty($obj->{$this->identifier_name})) {
                     array_pop($this->toolbar_title);
                     array_pop($this->meta_title);
-                    $this->toolbar_title[] = is_array($obj->{$this->identifier_name}) ? $obj->{$this->identifier_name}[$this->context->employee->id_lang] : $obj->{$this->identifier_name};
+                    $this->toolbar_title[] = $this->getObjectNameForToolbar($obj);
                     $this->addMetaTitle($this->toolbar_title[count($this->toolbar_title) - 1]);
                 }
 
@@ -1634,11 +1634,7 @@ class AdminControllerCore extends Controller
                     $this->toolbar_title[] = $this->trans(
                         'Edit: %s',
                         [
-                            (is_array($obj->{$this->identifier_name})
-                                && isset($obj->{$this->identifier_name}[$this->context->employee->id_lang])
-                            )
-                                ? htmlspecialchars($obj->{$this->identifier_name}[$this->context->employee->id_lang])
-                                : htmlspecialchars($obj->{$this->identifier_name}),
+                            htmlspecialchars($this->getObjectNameForToolbar($obj)),
                         ],
                         'Admin.Actions'
                     );
@@ -1661,6 +1657,47 @@ class AdminControllerCore extends Controller
 
         $this->context->smarty->assign('help_link', 'https://help.prestashop-project.org/' . Language::getIsoById($this->context->employee->id_lang) . '/doc/'
             . Tools::getValue('controller') . '?version=' . _PS_VERSION_ . '&country=' . Language::getIsoById($this->context->employee->id_lang));
+    }
+
+    /**
+     * Reads the object's display name for the page header, whatever language rows it happens to have.
+     *
+     * WHY: a multilang field is keyed by the languages that actually have a row in the *_lang table,
+     * which is not guaranteed to include the employee's. When it does not, the edit branch used to hand
+     * the whole array to htmlspecialchars() - a TypeError on PHP 8 - and the view branch indexed it
+     * blindly, which is an undefined key. A shop reaches that state whenever a language is installed
+     * without the rows for an entity, or an employee keeps a language that was removed.
+     *
+     * @param ObjectModel $object
+     *
+     * @return string
+     */
+    protected function getObjectNameForToolbar($object)
+    {
+        $name = $object->{$this->identifier_name};
+
+        if (!is_array($name)) {
+            return (string) $name;
+        }
+
+        $preferredLanguageIds = [
+            (int) $this->context->employee->id_lang,
+            (int) Configuration::get('PS_LANG_DEFAULT'),
+        ];
+
+        foreach ($preferredLanguageIds as $idLang) {
+            if (isset($name[$idLang]) && is_scalar($name[$idLang]) && '' !== (string) $name[$idLang]) {
+                return (string) $name[$idLang];
+            }
+        }
+
+        foreach ($name as $translation) {
+            if (is_scalar($translation) && '' !== (string) $translation) {
+                return (string) $translation;
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/tests/Integration/Classes/Controller/AdminToolbarTitleTest.php
+++ b/tests/Integration/Classes/Controller/AdminToolbarTitleTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use AdminCountriesController;
+use Configuration;
+use Context;
+use Country;
+use Employee;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The page header shows the edited object's name, taken from a multilang field keyed by the languages
+ * that actually have a row. The employee's language is not guaranteed to be one of them.
+ */
+class AdminToolbarTitleTest extends KernelTestCase
+{
+    private ?int $originalEmployeeLang = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+        Context::getContext()->employee = new Employee(1);
+        $this->originalEmployeeLang = (int) Context::getContext()->employee->id_lang;
+    }
+
+    protected function tearDown(): void
+    {
+        if (null !== $this->originalEmployeeLang && null !== Context::getContext()->employee) {
+            Context::getContext()->employee->id_lang = $this->originalEmployeeLang;
+        }
+
+        parent::tearDown();
+    }
+
+    public function testItUsesTheEmployeeLanguage(): void
+    {
+        $country = new Country(1);
+        $defaultLang = (int) Configuration::get('PS_LANG_DEFAULT');
+        Context::getContext()->employee->id_lang = $defaultLang;
+
+        self::assertIsArray($country->name, 'the fixture must be a multilang field');
+        self::assertSame($country->name[$defaultLang], $this->buildTitle($country));
+    }
+
+    public function testItFallsBackWhenTheEmployeeLanguageHasNoRow(): void
+    {
+        // A shop reaches this whenever a language is installed without the rows for an entity, or an
+        // employee keeps a language that was later removed.
+        $country = new Country(1);
+        $defaultLang = (int) Configuration::get('PS_LANG_DEFAULT');
+        Context::getContext()->employee->id_lang = max(array_keys($country->name)) + 100;
+
+        // must not raise, and must show something rather than nothing
+        self::assertSame($country->name[$defaultLang], $this->buildTitle($country));
+    }
+
+    public function testItPassesAScalarNameThrough(): void
+    {
+        $object = new Country(1);
+        $object->name = 'Plain name';
+
+        self::assertSame('Plain name', $this->buildTitle($object));
+    }
+
+    /**
+     * The reported symptom: opening the country edit page as an employee whose language has no row
+     * answered HTTP 500 with "htmlspecialchars(): Argument #1 ($string) must be of type string, array
+     * given" from the page header builder.
+     */
+    public function testTheEditHeaderDoesNotFailOnAMissingLanguageRow(): void
+    {
+        $country = new Country(1);
+        Context::getContext()->employee->id_lang = max(array_keys($country->name)) + 100;
+
+        $controller = new class() extends AdminCountriesController {
+            /** @var Country */
+            public $forcedObject;
+
+            public function loadObject($opt = false)
+            {
+                return $this->forcedObject;
+            }
+
+            public function forceEditDisplay(): void
+            {
+                $this->display = 'edit';
+            }
+        };
+        $controller->forcedObject = $country;
+        $controller->forceEditDisplay();
+
+        $controller->initPageHeaderToolbar();
+
+        self::assertNotEmpty($controller->page_header_toolbar_title);
+        self::assertStringContainsString(
+            $country->name[(int) Configuration::get('PS_LANG_DEFAULT')],
+            $controller->page_header_toolbar_title
+        );
+    }
+
+    private function buildTitle(Country $country): string
+    {
+        $controller = new class() extends AdminCountriesController {
+            /** @var Country */
+            public $forcedObject;
+
+            public function loadObject($opt = false)
+            {
+                return $this->forcedObject;
+            }
+
+            public function readNameForToolbar(): string
+            {
+                return $this->getObjectNameForToolbar($this->forcedObject);
+            }
+        };
+        $controller->forcedObject = $country;
+
+        return $controller->readNameForToolbar();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `AdminController::initPageHeaderToolbar()` reads the edited object's name from a multilang field, which is keyed by the languages that actually have a row in the `*_lang` table. The employee's language is not guaranteed to be one of them - install a language without the rows for an entity, or leave an employee on a language that was later removed, and it is not. The edit branch then passed the whole array to `htmlspecialchars()`, a `TypeError` on PHP 8 that answers the page with HTTP 500, and the view branch indexed the array blindly, which is an undefined key. Both now read the name through one helper that prefers the employee's language, falls back to the shop default, then to any filled translation.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `tests/Integration/Classes/Controller/AdminToolbarTitleTest.php`. Its last case drives the real `AdminCountriesController::initPageHeaderToolbar()` in the `edit` display with an employee whose language has no `country_lang` row: on 9.2.x it raises `htmlspecialchars(): Argument #1 ($string) must be of type string, array given` at `classes/controller/AdminController.php:1641`, with this change the header shows the default-language name. In the back office: install a second language, delete its rows for one entity, set an employee to that language, and open that entity's edit page.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     |
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/40624
| Sponsor company   |

### Where this came from

QA of #40624, which is APPROVED twice and has been stuck since March on a 500 that @SiraDIOP hit while
testing it, and which @mcaldex argued was unrelated to his change. **Both were right.** The crash is real and
reproducible, and it has nothing to do with that PR's regex - it is reached through
`$this->context->employee->id_lang` not being a key of the multilang array, which no change to
`AddressFormat::getValidateFields()` can influence.

### Measured on 9.2.x

Driving the real `AdminCountriesController::initPageHeaderToolbar()` with `display = 'edit'`:

```
employee language has a country_lang row      -> header renders
employee language has none                    -> TypeError: htmlspecialchars(): Argument #1 ($string)
                                                 must be of type string, array given
                                                 at classes/controller/AdminController.php:1641
```

The second state is reachable without touching any code: adding a language leaves `Country::$name` keyed
`[1]` until the `country_lang` rows exist, so an employee on the new language hits it on the country edit
page. Same shape for every controller that leaves `identifier_name` at its default `name`.

### The view branch has the sibling defect

Two cases above, `view` does `is_array(...) ? $obj->{...}[$id_lang] : ...` with no `isset`, so the same state
gives an undefined-key warning and a blank title instead of a TypeError. Both go through the helper now.

### Verification

- 4 integration tests. Reverting only `classes/controller/AdminController.php` makes the end-to-end case fail
  with the exact reported message; the other three fail only because the new helper does not exist on base.
- `tests/Integration/Classes`: 187 tests, 0 failures.
- php-cs-fixer clean, phpstan `[OK] No errors`.
