### PR TITLE
Exclude shipping from a discount minimum amount unless it is asked for

### DIFF
--- a/src/Core/Domain/Discount/Command/AddDiscountCommand.php
+++ b/src/Core/Domain/Discount/Command/AddDiscountCommand.php
@@ -371,7 +371,16 @@ class AddDiscountCommand
      * Note: the parameters names are important here for API serialization.
      * To unset the minimum amount set the first parameter to null (the other parameters can remain empty)
      */
-    public function setMinimumAmount(?DecimalNumber $amount, int $currencyId = 0, bool $taxIncluded = true, bool $shippingIncluded = true): self
+    /*
+     * WHY shipping is excluded by default: it is the value every other part of the stack already
+     * uses for a minimum amount nobody said anything about. The column is declared
+     * `minimum_amount_shipping tinyint(1) NOT NULL DEFAULT '0'`, the legacy cart rule form offers
+     * "Shipping excluded" first, and the discount form has had no such field since #40809 removed
+     * it, so its data handler sends false. A default of true made a caller that omits the argument
+     * - which is every Admin API request whose minimumAmount carries only amount, currency and tax -
+     * store the opposite condition from the same discount created in the back office.
+     */
+    public function setMinimumAmount(?DecimalNumber $amount, int $currencyId = 0, bool $taxIncluded = true, bool $shippingIncluded = false): self
     {
         if (null === $amount) {
             $this->minimumAmount = null;

--- a/src/Core/Domain/Discount/Command/UpdateDiscountCommand.php
+++ b/src/Core/Domain/Discount/Command/UpdateDiscountCommand.php
@@ -406,7 +406,16 @@ class UpdateDiscountCommand
      * Note: the parameters names are important here for API serialization.
      * To unset the minimum amount set the first parameter to null (the other parameters can remain empty)
      */
-    public function setMinimumAmount(?DecimalNumber $amount, int $currencyId = 0, bool $taxIncluded = true, bool $shippingIncluded = true): self
+    /*
+     * WHY shipping is excluded by default: it is the value every other part of the stack already
+     * uses for a minimum amount nobody said anything about. The column is declared
+     * `minimum_amount_shipping tinyint(1) NOT NULL DEFAULT '0'`, the legacy cart rule form offers
+     * "Shipping excluded" first, and the discount form has had no such field since #40809 removed
+     * it, so its data handler sends false. A default of true made a caller that omits the argument
+     * - which is every Admin API request whose minimumAmount carries only amount, currency and tax -
+     * store the opposite condition from the same discount created in the back office.
+     */
+    public function setMinimumAmount(?DecimalNumber $amount, int $currencyId = 0, bool $taxIncluded = true, bool $shippingIncluded = false): self
     {
         if (null === $amount) {
             $this->minimumAmount = null;

--- a/tests/Integration/Adapter/Discount/CommandHandler/DiscountMinimumAmountShippingTest.php
+++ b/tests/Integration/Adapter/Discount/CommandHandler/DiscountMinimumAmountShippingTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Discount\CommandHandler;
+
+use Db;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Discount\Command\AddDiscountCommand;
+use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountCommand;
+use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountId;
+use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountType;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * A minimum amount says whether the shipping total counts towards it, and CartRule::checkValidity()
+ * adds that total only when it does. The discount form has had no field for it since #40809, so its
+ * data handler sends false; a caller that omits the argument instead - which is what the Admin API
+ * does when minimumAmount carries only amount, currency and tax - must land on the same value, not
+ * the opposite one.
+ */
+class DiscountMinimumAmountShippingTest extends KernelTestCase
+{
+    private CommandBusInterface $commandBus;
+
+    private int $defaultLangId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['cart_rule', 'cart_rule_lang', 'cart_rule_shop']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['cart_rule', 'cart_rule_lang', 'cart_rule_shop']);
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->commandBus = self::getContainer()->get('prestashop.core.command_bus');
+        $this->defaultLangId = (int) self::getContainer()->get('prestashop.adapter.legacy.configuration')->get('PS_LANG_DEFAULT');
+    }
+
+    public function testAMinimumAmountWithNoShippingInclusionGivenExcludesShipping(): void
+    {
+        $discountId = $this->addDiscount('No shipping inclusion given', function (AddDiscountCommand $command): void {
+            $command->setMinimumAmount(new DecimalNumber('50'), 1, true);
+        });
+
+        $this->assertSame(0, $this->storedShippingInclusion($discountId), 'the schema default for minimum_amount_shipping is 0');
+    }
+
+    public function testAMinimumAmountCanStillIncludeShippingWhenItIsAskedFor(): void
+    {
+        $discountId = $this->addDiscount('Shipping included', function (AddDiscountCommand $command): void {
+            $command->setMinimumAmount(new DecimalNumber('50'), 1, true, true);
+        });
+
+        $this->assertSame(1, $this->storedShippingInclusion($discountId));
+    }
+
+    /**
+     * An update that restates the amount without restating the shipping inclusion must not silently
+     * turn it on: the condition it writes has to be the one the caller described.
+     */
+    public function testUpdatingTheAmountWithNoShippingInclusionGivenExcludesShipping(): void
+    {
+        $discountId = $this->addDiscount('Updated amount', function (AddDiscountCommand $command): void {
+            $command->setMinimumAmount(new DecimalNumber('50'), 1, true, true);
+        });
+        $this->assertSame(1, $this->storedShippingInclusion($discountId));
+
+        $update = new UpdateDiscountCommand($discountId);
+        $update->setMinimumAmount(new DecimalNumber('80'), 1, true);
+        $this->commandBus->handle($update);
+
+        $this->assertSame(0, $this->storedShippingInclusion($discountId));
+    }
+
+    private function addDiscount(string $name, callable $configure): int
+    {
+        $command = new AddDiscountCommand(DiscountType::CART_LEVEL, [$this->defaultLangId => $name]);
+        $command->setReductionPercent(new DecimalNumber('10'));
+        $configure($command);
+
+        /** @var DiscountId $id */
+        $id = $this->commandBus->handle($command);
+
+        return $id->getValue();
+    }
+
+    private function storedShippingInclusion(int $discountId): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT `minimum_amount_shipping` FROM ' . _DB_PREFIX_ . 'cart_rule WHERE `id_cart_rule` = ' . $discountId
+        );
+    }
+}

