### PR TITLE
Let a module stop an order status change from adjusting stock

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -199,14 +199,16 @@ class OrderHistoryCore extends ObjectModel
                     if ($new_os->logable && !$old_os->logable) {
                         ProductSale::addProductSale($product['product_id'], $product['product_quantity']);
                         if (!Pack::isPack($product['product_id'])
-                            && in_array($old_os->id, $error_or_canceled_statuses)) {
+                            && in_array($old_os->id, $error_or_canceled_statuses)
+                            && $this->shouldUpdateStock($order, $product, -(int) $product['product_quantity'], $new_os, $old_os)) {
                             StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
                         }
                     } elseif (!$new_os->logable && $old_os->logable) {
                         // if becoming unlogable => removes sale
                         ProductSale::removeProductSale($product['product_id'], $product['product_quantity']);
                         if (!Pack::isPack($product['product_id'])
-                            && in_array($new_os->id, $error_or_canceled_statuses)) {
+                            && in_array($new_os->id, $error_or_canceled_statuses)
+                            && $this->shouldUpdateStock($order, $product, (int) $product['product_quantity'], $new_os, $old_os)) {
                             StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
                         }
                     } elseif (!$new_os->logable && !$old_os->logable
@@ -214,13 +216,17 @@ class OrderHistoryCore extends ObjectModel
                         && !in_array($old_os->id, $error_or_canceled_statuses)
                     ) {
                         // Status is changed from not loggable status as Processing in progress etc. to Payment error/Canceled
-                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
+                        if ($this->shouldUpdateStock($order, $product, (int) $product['product_quantity'], $new_os, $old_os)) {
+                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
+                        }
                     } elseif (!$new_os->logable && !$old_os->logable
                         && !in_array($new_os->id, $error_or_canceled_statuses)
                         && in_array($old_os->id, $error_or_canceled_statuses)
                     ) {
                         // Status is changed from Payment error/Canceled to not loggable status as Processing in progress etc.
-                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
+                        if ($this->shouldUpdateStock($order, $product, -(int) $product['product_quantity'], $new_os, $old_os)) {
+                            StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
+                        }
                     }
                 }
                 // From here, there is 2 cases : $old_os exists, and we can test shipped state evolution,
@@ -513,5 +519,62 @@ class OrderHistoryCore extends ObjectModel
         } else {
             return $this->add();
         }
+    }
+
+    /**
+     * Lets a module stop this status change from adjusting the stock of one product, by returning
+     * false from actionOrderStatusUpdateStockBefore.
+     *
+     * A merchant who cancels an order whose goods already shipped, and is not expecting them back,
+     * has no way to keep the stock as it is today, and an override cannot serve two modules at once.
+     *
+     * The delta is passed rather than only the fact of a cancellation, because a module that
+     * suppresses a restock has to suppress the matching decrease if the order later leaves the
+     * cancelled state, or the stock drifts.
+     *
+     * @param OrderCore $order the order being moved, as changeIdOrderState() declares it
+     * @param array $product row from Order::getProductsDetail()
+     * @param int $deltaQuantity negative when stock is taken, positive when it is given back
+     * @param OrderStateCore $newOrderState
+     * @param OrderStateCore $oldOrderState
+     *
+     * @return bool
+     */
+    protected function shouldUpdateStock($order, array $product, $deltaQuantity, $newOrderState, $oldOrderState): bool
+    {
+        $results = $this->dispatchStockUpdateVeto([
+            'order' => $order,
+            'product' => $product,
+            'delta_quantity' => $deltaQuantity,
+            'new_order_state' => $newOrderState,
+            'old_order_state' => $oldOrderState,
+        ]);
+
+        // Anything other than a module answering false leaves the stock update alone, so a shop with
+        // no module listening behaves exactly as before, and a hook that cannot be dispatched cannot
+        // silently stop stock from being given back.
+        if (!is_array($results)) {
+            return true;
+        }
+
+        return array_reduce(
+            $results,
+            function ($carry, $item) {
+                return false === $item ? false : $carry;
+            },
+            true
+        );
+    }
+
+    /**
+     * Isolated so it can be replaced in tests.
+     *
+     * @param array $params
+     *
+     * @return array|null one entry per listening module
+     */
+    protected function dispatchStockUpdateVeto(array $params)
+    {
+        return Hook::exec('actionOrderStatusUpdateStockBefore', $params, null, true);
     }
 }

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5938,5 +5938,10 @@
       <title>Action when a page is not found</title>
       <description>Allows modules to react when a page is not found - log it, redirect or perform other actions.</description>
     </hook>
