### PR TITLE
Keep the payment method the customer chose in the checkout session

### DIFF
--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -40,8 +40,26 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
         $this->conditionsToApproveFinder = $conditionsToApproveFinder;
     }
 
+    public function getDataToPersist()
+    {
+        return [
+            'selected_payment_option' => $this->selected_payment_option,
+        ];
+    }
+
+    public function restorePersistedData(array $data)
+    {
+        if (array_key_exists('selected_payment_option', $data)) {
+            $this->selected_payment_option = $data['selected_payment_option'];
+        }
+
+        return $this;
+    }
+
     public function handleRequest(array $requestParams = [])
     {
+        // WHY the request still wins: OrderController restores the persisted data first and then hands
+        // the request over, so a customer who picks another option overwrites what was remembered.
         if (isset($requestParams['select_payment_option'])) {
             $this->selected_payment_option = $requestParams['select_payment_option'];
         }

--- a/tests/Integration/Classes/Checkout/CheckoutPaymentStepTest.php
+++ b/tests/Integration/Classes/Checkout/CheckoutPaymentStepTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Checkout;
+
+use CheckoutPaymentStep;
+use CheckoutProcess;
+use CheckoutSession;
+use ConditionsToApproveFinder;
+use Context;
+use Language;
+use PaymentOptionsFinder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Every other checkout step keeps what the customer chose across requests - the addresses step through
+ * getDataToPersist(), the delivery step through the cart's delivery_option column. The payment step kept
+ * nothing, so without JavaScript, where the choice travels as a GET parameter, picking a payment method
+ * and then reloading the checkout silently reset the selection.
+ */
+class CheckoutPaymentStepTest extends TestCase
+{
+    private CheckoutPaymentStep $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $context = $this->createMock(Context::class);
+        $context->language = $this->createMock(Language::class);
+
+        $this->step = new CheckoutPaymentStep(
+            $context,
+            $this->createMock(TranslatorInterface::class),
+            $this->createMock(PaymentOptionsFinder::class),
+            $this->createMock(ConditionsToApproveFinder::class)
+        );
+        $this->step->setCheckoutProcess(
+            new CheckoutProcess($context, $this->createMock(CheckoutSession::class))
+        );
+    }
+
+    public function testTheChosenPaymentOptionIsHandedToTheCheckoutSessionData(): void
+    {
+        $this->step->handleRequest(['select_payment_option' => 'ps_checkpayment-2']);
+
+        $this->assertSame(
+            ['selected_payment_option' => 'ps_checkpayment-2'],
+            $this->step->getDataToPersist()
+        );
+    }
+
+    public function testAChoiceMadeOnAnEarlierRequestSurvives(): void
+    {
+        $this->step->restorePersistedData(['selected_payment_option' => 'ps_wirepayment-1']);
+        $this->step->handleRequest([]);
+
+        $this->assertSame(
+            ['selected_payment_option' => 'ps_wirepayment-1'],
+            $this->step->getDataToPersist()
+        );
+    }
+
+    public function testChangingTheOptionOverwritesWhatWasRemembered(): void
+    {
+        // OrderController restores first and handles the request second, so the newer choice has to win.
+        $this->step->restorePersistedData(['selected_payment_option' => 'ps_wirepayment-1']);
+        $this->step->handleRequest(['select_payment_option' => 'ps_checkpayment-2']);
+
+        $this->assertSame(
+            ['selected_payment_option' => 'ps_checkpayment-2'],
+            $this->step->getDataToPersist()
+        );
+    }
+
+    public function testRestoringDataThatCarriesNoPaymentOptionChangesNothing(): void
+    {
+        // The cart's checkout_session_data holds every step's keys, and a cart saved before this change
+        // has no payment key at all.
+        $this->step->handleRequest(['select_payment_option' => 'ps_checkpayment-2']);
+        $this->step->restorePersistedData(['use_same_address' => true]);
+
+        $this->assertSame(
+            ['selected_payment_option' => 'ps_checkpayment-2'],
+            $this->step->getDataToPersist()
+        );
+    }
+
+    public function testNothingChosenYetPersistsNothingUsable(): void
+    {
+        $this->step->handleRequest([]);
+
+        $this->assertSame(['selected_payment_option' => null], $this->step->getDataToPersist());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CheckoutPaymentStep` reads `select_payment_option` in `handleRequest()` and passes it to the template, but never implemented `getDataToPersist()` or `restorePersistedData()`, so `AbstractCheckoutStep`'s empty defaults applied and the chosen payment method survived exactly one request. Every sibling step keeps its state - `CheckoutAddressesStep` through the same two methods, the delivery step through the cart's `delivery_option` column. Without JavaScript the choice is submitted by the GET form at `templates/checkout/_partials/steps/payment.tpl:47`, so any later render of the checkout reset every radio button. This implements the two methods, mirroring `CheckoutAddressesStep`, so the option is stored in the `checkout_session_data` the checkout process already writes to the cart.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Disable JavaScript in the browser. Fill a cart, go through the checkout to the payment step and pick a payment method - the no-JS form submits it. Reload the checkout page. Before: no radio button is selected any more. After: the method picked earlier is still selected. With JavaScript on there is no visible change, because the theme does not submit the choice when the radio is clicked.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | #37333
| Related PRs       | PrestaShop/classic-theme#158 is open on the template this issue also names, by the issue's reporter. Not touched here.
| Sponsor company   |

### Why this, and not the hook the issue asks for

The issue asks for `displayOrderSummaryTable`, a display hook in the order summary table, so a COD module
can inject a fee row and drive it with JavaScript. Two maintainers pushed back on that in #37334 and the
thread never resolved. Reading it back, the disagreement has a cause that nobody named:

- @Hlavtox: "the cart is not refreshed when changing payment method. So the modules do it by JS", and
  separately "prestashop does not remember selected payment method in the checkout".
- That second sentence is literally true, and it is this defect. Fixing it makes the first sentence
  addressable, because a module can then condition its fee inside `actionPresentCart` on server-side
  state, and the summary is computed with the fee in it rather than having the number patched into the
  DOM afterwards. @Hlavtox on the same thread: "I definitely agree, we should have nice way to alter this
  with no JS and template modifications."

So the hook is deliberately NOT added here. A public hook cannot be withdrawn once modules depend on it,
and the only thing that one can do today is host markup that JavaScript then patches - the practice the
thread set out to replace. It stays cheap to add later; it is not cheap to remove. #37334 was blocked for
a sound reason at the time: it declared the hook in `hook.xml` and nothing dispatched it.

### What this does not finish

With JavaScript on, clicking a payment radio does no round trip, so the summary does not refresh until
some other request happens. That half belongs to the themes. It is the smaller problem now that the state
exists to refresh against.

### Verification

- `tests/Integration/Classes/Checkout/CheckoutPaymentStepTest.php` is new: 5 tests. **All 5 fail on
  upstream `9.2.x`** and pass with the change. The revert was verified - after
  `git checkout upstream/9.2.x -- classes/checkout/CheckoutPaymentStep.php` the file greps 0 occurrences
  of `getDataToPersist`, and the RED run was taken in that state; `git checkout HEAD -- <path>` restored
  it to 1.
- The cases cover the round trip, a restore with no payment key (a cart saved before this change), and the
  precedence rule - `OrderController:252-253` restores and then handles the request, so a newer choice
  overwrites what was remembered.
- Whole directory green afterwards: `tests/Integration/Classes/Checkout/` 9 tests, 15 assertions.
- php-cs-fixer: 0 of 2 files to fix. PHPStan: `[OK] No errors`.

### Notes for reviewers

- The issue carries `Waiting for PM` and `NMI` since 2024-11-12, both about the hook proposal. This branch
  does not decide that question, it removes the reason the question was unanswerable.
- The comment posted on the issue is
  https://github.com/PrestaShop/PrestaShop/issues/37333#issuecomment-5571258409

