### PR TITLE
Count new notifications without SQL_CALC_FOUND_ROWS

### DIFF
--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -94,39 +94,55 @@ class NotificationCore
 
         switch ($type) {
             case 'order':
-                $sql = '
-					SELECT SQL_CALC_FOUND_ROWS o.`id_order`, o.`id_customer`, o.`total_paid`, o.`id_currency`, o.`date_upd`, c.`firstname`, c.`lastname`, ca.`name`, co.`iso_code`
-					FROM `' . _DB_PREFIX_ . 'orders` as o
+                $from = '
+					FROM `' . _DB_PREFIX_ . 'orders` as o';
+                $joins = '
 					LEFT JOIN `' . _DB_PREFIX_ . 'customer` as c ON (c.`id_customer` = o.`id_customer`)
 					LEFT JOIN `' . _DB_PREFIX_ . 'carrier` as ca ON (ca.`id_carrier` = o.`id_carrier`)
 					LEFT JOIN `' . _DB_PREFIX_ . 'address` as a ON (a.`id_address` = o.`id_address_delivery`)
-					LEFT JOIN `' . _DB_PREFIX_ . 'country` as co ON (co.`id_country` = a.`id_country`)
+					LEFT JOIN `' . _DB_PREFIX_ . 'country` as co ON (co.`id_country` = a.`id_country`)';
+                $where = '
 					WHERE `id_order` > ' . (int) $idLastElement .
-                    Shop::addSqlRestriction(false, 'o') . '
+                    Shop::addSqlRestriction(false, 'o');
+
+                $sql = '
+					SELECT o.`id_order`, o.`id_customer`, o.`total_paid`, o.`id_currency`, o.`date_upd`, c.`firstname`, c.`lastname`, ca.`name`, co.`iso_code`'
+                    . $from . $joins . $where . '
 					ORDER BY `id_order` DESC
 					LIMIT 5';
 
                 break;
 
             case 'customer_message':
-                $sql = '
-					SELECT SQL_CALC_FOUND_ROWS c.`id_customer_message`, ct.`id_customer`, ct.`id_customer_thread`, ct.`email`, ct.`status`, c.`date_add`, cu.`firstname`, cu.`lastname`
+                // The customer thread is joined here and not in $joins because the WHERE clause filters on it.
+                $from = '
 					FROM `' . _DB_PREFIX_ . 'customer_message` as c
-					LEFT JOIN `' . _DB_PREFIX_ . 'customer_thread` as ct ON (c.`id_customer_thread` = ct.`id_customer_thread`)
-					LEFT JOIN `' . _DB_PREFIX_ . 'customer` as cu ON (cu.`id_customer` = ct.`id_customer`)
+					LEFT JOIN `' . _DB_PREFIX_ . 'customer_thread` as ct ON (c.`id_customer_thread` = ct.`id_customer_thread`)';
+                $joins = '
+					LEFT JOIN `' . _DB_PREFIX_ . 'customer` as cu ON (cu.`id_customer` = ct.`id_customer`)';
+                $where = '
 					WHERE c.`id_customer_message` > ' . (int) $idLastElement . '
 						AND c.`id_employee` = 0
-						AND ct.id_shop IN (' . implode(', ', Shop::getContextListShopID()) . ')
+						AND ct.id_shop IN (' . implode(', ', Shop::getContextListShopID()) . ')';
+
+                $sql = '
+					SELECT c.`id_customer_message`, ct.`id_customer`, ct.`id_customer_thread`, ct.`email`, ct.`status`, c.`date_add`, cu.`firstname`, cu.`lastname`'
+                    . $from . $joins . $where . '
 					ORDER BY c.`id_customer_message` DESC
 					LIMIT 5';
 
                 break;
             default:
-                $sql = '
-					SELECT SQL_CALC_FOUND_ROWS t.`id_' . bqSQL($type) . '`, t.*
-					FROM `' . _DB_PREFIX_ . bqSQL($type) . '` t
+                $from = '
+					FROM `' . _DB_PREFIX_ . bqSQL($type) . '` t';
+                $joins = '';
+                $where = '
 					WHERE t.`deleted` = 0 AND t.`id_' . bqSQL($type) . '` > ' . (int) $idLastElement .
-                    Shop::addSqlRestriction(false, 't') . '
+                    Shop::addSqlRestriction(false, 't');
+
+                $sql = '
+					SELECT t.`id_' . bqSQL($type) . '`, t.*'
+                    . $from . $joins . $where . '
 					ORDER BY t.`id_' . bqSQL($type) . '` DESC
 					LIMIT 5';
 
@@ -134,7 +150,12 @@ class NotificationCore
         }
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql, true, false);
-        $total = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('SELECT FOUND_ROWS()', false);
+        // A dedicated COUNT() is used instead of SQL_CALC_FOUND_ROWS: the latter is deprecated since
+        // MySQL 8.0.17, and it forces the optimizer to resolve every matching row even though the
+        // displayed list is capped at 5. $from and $where are shared with the query above, so both
+        // statements always see the same set of rows. Presentation-only joins are left out of the
+        // count: they all match at most one row on a primary key, so they cannot change the total.
+        $total = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('SELECT COUNT(*)' . $from . $where, false);
         $json = ['total' => $total, 'results' => []];
         foreach ($result as $value) {
             $customerName = '';

--- a/tests/Integration/Classes/NotificationTest.php
+++ b/tests/Integration/Classes/NotificationTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Context;
+use Customer;
+use Db;
+use Employee;
+use Notification;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+use Tools;
+
+class NotificationTest extends KernelTestCase
+{
+    /**
+     * The notification panel only ever displays five elements, so the number of
+     * customers created here has to be greater than that for the total to be
+     * distinguishable from the size of the returned list.
+     */
+    private const NEW_CUSTOMERS = 8;
+
+    private const DISPLAYED_ELEMENTS = 5;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['customer']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        DatabaseDump::restoreTables(['customer']);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $context = Context::getContext();
+        // Order notifications format prices through the locale service, which needs the container.
+        $context->container = self::bootKernel()->getContainer();
+        // Notification results carry back-office links, which need an employee in the context.
+        if (!$context->employee || !$context->employee->id) {
+            $context->employee = new Employee(1);
+        }
+    }
+
+    /**
+     * The badge shows how many elements are new, not how many of them fit in the
+     * dropdown, so the total has to keep counting past the LIMIT of the list query.
+     */
+    public function testTotalCountsEveryNewElementBeyondTheDisplayedOnes(): void
+    {
+        $lastSeenCustomerId = $this->getLastCustomerId();
+
+        for ($i = 0; $i < self::NEW_CUSTOMERS; ++$i) {
+            $this->createDummyCustomer();
+        }
+
+        $notifications = Notification::getLastElementsIdsByType('customer', $lastSeenCustomerId);
+
+        $this->assertSame(self::NEW_CUSTOMERS, (int) $notifications['total']);
+        $this->assertCount(self::DISPLAYED_ELEMENTS, $notifications['results']);
+    }
+
+    public function testTotalIsZeroWhenNothingIsNew(): void
+    {
+        $notifications = Notification::getLastElementsIdsByType('customer', $this->getLastCustomerId());
+
+        $this->assertSame(0, (int) $notifications['total']);
+        $this->assertSame([], $notifications['results']);
+    }
+
+    /**
+     * Every type builds its own list and count statements; this makes sure all of
+     * them are valid SQL and agree with each other.
+     *
+     * @dataProvider provideNotificationTypes
+     */
+    public function testEveryTypeReturnsATotalConsistentWithItsResults(string $type): void
+    {
+        $notifications = Notification::getLastElementsIdsByType($type, 0);
+
+        $this->assertIsNumeric($notifications['total']);
+        $this->assertLessThanOrEqual(self::DISPLAYED_ELEMENTS, count($notifications['results']));
+        $this->assertLessThanOrEqual((int) $notifications['total'], count($notifications['results']));
+    }
+
+    public static function provideNotificationTypes(): array
+    {
+        return [
+            'order' => ['order'],
+            'customer message' => ['customer_message'],
+            'customer' => ['customer'],
+        ];
+    }
+
+    private function getLastCustomerId(): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT MAX(`id_customer`) FROM `' . _DB_PREFIX_ . 'customer`'
+        );
+    }
+
+    private function createDummyCustomer(): Customer
+    {
+        $customer = new Customer();
+        $customer->firstname = 'Jenna';
+        $customer->lastname = 'Doe';
+        $customer->email = 'pub+' . uniqid() . '@prestashop.com';
+        $customer->passwd = Tools::hash('prestashop');
+        $customer->save();
+
+        return $customer;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `Notification::getLastElementsIdsByType()` runs on every back-office page (the notification poll) and uses `SQL_CALC_FOUND_ROWS` + `SELECT FOUND_ROWS()` to get the total number of new orders / customers / messages. Both are deprecated since MySQL 8.0.17 and emit a warning on every call: `Warning 1287: SQL_CALC_FOUND_ROWS is deprecated and will be removed in a future release. Consider using two separate queries instead.` / `Warning 1287: FOUND_ROWS() is deprecated and will be removed in a future release. Consider using COUNT(*) instead.` They are also the slow way to do it: the optimizer has to materialize every matching row even though the panel only shows 5. This PR replaces the pattern with a dedicated `COUNT(*)` that shares the exact same `FROM` and `WHERE` as the list query. The presentation-only joins (customer name, shop name, currency…) are left out of the count: they all match at most one row on a primary key, so they cannot change the total. The `customer_thread` join is kept in the shared part because the `WHERE` filters on `ct.id_shop`. Output of the endpoint is unchanged.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Have more than 5 new orders / new customers / new messages. 2. Open the back office and check the notification bell: the badge count and the 5 listed entries must be identical to before the change, for the three types. 3. On MySQL 8.0.17+, `SHOW WARNINGS` after the notification query no longer reports `Warning 1287`. 4. `./vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/NotificationTest.php`
| UI Tests          | —
| Fixed issue or discussion? | —
| Related PRs       | —
| Sponsor company   | Lotus Web Agency — https://lotuswebagency.com/
