### PR TITLE
Expose catalog price rule conditions over the webservice

### DIFF
--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -21,6 +21,13 @@ class SpecificPriceRuleCore extends ObjectModel
     protected static $rules_application_enable = true;
 
     /**
+     * Condition types getAffectedProducts() knows how to turn into a product filter.
+     * A condition of any other type contributes no restriction, which would silently
+     * widen the rule to the whole catalog.
+     */
+    public const CONDITION_TYPES = ['attribute', 'category', 'feature', 'manufacturer', 'supplier'];
+
+    /**
      * @see ObjectModel::$definition
      */
     public static $definition = [
@@ -50,6 +57,17 @@ class SpecificPriceRuleCore extends ObjectModel
             'id_country' => ['xlink_resource' => 'countries', 'required' => true],
             'id_currency' => ['xlink_resource' => 'currencies', 'required' => true],
             'id_group' => ['xlink_resource' => 'groups', 'required' => true],
+        ],
+        'associations' => [
+            'specific_price_rule_conditions' => [
+                'resource' => 'specific_price_rule_condition',
+                'virtual_entity' => true,
+                'fields' => [
+                    'id_specific_price_rule_condition_group' => ['required' => true],
+                    'type' => ['required' => true],
+                    'value' => ['required' => true],
+                ],
+            ],
         ],
     ];
 
@@ -89,10 +107,44 @@ class SpecificPriceRuleCore extends ObjectModel
         SpecificPriceRule::$rules_application_enable = true;
     }
 
