### PR TITLE
Bind the tax switch to its own configuration key in multistore

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -78,7 +78,7 @@ class TaxOptionsType extends TranslatorAwareType
                     'attr' => [
                         'class' => 'js-enable-tax',
                     ],
-                    'multistore_configuration_key' => 'PS_USE_ECOTAX',
+                    'multistore_configuration_key' => 'PS_TAX',
                 ]
             )
             ->add(

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsTypeTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Improve\International\Tax;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Tax\TaxOptionsConfiguration;
+use PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxOptionsType;
+use PrestaShopBundle\Form\Extension\MultistoreExtension;
+use ReflectionClass;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TaxOptionsTypeTest extends TypeTestCase
+{
+    /**
+     * Each field's multistore key decides which configuration value the back office reads to
+     * tell whether the field is overridden for the current shop. A key that does not belong to
+     * the field leaves the field disabled, and its override checkbox unticked, while the value
+     * the merchant set for the shop is stored and used.
+     */
+    public function testEveryFieldDeclaresTheConfigurationKeyItReadsAndWrites(): void
+    {
+        $expectedKeys = [
+            'enable_tax' => 'PS_TAX',
+            'display_tax_in_cart' => 'PS_TAX_DISPLAY',
+            'tax_address_type' => 'PS_TAX_ADDRESS_TYPE',
+            'use_eco_tax' => 'PS_USE_ECOTAX',
+            'eco_tax_rule_group' => 'PS_ECOTAX_TAX_RULES_GROUP_ID',
+        ];
+
+        $form = $this->factory->create(TaxOptionsType::class);
+
+        foreach ($expectedKeys as $field => $expectedKey) {
+            $this->assertTrue($form->has($field), sprintf('Field "%s" is missing from the form', $field));
+            $this->assertSame(
+                $expectedKey,
+                $form->get($field)->getConfig()->getOption('multistore_configuration_key'),
+                sprintf('Field "%s" declares the wrong multistore configuration key', $field)
+            );
+        }
+    }
+
+    /**
+     * The form must cover exactly the fields the configuration object manages, so that a field
+     * added on one side without the other is caught here.
+     */
+    public function testFormCoversEveryConfiguredField(): void
+    {
+        $form = $this->factory->create(TaxOptionsType::class);
+
+        $formFields = array_keys($form->all());
+        sort($formFields);
+
+        $configuredFields = (new ReflectionClass(TaxOptionsConfiguration::class))
+            ->getConstant('CONFIGURATION_FIELDS');
+        sort($configuredFields);
+
+        $this->assertSame($configuredFields, $formFields);
+    }
+
+    protected function getExtensions(): array
+    {
+        return [
+            new PreloadedExtension([$this->createTaxOptionsType()], [
+                FormType::class => [new MultistoreExtension()],
+            ]),
+        ];
+    }
+
+    private function createTaxOptionsType(): TaxOptionsType
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $emptyChoiceProvider = $this->createMock(FormChoiceProviderInterface::class);
+        $emptyChoiceProvider->method('getChoices')->willReturn([]);
+
+        return new TaxOptionsType($translator, ['en'], true, $emptyChoiceProvider, $emptyChoiceProvider);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The `Enable tax` field in International > Taxes declared `PS_USE_ECOTAX` as its `multistore_configuration_key` while it reads and writes `PS_TAX`. That key is what `MultistoreCheckboxEnabler` uses to decide whether the field is overridden for the current shop, so the decision was taken from the ecotax setting. A shop that overrode `PS_TAX` got the field rendered disabled with its override checkbox unticked - hiding the value it had actually stored - and overriding the ecotax unlocked the tax switch instead. One line, plus a unit test that pins every field in the form to the key it manages.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With multistore enabled, override `Enable tax` for a single shop, then open International > Taxes in that shop's context. Before, the field is greyed out and its multistore checkbox is unticked although the override exists. After, the field is editable and the checkbox reflects the override.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | N/A
| Related PRs       |
| Sponsor company   |

There is no issue for this yet. The defect is described in full above and was found while
reading the surrounding code rather than reported; a tracking issue can be opened on request.

## Evidence

`src/Core/Tax/TaxOptionsConfiguration.php` maps `enable_tax` to `PS_TAX` for both read (line 49) and
write (line 65). `TaxOptionsType` declared `PS_USE_ECOTAX` for the same field, and `PS_USE_ECOTAX`
appeared twice in that form - once here and once, correctly, on `use_eco_tax`.

Measured on a 9.2 multistore install, evaluating the exact predicate
`MultistoreCheckboxEnabler::isOverriddenInCurrentContext()` uses, after overriding `PS_TAX` for shop 2
and nothing else:

```
has('PS_TAX',        shop 2 strict) = true     <- the override the merchant made
has('PS_USE_ECOTAX', shop 2 strict) = false    <- what the field actually consulted
TaxOptionsConfiguration maps enable_tax to: PS_TAX
TaxOptionsType declared for enable_tax:     PS_USE_ECOTAX
```

`isOverriddenInCurrentContext()` therefore returned false for that field, and
`updateCurrentField()` sets `attr.disabled = !isAllShopContext && !isOverridden`, so the field was
disabled in the very shop that had overridden it.

## Scope: the whole class was checked, not just this field

All 96 fields declaring a `multistore_configuration_key` across `src/PrestaShopBundle/Form` were
cross-checked against the configuration key their data configuration object reads. Exactly one
mismatch exists, and it is this field. (`UrlSchemaType` looks like a duplicate under a naive scan but
is not: its keys are `PS_ROUTE_product_rule`, `PS_ROUTE_category_rule` and so on.)

## Test

`tests/Unit/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsTypeTest.php`, 2 cases,
11 assertions. It pins each field to the key it manages, and asserts the form covers exactly
`TaxOptionsConfiguration::CONFIGURATION_FIELDS` so a field added on one side alone is caught.

Mutation proof: reverting the one-line change makes exactly one assertion fail, on `enable_tax`,
`Expected 'PS_TAX' / Actual 'PS_USE_ECOTAX'`, while the second test stays green. With the fix, both
pass. `php-cs-fixer` and `phpstan` clean.

