### PR TITLE
Refuse a carrier that is priced from ranges but has none

### DIFF
--- a/src/Adapter/Carrier/QueryHandler/GetCarrierForEditingHandler.php
+++ b/src/Adapter/Carrier/QueryHandler/GetCarrierForEditingHandler.php
@@ -58,6 +58,8 @@ final class GetCarrierForEditingHandler implements GetCarrierForEditingHandlerIn
             $zones,
             $logoPath,
             $this->carrierRepository->getOrdersCount($query->getCarrierId()),
+            (bool) $carrier->shipping_external,
+            (bool) $carrier->need_range,
         );
     }
 }

--- a/src/Core/Domain/Carrier/Exception/CarrierConstraintException.php
+++ b/src/Core/Domain/Carrier/Exception/CarrierConstraintException.php
@@ -132,4 +132,10 @@ class CarrierConstraintException extends CarrierException
      * Thrown when a product quantity of an availability search is missing or not strictly positive
      */
     public const INVALID_PRODUCT_QUANTITY = 230;
+
+    /**
+     * A carrier priced from its own ranges was saved without any, which leaves it invisible in the front
+     * office rather than free of charge - the shipping cost lookup simply finds nothing to apply.
+     */
+    public const MISSING_RANGES = 240;
 }

--- a/src/Core/Domain/Carrier/QueryResult/EditableCarrier.php
+++ b/src/Core/Domain/Carrier/QueryResult/EditableCarrier.php
@@ -36,7 +36,26 @@ class EditableCarrier
         private array $zones,
         private ?string $logoPath = null,
         private int $ordersCount = 0,
+        private bool $shippingExternal = false,
+        private bool $needRange = false,
     ) {
+    }
+
+    /**
+     * True when a module supplies the shipping cost for this carrier instead of the shop.
+     */
+    public function isShippingExternal(): bool
+    {
+        return $this->shippingExternal;
+    }
+
+    /**
+     * True when the carrier is priced from the ranges configured in the back office. A module carrier
+     * may turn this off and price everything itself.
+     */
+    public function needsRange(): bool
+    {
+        return $this->needRange;
     }
 
     public function getZones(): array

