### PR TITLE
Log order carrier changes in the employee log

### DIFF
--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -20,6 +20,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCo
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\UpdateOrderShippingDetailsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\TransistEmailSendingException;
+use PrestaShopLogger;
 use Validate;
 
 /**
@@ -85,6 +86,8 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
 
                 $order->id_carrier = $carrierId;
                 $this->orderAmountUpdater->update($order, $cart);
+
+                $this->logCarrierChange((int) $order->id, $oldCarrierId, $carrierId);
             }
 
             // load fresh order carrier because updated just before
@@ -115,5 +118,30 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
         } finally {
             $this->contextStateManager->restorePreviousContext();
         }
+    }
+
+    /**
+     * Changing the carrier of an order changes what the customer is charged for shipping, but
+     * nothing recorded who did it. Keep a trace of it next to the other employee actions.
+     */
+    private function logCarrierChange(int $orderId, int $oldCarrierId, int $newCarrierId): void
+    {
+        $oldCarrier = new Carrier($oldCarrierId);
+        $newCarrier = new Carrier($newCarrierId);
+
+        PrestaShopLogger::addLog(
+            sprintf(
+                'Order carrier updated: from "%s" (#%d) to "%s" (#%d)',
+                $oldCarrier->name,
+                $oldCarrierId,
+                $newCarrier->name,
+                $newCarrierId
+            ),
+            PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE,
+            null,
+            'Order',
+            $orderId,
+            true
+        );
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderShippingFeatureContext.php
@@ -6,6 +6,8 @@
 
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
+use Carrier;
+use Db;
 use Order;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand;
@@ -43,6 +45,48 @@ class OrderShippingFeatureContext extends AbstractDomainFeatureContext
                 $trackingNumber
             )
         );
+    }
+
+    /**
+     * @Then order :orderReference should have a logged carrier change from :oldCarrierReference to :newCarrierReference
+     *
+     * @param string $orderReference
+     * @param string $oldCarrierReference
+     * @param string $newCarrierReference
+     */
+    public function orderShouldHaveALoggedCarrierChange(
+        string $orderReference,
+        string $oldCarrierReference,
+        string $newCarrierReference
+    ) {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+        $oldCarrier = new Carrier(SharedStorage::getStorage()->get($oldCarrierReference));
+        $newCarrier = new Carrier(SharedStorage::getStorage()->get($newCarrierReference));
+
+        $logs = Db::getInstance()->executeS(
+            'SELECT `message`, `id_employee` FROM `' . _DB_PREFIX_ . 'log`
+            WHERE `object_type` = "Order" AND `object_id` = ' . (int) $orderId
+        );
+
+        $matching = array_filter($logs, static function (array $log) use ($oldCarrier, $newCarrier): bool {
+            return str_contains($log['message'], '"' . $oldCarrier->name . '"')
+                && str_contains($log['message'], '"' . $newCarrier->name . '"');
+        });
+
+        Assert::assertNotEmpty(
+            $matching,
+            sprintf(
+                'Expected a log of the carrier change from "%s" to "%s" on order %d, got: %s',
+                $oldCarrier->name,
+                $newCarrier->name,
+                $orderId,
+                json_encode(array_column($logs, 'message'))
+            )
+        );
+
+        foreach ($matching as $log) {
+            Assert::assertNotEmpty($log['id_employee'], 'The carrier change was logged without the employee who made it');
+        }
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -268,6 +268,7 @@ Feature: Order from Back Office (BO)
     When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "default_carrier"
     Then cart "dummy_cart" should have "default_carrier" as a carrier
     And order "bo_order1" should have "default_carrier" as a carrier
+    And order "bo_order1" should have a logged carrier change from "weight_carrier" to "default_carrier"
     And order "bo_order1" should have following details:
       | total_products           | 53.800 |
       | total_products_wt        | 57.030 |
@@ -287,6 +288,7 @@ Feature: Order from Back Office (BO)
     When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "price_carrier"
     Then cart "dummy_cart" should have "price_carrier" as a carrier
     And order "bo_order1" should have "price_carrier" as a carrier
+    And order "bo_order1" should have a logged carrier change from "default_carrier" to "price_carrier"
     And order "bo_order1" should have following details:
       | total_products           | 53.800 |
       | total_products_wt        | 57.030 |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Changing the carrier of an existing order from the back office changes the shipping the customer is charged for, but nothing is recorded: `UpdateOrderShippingDetailsHandler` updates the carrier and the order totals silently. Other employee actions on an order (status change, payment, invoice…) leave a trace in Advanced parameters > Logs. This PR adds a log entry with the old and the new carrier when — and only when — the carrier actually changes.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Open an order in the back office, edit the shipping block and pick a different carrier, save. 2. Advanced parameters > Logs shows `Order carrier updated: from "<old>" (#id) to "<new>" (#id)`, attached to the order (object type `Order`, object ID = the order ID) and to the employee who made the change. 3. Saving the shipping block without changing the carrier (only the tracking number, for instance) logs nothing. 4. `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-shipping`
| UI Tests          | —
| Fixed issue or discussion? | —
| Related PRs       | —
| Sponsor company   | Lotus Web Agency — https://lotuswebagency.com/
