### PR TITLE
Attach the shop logo only to emails that show it

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -545,9 +545,16 @@ class MailCore extends ObjectModel
                 }
             }
             ShopUrl::cacheMainDomainForShop((int) $idShop);
-            if (isset($logo) && $configuration['PS_MAIL_TYPE'] != Mail::TYPE_TEXT) {
+            if (isset($logo)
+                && $configuration['PS_MAIL_TYPE'] != Mail::TYPE_TEXT
+                && self::templateShowsShopLogo($templateHtml)
+            ) {
                 $templateVars['{shop_logo}'] = 'cid:shop_logo';
                 $email->embedFromPath($logo, 'shop_logo');
+            } else {
+                // Nothing will display it, so the file is not attached and the placeholder resolves
+                // to nothing rather than to a cid that points at an attachment we did not add.
+                $templateVars['{shop_logo}'] = '';
             }
 
             // Now, we add common links that are available in every template
@@ -1055,5 +1062,28 @@ class MailCore extends ObjectModel
         }
 
         return Tools::strtolower((string) $smtpEncryption) !== 'off';
+    }
+
+    /**
+     * Whether the html body has anywhere to show the shop logo.
+     *
+     * The logo used to be attached to every message as soon as one was configured, so a template
+     * that does not display it still carried the image, which mail clients then show as an
+     * attachment. This is checked after actionEmailAddAfterContent so a module that adds the
+     * placeholder still gets the logo.
+     *
+     * @param string $templateHtml
+     *
+     * @return bool
+     */
+    private static function templateShowsShopLogo($templateHtml)
+    {
+        if (!is_string($templateHtml) || '' === $templateHtml) {
+            return false;
+        }
+
+        // Either the placeholder, or the content id itself for a template that writes the img tag.
+        return false !== strpos($templateHtml, '{shop_logo}')
+            || false !== strpos($templateHtml, 'cid:shop_logo');
     }
 }

--- a/tests/Unit/Classes/Mail/MailShopLogoEmbeddingTest.php
+++ b/tests/Unit/Classes/Mail/MailShopLogoEmbeddingTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Mail;
+
+use Mail;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * The logo was attached to every message as soon as one was configured, so a template that does not
+ * display it still carried the image and mail clients showed it as an attachment. It is now attached
+ * only when the html body has somewhere to show it.
+ *
+ * All 34 html templates PrestaShop ships do reference it, through the shared header component, so
+ * this changes nothing for them; it is custom and module templates that stop carrying the file.
+ */
+class MailShopLogoEmbeddingTest extends TestCase
+{
+    /**
+     * @dataProvider bodies
+     *
+     * @param mixed $templateHtml
+     */
+    public function testTheLogoIsAttachedOnlyWhenTheBodyCanShowIt($templateHtml, bool $expected): void
+    {
+        $method = new ReflectionMethod(Mail::class, 'templateShowsShopLogo');
+        $method->setAccessible(true);
+
+        $this->assertSame($expected, $method->invoke(null, $templateHtml));
+    }
+
+    public static function bodies(): iterable
+    {
+        yield 'the placeholder, as the shipped header component uses it' => [
+            '<table><tr><td><img src="{shop_logo}" alt=""></td></tr></table>', true,
+        ];
+        yield 'the content id written directly' => [
+            '<img src="cid:shop_logo" alt="">', true,
+        ];
+        yield 'the placeholder anywhere in the body' => [
+            "<p>hello</p>\n<div>{shop_logo}</div>", true,
+        ];
+        yield 'a body that never shows it' => [
+            '<p>Your order has shipped.</p>', false,
+        ];
+        yield 'another placeholder is not this one' => [
+            '<p>{shop_name} says hello</p>', false,
+        ];
+        // Reached when the html file is missing, since $templateHtml starts empty.
+        yield 'an empty body' => ['', false];
+        yield 'not a string at all' => [null, false];
+    }
+
+    public function testTheShippedHeaderComponentStillAsksForTheLogo(): void
+    {
+        $method = new ReflectionMethod(Mail::class, 'templateShowsShopLogo');
+        $method->setAccessible(true);
+
+        foreach (['classic', 'modern'] as $theme) {
+            $header = _PS_ROOT_DIR_ . '/mails/themes/' . $theme . '/components/header.html.twig';
+            $this->assertFileExists($header);
+            $this->assertTrue(
+                $method->invoke(null, (string) file_get_contents($header)),
+                sprintf('The %s header component should still reference the shop logo.', $theme)
+            );
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Mail::Send()` embedded the shop logo as soon as one was configured and the message was not plain text, whatever the template contained. A template that never displays it still carried the image, which mail clients then present as an attachment on a message with no visible logo. The logo is now attached only when the html body has somewhere to show it.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Configure a mail logo. Send any of the shipped templates: the logo is embedded and displayed exactly as before. Then send a template whose html does not contain `{shop_logo}`, from a module or a custom mail theme: the message no longer carries the image, and no longer shows an attachment. With `PS_MAIL_TYPE` set to text only, nothing is embedded either way, as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #27645
| Related PRs       | None
| Sponsor company   | None

### What changes and what does not

Measured on the shipped templates: all 34 html templates in `mails/en` reference the logo, through the shared `header.html.twig` component, and none of the 34 text templates do. So this changes nothing for a stock shop.

What it changes is the case in the report: a custom mail theme or a module template that does not display the logo stops carrying the file. That is also why the change is worth making as a condition on the template rather than as a new setting - the template already states whether it wants the logo, so a setting would be a second place to say the same thing and a chance for the two to disagree.

### Where the check sits

After `actionEmailAddAfterContent`. A module that adds `{shop_logo}` to the body through that hook still gets the logo embedded, which would not be true if the decision were taken when the template was read.

Both spellings count: the `{shop_logo}` placeholder that the shipped header uses, and `cid:shop_logo` for a template that writes the `img` tag itself.

### The placeholder when nothing displays it

Previously `{shop_logo}` was set to `cid:shop_logo` whenever a logo existed. When the logo is not attached it is now set to an empty string instead, so a text part that happens to carry the placeholder resolves to nothing rather than to a content id pointing at an attachment that was never added.

### Not included

The report also asks for a way to embed arbitrary extra files and get their content id back, for product images in templates. That is a new public API on `Mail` rather than a condition on an existing one, so it belongs in its own change.

### Test

`tests/Unit/Classes/Mail/MailShopLogoEmbeddingTest.php` covers the decision: the placeholder, the content id, the placeholder anywhere in the body, a body that never shows it, a different placeholder, an empty body, and a non-string. It also asserts that both shipped header components still reference the logo, so removing it from a header cannot silently stop the logo being attached.

Two mutations were checked: always answering that the body shows the logo fails four cases, and dropping the `cid:shop_logo` spelling fails one.
