### PR TITLE
Fix the theme selector in the Translations page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.ts
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.ts
@@ -66,9 +66,6 @@ export default class FormFieldToggle {
     const $modulesFormGroup = $(TranslationSettingsMap.modulesFormGroup);
     const $emailFormGroup = $(TranslationSettingsMap.emailFormGroup);
     const $themesFormGroup = $(TranslationSettingsMap.themesFormGroup);
-    const $defaultThemeOption = $themesFormGroup.find(
-      TranslationSettingsMap.defaultThemeOption,
-    );
 
     switch (selectedOption) {
       case back:
@@ -78,7 +75,7 @@ export default class FormFieldToggle {
 
       case themes:
         this.show($themesFormGroup);
-        this.hide($modulesFormGroup, $emailFormGroup, $defaultThemeOption);
+        this.hide($modulesFormGroup, $emailFormGroup);
         break;
 
       case modules:
@@ -113,15 +110,12 @@ export default class FormFieldToggle {
     const $noThemeOption = $themesFormGroup.find(
       TranslationSettingsMap.noThemeOption,
     );
-    const $defaultThemeOption = $themesFormGroup.find(
-      TranslationSettingsMap.defaultThemeOption,
-    );
 
     if (selectedEmailContentType === emailContentBody) {
       $noThemeOption.prop('selected', true);
-      this.show($noThemeOption, $themesFormGroup, $defaultThemeOption);
+      this.show($themesFormGroup);
     } else {
-      this.hide($noThemeOption, $themesFormGroup, $defaultThemeOption);
+      this.hide($themesFormGroup);
     }
   }
 

--- a/admin-dev/themes/new-theme/js/pages/translation-settings/TranslationSettingsMap.ts
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/TranslationSettingsMap.ts
@@ -9,7 +9,6 @@ export default {
   emailFormGroup: '.js-email-form-group',
   modulesFormGroup: '.js-module-form-group',
   themesFormGroup: '.js-theme-form-group',
-  defaultThemeOption: '.js-default-theme',
   noThemeOption: '.js-no-theme',
   exportCoreType: '#form_core_selectors_core_type',
   exportCoreValues: '#form_core_selectors_selected_value',

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -6,7 +6,6 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Translations;
 
-use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShopBundle\Form\Admin\Type\LocaleChoiceType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -75,13 +74,6 @@ class ModifyTranslationsType extends TranslatorAwareType
                 'class' => 'js-no-theme',
             ],
         ];
-
-        // Only one theme must be identified as the default one
-        if (isset($this->themeChoices[Theme::getDefaultTheme()])) {
-            $themeChoiceAttributes[Theme::getDefaultTheme()] = [
-                'class' => 'js-default-theme',
-            ];
-        }
 
         $builder
             ->add('translation_type', ChoiceType::class, [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | In `Improve → International → Translations`, the "Modify translations" block did not offer hummingbird in the "Select your theme" list, so the default theme's front-office wordings could not be translated. The option was rendered but hidden by `d-none`.<br><br>This also fixes a pre-existing bug where the `Core (no theme selected)` option stayed hidden after visiting `Email → subject`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Rebuild the BO assets (`make admin-new-theme`).<br><br>1. Go to `Improve > International > Translations`.<br>2. Set **Type of translation** to `Front office Translations`.<br>3. **Select your theme** lists `Core (no theme selected)`, `classic` and `hummingbird`. Before the fix, `hummingbird` was absent.<br>4. Pick `hummingbird` + a language, **Modify**, translate a wording (e.g. `Add to cart`) and save, it shows in the FO and is stored in `ps_translation` with `theme = 'hummingbird'`.<br>5. Regression: **Back office**, **Installed modules** and **Email → subject** hide the theme row; **Email → body** shows it with all options available.
| UI Tests          | https://github.com/tblivet/ga.tests.ui.pr/actions/runs/34226581040
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33521
| Related PRs       | --
| Sponsor company   | @PrestaShopCorp