--- a/tests/UI/campaigns/functional/API/02_endpoints/discount/04_postDiscounts.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/discount/04_postDiscounts.ts
@@ -182,8 +182,7 @@ describe('API : POST /admin-api/discounts', async () => {
       expect(jsonResponse.productConditions).to.deep.equal([]);
       expect(jsonResponse.minimumProductQuantity).to.equals(0);
       expect(jsonResponse.minimumAmount).to.deep.equals({
-        // @todo : https://github.com/PrestaShop/PrestaShop/issues/41199
-        shippingIncluded: true,
+        shippingIncluded: false,
         amount: dataDiscount.minimumAmountValue,
         currencyId: dataCurrencies.euro.id,
         taxIncluded: dataDiscount.minimumAmountTax === 'Tax included',
@@ -383,8 +382,7 @@ describe('API : POST /admin-api/discounts', async () => {
       } else if (cartConditionType === 'minimum_amount') {
         expect(jsonResponse.minimumProductQuantity).to.equals(0);
         expect(jsonResponse.minimumAmount).to.deep.equals({
-          // @todo : https://github.com/PrestaShop/PrestaShop/issues/41199
-          shippingIncluded: true,
+          shippingIncluded: false,
           amount: minimalAmount,
           currencyId: minimalAmountCurrency,
           taxIncluded: minimalAmountIncludeTax === '1',

--- a/tests/Unit/Core/Domain/Discount/DiscountCommandTest.php
+++ b/tests/Unit/Core/Domain/Discount/DiscountCommandTest.php
@@ -7,6 +7,7 @@
 namespace Core\Domain\Discount;
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\AddDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Exception\DiscountConstraintException;
@@ -18,6 +19,30 @@ use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountType;
 
 class DiscountCommandTest extends TestCase
 {
+    /**
+     * The minimum amount's shipping inclusion has no field in the discount form since #40809 removed it,
+     * so the form's data handler sends false. A caller that omits the argument has to land on the same
+     * value: `install-dev/data/db_structure.sql` declares the column `DEFAULT '0'` and the legacy cart
+     * rule form offers "Shipping excluded" first.
+     *
+     * @dataProvider getCommandsWithAMinimumAmountAndNoShippingInclusion
+     */
+    public function testAMinimumAmountExcludesShippingUnlessItIsAskedFor(AddDiscountCommand|UpdateDiscountCommand $command): void
+    {
+        $this->assertFalse($command->getMinimumAmount()->isShippingIncluded());
+    }
+
+    public static function getCommandsWithAMinimumAmountAndNoShippingInclusion(): iterable
+    {
+        $add = new AddDiscountCommand(DiscountType::CART_LEVEL, [1 => 'name']);
+        $add->setMinimumAmount(new DecimalNumber('50'), 1, true);
+        yield 'add' => [$add];
+
+        $update = new UpdateDiscountCommand(1);
+        $update->setMinimumAmount(new DecimalNumber('50'), 1, true);
+        yield 'update' => [$update];
+    }
+
     /**
      * @dataProvider getAddProductConditionsData
      */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `AddDiscountCommand::setMinimumAmount()` and its `UpdateDiscountCommand` twin default `$shippingIncluded` to `true`, which is the opposite of what the rest of the stack uses: `install-dev/data/db_structure.sql` declares `minimum_amount_shipping tinyint(1) NOT NULL DEFAULT '0'`, the legacy cart rule form offers "Shipping excluded" first, and the discount form has had no such field since #40809 removed it, so `DiscountFormDataHandler` sends `false`. The only callers that omit the argument are the Admin API ones, so a `POST /discounts` whose `minimumAmount` carries amount, currency and `taxIncluded` stored `minimum_amount_shipping` as 1 while the same discount created in the back office stored 0, and `CartRule::checkValidity()` then added the shipping total for one and not the other. This is why the response reported in this issue says `shippingIncluded: true`: it is not a stray serialization key, it is the stored value.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a discount with a minimum purchase amount through `POST /admin-api/discounts`, sending `minimumAmount` with `amount`, `currencyId` and `taxIncluded` only. Before: the response reads `"shippingIncluded":true` and `ps_cart_rule.minimum_amount_shipping` is 1, so a cart below the minimum on products alone still qualifies once shipping is counted. After: both read false, matching the same discount created in Catalog > Discounts. Sending `shippingIncluded: true` explicitly still stores 1.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #41199
| Related PRs       |
| Sponsor company   |

### Measured on 9.2.x

Both creation paths dispatched against the same shop and the stored row read back.

| creation path | `$shippingIncluded` | `ps_cart_rule.minimum_amount_shipping` |
| --- | --- | --- |
| the discount form (`DiscountFormDataHandler:280`, `$minimumAmount['shipping_included'] ?? false`) | explicit `false` | 0 |
| the Admin API payload of this issue (argument omitted) | defaulted `true` | **1** |
| `install-dev/data/db_structure.sql:180` | - | `DEFAULT '0'` |
| `admin-dev/.../cart_rules/conditions.tpl:85` (legacy form) | - | first option "Shipping excluded" |

### Why the default and not the response shape

The issue asks for `shippingIncluded` to be removed from the response because the interface no longer
shows it. The field is not the problem: it maps `minimum_amount_shipping`, a live column that
`CartRule::checkValidity():994` reads to decide whether to add `Cart::ONLY_SHIPPING` to the compared
total. Removing it from the response would hide a value that is still applied and would change the
contract of an endpoint; correcting the default fixes the value itself, and the response then reports
`false`, which is both accurate and what the interface implies.

There is a second reason to keep it. Since #40809 no interface sets `minimum_amount_shipping` at all, so
the API is now the only way a merchant can turn it on. Dropping the field from the resource would leave a
column that `CartRule::checkValidity()` still reads permanently unsettable, which is a larger change than
this issue is asking for.

Every call site was enumerated before changing the signature. `DiscountFormDataHandler:276` passes four
arguments. Both `DiscountFeatureContext` call sites sit behind an `isset()` that requires the shipping
key, so a scenario omitting it never sets a minimum amount at all; the scenarios that leave the cell
*empty* do take the four-argument path, with `PrimitiveUtils::castStringBooleanIntoBoolean('')`, which is
`boolval('')` and so already `false`. `CQRSApiSerializerTest:474`/`:504` and the module's own
`DiscountEndpointTest:406` send `shippingIncluded` explicitly. Nothing in core or in ps_apiresources
reached the old default.

### Verification

- `tests/Integration/Adapter/Discount/CommandHandler/DiscountMinimumAmountShippingTest.php` is new:
  3 tests, 4 assertions. **Two fail on upstream `9.2.x`** ("Failed asserting that 1 is identical to 0")
  for the add and the update path; the third - an explicit `true` still storing 1 - is green on both and
  is the control that the feature is not being disabled.
- `tests/Unit/Core/Domain/Discount/DiscountCommandTest.php` gains
  `testAMinimumAmountExcludesShippingUnlessItIsAskedFor` over both commands: 2 cases, both red on base
  ("Failed asserting that true is false").
- The revert was verified: after `git checkout upstream/9.2.x -- <the two commands>` the files grep
  1 occurrence of `shippingIncluded = true` each, and the RED runs above were taken in that state.
- `tests/UI/.../API/02_endpoints/discount/04_postDiscounts.ts` asserted `shippingIncluded: true` twice
  behind a `@todo` naming this issue. Both are updated to `false` and the `@todo` lines dropped. eslint
  clean.
- php-cs-fixer: 0 of 4 files to fix. PHPStan: `[OK] No errors`.
- `tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php` errors identically on
  `upstream/9.2.x` and on this branch (`ApiClientList::$enabled` bool/int denormalization, unrelated).
- UI tests: not run. A campaign can be launched on request.

### Notes for reviewers

- Same #40809 family as #41196 (`cheapestProduct`) and #41198 (`allowPartialUse`, addressed by the open
  PR #42228). #41198 differs from this one: partial use was reported as *missing* and was never in the v2
  form, whereas shipping inclusion was removed on request in #40804.
