### PR TITLE
Remove deprecated imagedestroy calls

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -332,7 +332,6 @@ class ImageManagerCore
         }
         $writeFile = ImageManager::write($destinationFileType, $destImage, $destinationFile);
         Hook::exec('actionOnImageResizeAfter', ['dst_file' => $destinationFile, 'file_type' => $destinationFileType]);
-        @imagedestroy($srcImage);
 
         return $writeFile;
     }
@@ -387,7 +386,6 @@ class ImageManagerCore
             $temp = imagecreatetruecolor($dstW * $quality + 1, $dstH * $quality + 1);
             imagecopyresized($temp, $srcImage, 0, 0, $srcX, $srcY, $dstW * $quality + 1, $dstH * $quality + 1, $srcW, $srcH);
             imagecopyresampled($dstImage, $temp, $dstX, $dstY, 0, 0, $dstW, $dstH, $dstW * $quality, $dstH * $quality);
-            imagedestroy($temp);
         } else {
             imagecopyresampled($dstImage, $srcImage, $dstX, $dstY, $srcX, $srcY, $dstW, $dstH, $srcW, $srcH);
         }
@@ -590,8 +588,6 @@ class ImageManagerCore
         imagecolortransparent($dest['ressource'], $white);
         $return = ImageManager::write($fileType, $dest['ressource'], $dstFile);
         Hook::exec('actionOnImageCutAfter', ['dst_file' => $dstFile, 'file_type' => $fileType]);
-        // @phpstan-ignore-next-line
-        @imagedestroy($src['ressource']);
 
         return $return;
     }
@@ -711,8 +707,6 @@ class ImageManagerCore
 
                 break;
         }
-        // @phpstan-ignore-next-line
-        imagedestroy($resource);
         @chmod($filename, 0664);
 
         return $success;

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -995,7 +995,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 
                 break;
         }
-        imagedestroy($dest_image);
+
         if (!$imaged) {
             throw new WebserviceException(sprintf('Unable to write the image "%s".', str_replace(_PS_ROOT_DIR_, '[SHOP_ROOT_DIR]', $new_path)), [70, 500]);
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -79,7 +79,6 @@ abstract class AbstractDomainFeatureContext extends AbstractPrestaShopFeatureCon
                 $dirImage . $objectId . self::JPG_IMAGE_TYPE,
                 0
             );
-            imagedestroy($im);
         }
 
         return $imageName;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.2.x
| Description?      | This PR removes all remaining usages of `imagedestroy()`.<br>The function has had no effect since PHP 8.0 and is deprecated as of PHP 8.5.<br>Since PrestaShop 9.2 only supports PHP versions where `imagedestroy()` is already a no-op, these calls can be safely removed without changing existing behavior.
| Type?             | bug fix
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/34188239018
| UI Tests          | 1. Use PHP 8.5 and enable debug mode.<br>2. Go to the Back Office and upload a new image to a product.<br>3. Regenerate product thumbnails from **Design > Image Settings**.<br>4. Verify that the images are correctly generated and no `imagedestroy()` deprecation warning is reported.<br>5. Check that the integration and UI tests pass.
| Fixed issue or discussion?     | 
| Related PRs       |
| Sponsor company   | Codencode snc
