### PR TITLE
Print the shipment quantity on a shipment delivery slip

### DIFF
--- a/pdf/shipment-delivery-slip.product-tab.tpl
+++ b/pdf/shipment-delivery-slip.product-tab.tpl
@@ -15,7 +15,7 @@
 	<tbody>
 		<!-- PRODUCTS -->
 		{foreach $products as $product}
-			{if $product.product_quantity-$product.product_quantity_refunded > 0}
+			{if $product.product_quantity > 0}
 				{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 				<tr class="product {$bgcolor_class}">
 
@@ -46,7 +46,7 @@
 						{/if}
 					</td>
 					<td class="product center">
-						{$product.product_quantity-$product.product_quantity_refunded}
+						{$product.product_quantity}
 					</td>
 
 				</tr>
@@ -82,7 +82,7 @@
                 </td>
 
                 <td class="center">
-                  ({if $customization.quantity == 0}1{else}{$customization.quantity-$product.product_quantity_refunded}{/if})
+                  ({if $customization.quantity == 0}1{else}{$customization.quantity}{/if})
                 </td>
 
               </tr>

--- a/tests/Unit/Pdf/ShipmentDeliverySlipQuantityTest.php
+++ b/tests/Unit/Pdf/ShipmentDeliverySlipQuantityTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Pdf;
+
+use PHPUnit\Framework\TestCase;
+use Smarty;
+
+/**
+ * A shipment delivery slip lists what left the warehouse in that shipment, so its quantities come
+ * from the shipment and not from the order. The refunded count on the row is the order's, which is
+ * why it must not be subtracted here: two shipments of two units against a four unit line, with two
+ * units refunded afterwards, would otherwise print nothing on either slip.
+ *
+ * The order based slip in delivery-slip.product-tab.tpl does subtract it, and should: there the
+ * quantity is the order's too.
+ */
+/**
+ * Carries the two constants the template reads, so the render needs no legacy autoloader.
+ */
+class CustomizationFieldTypes
+{
+    public const CUSTOMIZE_FILE = 0;
+    public const CUSTOMIZE_TEXTFIELD = 1;
+}
+
+class ShipmentDeliverySlipQuantityTest extends TestCase
+{
+    private const TEMPLATE = __DIR__ . '/../../../pdf/shipment-delivery-slip.product-tab.tpl';
+
+    public function testAShippedLineIsPrintedEvenWhenTheOrderHasRefundsAgainstIt(): void
+    {
+        $html = $this->render(['product_quantity' => 2, 'product_quantity_refunded' => 2]);
+
+        $this->assertSame(1, $this->countProductRows($html));
+        $this->assertSame(['2'], $this->quantityCells($html));
+    }
+
+    public function testTheQuantityPrintedIsTheShipmentQuantity(): void
+    {
+        $html = $this->render(['product_quantity' => 3, 'product_quantity_refunded' => 1]);
+
+        $this->assertSame(['3'], $this->quantityCells($html));
+    }
+
+    public function testACustomizedLineAlsoKeepsItsShipmentQuantity(): void
+    {
+        $html = $this->render([
+            'product_quantity' => 2,
+            'product_quantity_refunded' => 2,
+            'customizedDatas' => [
+                'address' => [
+                    'customization-1' => [
+                        'quantity' => 2,
+                        'datas' => [CustomizationFieldTypes::CUSTOMIZE_TEXTFIELD => [
+                            ['name' => 'Engraving', 'value' => 'Probe'],
+                        ]],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString('customization_data', $html);
+        $this->assertSame(['(2)'], $this->customizationQuantityCells($html));
+    }
+
+    public function testALineWithNothingInTheShipmentIsNotPrinted(): void
+    {
+        $html = $this->render(['product_quantity' => 0, 'product_quantity_refunded' => 0]);
+
+        $this->assertSame(0, $this->countProductRows($html));
+    }
+
+    private function render(array $overrides): string
+    {
+        $smarty = new Smarty();
+        $smarty->setCompileDir(sys_get_temp_dir() . '/ps-smarty-' . getmypid());
+        $smarty->setCaching(Smarty::CACHING_OFF);
+        $smarty->setErrorReporting(E_ALL & ~E_NOTICE & ~E_WARNING);
+        // The translation plugin the template calls; the wording is not what is under test.
+        $smarty->registerPlugin('function', 'l', static fn (array $params): string => (string) ($params['s'] ?? ''));
+        // The template reads two Product constants in its customization branch, and Smarty wants any
+        // class it resolves statically to be registered.
+        $smarty->registerClass('Product', CustomizationFieldTypes::class);
+
+        // The template also reads this flag; images are not what is under test.
+        $smarty->assign('display_product_images', false);
+        $smarty->assign('products', [$overrides + [
+            'product_name' => 'Probe product',
+            'product_reference' => 'PROBE',
+            'customizedDatas' => [],
+        ]]);
+
+        return $smarty->fetch(self::TEMPLATE);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function customizationQuantityCells(string $html): array
+    {
+        preg_match_all('~<td class="center">\s*(\([0-9-]*\))\s*</td>~', $html, $m);
+
+        return $m[1];
+    }
+
+    private function countProductRows(string $html): int
+    {
+        return preg_match_all('~<tr class="product~', $html);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function quantityCells(string $html): array
+    {
+        preg_match_all('~<td class="product center">\s*([0-9-]*)\s*</td>~', $html, $m);
+
+        return $m[1];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `pdf/shipment-delivery-slip.product-tab.tpl` subtracted the order's refunded quantity from the shipment's own quantity. `HTMLTemplateShipmentDeliverySlip::getShipmentProducts()` sets `product_quantity` from `ShipmentProduct::getQuantity()`, the units that left in that shipment, while `product_quantity_refunded` arrives with the rest of the `OrderDetail` fields and counts refunds across the whole order line. Subtracting one from the other mixes a per-shipment number with an order-level one.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With `improved_shipment` enabled: order 4 units of one product, ship them as two shipments of 2, then refund 2 units. Print either shipment's delivery slip. Before this change the product line is absent from both slips, because 2 minus 2 is 0 in each; after it, each slip lists 2. The order based delivery slip is unchanged and still nets the refund off.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Relates to #27881
| Related PRs       | The order based slip was fixed separately by #39430
| Sponsor company   | None

### Why the two numbers are different

`getShipmentProducts()` builds each row from the order detail and then overwrites the quantity:

```php
$product = $orderDetail->getFields();          // brings product_quantity_refunded, order level
$product['product_quantity'] = $shipmentProduct->getQuantity();   // this shipment only
```

`product_quantity_refunded` is a column on `order_detail` and is in `OrderDetail::$definition`, so `getFields()` returns it. `ShipmentProduct::$quantity` is its own column on the shipment product. Nothing relates the two, so the subtraction has no meaning at the shipment level.

A shipment slip records what physically left the warehouse. A refund afterwards does not change that, which is why the fix is to drop the subtraction rather than to scope the refunded count per shipment.

### Measured

Rendering the template directly, with a shipment quantity of 2 and an order refunded count of 2:

| | product rows | quantity printed |
| --- | --- | --- |
| before | 0 | none |
| after | 1 | 2 |

Zero rows is the failure: the line the warehouse is packing disappears from its own packing document.

### Where this came from

#39430 fixed exactly this class of problem on the order based slip in 8.2.3, and correctly: there `product_quantity` is the order's quantity, so netting the refund off is what makes a partly refunded line print the deliverable amount. The shipment template, added later by #41015, carries the same three expressions, and that is where the units stopped matching.

### Test

`tests/Unit/Pdf/ShipmentDeliverySlipQuantityTest.php` renders the real template through a bare Smarty instance, with a stub for the `l` translation plugin and for the two `Product` constants the customization branch reads, so it needs no legacy autoloader. Four cases: a shipped line survives refunds against the order, the printed quantity is the shipment's, a customized line behaves the same, and a line with nothing in the shipment is still not printed.

All three changed expressions are covered: restoring the subtraction on the row guard, on the printed quantity, or on the customization quantity each fails exactly one case.