--- a/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
@@ -11,6 +11,9 @@ use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\AddCarrierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\EditCarrierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\SetCarrierRangesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\SetCarrierTaxRuleGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Query\GetCarrierForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryResult\EditableCarrier;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -19,11 +22,15 @@ class CarrierFormDataHandler implements FormDataHandlerInterface
 {
     public function __construct(
         private readonly CommandBusInterface $commandBus,
+        private readonly CommandBusInterface $queryBus,
     ) {
     }
 
     public function create(array $data)
     {
+        // A carrier created here is never a module carrier, so it is always priced from its own ranges.
+        $this->assertRangesAreDefined($data, true);
+
         /** @var UploadedFile|null $logo */
         $logo = $data['general_settings']['logo'];
         if ($logo instanceof UploadedFile) {
@@ -64,6 +71,10 @@ class CarrierFormDataHandler implements FormDataHandlerInterface
 
     public function update($id, array $data)
     {
+        /** @var EditableCarrier $carrier */
+        $carrier = $this->queryBus->handle(new GetCarrierForEditing((int) $id, ShopConstraint::allShops()));
+        $this->assertRangesAreDefined($data, $this->isPricedFromItsOwnRanges($carrier));
+
         // If the courier has no costs, 'has_additional_handling_fee' must be false.
         if ((bool) $data['shipping_settings']['is_free'] === true) {
             $data['shipping_settings']['has_additional_handling_fee'] = false;
@@ -106,6 +117,41 @@ class CarrierFormDataHandler implements FormDataHandlerInterface
         $carrierId = $this->setCarrierTaxRuleGroup($carrierId, $data);
 
         return $carrierId->getValue();
+    }
+
+    /**
+     * A carrier that is priced from its ranges but has none is accepted by the back office and then never
+     * offered at checkout, with nothing to tell the merchant why - the reported defect. Refuse the save
+     * instead, so the message arrives where the mistake was made.
+     *
+     * A free carrier is exempt because it has no cost to look up: update() already skips saving ranges for
+     * one, and requiring them would block a shop that offers free delivery.
+     */
+    private function assertRangesAreDefined(array $data, bool $pricedFromItsOwnRanges): void
+    {
+        if (!$pricedFromItsOwnRanges || (bool) $data['shipping_settings']['is_free']) {
+            return;
+        }
+
+        if ([] !== $this->formatFormRangesData($data)) {
+            return;
+        }
+
+        throw new CarrierConstraintException(
+            'A carrier priced from its own ranges must have at least one range.',
+            CarrierConstraintException::MISSING_RANGES
+        );
+    }
+
+    /**
+     * WHY these two flags and not is_module: Cart::getPackageShippingCostFromModule() is what decides.
+     * It returns the range price untouched unless shipping_external is set, and when a module carrier also
+     * turns need_range off the module replaces the cost entirely - that is the only case where a carrier
+     * legitimately has no ranges. A module carrier that keeps need_range on is still priced from them.
+     */
+    private function isPricedFromItsOwnRanges(EditableCarrier $carrier): bool
+    {
+        return !$carrier->isShippingExternal() || $carrier->needsRange();
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/CarrierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/CarrierController.php
@@ -18,6 +18,7 @@ use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\ToggleCarrierStatusCommand
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CannotDeleteCarrierException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CannotToggleCarrierIsFreeStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CannotToggleCarrierStatusException;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Query\GetCarrierForEditing;
@@ -360,6 +361,13 @@ class CarrierController extends PrestaShopAdminController
                 [],
                 'Admin.Notifications.Error'
             ),
+            CarrierConstraintException::class => [
+                CarrierConstraintException::MISSING_RANGES => $this->trans(
+                    'You must set at least one range and its price, otherwise this carrier will not be offered at checkout.',
+                    [],
+                    'Admin.Shipping.Notification'
+                ),
+            ],
             CannotToggleCarrierStatusException::class => [
                 CannotToggleCarrierStatusException::SINGLE_TOGGLE => $this->trans(
                     'An error occurred while updating the status for an object.',

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -3,6 +3,7 @@ services:
     public: true
     bind:
       $commandBus: '@prestashop.core.command_bus'
+      $queryBus: '@prestashop.core.query_bus'
 
   prestashop.core.form.identifiable_object.sql_request_form_data_handler:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\SqlRequestFormDataHandler'

--- a/tests/Unit/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandlerTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandlerTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\DataHandler;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\QueryResult\EditableCarrier;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CarrierFormDataHandler;
+
+/**
+ * A carrier priced from its own ranges but saved without any is accepted and then never offered at
+ * checkout, with nothing shown to the merchant. These pin the refusal, and - just as important - that
+ * the refusal happens before anything is written.
+ */
+class CarrierFormDataHandlerTest extends TestCase
+{
+    public function testCreatingACarrierWithNoRangeIsRefusedBeforeAnythingIsSaved(): void
+    {
+        $commandBus = $this->createMock(CommandBusInterface::class);
+        $commandBus->expects($this->never())->method('handle');
+
+        $handler = new CarrierFormDataHandler($commandBus, $this->createMock(CommandBusInterface::class));
+
+        $this->expectException(CarrierConstraintException::class);
+        $this->expectExceptionCode(CarrierConstraintException::MISSING_RANGES);
+
+        $handler->create($this->formData([]));
+    }
+
+    public function testAFreeCarrierNeedsNoRange(): void
+    {
+        $handler = new CarrierFormDataHandler($this->acceptingCommandBus(), $this->createMock(CommandBusInterface::class));
+
+        $handler->create($this->formData([], true));
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testACarrierWithARangeIsAccepted(): void
+    {
+        $handler = new CarrierFormDataHandler($this->acceptingCommandBus(), $this->createMock(CommandBusInterface::class));
+
+        $handler->create($this->formData($this->oneRange()));
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * The exception the maintainers raised on the issue: a module carrier that prices everything itself
+     * has no ranges by design, and must still be saveable.
+     *
+     * @dataProvider provideCarriersAndWhetherTheyNeedARange
+     */
+    public function testWhetherAnEditedCarrierNeedsARangeFollowsHowItIsPriced(
+        bool $shippingExternal,
+        bool $needRange,
+        bool $expectsRefusal
+    ): void {
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        $queryBus->method('handle')->willReturn($this->carrier($shippingExternal, $needRange));
+
+        $handler = new CarrierFormDataHandler($this->acceptingCommandBus(), $queryBus);
+
+        if ($expectsRefusal) {
+            $this->expectException(CarrierConstraintException::class);
+            $this->expectExceptionCode(CarrierConstraintException::MISSING_RANGES);
+        }
+
+        $handler->update(1, $this->formData([]));
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function provideCarriersAndWhetherTheyNeedARange(): iterable
+    {
+        // Cart::getPackageShippingCostFromModule() returns the range price untouched for these
+        yield 'shop carrier' => [false, false, true];
+        yield 'shop carrier that asks for ranges' => [false, true, true];
+        // a module carrier that keeps need_range on is still priced from the ranges
+        yield 'module carrier that keeps its ranges' => [true, true, true];
+        // and this is the one that replaces the cost entirely
+        yield 'module carrier pricing externally' => [true, false, false];
+    }
+
+    private function acceptingCommandBus(): CommandBusInterface
+    {
+        $bus = $this->createMock(CommandBusInterface::class);
+        $bus->method('handle')->willReturn(new CarrierId(1));
+
+        return $bus;
+    }
+
+    private function carrier(bool $shippingExternal, bool $needRange): EditableCarrier
+    {
+        return new EditableCarrier(
+            carrierId: 1,
+            name: 'carrier',
+            grade: 0,
+            trackingUrl: '',
+            position: 0,
+            active: true,
+            delay: [1 => 'delay'],
+            max_width: 0,
+            max_height: 0,
+            max_depth: 0,
+            max_weight: 0.0,
+            associatedGroupIds: [],
+            hasAdditionalHandlingFee: false,
+            isFree: false,
+            shippingMethod: 1,
+            idTaxRuleGroup: 0,
+            rangeBehavior: 0,
+            associatedShopIds: [1],
+            zones: [1],
+            shippingExternal: $shippingExternal,
+            needRange: $needRange,
+        );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $zones
+     */
+    private function formData(array $zones, bool $isFree = false): array
+    {
+        return [
+            'general_settings' => [
+                'name' => 'carrier',
+                'localized_delay' => [1 => 'delay'],
+                'grade' => 0,
+                'tracking_url' => '',
+                'active' => true,
+                'group_access' => [],
+                'associated_shops' => [1],
+                'logo' => null,
+            ],
+            'shipping_settings' => [
+                'has_additional_handling_fee' => false,
+                'is_free' => $isFree,
+                'shipping_method' => 1,
+                'range_behavior' => 0,
+                'zones' => [1],
+                'id_tax_rule_group' => 0,
+                'ranges_costs' => $zones,
+            ],
+            'size_weight_settings' => [
+                'max_width' => 0, 'max_height' => 0, 'max_depth' => 0, 'max_weight' => 0,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function oneRange(): array
+    {
+        return [
+            ['zoneId' => 1, 'ranges' => [['from' => 0, 'to' => 1000, 'price' => '5']]],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A carrier that is priced from its own ranges but saved without any is accepted by the back office and then never offered at checkout, with nothing shown to the merchant. The shipping cost lookup finds no range to apply and the carrier is filtered out of the delivery options. This refuses the save instead, in `CarrierFormDataHandler` before any command is dispatched, and surfaces the reason through the controller's existing error mapping.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shipping > Carriers > add a carrier, fill the name and transit time, enable it, add a zone, and save without touching "Set ranges and prices". Before: it saves, and the carrier never appears at checkout step 3. After: the save is refused with "You must set at least one range and its price, otherwise this carrier will not be offered at checkout." Add one range and price and it saves. A carrier marked free still saves without ranges, and so does a module carrier with "need_range" off, which the checkout never lists by ranges anyway.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #38005
| Related PRs       | Supersedes the closed #38009 by @Codencode (closed 2026-04-07 for staleness after an unanswered rebase request, not on the merits).
| Sponsor company   |

### Measured on 9.2

Carrier created exactly as the report describes - active, one zone, all groups, no range - then asked
`Carrier::getAvailableCarrierList()` what the front office can offer:

```
baseline                             available: 1,7
carrier saved WITHOUT any range      available: 1,7      (carrier 8 absent)
after ONE range + price              available: 1,7,8
```

The feature flag `carrier` is enabled by default on 9.2, so this is the shipped behaviour.

### The rule, and where it comes from

The thread left open when ranges may legitimately be missing. The authority is the checkout's own carrier
query: `Carrier::getCarriersForOrder()` asks `getCarriers()` for `PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE`,
which adds

```sql
AND (c.is_module = 0 OR c.need_range = 1)
```

before any range is looked at. A shop carrier, or a module carrier that keeps `need_range` on, is listed only
once it has a range, so its save is refused without one. A module carrier with `need_range` off is never listed
by the native checkout, whether it has ranges or not, so asking it for a range would send the merchant to a fix
that changes nothing; it stays exempt. The handler's condition is that filter: `!isModule() || needsRange()`.

### Why the data handler and not the browser

#38009 guards on submit in `carrier-form-manager.ts`. That only prevents the save in the browser: a form
posted without the script running, or the same data arriving another way, still stores a carrier that
cannot be offered. The handler runs for every save, and refusing there also means nothing is written
before the refusal - the tests assert the command bus is never called.

### Verification

- `tests/Unit/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandlerTest.php` is new: 7 tests,
  12 assertions, covering the four `is_module` x `need_range` combinations, the free carrier, a carrier with a
  range, and that creation is refused before anything is saved (the command bus is never called).
- `tests/Integration/Classes/CarrierListedForOrderTest.php` is new: 6 tests, 6 assertions. It pins which carriers
  `getCarriersForOrder()` lists - a shop carrier and module carriers with `need_range` on or off, each with and
  without a range - which is the rule the handler mirrors, so a change on either side fails.
- CI on this head: PHP CS Fixer, PHP Static Analysis (8.1, 8.5), PHPUnit, Integration and Behaviour tests all
  green.

### Implementation notes

- The `$queryBus` bind was added to `form_data_handler.yml`'s `_defaults`, mirroring what
  `form_data_provider.yml` already does, so every handler in that file can query without extra wiring.
- `EditableCarrier` gains `isModule()` and `needsRange()`. @kpodemski asked on the issue for the back office to
  indicate which carriers a module manages; those two facts are what such an indicator would read.
