### PR TITLE
Use querySelector's generic instead of casting its result

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/attribute/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute/form/index.ts
@@ -22,9 +22,9 @@ $(() => {
 });
 
 document.addEventListener('DOMContentLoaded', () => {
-  const attributeGroupSelect = document.querySelector(AttributeFormMap.attributeGroupSelect) as HTMLSelectElement | null;
-  const attributeColorRow = document.querySelector(AttributeFormMap.attributeColorFormRow) as HTMLElement | null;
-  const attributeTextureRow = document.querySelector(AttributeFormMap.attributeTextureFormRow) as HTMLElement | null;
+  const attributeGroupSelect = document.querySelector<HTMLSelectElement>(AttributeFormMap.attributeGroupSelect);
+  const attributeColorRow = document.querySelector<HTMLElement>(AttributeFormMap.attributeColorFormRow);
+  const attributeTextureRow = document.querySelector<HTMLElement>(AttributeFormMap.attributeTextureFormRow);
 
   if (!attributeGroupSelect || !attributeColorRow || !attributeTextureRow) return;
 

--- a/admin-dev/themes/new-theme/js/pages/discount/form/specific-products.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/form/specific-products.ts
@@ -41,7 +41,7 @@ export default class SpecificProducts {
 
   init(): void {
     if (this.$specificProductsSearchInput.length) {
-      const autocompleteUrl = (document.querySelector(DiscountMap.specificProductsSearchContainer) as HTMLElement)
+      const autocompleteUrl = (document.querySelector<HTMLElement>(DiscountMap.specificProductsSearchContainer))
         ?.dataset.remoteUrl;
 
       this.entitySearchInput = new EntitySearchInput(

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-view-page.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-view-page.ts
@@ -402,7 +402,7 @@ export default class OrderViewPage {
       container = OrderViewPageMap.productEditModal;
     }
 
-    const modal = document.querySelector(container) as HTMLDivElement;
+    const modal = document.querySelector<HTMLDivElement>(container);
 
     if (!modal) {
       throw new Error(`${type} product modal not found`);
@@ -463,7 +463,7 @@ export default class OrderViewPage {
       if (!response.ok) {
         throw new Error(await response.text());
       }
-      const formContainer = document.querySelector(OrderViewPageMap.editProductModalContainer) as HTMLElement;
+      const formContainer = document.querySelector<HTMLElement>(OrderViewPageMap.editProductModalContainer);
       formContainer!.innerHTML = await response.text();
       modal.dataset.state = 'loaded';
     } catch (error) {

--- a/admin-dev/themes/new-theme/js/pages/product/category/tags-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/category/tags-renderer.ts
@@ -22,7 +22,7 @@ export default class TagsRenderer {
     tagRemovedEventName: string,
   ) {
     this.eventEmitter = eventEmitter;
-    this.container = document.querySelector(containerSelector) as HTMLElement;
+    this.container = document.querySelector<HTMLElement>(containerSelector)!;
     this.tagRemovedEventName = tagRemovedEventName;
     this.listenTagRemoval();
   }
@@ -45,10 +45,10 @@ export default class TagsRenderer {
 
       if (tplFragment && tplFragment.firstChild && tplFragment.firstChild.parentNode) {
         const frag = tplFragment.firstChild.parentNode;
-        const idInput = frag.querySelector(ProductCategoryMap.tagCategoryIdInput) as HTMLInputElement;
+        const idInput = frag.querySelector<HTMLInputElement>(ProductCategoryMap.tagCategoryIdInput)!;
         idInput.value = String(category.id);
 
-        const tagRemoveBtn = frag.querySelector(ProductCategoryMap.tagRemoveBtn) as HTMLElement;
+        const tagRemoveBtn = frag.querySelector<HTMLElement>(ProductCategoryMap.tagRemoveBtn)!;
 
         // don't show the tag removal element when it is the last category
         if (categories.length === 1) {
@@ -93,7 +93,7 @@ export default class TagsRenderer {
         const tagItem = clickedBtn.closest(ProductCategoryMap.tagItem) as HTMLElement;
 
         if (tagItem) {
-          const idInput = tagItem.querySelector(ProductCategoryMap.tagCategoryIdInput) as HTMLInputElement;
+          const idInput = tagItem.querySelector<HTMLInputElement>(ProductCategoryMap.tagCategoryIdInput)!;
           tagItem.remove();
           this.eventEmitter.emit(this.tagRemovedEventName, Number(idInput.value));
         }

--- a/admin-dev/themes/new-theme/js/pages/product/specific-price/specific-price-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/specific-price/specific-price-list-renderer.ts
@@ -28,7 +28,7 @@ export default class SpecificPriceListRenderer implements RendererType {
     productId: number,
   ) {
     this.productId = productId;
-    this.listContainer = document.querySelector(SpecificPriceMap.listContainer) as HTMLElement;
+    this.listContainer = document.querySelector<HTMLElement>(SpecificPriceMap.listContainer)!;
     this.eventEmitter = window.prestashop.instance.eventEmitter;
     this.$loadingSpinner = $(ProductMap.specificPrice.loadingSpinner);
     this.$listTable = $(ProductMap.specificPrice.listTable);
@@ -41,8 +41,8 @@ export default class SpecificPriceListRenderer implements RendererType {
 
   public render(data: Record<string, any>): void {
     const {listFields} = SpecificPriceMap;
-    const tbody = this.listContainer.querySelector(`${SpecificPriceMap.listContainer} tbody`) as HTMLElement;
-    const trTemplateContainer = this.listContainer.querySelector(SpecificPriceMap.listRowTemplate) as HTMLScriptElement;
+    const tbody = this.listContainer.querySelector<HTMLElement>(`${SpecificPriceMap.listContainer} tbody`)!;
+    const trTemplateContainer = this.listContainer.querySelector<HTMLScriptElement>(SpecificPriceMap.listRowTemplate)!;
     const trTemplate = trTemplateContainer.innerHTML as string;
     tbody.innerHTML = '';
 
@@ -99,7 +99,7 @@ export default class SpecificPriceListRenderer implements RendererType {
   }
 
   private selectListField(templateTrClone: HTMLElement, selector: string): HTMLElement {
-    return templateTrClone.querySelector(selector) as HTMLElement;
+    return templateTrClone.querySelector<HTMLElement>(selector)!;
   }
 
   private addEventListenerForDeleteBtn(deleteBtn: HTMLElement): void {

--- a/admin-dev/themes/new-theme/js/pages/tax-rules/tax-rules-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax-rules/tax-rules-list-renderer.ts
@@ -48,8 +48,8 @@ export default class TaxRulesListRenderer implements RendererType {
   }
 
   public render(data: Record<string, any>): void {
-    const tbody = this.listContainer.querySelector('tbody') as HTMLElement;
-    const trTemplateEl = this.listContainer.querySelector(ROW_TEMPLATE_ID) as HTMLScriptElement;
+    const tbody = this.listContainer.querySelector<HTMLElement>('tbody')!;
+    const trTemplateEl = this.listContainer.querySelector<HTMLScriptElement>(ROW_TEMPLATE_ID)!;
     const trTemplate = trTemplateEl.innerHTML;
     tbody.innerHTML = '';
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `querySelector` and `querySelectorAll` take the element type as a generic and return it or `null`. Casting the result instead, `as HTMLElement`, asserts the type and silently discards the `null`. The sixteen remaining casts in the back office theme now use the generic, and the ten places that were relying on the discarded `null` say so explicitly.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `cd admin-dev/themes/new-theme && npm ci && npx tsc --noEmit -p tsconfig.json` reports the same 16 errors as before the change, all of them inside `node_modules`. `npm run lint` reports nothing. The pages touched are Attributes (add/edit), Discounts (specific products), the order view product edit modal, Product categories tags, Product specific prices and Tax rules.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #27743
| Related PRs       | Supersedes the closed #27809 and #29704, which attempted the same change
| Sponsor company   | None

### What the casts were hiding

Converting all sixteen and running the type checker is what makes this worth doing rather than a stylistic sweep. Six needed nothing further. The other ten produced compiler errors:

| file | errors surfaced |
| ---- | --------------- |
| `js/pages/product/category/tags-renderer.ts` | 5 |
| `js/pages/product/specific-price/specific-price-list-renderer.ts` | 4 |
| `js/pages/tax-rules/tax-rules-list-renderer.ts` | 3 |

They are all the same shape: a list renderer takes its container or its row template with `querySelector`, then dereferences it. With the cast the compiler had nothing to say; with the generic it reports `'tbody' is possibly 'null'`.

### Why those ten keep the assumption rather than gaining a guard

These renderers cannot function without their container and row template - a missing one means the page did not render, not that there is a branch to take. Adding a runtime guard would be inventing behaviour for a state the page never reaches.

So they keep the assumption and state it, with the non-null assertion those same files already use, for instance in `tax-rules-list-renderer.ts`:

```ts
const editBtn = trClone.querySelector<HTMLElement>('.js-edit-tax-rule-btn')!;
```

That idiom is already at 23 sites in this theme, so this follows it rather than introducing a second convention. The difference from a cast is worth being precise about: `as HTMLElement` asserts the type *and* absorbs the `null`, while `querySelector<HTMLElement>(...)!` takes the type from the DOM API and leaves the null assumption visible and greppable.

### Measured

| | tsc errors |
| --- | --- |
| `9.2.x` baseline | 16, all in `node_modules` |
| after converting the casts, before the assertions | 29 |
| final | 16, all in `node_modules` |

The middle row is the ten hidden dereferences plus three assignment mismatches. The diff is types only: every changed line contains `querySelector`.