+    /**
+     * An empty group adds no restriction to getAffectedProducts() and would apply the
+     * rule to every product of the shop, and a condition of an unhandled type is skipped
+     * there the same way, so neither is accepted as a condition group.
+     *
+     * @param array $conditions
+     *
+     * @return bool
+     */
+    protected static function areValidConditions($conditions)
+    {
+        if (!is_array($conditions) || !$conditions) {
+            return false;
+        }
+
+        foreach ($conditions as $condition) {
+            if (!is_array($condition)
+                || !isset($condition['type'], $condition['value'])
+                || !in_array($condition['type'], self::CONDITION_TYPES, true)
+                || !Validate::isUnsignedInt($condition['value'])
+                || 0 === (int) $condition['value']
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array $conditions AND-combined conditions forming one condition group
+     *
+     * @return bool
+     */
     public function addConditions($conditions)
     {
-        if (!is_array($conditions)) {
-            return;
+        if (!self::areValidConditions($conditions)) {
+            return false;
         }
 
         $result = Db::getInstance()->insert('specific_price_rule_condition_group', [
@@ -182,6 +234,84 @@ class SpecificPriceRuleCore extends ObjectModel
         }
 
         return $conditions_group;
+    }
+
+    /**
+     * Flatten the condition groups into the rows exposed by the webservice. The group a
+     * condition belongs to is carried by id_specific_price_rule_condition_group.
+     *
+     * @return array
+     */
+    public function getWsSpecificPriceRuleConditions()
+    {
+        $rows = [];
+        foreach ($this->getConditions() as $idConditionGroup => $conditions) {
+            foreach ($conditions as $condition) {
+                // getConditions() left-joins the conditions, so a group holding none
+                // yields a single row with no type.
+                if (empty($condition['type'])) {
+                    continue;
+                }
+                $rows[] = [
+                    'id_specific_price_rule_condition_group' => (int) $idConditionGroup,
+                    'type' => $condition['type'],
+                    'value' => $condition['value'],
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Replace the conditions of the rule with the rows received from the webservice.
+     *
+     * The association carries a flat list of rows because the webservice only reads two
+     * levels of XML; id_specific_price_rule_condition_group groups the rows into the
+     * condition groups the rule is made of. On write it is a grouping key only: rows
+     * sharing a value land in the same group, and the stored group ids are generated.
+     *
+     * @param array $values
+     *
+     * @return bool
+     */
+    public function setWsSpecificPriceRuleConditions($values)
+    {
+        if (!is_array($values)) {
+            return false;
+        }
+
+        $groups = [];
+        foreach ($values as $value) {
+            if (!is_array($value) || !isset($value['type'], $value['value'])) {
+                return false;
+            }
+            $idConditionGroup = isset($value['id_specific_price_rule_condition_group'])
+                ? (int) $value['id_specific_price_rule_condition_group']
+                : 0;
+            $groups[$idConditionGroup][] = ['type' => $value['type'], 'value' => $value['value']];
+        }
+
+        // Validated before anything is removed: a rejected payload must not leave the rule
+        // without conditions, which would widen it to the whole catalog.
+        foreach ($groups as $conditions) {
+            if (!self::areValidConditions($conditions)) {
+                return false;
+            }
+        }
+
+        $this->deleteConditions();
+        foreach ($groups as $conditions) {
+            if (!$this->addConditions($conditions)) {
+                return false;
+            }
+        }
+
+        // The generated specific prices are derived from the conditions, so they have to
+        // be rebuilt here the same way AdminSpecificPriceRuleController does on save.
+        $this->apply();
+
+        return true;
     }
 
     /**

--- a/tests/Integration/Classes/SpecificPriceRuleConditionsWebserviceTest.php
+++ b/tests/Integration/Classes/SpecificPriceRuleConditionsWebserviceTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Context;
+use Db;
+use SpecificPriceRule;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class SpecificPriceRuleConditionsWebserviceTest extends KernelTestCase
+{
+    private const CAT_A = 900001;
+    private const CAT_B = 900002;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::restore();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::restore();
+    }
+
+    private static function restore(): void
+    {
+        DatabaseDump::restoreTables([
+            'specific_price',
+            'specific_price_rule',
+            'specific_price_rule_condition',
+            'specific_price_rule_condition_group',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+    }
+
+    public function testGetterFlattensTheConditionGroupsIntoRowsCarryingTheirGroup(): void
+    {
+        $rule = $this->createRule();
+        $rule->addConditions([
+            ['type' => 'category', 'value' => self::CAT_A],
+            ['type' => 'category', 'value' => self::CAT_B],
+        ]);
+        $rule->addConditions([['type' => 'manufacturer', 'value' => 5]]);
+
+        $rows = $rule->getWsSpecificPriceRuleConditions();
+
+        $this->assertCount(3, $rows);
+        $groups = array_unique(array_column($rows, 'id_specific_price_rule_condition_group'));
+        $this->assertCount(2, $groups, 'the two groups must stay distinct');
+
+        $byGroup = [];
+        foreach ($rows as $row) {
+            $byGroup[$row['id_specific_price_rule_condition_group']][] = $row['type'] . ':' . $row['value'];
+        }
+        sort($byGroup);
+        $this->assertSame(
+            [['manufacturer:5'], ['category:' . self::CAT_A, 'category:' . self::CAT_B]],
+            array_values($byGroup)
+        );
+    }
+
+    public function testSetterRebuildsTheGroupsFromTheGroupKeyOfEachRow(): void
+    {
+        $rule = $this->createRule();
+
+        $this->assertTrue($rule->setWsSpecificPriceRuleConditions([
+            ['id_specific_price_rule_condition_group' => '1', 'type' => 'category', 'value' => (string) self::CAT_A],
+            ['id_specific_price_rule_condition_group' => '1', 'type' => 'category', 'value' => (string) self::CAT_B],
+            ['id_specific_price_rule_condition_group' => '2', 'type' => 'manufacturer', 'value' => '5'],
+        ]));
+
+        $stored = $rule->getConditions();
+        $this->assertCount(2, $stored);
+        $sizes = array_map('count', array_values($stored));
+        sort($sizes);
+        $this->assertSame([1, 2], $sizes);
+    }
+
+    public function testSetterKeepsTheExistingConditionsWhenThePayloadIsRejected(): void
+    {
+        $rule = $this->createRule();
+        $rule->addConditions([['type' => 'category', 'value' => self::CAT_A]]);
+
+        $this->assertFalse($rule->setWsSpecificPriceRuleConditions([
+            ['id_specific_price_rule_condition_group' => '1', 'type' => 'shipping_cost', 'value' => '5'],
+        ]));
+
+        // A rejected payload that had already dropped the conditions would leave the rule
+        // with none, which applies it to the whole catalog.
+        $this->assertCount(1, $rule->getWsSpecificPriceRuleConditions());
+    }
+
+    public function testAddConditionsRefusesToCreateAGroupWithoutConditions(): void
+    {
+        $rule = $this->createRule();
+
+        $this->assertFalse($rule->addConditions([]));
+        $this->assertFalse($rule->addConditions([['type' => 'category', 'value' => 0]]));
+        $this->assertSame(
+            '0',
+            (string) Db::getInstance()->getValue(
+                'SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'specific_price_rule_condition_group
+                 WHERE id_specific_price_rule = ' . (int) $rule->id
+            )
+        );
+    }
+
+    private function createRule(): SpecificPriceRule
+    {
+        $rule = new SpecificPriceRule();
+        $rule->name = 'test-rule-27396';
+        $rule->id_shop = (int) Context::getContext()->shop->id;
+        $rule->id_country = 0;
+        $rule->id_currency = 0;
+        $rule->id_group = 0;
+        $rule->from_quantity = 1;
+        $rule->price = -1;
+        $rule->reduction = 0;
+        $rule->reduction_tax = 1;
+        $rule->reduction_type = 'amount';
+        $rule->from = '2020-01-01 00:00:00';
+        $rule->to = '2030-01-01 00:00:00';
+        $rule->add();
+
+        return $rule;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The `specific_price_rules` webservice resource exposed the rule but none of its conditions, so a rule read over the API did not say what it applies to and a rule created over the API could only ever be a catalog-wide one. This adds a `specific_price_rule_conditions` association to the resource, and rebuilds the generated specific prices when it is written.<br><br>The webservice reads two levels of XML (association -> item -> scalar fields), so the condition groups cannot be nested. The association carries one flat row per condition and the group it belongs to travels in `id_specific_price_rule_condition_group`. On read that is the stored group id. On write it is a grouping key only: rows sharing a value land in the same group, and the group ids actually stored are generated, so a body taken from a GET round-trips to the same grouping under new ids. Conditions within a group are AND-combined and groups are OR-combined, matching the back office.<br><br>`SpecificPriceRule::addConditions()` now rejects a group that holds no condition or a condition whose type is not one of `attribute`, `category`, `feature`, `manufacturer`, `supplier`. `getAffectedProducts()` contributes no restriction for either case, so such a group silently turns the rule into a catalog-wide discount. The whole payload is validated before the existing conditions are removed, so a rejected request leaves the rule as it was.
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the webservice and grant `specific_price_rules` GET/POST/PUT to a key.<br>1. `GET /api/specific_price_rules?schema=blank` shows the new `specific_price_rule_conditions` association.<br>2. POST a rule with two condition groups, for example group `1` holding `category` `3` and `category` `4` and group `2` holding `manufacturer` `1`. `GET /api/specific_price_rules/{id}?display=full` returns the three rows under their two groups, and `ps_specific_price` holds the generated prices for the products matching `(3 AND 4) OR manufacturer 1`.<br>3. PUT the same rule with a single group. The conditions are replaced and the generated prices follow.<br>4. PUT a row with `type` `shipping_cost`. The request fails with error 85 and the rule keeps its previous conditions.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #27396
| Related PRs       |
| Sponsor company   |
