### PR TITLE
Show the cheapest product target on a discount that already uses it

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -144,10 +144,12 @@ class DiscountFormDataProvider implements FormDataProviderInterface
         } elseif ($productSegmentDefined) {
             $selectedProductCondition = ProductConditionsType::PRODUCT_SEGMENT;
         }
-        // Cheapest product condition has been decided not relevant
-        /*elseif ($discountForEditing->getCheapestProduct()) {
+        // Not offered to a discount that does not already use it - see ProductConditionsType - but a
+        // discount that does has to report it, or the form shows "none", which is not a valid target
+        // for this type, and the discount can no longer be saved.
+        elseif ($discountForEditing->getCheapestProduct()) {
             $selectedProductCondition = ProductConditionsType::CHEAPEST_PRODUCT;
-        }*/
+        }
 
         if ($discountForEditing->getMinimumProductQuantity()) {
             $selectedCartCondition = CartConditionsType::MINIMUM_PRODUCT_QUANTITY;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/ProductConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/ProductConditionsType.php
@@ -14,6 +14,8 @@ use PrestaShopBundle\Form\Admin\Type\ToggleChildrenChoiceType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\When;
@@ -36,12 +38,28 @@ class ProductConditionsType extends TranslatorAwareType
         ]);
 
         if ($discountType === DiscountType::PRODUCT_LEVEL) {
-            // Cheapest product condition has been decided not relevant
-            /*$builder
-                ->add(self::CHEAPEST_PRODUCT, HiddenType::class, [
-                    'label' => $this->trans('Cheapest product', 'Admin.Catalog.Feature'),
-                ])
-            ;*/
+            /*
+             * The cheapest product target is no longer offered when building a discount, and that is
+             * deliberate. It is still offered here to a discount that ALREADY targets it, because the
+             * cart rule keeps storing it and the price engine keeps applying it: such a discount exists
+             * on any shop that used the legacy voucher form, or that created one before the option was
+             * taken out. Without the field the selector falls back to "none", which is not a target a
+             * product level discount may have, so the merchant is shown the wrong target and then cannot
+             * save the discount at all: the save is refused with "Product discount must target at least
+             * one product", naming something the form never offered.
+             *
+             * The listener runs ahead of the one ToggleChildrenChoiceType registers, which builds the
+             * radio choices from the children present at that moment.
+             */
+            $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
+                $data = $event->getData();
+                if (is_array($data) && ($data['children_selector'] ?? null) === self::CHEAPEST_PRODUCT) {
+                    $event->getForm()->add(self::CHEAPEST_PRODUCT, HiddenType::class, [
+                        'label' => $this->trans('Cheapest product', 'Admin.Catalog.Feature'),
+                    ]);
+                }
+            }, 10);
+
             $specificProductsLabel = $this->trans('Single product', 'Admin.Catalog.Feature');
             $specificProductsLimit = 1;
         } else {

--- a/tests/Integration/Core/Form/IdentifiableObject/DiscountCheapestProductTest.php
+++ b/tests/Integration/Core/Form/IdentifiableObject/DiscountCheapestProductTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Form\IdentifiableObject;
+
+use CartRule;
+use Configuration;
+use Context;
+use Currency;
+use Db;
+use Language;
+use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
+use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountType;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\DiscountFormDataHandler;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\DiscountFormDataProvider;
+use PrestaShopBundle\Form\Admin\Sell\Discount\DiscountConditionsType;
+use PrestaShopBundle\Form\Admin\Sell\Discount\ProductConditionsType;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The cheapest product target is not offered when building a discount any more, but the cart rule still
+ * stores it (reduction_product = -1) and the price engine still applies it, so shops carry such
+ * discounts - the legacy voucher form writes them to this day. The form has to show that target and
+ * give it back unchanged; when it does not, it reports "none", which is not a target this type may
+ * have, and the discount can no longer be saved at all.
+ */
+class DiscountCheapestProductTest extends KernelTestCase
+{
+    private const PRODUCT_LEVEL_DISCOUNT_TYPE_ID = 4;
+    private const HOME_CATEGORY_ID = 2;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        static::resetDatabase();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::resetDatabase();
+    }
+
+    protected static function resetDatabase(): void
+    {
+        DatabaseDump::restoreTables(['cart_rule', 'cart_rule_lang', 'cart_rule_shop']);
+    }
+
+    /**
+     * @dataProvider getStoredTargetAndExpectedSelector
+     */
+    public function testTheStoredTargetReachesTheForm(int $storedTarget, string $expectedSelector): void
+    {
+        $discountId = $this->createProductLevelDiscount($storedTarget);
+
+        $data = $this->getProvider()->getData($discountId);
+
+        self::assertSame(
+            $expectedSelector,
+            $data['conditions'][DiscountConditionsType::PRODUCT_CONDITIONS]['children_selector']
+        );
+    }
+
+    public function getStoredTargetAndExpectedSelector(): iterable
+    {
+        yield 'cheapest product' => [DiscountSettings::CHEAPEST_PRODUCT, ProductConditionsType::CHEAPEST_PRODUCT];
+        yield 'no target' => [DiscountSettings::PRODUCTS_TOTAL, ProductConditionsType::NONE];
+    }
+
+    /**
+     * Saving the discount without touching its target - renaming it, moving its dates - must leave the
+     * target alone. This is the one that bites a merchant: without the fix the save is refused with
+     * "Product discount must target at least one product".
+     */
+    public function testSavingTheDiscountKeepsTheTarget(): void
+    {
+        $discountId = $this->createProductLevelDiscount(DiscountSettings::CHEAPEST_PRODUCT);
+
+        $data = $this->getProvider()->getData($discountId);
+        $this->getHandler()->update($discountId, $data);
+
+        self::assertSame(DiscountSettings::CHEAPEST_PRODUCT, $this->readStoredTarget($discountId));
+    }
+
+    /**
+     * The other half: the target is shown so that it can also be changed. Moving to a product segment
+     * has to take effect, or the fix would trade a rejected save for a value nobody can change.
+     */
+    public function testTheTargetCanStillBeReplaced(): void
+    {
+        $discountId = $this->createProductLevelDiscount(DiscountSettings::CHEAPEST_PRODUCT);
+
+        $data = $this->getProvider()->getData($discountId);
+        $productConditions = &$data['conditions'][DiscountConditionsType::PRODUCT_CONDITIONS];
+        $productConditions['children_selector'] = ProductConditionsType::PRODUCT_SEGMENT;
+        $productConditions[ProductConditionsType::PRODUCT_SEGMENT]['category'] = self::HOME_CATEGORY_ID;
+        $productConditions[ProductConditionsType::PRODUCT_SEGMENT]['quantity'] = 1;
+        unset($productConditions);
+        $this->getHandler()->update($discountId, $data);
+
+        self::assertSame(DiscountSettings::PRODUCT_SEGMENT, $this->readStoredTarget($discountId));
+    }
+
+    /**
+     * @dataProvider getSelectorAndExpectedField
+     */
+    public function testTheFieldIsOfferedOnlyToADiscountThatAlreadyUsesIt(string $selector, bool $expected): void
+    {
+        $this->bootWithShopContext();
+
+        $form = self::getContainer()->get('form.factory')->create(
+            ProductConditionsType::class,
+            ['children_selector' => $selector],
+            ['discount_type' => DiscountType::PRODUCT_LEVEL]
+        );
+
+        self::assertSame($expected, $form->has(ProductConditionsType::CHEAPEST_PRODUCT));
+        self::assertSame(
+            $expected,
+            in_array(ProductConditionsType::CHEAPEST_PRODUCT, $form->get('children_selector')->getConfig()->getOption('choices'), true)
+        );
+    }
+
+    public function getSelectorAndExpectedField(): iterable
+    {
+        yield 'already targets the cheapest product' => [ProductConditionsType::CHEAPEST_PRODUCT, true];
+        yield 'targets nothing' => [ProductConditionsType::NONE, false];
+        yield 'targets a single product' => [ProductConditionsType::SPECIFIC_PRODUCTS, false];
+    }
+
+    private function readStoredTarget(int $discountId): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT reduction_product FROM ' . _DB_PREFIX_ . 'cart_rule WHERE id_cart_rule = ' . $discountId
+        );
+    }
+
+    private function getProvider(): DiscountFormDataProvider
+    {
+        $this->bootWithShopContext();
+
+        return self::getContainer()->get(DiscountFormDataProvider::class);
+    }
+
+    private function getHandler(): DiscountFormDataHandler
+    {
+        $this->bootWithShopContext();
+
+        return self::getContainer()->get(DiscountFormDataHandler::class);
+    }
+
+    private function bootWithShopContext(): void
+    {
+        if (null === self::$kernel) {
+            self::bootKernel();
+        }
+
+        $context = Context::getContext();
+        $context->container = self::getContainer();
+        $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->shop = new Shop(1);
+    }
+
+    private function createProductLevelDiscount(int $reductionProduct): int
+    {
+        $this->bootWithShopContext();
+
+        $cartRule = new CartRule();
+        $cartRule->name = [(int) Configuration::get('PS_LANG_DEFAULT') => 'Cheapest product discount'];
+        $cartRule->quantity = 10;
+        $cartRule->quantity_per_user = 1;
+        $cartRule->date_from = date('Y-m-d H:i:s', strtotime('-1 day'));
+        $cartRule->date_to = date('Y-m-d H:i:s', strtotime('+1 year'));
+        $cartRule->active = true;
+        $cartRule->priority = 1;
+        $cartRule->reduction_percent = 10.0;
+        $cartRule->reduction_product = $reductionProduct;
+        $cartRule->add();
+
+        // The rewritten form only reads discounts that carry one of its types.
+        Db::getInstance()->execute(sprintf(
+            'UPDATE `%scart_rule` SET `id_cart_rule_type` = %d WHERE `id_cart_rule` = %d',
+            _DB_PREFIX_,
+            self::PRODUCT_LEVEL_DISCOUNT_TYPE_ID,
+            (int) $cartRule->id
+        ));
+
+        return (int) $cartRule->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A product level discount can target the cheapest product in the cart. The option is not offered when building a discount any more, but the cart rule still stores that target and the price engine still applies it, so shops carry such discounts - the legacy voucher form writes them to this day. The rewritten form does not read the target back: it reports `none`, which is not a target this discount type may have, so it shows the merchant the wrong target and then refuses to save the discount at all with "Product discount must target at least one product", naming something the form never offered. Editing the discount's name or its dates is enough to hit it, and the discount can then not be saved again. The field is now registered for a discount that already carries the target, so it is shown, kept when unrelated fields are edited, and can be replaced. A discount that does not carry it is unchanged and still cannot select it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with the `discount` feature flag off, create a cart rule with a percentage reduction and "Apply a discount to: Cheapest product", which stores `reduction_product = -1`. Turn the flag on, open that discount in Discounts and save it without changing the target. Before: the target shows as none and the save fails with "Product discount must target at least one product". After: the target shows as Cheapest product, saving keeps it, and switching to a single product or a product segment works. `tests/Integration/Core/Form/IdentifiableObject/DiscountCheapestProductTest.php` covers all three.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41196
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/42228
| Sponsor company   |

### What is actually broken

The target was hidden, not removed. Everything below the form still supports it:
`ProductConditionsType::CHEAPEST_PRODUCT`, the `CHEAPEST_PRODUCT` branch in `DiscountFormDataHandler`,
`cheapestProduct` on both discount commands, `DiscountFiller` mapping it to `reduction_product = -1`,
`DiscountValidator` counting it as a valid target, and `CartRule::getContextualValue()` applying it. Two
places were commented out by `02c44645d21` ("Hide the cheapest product possibility", #40809, which
answered #40802): `ProductConditionsType.php:39` and `DiscountFormDataProvider.php:147`.

The legacy voucher form still ships and still writes the value -
`admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:98` and `form.js:170` - so the
discounts this form cannot represent keep being created.

Measured on `9.2.x`, driving the real provider and handler:

```
getData()  ->  conditions.product_conditions.children_selector = 'none'
update()   ->  DiscountConstraintException: "Product discount must target at least one product."
               DiscountValidator.php:231 <- UpdateDiscountHandler.php:45
```

`none` is not a valid target for this type - the validator requires exactly one of cheapest / single
product / segment - so the form reports a state it then rejects.

### Why grandfather it instead of restoring the option

Restoring the option outright would undo #40809, which answered #40802 ("Cheapest product must not be an
option for the product-level type") on purpose. Whether the target should be offered when building a
discount is a product decision, and #40802 and #41196 answer it differently. Registering the field only
when the loaded data already selects it settles the defect without touching that decision: existing data
is represented truthfully and stays editable, new discounts see exactly what they see today.

The field is added from a `PRE_SET_DATA` listener at priority 10 so it exists before
`ToggleChildrenChoiceType`'s own `PRE_SET_DATA` listener builds the radio choices from the children
present at that moment. No option plumbing through `DiscountType` -> `DiscountConditionsType` ->
`ProductConditionsType` is needed, and the handler is untouched: its `CHEAPEST_PRODUCT` branch simply
becomes reachable again.

### Verification

- `tests/Integration/Core/Form/IdentifiableObject/DiscountCheapestProductTest.php` is new: 7 tests,
  10 assertions. **On `9.2.x` it reports 2 failures and 1 error**, one per leg - the provider returns
  `none`, the form does not offer the field, and the save raises the constraint exception. All pass with
  the change. The revert was verified in both directions.
- The tests also pin what must NOT change: a discount with no such target still reports `none`, a
  discount that does not carry the target is not offered the field, and a discount that carries it can
  still be moved to a product segment.
- `tests/Integration/Core/Form` and a `--filter Discount` run over the integration suite: 12 tests,
  25 assertions, 0 failures.
- php-cs-fixer clean, PHPStan `[OK] No errors` on all three files.

### Notes for reviewers

- Overlaps two of my own open PRs on `DiscountFormDataProvider.php`, both at distant hunks: **#42228**
  (partial use, hunks at 71 and 186) and **#42658** (imports and constructor, hunks at 32 and 50). Mine
  is at 147. Neither touches `ProductConditionsType.php`. No rebase expected, but say it in the body.
- **#42228 is the sibling of this fix** - the same form dropped `partial_use` the same way. Worth
  cross-referencing: two settings the cart rule stores that the rewritten form did not read back.
- The issue asks for the option to be offered again. This PR deliberately does not do that; say so
  plainly so it is not merged under a false impression, and let the team answer #40802 vs #41196.