+    <hook id="actionOrderStatusUpdateStockBefore">
+      <name>actionOrderStatusUpdateStockBefore</name>
+      <title>Before a status change adjusts the stock of a product</title>
+      <description>Allows modules to stop an order status change from adjusting the stock of one product, by returning false. Receives the order, the order detail row, the quantity delta, and the new and old order states.</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/tests/Unit/Classes/Order/OrderHistoryStockVetoTest.php
+++ b/tests/Unit/Classes/Order/OrderHistoryStockVetoTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Order;
+
+use Order;
+use OrderHistory;
+use OrderState;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A merchant who cancels an order whose goods already shipped, and is not expecting them back, has
+ * no way to keep the stock as it is. An override cannot serve two modules at once, which is why this
+ * is a hook, and why the decision fails towards today's behaviour: only a module answering false
+ * stops the stock update, so a shop with nothing listening is unaffected.
+ */
+class OrderHistoryStockVetoTest extends TestCase
+{
+    /**
+     * @dataProvider hookResults
+     *
+     * @param mixed $hookResults
+     */
+    public function testOnlyAModuleAnsweringFalseStopsTheStockUpdate($hookResults, bool $expected): void
+    {
+        $history = $this->historyReturning($hookResults);
+
+        $this->assertSame($expected, $history->askShouldUpdateStock(-2));
+    }
+
+    public static function hookResults(): iterable
+    {
+        yield 'no module listening' => [[], true];
+        yield 'one module says false' => [['moduleA' => false], false];
+        yield 'one module says true' => [['moduleA' => true], true];
+        yield 'any false wins over true' => [['moduleA' => true, 'moduleB' => false], false];
+        yield 'false first still wins' => [['moduleA' => false, 'moduleB' => true], false];
+        // A module answering something meaningless must not read as a veto, or one careless module
+        // would silently stop stock being given back on every cancellation.
+        yield 'a module returns null' => [['moduleA' => null], true];
+        yield 'a module returns a string' => [['moduleA' => 'no'], true];
+        yield 'a module returns zero' => [['moduleA' => 0], true];
+        // Hook::exec answers null when it cannot dispatch at all.
+        yield 'the hook could not be dispatched' => [null, true];
+    }
+
+    public function testTheHookIsToldTheDeltaAndBothStates(): void
+    {
+        $history = $this->historyReturning([]);
+
+        $history->askShouldUpdateStock(3);
+
+        $this->assertSame($history->order, $history->seen['order']);
+        $this->assertSame(['product_id' => 7], $history->seen['product']);
+        $this->assertSame(3, $history->seen['delta_quantity']);
+        $this->assertSame($history->newState, $history->seen['new_order_state']);
+        $this->assertSame($history->oldState, $history->seen['old_order_state']);
+    }
+
+    /**
+     * @param mixed $hookResults
+     */
+    private function historyReturning($hookResults): object
+    {
+        return new class($hookResults) extends OrderHistory {
+            /** @var array<string, mixed> */
+            public array $seen = [];
+
+            public Order $order;
+
+            public OrderState $newState;
+
+            public OrderState $oldState;
+
+            /** @var mixed */
+            private $hookResults;
+
+            /**
+             * @param mixed $hookResults
+             */
+            public function __construct($hookResults)
+            {
+                $this->hookResults = $hookResults;
+                // These are only handed to the hook, never read. They skip ObjectModel's constructor
+                // because it reaches Configuration and therefore the database.
+                $this->order = new class() extends Order {
+                    public function __construct()
+                    {
+                    }
+                };
+                $this->newState = new class() extends OrderState {
+                    public function __construct()
+                    {
+                    }
+                };
+                $this->oldState = new class() extends OrderState {
+                    public function __construct()
+                    {
+                    }
+                };
+            }
+
+            public function askShouldUpdateStock(int $deltaQuantity): bool
+            {
+                return $this->shouldUpdateStock(
+                    $this->order,
+                    ['product_id' => 7],
+                    $deltaQuantity,
+                    $this->newState,
+                    $this->oldState
+                );
+            }
+
+            protected function dispatchStockUpdateVeto(array $params)
+            {
+                $this->seen = $params;
+
+                return $this->hookResults;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When an order status change moves stock, `OrderHistory::changeIdOrderState()` calls `StockAvailable::updateQuantity()` in four branches with no way for a module to opt out. A merchant who cancels an order whose goods already shipped, and is not expecting them back, cannot stop the quantities going back. Those four calls now ask `actionOrderStatusUpdateStockBefore` first, and a module returning `false` stops that one product's adjustment.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Register a module on `actionOrderStatusUpdateStockBefore` returning `false`. Place an order, set it to a shipped status, then cancel it: the stock stays as it is, and without the module, or with the module returning anything else, it is put back exactly as before. `$params` carries `order`, `product`, `delta_quantity`, `new_order_state` and `old_order_state`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #27726
| Related PRs       | None
| Sponsor company   | None

### Why a hook rather than an override

An override replaces a method for the whole shop, so the first module to ship one owns it and a second module wanting a say cannot have one. That is the reporter's point in the thread and it is the deciding argument: this is a decision several modules can legitimately hold an opinion about, and only a hook lets them all be asked.

### All four calls, and why the delta is passed

The status change adjusts stock in four branches: taking stock back when an order becomes logable from a cancelled state, giving it back when it becomes unlogable into one, and the two non-logable transitions in and out of a cancelled state. All four ask the hook.

Covering only the restock would be a trap. A module that stops stock being given back on cancellation has to stop the matching decrease if the order later leaves that state, or the shop's stock drifts by that quantity every time an order moves back and forth. Passing the delta, negative when stock is taken and positive when it is given back, lets a module decide per direction instead of guessing from the states.

### The decision fails towards today's behaviour

Only a module answering exactly `false` stops an update. An empty result, a module answering `null`, a string or `0`, or `Hook::exec()` being unable to dispatch at all, all leave the stock adjustment alone.

This is a deliberate difference from `Mail::Send()`, which uses the same array-reduce shape for `actionEmailSendBefore` but treats a non-array result as a reason not to send. Not sending an email is recoverable; silently not returning stock is not, and one careless module returning `null` would otherwise stop every cancellation from restocking, shop-wide, with nothing in the logs.

### Test

`tests/Unit/Classes/Order/OrderHistoryStockVetoTest.php` drives the decision through the `dispatchStockUpdateVeto()` seam, so no hook system or database is needed: nine cases for what does and does not count as a veto, and one that the hook is told the delta and both states.

Two mutations were checked: making the undispatchable case fail closed fails one case, and treating any falsy module answer as a veto fails two.

The four call sites themselves are wired by inspection rather than by test. `changeIdOrderState()` needs a real order, both order states and the database, so exercising them belongs to an integration or UI test rather than here; what is unit tested is the decision they all consult.

### Also

The hook is declared in `install-dev/data/xml/hook.xml` with a description of its parameters, so it appears with the others rather than only existing once a module registers it.
