### PR TITLE
Do not reuse a memoized session that does not match the requested id

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -572,9 +572,15 @@ class CookieCore
      */
     public function getSession($sessionId)
     {
-        if ($this->session !== null) {
+        // The memoized session is only reusable when it actually holds the requested session.
+        // Keeping it otherwise returns a session that does not match $sessionId anymore, which
+        // happens as soon as registerSession() issues a new one during the request, or when a
+        // previous call memoized a session that could not be loaded (its id is null).
+        if ($this->session !== null && (int) $this->session->getId() === (int) $sessionId) {
             return $this->session;
         }
+
+        $this->session = null;
 
         if (isset($this->id_employee)) {
             $this->session = new EmployeeSession($sessionId);

--- a/tests/Integration/Classes/CookieTest.php
+++ b/tests/Integration/Classes/CookieTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Customer;
+use CustomerSession;
+use PHPUnit\Framework\TestCase;
+use Tests\Resources\classes\TestCookie;
+use Tools;
+
+class CookieTest extends TestCase
+{
+    /**
+     * getSession() memoizes the session it built, and until now it returned that copy
+     * whatever session id was asked for. A cookie carrying an expired session id therefore
+     * kept the unloaded session it had built on the first call, so the session registered
+     * later during the same request (on login, for instance) was never seen and
+     * isSessionAlive() stayed false for the rest of the request.
+     */
+    public function testSessionIsAliveAfterRegisteringANewSessionOverAStaleOne(): void
+    {
+        $customer = $this->createDummyCustomer();
+
+        $cookie = new TestCookie();
+        $cookie->id_customer = (int) $customer->id;
+        $cookie->session_id = 123456789;
+        $cookie->session_token = sha1('expired-session-token');
+
+        // Builds and memoizes a session that cannot be loaded, as it does not exist anymore
+        $this->assertFalse($cookie->isSessionAlive());
+
+        $cookie->registerSession(new CustomerSession());
+
+        $this->assertTrue($cookie->isSessionAlive());
+
+        $cookie->deleteSession();
+    }
+
+    /**
+     * Reading the same session twice must not hit the database again: the session is saved
+     * when it is loaded, and that save triggers hooks which can read the session back.
+     */
+    public function testSessionOfTheSameIdIsOnlyBuiltOnce(): void
+    {
+        $customer = $this->createDummyCustomer();
+
+        $cookie = new TestCookie();
+        $cookie->id_customer = (int) $customer->id;
+        $cookie->registerSession(new CustomerSession());
+
+        $session = $cookie->getSession($cookie->session_id);
+
+        $this->assertInstanceOf(CustomerSession::class, $session);
+        $this->assertSame($session, $cookie->getSession($cookie->session_id));
+
+        $cookie->deleteSession();
+    }
+
+    private function createDummyCustomer(): Customer
+    {
+        $customer = new Customer();
+        $customer->firstname = 'Jenna';
+        $customer->lastname = 'Doe';
+        $customer->email = 'pub+' . uniqid() . '@prestashop.com';
+        $customer->passwd = Tools::hash('prestashop');
+        $customer->save();
+
+        return $customer;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CookieCore::getSession($sessionId)` memoizes the session it built into `$this->session` and then returns that copy whatever `$sessionId` is asked for — including a `CustomerSession` that could not be loaded, whose `getId()` and `getToken()` are `null`. `registerSession()` updates `session_id` / `session_token` on the cookie but never refreshes that memo. So when a browser carries an **expired `session_id`**, `AuthController::checkAccess()` memoizes an unloaded session through `isLogged()`, the login then issues a fresh one, and `isSessionAlive()` keeps comparing the new token against the stale `null` — `Customer::isLogged()` stays `false` for the rest of the login request and every `actionAuthentication` listener guarding on it silently does nothing. In a private window there is no `session_id`, `isSessionAlive()` returns early without memoizing, and the same login behaves — which is what makes this look like a browser cookie problem. This PR only reuses the memo when it actually holds the requested session id. Present since 8.0.1, reproduced on `9.2.x` and `develop` (9.3.0).
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The added integration test covers it: `php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/CookieTest.php` — `testSessionIsAliveAfterRegisteringANewSessionOverAStaleOne` fails before this change and passes after it.<br><br>Manually: <br>1. Log in on the front office as a customer, then delete that customer's row in Advanced Parameters > Security > Customer sessions, keeping the browser cookie.<br>2. Register a module on `actionAuthentication` whose handler logs `Context::getContext()->customer->isLogged()`.<br>3. Log in again in the same browser (not a private window).<br>4. Before: the handler logs `false`. After: it logs `true`.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/34445426283
| Fixed issue or discussion?     | Fixes #42766
| Related PRs       | –
| Sponsor company   | Evolutive

### Why the memo is kept

The memo was added in 5c823dc73a5 to fix #29560: `getSession()` calls `$this->session->save()` on a loaded session, that save fires `actionObjectUpdateAfter`, and a listener reading the session back caused an infinite loop. That protection is preserved here — `$this->session` is still assigned *before* `save()`, and a re-entrant `getSession()` with the same id now matches the memo and returns immediately without saving again. `testSessionOfTheSameIdIsOnlyBuiltOnce` locks that behaviour in.

The only case that now rebuilds is a session that does not match the requested id: either a different id (which previously returned the wrong session) or one that failed to load (`getId()` is `null`, and no `save()` happens on it, so there is no loop to reintroduce).

