### PR TITLE
Say in sanity.yml why webkit is not in the browser matrix

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -26,6 +26,13 @@ jobs:
     name: Sanity
     needs: workflow_matrix_generator
     strategy:
+      # The browsers, PHP versions and databases come from
+      # .github/workflows/workflow-matrix/{default,complete}-sanity-matrix.json.
+      # webkit is deliberately absent from both: it was parked because it turned the job red roughly
+      # two runs out of three, and the leg was carried here as a commented entry until the matrix moved
+      # to JSON, which cannot hold a comment. Tracked by
+      # https://github.com/PrestaShop/PrestaShop/issues/37680 - add the entry back to the JSON files once
+      # that issue concludes it is stable enough.
       matrix: ${{ fromJSON(needs.workflow_matrix_generator.outputs.dynamic_matrix) }}
       fail-fast: false
     steps:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The Sanity browser matrix used to live inline in `.github/workflows/sanity.yml`, where the webkit leg was kept as a commented entry under `## @todo : https://github.com/PrestaShop/PrestaShop/issues/37680`. The matrix has since moved to `.github/workflows/workflow-matrix/{default,complete}-sanity-matrix.json`, and JSON holds no comments, so both the parked leg and the link to the issue that parked it were dropped. Nothing in the tree references #37680 any more, and a reader of the matrix cannot tell that webkit is parked rather than simply unwanted. This puts the note back in the file that owns the matrix.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Comment only, no behaviour change. `yamllint -c .github/workflows/yamllint/.yamllint.yml .github/workflows/sanity.yml` stays clean and the Sanity workflow runs the same four matrix legs as before.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | #37680
| Related PRs       |
| Sponsor company   |

### Why the cell is a bare `#37680` and not `Fixes #37680`

This does not fix the webkit instability. It restores the pointer that the migration dropped. The issue
stays open and stays with its assignee.

### Verification

- `yamllint` with the repository's own config (`.github/workflows/yamllint/.yamllint.yml`) reports clean.
  The config disables `line-length`, so the comment lines are fine as written.
- The diff is additive: 7 lines, 0 deletions, and the `matrix:` expression is untouched.

### The rest of the finding, which is on the issue rather than in this branch

Posted as https://github.com/PrestaShop/PrestaShop/issues/37680#issuecomment-5571147372:

- `sanity.yml` is the only workflow on `9.2.x` or `develop` that sets `BROWSER`, so webkit runs nowhere in
  core CI today.
- `tests/UI/package-lock.json` resolves `@playwright/test` / `playwright` / `playwright-core` to **1.60.0**
  and `.github/actions/ui-test/action.yml:56` runs `npm ci`, so that is what CI uses. The `^1.48.1` in
  `ui-testing-library`'s `package.json` is only a floor and has not moved since 2024-10-15 - two months
  before the issue was opened. The issue's own ask, "test with newer versions of PW", is therefore already
  satisfied on the version axis; what has never happened is re-running webkit on it.
- `ui-testing-library/src/utils/playwright.ts` still launches webkit, and
  `.github/actions/ui-test/action.yml:62` runs `npx playwright install ${{ inputs.BROWSER }} --with-deps`,
  so re-enabling the leg is one JSON entry with no other plumbing.
- Base rate for comparison, last 30 Sanity runs per branch with cancelled excluded: `9.2.x` 3/27 (11.1%),
  `develop` 3/29 (10.3%).

### Not measured, deliberately

Webkit stability on Playwright 1.60.0 was NOT measured. A credible flakiness number needs repeated CI
runs, not one local pass, and the local attempt was invalid anyway - the 9.2 shop container had exited
(`AH00170: caught SIGWINCH, shutting down gracefully`) before the run started, so the campaign was talking
to a dead target. The host also cannot run webkit directly: the browser downloads on 1.60.0 but Arch lacks
`libicu74`, `libflite1`, `libmanette-0.2-0`, `libenchant-2-2` and `libwoff1`, which would need the
`mcr.microsoft.com/playwright:v1.60.0-noble` image. No stability claim was published.

### Notes for publishing

- The issue is a `Task`, labelled `TE`, assigned to @Progi1984, who reopened it on 2025-12-01 with "No,
  it's not fixed. It's on my todolist." This branch does not touch the matrix itself, so it does not
  compete with that work - re-adding the webkit leg remains his call.
- Small diff. If it reads as churn at publish time, dropping it costs nothing; the substance is in the
  issue comment.
