### PR TITLE
Name the combination attributes separator instead of inlining it

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/product.yml
@@ -1,3 +1,9 @@
+parameters:
+  # Separator placed between two attributes of a combination name, as in "Size: M, Color: Blue".
+  # Declared here rather than inline so a shop or a module can redefine it in one place, and so it
+  # can be shared by any other service that has to render the same list.
+  ps_combination_attributes_separator: ', '
+
 services:
   _defaults:
     public: true
@@ -9,9 +15,7 @@ services:
     public: false
     arguments:
       - '@translator'
-      # separator between attributes (ex : size: M, color: blue), to be replaced by a configuration parameter (env or php const)
-      # https://github.com/PrestaShop/PrestaShop/issues/28512
-      - ', '
+      - '%ps_combination_attributes_separator%'
       - '@=service("prestashop.adapter.legacy.configuration").get("PS_ATTRIBUTE_ANCHOR_SEPARATOR")'
 
   PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilderInterface: '@PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `src/PrestaShopBundle/Resources/config/services/core/product.yml` passed the combination attributes separator to `CombinationNameBuilder` as a bare `', '`, with a comment asking for it to be replaced by a configuration parameter and linking this issue. It is now declared as `ps_combination_attributes_separator` in a `parameters:` block at the top of the same file, which is how this bundle already declares parameters elsewhere, and the argument reads `%ps_combination_attributes_separator%`.
| Branch?           | 9.2.x
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. `php bin/console debug:container --parameter=ps_combination_attributes_separator` returns `, `. 2. `php bin/console debug:container "PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder" --show-arguments` shows that value as the second argument, exactly as the inline literal did. 3. Redefine the parameter in any yml loaded after this one, clear the cache, and the argument follows. 4. Combination names in the back office and the front office read the same as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28512
| Related PRs       | None
| Sponsor company   | None

### Why a container parameter and not a shop setting

The two arguments are different kinds of value. `PS_ATTRIBUTE_ANCHOR_SEPARATOR`, the second one, is a merchant setting and stays where it is. The attributes separator is a deployment or presentation choice with no back office control, and the issue asks for it in a configuration file rather than in the database, so a named container parameter is the smallest thing that answers it and keeps it shareable.

### Measured

`debug:container --show-arguments` on the builder:

| parameter value | second argument |
| --------------- | --------------- |
| `', '` (shipped) | `, ` |
| `' // '` | ` // ` |

The second row is only a check that the parameter is load-bearing rather than shadowed by the old literal; it is not part of the change. The shipped value is identical to the literal it replaces, so nothing renders differently.

### On sharing it further

`debug:container` lists the builder's consumers as `SpecificProductType`, `SpecificPriceType` and `DiscountFormDataProvider`, all of which go through the builder rather than formatting the list themselves, so none of them needs the parameter directly today. `Product::getAttributesResume()` carries the same `', '` as a default argument, but it is a legacy static that cannot read a container parameter, so it is left alone rather than half-converted.

### No test

The change replaces a literal with a parameter holding the same value, so there is no behaviour to pin that `tests/Unit/Core/Product/Combination/NameBuilder/CombinationNameBuilderTest.php` does not already cover; it passes unchanged. The wiring is verified by the `debug:container` output above.
