### PR TITLE
Say which rule each eslint disable is for, and drop the dead ones

### DIFF
--- a/admin-dev/themes/default/.eslintrc.js
+++ b/admin-dev/themes/default/.eslintrc.js
@@ -17,6 +17,9 @@ module.exports = {
   parserOptions: {
     parser: 'babel-eslint',
   },
+  // A disable directive that suppresses nothing is dead weight and hides the next real one,
+  // so an unused one is an error rather than something only the CLI flag reveals.
+  reportUnusedDisableDirectives: true,
   extends: [
     'airbnb-base',
   ],

--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -4,7 +4,7 @@
  */
 
 // build confirmation modal
-// eslint-disable-next-line
+// eslint-disable-next-line no-unused-vars
 function confirm_modal(
   heading,
   question,
@@ -45,7 +45,7 @@ function confirm_modal(
 
 // build error modal
 /* global errorContinueMsg */
-// eslint-disable-next-line
+// eslint-disable-next-line no-unused-vars
 function error_modal(heading, msg) {
   const errorModal = $(
     `${'<div class="bootstrap modal hide fade">'
@@ -72,9 +72,9 @@ function error_modal(heading, msg) {
 }
 
 // move to hash after clicking on anchored links
-// eslint-disable-next-line
+// eslint-disable-next-line consistent-return
 function scroll_if_anchor(href) {
-  // eslint-disable-next-line
+  // eslint-disable-next-line no-param-reassign
   href = typeof href === 'string' ? href : $(this).attr('href');
   const fromTop = 120;
 
@@ -567,7 +567,7 @@ $(() => {
     $('#header_search .form-group').removeClass('focus-search');
   });
 
-  // eslint-disable-next-line
+  // eslint-disable-next-line consistent-return
   $('#header_search #bo_query').on('click', (e) => {
     e.stopPropagation();
     e.preventDefault();

--- a/admin-dev/themes/default/js/bundle/admin_parameters/performancePage.js
+++ b/admin-dev/themes/default/js/bundle/admin_parameters/performancePage.js
@@ -2,7 +2,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
-// eslint-disable-next-line
+// eslint-disable-next-line no-unused-vars
 function PerformancePage(addServerUrl, removeServerUrl, testServerUrl) {
   this.addServerUrl = addServerUrl;
   this.removeServerUrl = removeServerUrl;
@@ -36,7 +36,7 @@ function PerformancePage(addServerUrl, removeServerUrl, testServerUrl) {
             + `<td>${params.server_port}</td>\n`
             + `<td>${params.server_weight}</td>\n`
             + '<td>\n'
-            // eslint-disable-next-line
+            // eslint-disable-next-line max-len
             + `    <a class="btn btn-default" href="#" onclick="app.removeServer(${params.id});"><i class="material-icons">remove_circle</i> Remove</a>\n`
             + '</td>\n';
     serversTable.appendChild(newRow);
@@ -45,7 +45,7 @@ function PerformancePage(addServerUrl, removeServerUrl, testServerUrl) {
   this.addServer = function () {
     const app = this;
     this.send(this.getAddServerUrl(), 'POST', this.getFormValues(), (results) => {
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-prototype-builtins
       if (!results.hasOwnProperty('error')) {
         app.createRow(results);
       }
@@ -69,7 +69,7 @@ function PerformancePage(addServerUrl, removeServerUrl, testServerUrl) {
     const app = this;
 
     this.send(this.getTestServerUrl(), 'GET', this.getFormValues(), (results) => {
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-prototype-builtins
       if (results.hasOwnProperty('error') || results.test === false) {
         app.addClass('is-invalid');
         return;

--- a/admin-dev/themes/default/js/bundle/admin_parameters/performancePageUI.js
+++ b/admin-dev/themes/default/js/bundle/admin_parameters/performancePageUI.js
@@ -68,9 +68,9 @@ window.addEventListener('load', () => {
 const cacheSystemInputs = document.querySelectorAll('input[type=radio]');
 let {length} = cacheSystemInputs;
 
-// eslint-disable-next-line
+// eslint-disable-next-line no-plusplus
 while (length--) {
-  // eslint-disable-next-line
+  // eslint-disable-next-line consistent-return
   cacheSystemInputs[length].addEventListener('change', (e) => {
     const name = e.target.getAttribute('name');
 

--- a/admin-dev/themes/default/js/bundle/category-tree.js
+++ b/admin-dev/themes/default/js/bundle/category-tree.js
@@ -24,11 +24,11 @@
           this.find('li').has('ul').removeClass('less').addClass('more');
           break;
         default:
-          // eslint-disable-next-line
+          // eslint-disable-next-line no-throw-literal
           throw 'Unknown method';
       }
 
-    // eslint-disable-next-line
+    // eslint-disable-next-line brace-style
     }
 
     // initialize tree
@@ -52,7 +52,7 @@
           $ui.parent('li').removeClass('less').addClass('more');
         }
 
-        // eslint-disable-next-line
+        // eslint-disable-next-line consistent-return
         return false;
       };
       this.find('li > ul').each((i, item) => {

--- a/admin-dev/themes/default/js/bundle/components/navbar-transition-handler.js
+++ b/admin-dev/themes/default/js/bundle/components/navbar-transition-handler.js
@@ -13,7 +13,7 @@
  * @method toggle - Add the listener if there is no transition launched yet.
  * @return {Object} The object with methods wich permit to toggle on specific event.
 */
-// eslint-disable-next-line
+// eslint-disable-next-line no-unused-vars
 function NavbarTransitionHandler($navBar, $mainMenu, endTransitionEvent, $body) {
   this.$body = $body;
   this.transitionFired = false;

--- a/admin-dev/themes/default/js/bundle/default.js
+++ b/admin-dev/themes/default/js/bundle/default.js
@@ -68,7 +68,6 @@ const rightSidebar = (function () {
 /**
  *  BO Events Handler
  */
-// eslint-disable-next-line
 window.BOEvent = {
   on(eventName, callback, context) {
     document.addEventListener(eventName, (event) => {

--- a/admin-dev/themes/default/js/bundle/pagination.js
+++ b/admin-dev/themes/default/js/bundle/pagination.js
@@ -17,10 +17,10 @@ $(() => {
   /*
    * Input field changes management
   */
-  // eslint-disable-next-line
+  // eslint-disable-next-line consistent-return
   function checkInputPage(eventOrigin) {
     const e = eventOrigin || event;
-    // eslint-disable-next-line
+    // eslint-disable-next-line max-len
     const char = e.type === 'keypress' ? String.fromCharCode(e.keyCode || e.which) : (e.clipboardData || window.clipboardData).getData('Text');
 
     if (/[^\d]/gi.test(char)) {
@@ -31,7 +31,7 @@ $(() => {
     this.onkeypress = checkInputPage;
     this.onpaste = checkInputPage;
 
-    // eslint-disable-next-line
+    // eslint-disable-next-line consistent-return
     $(this).on('keyup', function (e) {
       const val = parseInt($(e.target).val(), 10);
 
@@ -52,7 +52,7 @@ $(() => {
       }
     });
 
-    // eslint-disable-next-line
+    // eslint-disable-next-line consistent-return
     $(this).on('blur', function (e) {
       const val = parseInt($(e.target).val(), 10);
 

--- a/admin-dev/themes/default/js/bundle/product/catalog.js
+++ b/admin-dev/themes/default/js/bundle/product/catalog.js
@@ -105,13 +105,12 @@ function productOrderTable(orderBy, orderWay) {
   window.location.href = url;
 }
 
-// eslint-disable-next-line
 function productOrderPrioritiesTable() {
   window.location.href = $('form#product_catalog_list').attr('orderingurl');
 }
 
 function updateBulkMenu() {
-  // eslint-disable-next-line
+  // eslint-disable-next-line max-len
   const selectedCount = $('form#product_catalog_list input:checked[name="bulk_action_selected_products[]"][disabled!="disabled"]').length;
   $('#product_bulk_menu').prop('disabled', (selectedCount === 0));
 }
@@ -204,7 +203,7 @@ function bulkModalAction(allItems, postUrl, redirectUrl, action) {
       url: postUrl,
       data: {bulk_action_selected_products: [item0]},
       success(data, status) {
-        // eslint-disable-next-line
+        // eslint-disable-next-line no-mixed-operators
         progressBar.css('width', `${currentItemIdx * 100 / itemsCount}%`);
         progressBar.find('span').html(`${currentItemIdx} / ${itemsCount}`);
 
@@ -288,11 +287,11 @@ function bulkProductAction(element, action) {
       // no break !
 
     // this case will post inline edition command
-    // eslint-disable-next-line
+    // eslint-disable-next-line no-fallthrough
     case 'edition':
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-case-declarations
       let editionAction;
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-case-declarations
       const bulkEditionSelector = '#bulk_edition_toolbar input:submit';
 
       if ($(bulkEditionSelector).length > 0) {
@@ -337,7 +336,7 @@ function unitProductAction(element, action) {
     .attr('type', 'hidden')
     .attr('name', 'redirect_url').val(redirectUrlHandler.attr('redirecturl'));
 
-  // eslint-disable-next-line
+  // eslint-disable-next-line default-case
   switch (action) {
     case 'delete':
       // Confirmation popup and callback...
@@ -378,7 +377,7 @@ function showBulkProductEdition(show) {
 function bulkProductEdition(element, action) {
   const form = $('form#product_catalog_list');
 
-  // eslint-disable-next-line
+  // eslint-disable-next-line default-case
   switch (action) {
     case 'sort':
       showBulkProductEdition(true);

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -233,7 +233,7 @@ window.displayFieldsManager = (function () {
         || typeProduct.val() === '2')
       ) {
         const typeOfProduct = this.getProductType();
-        // eslint-disable-next-line
+        // eslint-disable-next-line max-len
         const errorMessage = `You can't create ${typeOfProduct} product with variations. Are you sure to disable variations ? they will all be deleted.`;
         modalConfirmation.create(translate_javascripts[errorMessage], null, {
           onCancel() {
@@ -244,7 +244,7 @@ window.displayFieldsManager = (function () {
           onContinue() {
             $.ajax({
               type: 'GET',
-              // eslint-disable-next-line
+              // eslint-disable-next-line max-len
               url: $('#accordion_combinations').attr('data-action-delete-all').replace(/delete-all\/\d+/, `delete-all/${$('#form_id_product').val()}`),
               success() {
                 $('#accordion_combinations .combination').remove();
@@ -323,7 +323,7 @@ const formCategory = (function () {
         }
 
         // inject new category in parent category selector
-        // eslint-disable-next-line
+        // eslint-disable-next-line max-len
         $('#form_step1_new_category_id_parent').append(`<option value="${response.category.id}">${response.category.name[1]}</option>`);
 
         // create label
@@ -461,7 +461,7 @@ const featuresCollection = (function () {
  */
 const supplier = (function () {
   const supplierInputManage = function (input) {
-    // eslint-disable-next-line
+    // eslint-disable-next-line max-len
     const supplierDefaultInput = $(`#form_step6_suppliers input[name="form[step6][default_supplier]"][value=${$(input).val()}]`);
 
     if ($(input).is(':checked')) {
@@ -503,7 +503,7 @@ window.supplierCombinations = (function () {
       const url = collectionHolder.attr('data-url')
         .replace(
           /refresh-product-supplier-combination-form\/\d+\/\d+/,
-          // eslint-disable-next-line
+          // eslint-disable-next-line max-len
           `refresh-product-supplier-combination-form/${idProduct}${suppliers.length > 0 ? `/${suppliers.join('-')}` : ''}`,
         );
       $.ajax({
@@ -569,7 +569,7 @@ window.form = (function () {
   function send(redirect, target, callBack) {
     // target value by default
     if (typeof (target) === 'undefined') {
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-param-reassign
       target = false;
     }
     seo.onSave();
@@ -871,12 +871,12 @@ window.form = (function () {
             selected.push($(this).val());
           });
 
-          // eslint-disable-next-line
+          // eslint-disable-next-line max-len
           return $.grep(suggestions, (suggestion) => $.inArray(suggestion.value, selected) === -1 && $.inArray(`group-${suggestion.data.id_group}`, selected) === -1);
         };
 
         /** On event "tokenfield:createtoken" : check values are valid if its not a typehead result */
-        // eslint-disable-next-line
+        // eslint-disable-next-line consistent-return
         $('#form_step3_attributes').on('tokenfield:createtoken', (e) => {
           if (!e.attrs.data) {
             if (e.handleObj.origType !== 'tokenfield:createtoken') {
@@ -915,7 +915,7 @@ window.form = (function () {
         /** On event "tokenfield:createdtoken" : store attributes in input when add a token */
         $('#form_step3_attributes').on('tokenfield:createdtoken', (e) => {
           if (e.attrs.data) {
-            // eslint-disable-next-line
+            // eslint-disable-next-line max-len
             $('#attributes-generator').append(`<input type="hidden" id="attribute-generator-${e.attrs.value}" class="attribute-generator" value="${e.attrs.value}" name="options[${e.attrs.data.id_group}][${e.attrs.value}]" />`);
           } else {
             $(e.relatedTarget).addClass('invalid');
@@ -1152,7 +1152,7 @@ window.attachmentProduct = (function () {
       }
 
       /** add attachment */
-      // eslint-disable-next-line
+      // eslint-disable-next-line prefer-arrow-callback
       $('#form_step6_attachment_product_add').on('click', function () {
         const data = new FormData();
 
@@ -1336,7 +1336,7 @@ window.imagesProduct = (function () {
           } if ($.type(response) === 'string') {
             message = response;
           } else if (response.message) {
-            // eslint-disable-next-line
+            // eslint-disable-next-line prefer-destructuring
             message = response.message;
           }
 
@@ -1414,7 +1414,7 @@ window.imagesProduct = (function () {
       checkDropzoneMode();
     },
     getOlderImageId() {
-      // eslint-disable-next-line
+      // eslint-disable-next-line prefer-spread
       return Math.min.apply(Math, $('.dz-preview').map(function () {
         return $(this).data('id');
       }));
@@ -1562,7 +1562,7 @@ window.priceCalculation = (function () {
     let i = 0;
 
     if (computationMethod === '0') {
-      // eslint-disable-next-line
+      // eslint-disable-next-line guard-for-in, no-restricted-syntax, no-unreachable-loop
       for (i in rates) {
         priceWithTaxes *= (1.00 + parseFloat(rates[i]) / 100.00);
         break;
@@ -1570,13 +1570,13 @@ window.priceCalculation = (function () {
     } else if (computationMethod === '1') {
       let rate = 0;
 
-      // eslint-disable-next-line
+      // eslint-disable-next-line guard-for-in, no-restricted-syntax
       for (i in rates) {
         rate += rates[i];
       }
       priceWithTaxes *= (1.00 + parseFloat(rate) / 100.00);
     } else if (computationMethod === '2') {
-      // eslint-disable-next-line
+      // eslint-disable-next-line guard-for-in, no-restricted-syntax
       for (i in rates) {
         priceWithTaxes *= (1.00 + parseFloat(rates[i]) / 100.00);
       }
@@ -1729,7 +1729,7 @@ window.priceCalculation = (function () {
       });
 
       /** combinations : update wholesale price, unity and price TE field on blur */
-      // eslint-disable-next-line
+      // eslint-disable-next-line max-len
       $(document).on('blur', '.combination-form .attribute_wholesale_price,.combination-form .attribute_unity,.combination-form .attribute_priceTE', function () {
         $(this).val(priceCalculation.normalizePrice($(this).val()));
       });
@@ -2225,7 +2225,7 @@ window.recommendedModules = (function () {
   return {
     init() {
       this.moduleActionMenuLinkSelectors = 'button.module_action_menu_install, button.module_action_menu_enable, '
-        // eslint-disable-next-line
+        // eslint-disable-next-line max-len
         + 'button.module_action_menu_uninstall, button.module_action_menu_disable, button.module_action_menu_reset, button.module_action_menu_update';
       $(this.moduleActionMenuLinkSelectors).on('module_card_action_event', this.saveProduct);
     },

--- a/admin-dev/themes/default/js/bundle/product/product-category-tags.js
+++ b/admin-dev/themes/default/js/bundle/product/product-category-tags.js
@@ -119,7 +119,7 @@ const productCategoriesTags = (function () {
         if ($(optionId).length === 0) {
           defaultCategoryForm.append(`${'<div class="radio">'
             + '<label class="required">'
-            // eslint-disable-next-line
+            // eslint-disable-next-line max-len, no-useless-concat
             + '<input type="radio"' + 'id="form_step1_id_category_default_'}${category.id}" name="form[step1][id_category_default]" required="required" value="${category.id}">${
             category.name}</label>`
             + '</div>');
@@ -149,7 +149,7 @@ const productCategoriesTags = (function () {
         });
       });
 
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-underscore-dangle
       searchBox.autocomplete({
         source: tags,
         minChars: 2,

--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -6,7 +6,7 @@
  * Function for removing bad characters from localization formating.
  */
 function replaceBadLocaleCharacters() {
-  // eslint-disable-next-line
+  // eslint-disable-next-line max-len
   $.each($('input.attribute_wholesale_price, input.attribute_priceTE, input.attribute_priceTI, input.attribute_unity, input.attribute_weight'), function () {
     $(this).val($(this).val().replace('−', '-')); // replace U+002D with U+2212
   });
@@ -22,7 +22,6 @@ window.combinations = (function () {
   function remove(elem) {
     const combinationElem = $(`#attribute_${elem.attr('data')}`);
 
-    // eslint-disable-next-line
     window.modalConfirmation.create(translate_javascripts['Are you sure you want to delete this item?'], null, {
       onContinue() {
         // We need this because there is a specific data="smthg" attribute so we can't use data() function
@@ -216,7 +215,7 @@ window.combinations = (function () {
                   onContinue() {
                     $.ajax({
                       type: 'GET',
-                      // eslint-disable-next-line
+                      // eslint-disable-next-line max-len
                       url: $('#accordion_combinations').attr('data-action-delete-all').replace(/\/\d+(?=\?.*)?/, `/${$('#form_id_product').val()}`),
                       success() {
                         combinationsList.remove();
@@ -277,7 +276,7 @@ window.combinations = (function () {
           }
 
           const number = $(`#combination_form_${contentElem.attr('data')} .number-of-images`);
-          // eslint-disable-next-line
+          // eslint-disable-next-line max-len
           const allProductCombination = $(`#combination_form_${contentElem.attr('data')} .product-combination-image`).length;
 
           number.text(`${countSelectedProducts()}/${allProductCombination}`);

--- a/admin-dev/themes/default/js/bundle/product/product-manufacturer.js
+++ b/admin-dev/themes/default/js/bundle/product/product-manufacturer.js
@@ -21,7 +21,6 @@ window.manufacturer = (function () {
       });
       resetButton.on('click', (e) => {
         e.preventDefault();
-        // eslint-disable-next-line
         modalConfirmation.create(translate_javascripts['Are you sure you want to delete this item?'], null, {
           onContinue() {
             manufacturerContent.addClass('hide');
@@ -34,7 +33,6 @@ window.manufacturer = (function () {
   };
 }());
 
-// eslint-disable-next-line
 BOEvent.on('Product Manufacturer Management started', () => {
   manufacturer.init();
 }, 'Back office');

--- a/admin-dev/themes/default/js/bundle/product/product-related.js
+++ b/admin-dev/themes/default/js/bundle/product/product-related.js
@@ -21,7 +21,6 @@ window.relatedProduct = (function () {
       });
       resetButton.on('click', (e) => {
         e.preventDefault();
-        // eslint-disable-next-line
         modalConfirmation.create(translate_javascripts['Are you sure you want to delete this item?'], null, {
           onContinue: function onContinue() {
             const items = productItems.find('li').toArray();
@@ -41,7 +40,6 @@ window.relatedProduct = (function () {
   };
 }());
 
-// eslint-disable-next-line
 BOEvent.on('Product Related Management started', () => {
   relatedProduct.init();
 }, 'Back office');

--- a/admin-dev/themes/default/js/bundle/right-sidebar.js
+++ b/admin-dev/themes/default/js/bundle/right-sidebar.js
@@ -52,7 +52,7 @@
     };
 
     if (!$.support.transition) {
-      // eslint-disable-next-line
+      // eslint-disable-next-line consistent-return
       return complete.call(this);
     }
 
@@ -84,7 +84,7 @@
     };
 
     if (!$.support.transition) {
-      // eslint-disable-next-line
+      // eslint-disable-next-line consistent-return
       return complete.call(this);
     }
 
@@ -106,7 +106,7 @@
       const options = $.extend({}, Sidebar.DEFAULTS, $this.data(), typeof this.options === 'object' && option);
 
       if (!data && options.toggle && option === 'show') {
-        // eslint-disable-next-line
+        // eslint-disable-next-line no-param-reassign
         option = !option;
       }
       if (!data) {
@@ -128,7 +128,7 @@
   $(document).on('click.bs.sidebar.data-api', '[data-toggle="sidebar"]', function (e) {
     const $this = $(this);
     let href;
-    // eslint-disable-next-line
+    // eslint-disable-next-line max-len, no-mixed-operators
     const target = $this.attr('data-target') || e.preventDefault() || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '');
     const $target = $(target);
     const data = $target.data('bs.sidebar');

--- a/admin-dev/themes/default/js/bundle/utils/animations.js
+++ b/admin-dev/themes/default/js/bundle/utils/animations.js
@@ -10,7 +10,7 @@
  * @return {string} The transition keywoard of the browser.
 */
 
-// eslint-disable-next-line
+// eslint-disable-next-line no-unused-vars
 function getAnimationEvent(type, lifecycle) {
   const el = document.createElement('element');
   const typeUpper = type.charAt(0).toUpperCase() + type.substring(1);

--- a/admin-dev/themes/default/js/help.js
+++ b/admin-dev/themes/default/js/help.js
@@ -8,7 +8,6 @@ $(() => {
   const psDocsDomain = 'https://help.prestashop-project.org';
 
   if (typeof (getStorageAvailable) !== 'undefined') {
-    // eslint-disable-next-line
     storage = getStorageAvailable();
   }
 
@@ -22,14 +21,12 @@ $(() => {
       $('#main').after('<div id="help-container"></div>');
     }
     // init help (it use a global javascript variable to get actual controller)
-    // eslint-disable-next-line
     pushContent(help_class_name);
     $('#help-container').on('click', '.popup', (e) => {
       e.preventDefault();
       if (storage) storage.setItem('helpOpen', false);
       $('.toolbarBox a.btn-help').trigger('click');
       window.open(
-        // eslint-disable-next-line
         `index.php?controller=${help_class_name}?token=${token}&ajax=1&action=OpenHelp`,
         'helpWindow',
         'width=450, height=650, scrollbars=yes',
@@ -46,7 +43,6 @@ $(() => {
       window.initHelp();
     } else if (!$('#main').hasClass('helpOpen') && document.body.clientWidth < 1200) {
       window.open(
-        // eslint-disable-next-line
         `index.php?controller=${help_class_name}?token=${token}&ajax=1&action=OpenHelp`,
         'helpWindow',
         'width=450, height=650, scrollbars=yes',
@@ -66,7 +62,6 @@ $(() => {
 
   // get content
   function getHelp(pageController) {
-    // eslint-disable-next-line
     const request = encodeURIComponent(`getHelp=${pageController}&version=${_PS_VERSION_}&language=${iso_user}`);
     const d = new $.Deferred();
     $.ajax({

--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -90,7 +90,6 @@ Tree.prototype = {
       if ($('select#id_category_default').length) {
         this.$element.find(':input[type=checkbox]').off('click');
         this.$element.find(':input[type=checkbox]').on('click', function () {
-          // eslint-disable-next-line
           if ($(this).prop('checked')) addDefaultCategory($(this));
           else {
             $(`select#id_category_default option[value=${$(this).val()}]`).remove();
@@ -104,7 +103,6 @@ Tree.prototype = {
       if (typeof (treeClickFunc) !== 'undefined') {
         this.$element.find(':input[type=radio]').off('click');
 
-        // eslint-disable-next-line
         this.$element.find(':input[type=radio]').on('click', treeClickFunc);
       }
     }

--- a/admin-dev/themes/default/webpack.config.js
+++ b/admin-dev/themes/default/webpack.config.js
@@ -102,7 +102,6 @@ module.exports = (env, argv) => {
         index: 'preload.tpl',
         extensions: ['woff2'],
         filter: /preload/,
-        // eslint-disable-next-line
         replaceCallback: ({indexSource, linksAsString}) => indexSource.replace('{{{preloadLinks}}}', linksAsString.replace(/href="/g, 'href="{$admin_dir}')),
       }),
       new CssoWebpackPlugin({

--- a/admin-dev/themes/new-theme/.eslintrc.js
+++ b/admin-dev/themes/new-theme/.eslintrc.js
@@ -20,6 +20,9 @@ module.exports = {
     parser: '@babel/eslint-parser',
     requireConfigFile: false,
   },
+  // A disable directive that suppresses nothing is dead weight and hides the next real one,
+  // so an unused one is an error rather than something only the CLI flag reveals.
+  reportUnusedDisableDirectives: true,
   extends: ['airbnb-base'],
   plugins: ['import'],
   rules: {

--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -459,14 +459,14 @@ module.exports = {
       index: 'preload.tpl',
       extensions: ['woff2'],
       filter: /preload/,
-      // eslint-disable-next-line
+      // eslint-disable-next-line max-len
       replaceCallback: ({indexSource, linksAsString}) => indexSource.replace('{{{preloadLinks}}}', linksAsString.replace(/href="/g, 'href="{$admin_dir}')),
     }),
     new FontPreloadPlugin({
       index: 'preload.html.twig',
       extensions: ['woff2'],
       filter: /preload/,
-      // eslint-disable-next-line
+      // eslint-disable-next-line max-len
       replaceCallback: ({indexSource, linksAsString}) => indexSource.replace('{{{preloadLinks}}}', linksAsString.replace(/href="([^"]+)"/g, 'href="{{ asset(\'themes/new-theme/public/$1\') }}"')),
     }),
     new CssoWebpackPlugin({

--- a/admin-dev/themes/new-theme/js/@types/global.d.ts
+++ b/admin-dev/themes/new-theme/js/@types/global.d.ts
@@ -12,14 +12,11 @@ interface Window {
   moduleURLs: Record<string, any>;
   str2url: any;
   prestaShopUiKit: any;
-  // eslint-disable-next-line
   update_success_msg: string;
   adminNotificationPushLink: string;
   baseAdminDir: string;
-  // eslint-disable-next-line
   translate_javascripts: Record<string, any>;
   modalConfirmation: any;
-  // eslint-disable-next-line
   ps_round: any;
   Dropzone: Dropzone;
   data: any;

--- a/admin-dev/themes/new-theme/js/app/cldr/number-formatter.ts
+++ b/admin-dev/themes/new-theme/js/app/cldr/number-formatter.ts
@@ -10,7 +10,7 @@ import NumberSymbol from '@app/cldr/number-symbol';
 import PriceSpecification from '@app/cldr/specifications/price';
 import NumberSpecification from '@app/cldr/specifications/number';
 
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const escapeRE = require('lodash.escaperegexp');
 
 const CURRENCY_SYMBOL_PLACEHOLDER = '¤';

--- a/admin-dev/themes/new-theme/js/app/cldr/specifications/number.ts
+++ b/admin-dev/themes/new-theme/js/app/cldr/specifications/number.ts
@@ -51,7 +51,7 @@ class NumberSpecification {
     this.symbol = symbol;
 
     this.maxFractionDigits = maxFractionDigits;
-    // eslint-disable-next-line
+    // eslint-disable-next-line operator-linebreak
     this.minFractionDigits =
       maxFractionDigits < minFractionDigits
         ? maxFractionDigits

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/app.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/app.vue
@@ -42,7 +42,6 @@
   import LowFilter from './header/filters/low-filter.vue';
   import {FiltersInstanceType} from './header/filters.vue';
 
-  /* eslint-disable camelcase */
   export interface StockFilters {
     active?: string;
     suppliers?: Array<number>;
@@ -56,7 +55,6 @@
     keywords?: any;
     low_stock?: number | boolean | string;
   }
-  /* eslint-enable camelcase */
 
   const FIRST_PAGE = 1;
 

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters.vue
@@ -130,7 +130,6 @@
 </template>
 
 <script lang="ts">
-  /* eslint-disable camelcase */
   import PSSelect from '@app/widgets/ps-select.vue';
   import PSDatePicker from '@app/widgets/ps-datepicker.vue';
   import PSRadio from '@app/widgets/ps-radio.vue';

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters/filter-component.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters/filter-component.vue
@@ -107,14 +107,12 @@
         this.tags = [];
       },
       getItems(): Array<any> {
-        /* eslint-disable camelcase */
         const matchList: Array<{
           id: number,
           name: string,
           supplier_id: number,
           visible: boolean,
         }> = [];
-        /* eslint-enable camelcase */
         this.list.filter((data: any) => {
           const label = data[this.label].toLowerCase();
           data.visible = false;

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/index.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/index.vue
@@ -104,7 +104,6 @@
 
   const DEFAULT_SORT = 'desc';
 
-  /* eslint-disable camelcase */
   export interface StockMovement {
     attribute_name: string | null;
     combination_cover_id: number;
@@ -134,7 +133,6 @@
     supplier_id: number;
     supplier_name: string;
   }
-  /* eslint-enable camelcase */
 
   export default defineComponent({
     computed: {

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/products-table.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/products-table.vue
@@ -123,7 +123,6 @@
   import TranslationMixin from '@app/pages/stock/mixins/translate';
   import ProductLine from './product-line.vue';
 
-  /* eslint-disable camelcase */
   export interface StockProduct {
     active: number;
     attribute_name: string;
@@ -152,7 +151,6 @@
     supplier_name: string;
     total_combinations: number;
   }
-  /* eslint-enable camelcase */
 
   export default defineComponent({
     props: {

--- a/admin-dev/themes/new-theme/js/app/pages/translations/store/actions.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/store/actions.ts
@@ -110,7 +110,6 @@ export const saveTranslations = async ({commit}: {commit: Commit}, payload: Reco
   }
 };
 
-/* eslint-disable-next-line no-unused-vars */
 export const resetTranslation = async (params: Record<string, any>, payload: Record<string, any>): Promise<void> => {
   const {url} = payload;
   const {translations} = payload;

--- a/admin-dev/themes/new-theme/js/clickable-dropdown.ts
+++ b/admin-dev/themes/new-theme/js/clickable-dropdown.ts
@@ -9,7 +9,7 @@
  * In order to make a dropdown behave like this, simply add the class "dropdown-clickable" to its parent element.
  */
 (($) => {
-  // eslint-disable-next-line
+  // eslint-disable-next-line no-param-reassign
   $.fn.clickableDropdown = function clickableDropdown() {
     $(document).on('click', '.dropdown-clickable .dropdown-menu', (e) => {
       e.stopPropagation();

--- a/admin-dev/themes/new-theme/js/components/form/product-search-input.ts
+++ b/admin-dev/themes/new-theme/js/components/form/product-search-input.ts
@@ -35,7 +35,6 @@ export default class ProductSearchInput extends EntitySearchInput {
           const combination = response[key];
 
           if (combination.reference) {
-            // eslint-disable-next-line no-param-reassign
             response[key].reference = referenceLabel.replace('%s', combination.reference);
           }
         }

--- a/admin-dev/themes/new-theme/js/components/grid/extension/action/row/submit-row-action-extension.ts
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/action/row/submit-row-action-extension.ts
@@ -37,7 +37,6 @@ export default class SubmitRowActionExtension {
           method,
         );
       } else {
-        // eslint-disable-next-line
         if (confirmMessage.length && !window.confirm(confirmMessage)) {
           return;
         }

--- a/admin-dev/themes/new-theme/js/components/router.ts
+++ b/admin-dev/themes/new-theme/js/components/router.ts
@@ -8,7 +8,6 @@ import routes from '@js/fos_js_routes.json';
 
 const {$} = window;
 
-/* eslint-disable */
 /**
  * Wraps FOSJsRoutingbundle with exposed routes.
  * To expose route add option `expose: true` in .yml routing config
@@ -21,7 +20,6 @@ const {$} = window;
  *      expose: true
  * And run `bin/console fos:js-routing:dump --format=json --target=admin-dev/themes/new-theme/js/fos_js_routes.json`
  */
-/* eslint-enable */
 export default class Router {
   constructor() {
     if (window.prestashop && window.prestashop.customRoutes) {

--- a/admin-dev/themes/new-theme/js/components/tinymce-editor.js
+++ b/admin-dev/themes/new-theme/js/components/tinymce-editor.js
@@ -61,7 +61,6 @@ class TinyMCEEditor {
     const cfg = {
       selector: '.rte',
       plugins:
-        /* eslint-disable-next-line max-len */
         'align colorpicker link image filemanager table media placeholder lists advlist code table autoresize hr',
       browser_spellcheck: true,
       toolbar1:

--- a/admin-dev/themes/new-theme/js/notifications.ts
+++ b/admin-dev/themes/new-theme/js/notifications.ts
@@ -91,7 +91,6 @@ let fillTpl = function (
     }
     const router = new Router();
 
-    /* eslint-disable max-len */
     eltAppendTo.children(GlobalMap.notifications.element).append(
       tpl
         .replace(/_id_order_/g, <string>(<unknown>parseInt(value.id_order, 10)))

--- a/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
@@ -151,14 +151,13 @@ class SpecificPriceFormHandler {
 
     $(SpecificMap.save).on('click', () => this.submitCreatePriceForm());
 
-    // eslint-disable-next-line
     $(SpecificMap.openCreate).on('click', () => this.loadAndFillOptionsForSelectCombinationInput(usePrefixForCreate),
     );
 
     $(SpecificMap.leavBPrice(selectorPrefix)).on('click', () => this.enableSpecificPriceFieldIfEligible(usePrefixForCreate),
     );
 
-    // eslint-disable-next-line
+    // eslint-disable-next-line max-len
     $(SpecificMap.reductionType(selectorPrefix)).on('change', () => this.enableSpecificPriceTaxFieldIfEligible(usePrefixForCreate),
     );
   }
@@ -297,7 +296,6 @@ class SpecificPriceFormHandler {
     );
     const url = baseUrl.replace(/update\/\d+/, `update/${specificPriceId}`);
 
-    /* eslint-disable-next-line max-len */
     const data = $(
       '#edit-specific-price-modal-form input, #edit-specific-price-modal-form select, #form_id_product',
     ).serialize();

--- a/admin-dev/themes/new-theme/js/pages/category/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/category/index.ts
@@ -50,13 +50,11 @@ $(() => {
 
   textToLinkRewriteCopier({
     sourceElementSelector: 'input[name^="category[name]"]',
-    /* eslint-disable-next-line max-len */
     destinationElementSelector: `${translatorInput.localeInputSelector}:not(.d-none) input[name^="category[link_rewrite]"]`,
   });
 
   textToLinkRewriteCopier({
     sourceElementSelector: 'input[name^="root_category[name]"]',
-    /* eslint-disable-next-line max-len */
     destinationElementSelector: `${translatorInput.localeInputSelector}:not(.d-none) input[name^="root_category[link_rewrite]"]`,
   });
 

--- a/admin-dev/themes/new-theme/js/pages/cms-page/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/form/index.ts
@@ -47,7 +47,6 @@ $(() => {
 
   textToLinkRewriteCopier({
     sourceElementSelector: 'input.js-copier-source-title',
-    /* eslint-disable-next-line max-len */
     destinationElementSelector: `${translatorInput.localeInputSelector}:not(.d-none) input.js-copier-destination-friendly-url`,
   });
 

--- a/admin-dev/themes/new-theme/js/pages/country/components/AddressFormatBuilder.vue
+++ b/admin-dev/themes/new-theme/js/pages/country/components/AddressFormatBuilder.vue
@@ -704,7 +704,6 @@
       confirmClear(): void {
         // window.confirm is fine here — the dropdown is closed by Bootstrap on item click
         // and we want a lightweight confirmation rather than pulling in a modal for this single case.
-        // eslint-disable-next-line no-alert
         if (window.confirm(this.$t('reset.confirm') as string)) {
           this.lines = [[]];
           this.rawText = '';

--- a/admin-dev/themes/new-theme/js/pages/currency/form/components/CurrencyFormatter.vue
+++ b/admin-dev/themes/new-theme/js/pages/currency/form/components/CurrencyFormatter.vue
@@ -82,7 +82,7 @@
 
         this.selectedLanguage.priceSpecification.currencySymbol = customData.symbol;
         this.selectedLanguage.priceSpecification.positivePattern = patterns[0];
-        // eslint-disable-next-line
+        // eslint-disable-next-line operator-linebreak
         this.selectedLanguage.priceSpecification.negativePattern =
           patterns.length > 1 ? patterns[1] : `-${patterns[0]}`;
 

--- a/admin-dev/themes/new-theme/js/pages/import/ImportPage.ts
+++ b/admin-dev/themes/new-theme/js/pages/import/ImportPage.ts
@@ -37,7 +37,6 @@ export default class ImportPage {
       const $this = $(this);
 
       if ($this.find('input[name="truncate"]:checked').val() === '1') {
-        /* eslint-disable-next-line max-len */
         return window.confirm(
           `${$this.data('delete-confirm-message')} ${$.trim(
             $('#entity > option:selected')

--- a/admin-dev/themes/new-theme/js/pages/localization/LocalizationPageMap.js
+++ b/admin-dev/themes/new-theme/js/pages/localization/LocalizationPageMap.js
@@ -3,8 +3,6 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
-/* eslint-disable max-len */
-
 export default {
   formDefaultCurrency: '#form_default_currency',
 };

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -976,7 +976,6 @@ class AdminModuleController {
       const modulesCount = $('.modules-list').find('.module-item').length;
       replaceFirstWordBy($('.module-search-result-wording'), modulesCount);
 
-      // eslint-disable-next-line
       $(this.addonItemListSelector).toggle(modulesCount !== this.modulesList.length / 2);
     }
   }

--- a/admin-dev/themes/new-theme/js/pages/order-return/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/order-return/form.ts
@@ -107,6 +107,5 @@ $(() => {
   if ($form.length === 0) {
     return;
   }
-  // eslint-disable-next-line no-new
   new OrderReturnDeletionStager($form);
 });

--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
@@ -324,7 +324,7 @@ export default class CreateOrderPage {
     ),
     );
 
-    // eslint-disable-next-line
+    // eslint-disable-next-line max-len
     this.$container.on('click', createOrderMap.sendProcessOrderEmailBtn, () => this.summaryManager.sendProcessOrderEmail(<number> this.cartId),
     );
 
@@ -682,7 +682,7 @@ export default class CreateOrderPage {
       );
 
       inputsQty.forEach((inputQty: HTMLInputElement) => {
-        // eslint-disable-next-line
+        // eslint-disable-next-line no-param-reassign
         inputQty.disabled = false;
       });
     }

--- a/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
@@ -10,7 +10,6 @@ import {EventEmitter} from '@components/event-emitter';
 
 const {$} = window;
 
-/* eslint-disable camelcase */
 export interface CustomerGroup {
   id_group: string;
   name: string;
@@ -26,7 +25,6 @@ export interface CustomerResult {
   birthday: string;
   company: string;
 }
-/* eslint-disable camelcase */
 
 /**
  * Responsible for customer information rendering
@@ -84,7 +82,7 @@ export default class CustomerRenderer {
         });
         customer.groups = `${window.translate_javascripts['Customer search - group label multiple']}: ${output.join(', ')}`;
       } else if (Object.keys(customerResult.groups).length > 0) {
-        // eslint-disable-next-line
+        // eslint-disable-next-line max-len
         customer.groups = `${window.translate_javascripts['Customer search - group label single']}: ${Object.values(customerResult.groups)[0].name}`;
       }
 

--- a/admin-dev/themes/new-theme/js/pages/order/create/product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-manager.ts
@@ -12,12 +12,10 @@ import Router from '@components/router';
 
 const {$} = window;
 
-/* eslint-disable */
 interface SearchParams {
   currency_id?: string;
   search_phrase: string;
 }
-/* eslint-enable */
 
 /**
  * Product component Object for "Create order" page
@@ -157,7 +155,7 @@ export default class ProductManager {
       );
 
       inputsQty.forEach((inputQty) => {
-        // eslint-disable-next-line
+        // eslint-disable-next-line no-param-reassign
         inputQty.disabled = false;
       });
     };

--- a/admin-dev/themes/new-theme/js/pages/order/preview-products-toggler.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/preview-products-toggler.ts
@@ -28,7 +28,7 @@ function toggleStockLocationColumn($container: JQuery): void {
   let showColumn = false;
   $(
     '.js-cell-product-stock-location',
-    // eslint-disable-next-line
+    // eslint-disable-next-line consistent-return
     $container.find('tr:not(.d-none)')).filter('td').each((index, element) => {
     if ($(element).html().trim() !== '') {
       showColumn = true;

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-add-autocomplete.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-add-autocomplete.ts
@@ -5,13 +5,11 @@
 import Router from '@components/router';
 import OrderViewPageMap from '@pages/order/OrderViewPageMap';
 
-/* eslint-disable */
 interface SearchParams extends Record<string, any> {
   search_phrase: string;
   currency_id?: number;
   order_id?: number;
 }
-/* eslint-enable */
 
 const {$} = window;
 
@@ -64,7 +62,7 @@ export default class OrderProductAutocomplete {
     /**
      * Permit to link to each value of dropdown a callback after item is clicked
      */
-    // eslint-disable-next-line
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     this.onItemClickedCallback = () => {};
   }
 

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.ts
@@ -12,11 +12,9 @@ import ConfirmModal from '@components/modal';
 import OrderPricesRefresher from '@pages/order/view/order-prices-refresher';
 
 export interface DisplayedProduct {
-  /* eslint-disable camelcase */
   price_tax_excl: number;
   price_tax_incl: number;
   tax_rate: number;
-  /* eslint-enable camelcase */
   quantity: number;
   location: string;
   availableQuantity: number;
@@ -119,7 +117,6 @@ export default class OrderProductEdit {
     this.shipmentInputs = [];
     if (this.isMultishipmentIsEnabled) {
       this.modalContainer = document.querySelector<HTMLElement>(OrderViewPageMap.editProductModalContainer)!;
-      // eslint-disable-next-line max-len
       this.shipmentQtyCounter = this.modalContainer.querySelector<HTMLElement>(OrderViewPageMap.productModalShipmentQtyHeader)!;
       // eslint-disable-next-line max-len
       this.shipmentInputs = Array.from(this.modalContainer.querySelectorAll<HTMLInputElement>(OrderViewPageMap.productModalShipmentQuantityInput));

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.ts
@@ -81,7 +81,6 @@ export default class OrderProductRenderer {
     this.resetAllEditRows();
     if (!this.isMultishipmentIsEnabled) {
       $(
-        /* eslint-disable-next-line max-len */
         `${OrderViewPageMap.productAddActionBtn}, ${OrderViewPageMap.productAddRow}, ${OrderViewPageMap.productActionBtn}`,
       ).addClass('d-none');
     } else {
@@ -275,7 +274,7 @@ export default class OrderProductRenderer {
     if (forceDisplay === null) {
       $(target)
         .filter('td')
-        // eslint-disable-next-line
+        // eslint-disable-next-line consistent-return, space-before-function-paren
         .each(function() {
           if ($(this).html() !== '') {
             isColumnDisplayed = true;

--- a/admin-dev/themes/new-theme/js/pages/product/combination/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/combination-list/bulk-choices-selector.ts
@@ -156,7 +156,6 @@ export default class BulkChoicesSelector {
       const span = this.tabContainer.querySelector<HTMLSpanElement>(`label[for=${input.id}] span`);
 
       if (!label || !span) {
-        // eslint-disable-next-line max-len
         console.error(`Each ${CombinationMap.commonBulkAllSelector} is expected to have a dedicated <label> containing a <span>`);
         return;
       }

--- a/admin-dev/themes/new-theme/js/pages/product/combination/types.d.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/types.d.ts
@@ -21,7 +21,6 @@ export interface AttributeGroup {
   attributes: Array<Attribute>;
 }
 
-/* eslint-disable camelcase */
 export interface Attribute {
   id: number;
   color: string;
@@ -30,4 +29,3 @@ export interface Attribute {
   name: string;
   texture: string|null;
 }
-/* eslint-enable camelcase */

--- a/admin-dev/themes/new-theme/js/pages/product/image/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/image/dropzone/Dropzone.vue
@@ -137,7 +137,6 @@
   import DropzoneWindow from './DropzoneWindow.vue';
   import DropzonePhotoSwipe from './DropzonePhotoSwipe.vue';
 
-  /* eslint-disable camelcase */
   export interface PSDropzoneFile extends Dropzone.DropzoneFile {
     image_id: string;
     is_cover: boolean;
@@ -145,7 +144,6 @@
     shop_ids: number[];
     isAssociatedToCurrentShop: boolean;
   }
-  /* eslint-enable camelcase */
 
   const {$} = window;
 

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -138,7 +138,6 @@ export default {
     },
     editionForm: 'form[name="combination_form"]',
     editionFormInputs:
-      // eslint-disable-next-line
       'form[name="combination_form"] input, form[name="combination_form"] textarea, form[name="combination_form"] select',
     editCombinationButtons: '.edit-combination-item',
     tableRow: {
@@ -299,7 +298,7 @@ export default {
     treeCheckboxInput: '.tree-checkbox-input',
     checkboxInput: '[type=checkbox]',
     checkedCheckboxInputs: '[type=checkbox]:checked',
-    // eslint-disable-next-line
+    // eslint-disable-next-line max-len
     checkboxName: (categoryId: string): string => `product[description][categories][product_categories][${categoryId}][is_associated]`,
     inputByValue: (value: number): string => `input[value="${value}"]`,
     defaultCategorySelectInput: '#product_description_categories_default_category_id',
@@ -312,7 +311,6 @@ export default {
     tagCategoryIdInput: '.category-id-input',
     tagItem: '.tag-item',
     categoryNamePreview: '.category-name-preview',
-    // eslint-disable-next-line max-len
     namePreviewInput: '.category-name-preview-input',
     categoryNameInput: '.category-name-input',
     searchInput: '#ps-select-product-category',

--- a/admin-dev/themes/new-theme/js/pages/product/service/attribute-group.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/service/attribute-group.ts
@@ -2,7 +2,6 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
-/* eslint-disable max-len */
 import Router from '@components/router';
 import {AttributeGroup} from '@pages/product/combination/types';
 

--- a/admin-dev/themes/new-theme/js/pages/product/shop/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/shop/index.ts
@@ -13,7 +13,7 @@ $(() => {
     'IframeClient',
   ]);
 
-  // eslint-disable-next-line
+  // eslint-disable-next-line prefer-destructuring
   const iframeClient: IframeClient = window.prestashop.instance.iframeClient;
   document.querySelector<HTMLElement>(ProductMap.shops.cancelButton)?.addEventListener('click', () => {
     iframeClient.dispatchEvent(ProductEventMap.cancelProductShops);

--- a/admin-dev/themes/new-theme/webpack.config.js
+++ b/admin-dev/themes/new-theme/webpack.config.js
@@ -2,7 +2,6 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
-/* eslint-disable indent,comma-dangle */
 
 /**
  * Three mode available:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A rule-less `// eslint-disable-next-line` suppresses whatever the next line happens to violate, including violations introduced later, which is what this issue asks to fix. All 91 of them across the two back office themes are resolved: 69 now name the rule they were hiding, and 22 turned out to suppress nothing and are removed. The rule names were not guessed - each directive was deleted and eslint asked what it then reported.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `cd admin-dev/themes/new-theme && npm ci && npm run lint` and the same in `admin-dev/themes/default`. Both report nothing, which is also what the `ESLint` CI job runs. Then add `// eslint-disable-next-line no-console` above any line that does not use `console`: the lint now fails with "Unused eslint-disable directive", which it did not before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #27979
| Related PRs       | None
| Sponsor company   | None

### What was found

| theme | rule-less directives | now name a rule | suppressed nothing |
| ----- | -------------------- | --------------- | ------------------ |
| `new-theme` | 23 | 16 | 7 |
| `default` | 68 | 53 | 15 |

The 22 in the last column are the interesting half: they had stopped suppressing anything, and each was hiding the next real violation on its line for as long as it stayed.

The rules behind the other 69 were mostly `max-len` (21) and `consistent-return` (12), then `no-param-reassign` (6), `no-unused-vars` (5), `guard-for-in` and `no-restricted-syntax` (3 each), and fifteen more once or twice each, including `no-throw-literal`, `no-fallthrough` and `no-unreachable-loop`. A single bare directive was standing in for twenty different rules.

### Method

Guessing the rule from the code is how a wrong rule name gets committed, and a wrong name is worse than a bare directive because it looks specific. So each directive was deleted, eslint was run, and the rule reported on the line it had protected was the answer.

Two things had to be got right for that to be trustworthy. Blanking the directive line instead of deleting it makes eslint report `no-multiple-empty-lines` or `padded-blocks` at that spot, which is the measurement's own artifact and not the suppressed rule; three sites were misdiagnosed that way before being redone by deletion. And deleting shifts every later line in the file, so the mapping from a directive to the line it protected was checked by comparing the recorded line text against the file after deletion, for all 68 sites in the `default` theme. Zero mismatches.

### Beyond the rule-less ones

Running the same check with `--report-unused-disable-directives` showed 30 more directives in `new-theme` that named a rule but suppressed nothing, three of them whole-file `/* eslint-disable */` blocks, plus the `/* eslint-enable */` comments that had nothing left to match once those were removed. They are gone for the same reason as the other 22.

`reportUnusedDisableDirectives: true` is now set in both themes' configs so this cannot come back silently. It was verified to take effect in each theme separately, by planting a directive that suppresses nothing and confirming the lint fails without any CLI flag. It immediately earned its place: it flagged a stale `/* eslint-disable indent,comma-dangle */` at the top of `new-theme/webpack.config.js` that nothing had reported before, which is removed here too.

### Deliberately not included

Nine whole-file `/* eslint-disable */` blocks remain, four in `new-theme` and five in `default`. Unlike the three that were removed, these do suppress real violations, which the unused-directive check proves by not flagging them. Replacing one means fixing the code it covers rather than editing a comment, so each is its own change rather than part of this one.

The front office default theme needs nothing: Hummingbird has no rule-less directives at all. `classic-theme` lives in its own repository.
