### PR TITLE
Let a shop say where its language packs are downloaded from

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1236,7 +1236,11 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     public static function downloadXLFLanguagePack($locale, &$errors = [], $type = self::PACK_TYPE_SYMFONY)
     {
         $file = self::getPathToCachedTranslationPack($locale, $type);
-        $url = (self::PACK_TYPE_EMAILS === $type) ? self::EMAILS_LANGUAGE_PACK_URL : self::SF_LANGUAGE_PACK_URL;
+        // A shop hosting its own packs overrides these in Improve > International > Localization;
+        // the constants stay the default the shop is installed with.
+        $url = (self::PACK_TYPE_EMAILS === $type)
+            ? (Configuration::get('PS_EMAILS_PACK_URL') ?: self::EMAILS_LANGUAGE_PACK_URL)
+            : (Configuration::get('PS_LANGUAGE_PACK_URL') ?: self::SF_LANGUAGE_PACK_URL);
         $url = str_replace(
             [
                 '%version%',

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -924,5 +924,11 @@ Country</value>
     <configuration id="PS_MIN_LOGGER_LEVEL_IN_DB" name="PS_MIN_LOGGER_LEVEL_IN_DB">
       <value>1</value>
     </configuration>
+    <configuration id="PS_LANGUAGE_PACK_URL" name="PS_LANGUAGE_PACK_URL">
+      <value>https://i18n.prestashop-project.org/translations/%version%/%locale%/%locale%.zip</value>
+    </configuration>
+    <configuration id="PS_EMAILS_PACK_URL" name="PS_EMAILS_PACK_URL">
+      <value>https://i18n.prestashop-project.org/mails/%version%/%locale%/%locale%.zip</value>
+    </configuration>
   </entities>
 </entity_configuration>

--- a/src/Adapter/Localization/AdvancedConfiguration.php
+++ b/src/Adapter/Localization/AdvancedConfiguration.php
@@ -6,6 +6,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Localization;
 
+use Language;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
 
@@ -36,6 +37,10 @@ class AdvancedConfiguration implements DataConfigurationInterface
         return [
             'language_identifier' => $this->configuration->get('PS_LOCALE_LANGUAGE'),
             'country_identifier' => $this->configuration->get('PS_LOCALE_COUNTRY'),
+            // A shop upgraded from before these settings existed has no row for them, and the form
+            // requires a value, so the constants answer for them until the merchant saves the page.
+            'language_pack_url' => $this->configuration->get('PS_LANGUAGE_PACK_URL') ?: Language::SF_LANGUAGE_PACK_URL,
+            'emails_pack_url' => $this->configuration->get('PS_EMAILS_PACK_URL') ?: Language::EMAILS_LANGUAGE_PACK_URL,
         ];
     }
 
@@ -49,6 +54,8 @@ class AdvancedConfiguration implements DataConfigurationInterface
         if ($this->validateConfiguration($config)) {
             $this->configuration->set('PS_LOCALE_LANGUAGE', $config['language_identifier']);
             $this->configuration->set('PS_LOCALE_COUNTRY', $config['country_identifier']);
+            $this->configuration->set('PS_LANGUAGE_PACK_URL', $config['language_pack_url']);
+            $this->configuration->set('PS_EMAILS_PACK_URL', $config['emails_pack_url']);
         }
 
         return $errors;
@@ -61,7 +68,9 @@ class AdvancedConfiguration implements DataConfigurationInterface
     {
         return isset(
             $config['language_identifier'],
-            $config['country_identifier']
+            $config['country_identifier'],
+            $config['language_pack_url'],
+            $config['emails_pack_url']
         );
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
@@ -9,6 +9,8 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Localization;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
 
 /**
  * Class AdvancedConfigurationType is responsible for building 'Improve > International > Localization' page
@@ -41,6 +43,52 @@ class AdvancedConfigurationType extends TranslatorAwareType
                     'The ISO 3166-1 alpha-2 identifier for the country/region where your web server is located, in lowercase (us, gb, fr, sp, ru, pl, nl, etc.).',
                     'Admin.International.Help'
                 ),
+            ])
+            ->add('language_pack_url', TextType::class, [
+                'label' => $this->trans(
+                    'Language pack URL',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'Where translation packs are downloaded from. %version% is replaced by the shop version and %locale% by the language being installed.',
+                    'Admin.International.Help'
+                ),
+                'constraints' => $this->getPackUrlConstraints(),
+            ])
+            ->add('emails_pack_url', TextType::class, [
+                'label' => $this->trans(
+                    'Email translations pack URL',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'Where email translation packs are downloaded from. The same %version% and %locale% placeholders apply.',
+                    'Admin.International.Help'
+                ),
+                'constraints' => $this->getPackUrlConstraints(),
             ]);
+    }
+
+    /**
+     * These values are URL templates rather than URLs, so the Url constraint cannot be used on them:
+     * it reads %ve of %version% as a percent escape and rejects the shop's own default value.
+     *
+     * The %locale% placeholder is required because a URL without it downloads the same archive for
+     * every language installed, and that failure is silent - the response is still a valid archive.
+     *
+     * @return array<int, mixed>
+     */
+    private function getPackUrlConstraints(): array
+    {
+        return [
+            new NotBlank(),
+            new Regex([
+                'pattern' => '~^https?://~',
+                'message' => $this->trans('The URL must start with http:// or https://.', 'Admin.International.Notification'),
+            ]),
+            new Regex([
+                'pattern' => '~%locale%~',
+                'message' => $this->trans('The URL must contain the %locale% placeholder.', 'Admin.International.Notification'),
+            ]),
+        ];
     }
 }

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationPackUrlTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationPackUrlTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Improve\International\Localization;
+
+use Language;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Localization\AdvancedConfiguration;
+use PrestaShopBundle\Form\Admin\Improve\International\Localization\AdvancedConfigurationType;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Validation;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The pack URLs carry %version% and %locale% placeholders, so the URL constraint has to accept a
+ * percent sign, and a URL without %locale% has to be refused: it would download one language for
+ * every language installed and the failure would be silent, since the response is a valid archive.
+ */
+class AdvancedConfigurationPackUrlTest extends TypeTestCase
+{
+    private const VALID = 'https://i18n.prestashop-project.org/translations/%version%/%locale%/%locale%.zip';
+
+    public function testAPackUrlKeepsItsPlaceholders(): void
+    {
+        $form = $this->submit(self::VALID);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertTrue($form->isValid(), $this->errorsOf($form));
+        $this->assertSame(self::VALID, $form->get('language_pack_url')->getData());
+    }
+
+    public function testAUrlWithoutTheLocalePlaceholderIsRefused(): void
+    {
+        $form = $this->submit('https://example.test/translations/9.2.0/pack.zip');
+
+        $this->assertFalse($form->isValid());
+    }
+
+    public function testSomethingThatIsNotAUrlIsRefused(): void
+    {
+        $form = $this->submit('%locale% is not a url');
+
+        $this->assertFalse($form->isValid());
+    }
+
+    public function testAnEmptyPackUrlIsRefused(): void
+    {
+        $form = $this->submit('');
+
+        $this->assertFalse($form->isValid());
+    }
+
+    /**
+     * A shop upgraded from before these settings existed has no configuration row for them. The form
+     * requires a value, so the read side has to answer with the constants or the whole Advanced page
+     * becomes unsavable until the merchant retypes both URLs.
+     */
+    public function testAShopWithNoStoredValueFallsBackToTheShippedDefaults(): void
+    {
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('get')->willReturn(false);
+
+        $read = (new AdvancedConfiguration($configuration))->getConfiguration();
+
+        $this->assertSame(Language::SF_LANGUAGE_PACK_URL, $read['language_pack_url']);
+        $this->assertSame(Language::EMAILS_LANGUAGE_PACK_URL, $read['emails_pack_url']);
+    }
+
+    private function submit(string $languagePackUrl): FormInterface
+    {
+        $form = $this->factory->create(AdvancedConfigurationType::class);
+        $form->submit([
+            'language_identifier' => 'en',
+            'country_identifier' => 'gb',
+            'language_pack_url' => $languagePackUrl,
+            'emails_pack_url' => self::VALID,
+        ]);
+
+        return $form;
+    }
+
+    private function errorsOf(FormInterface $form): string
+    {
+        $messages = [];
+
+        foreach ($form->getErrors(true) as $error) {
+            $messages[] = $error->getMessage();
+        }
+
+        return implode(' | ', $messages);
+    }
+
+    protected function getExtensions(): array
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        // A real validator, not the mock ValidatorExtensionTrait provides: that one returns an empty
+        // violation list whatever is submitted, so every rejection case below would pass vacuously.
+        return [
+            new PreloadedExtension([new AdvancedConfigurationType($translator, [])], []),
+            new ValidatorExtension(Validation::createValidator()),
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The two language pack URLs were class constants on `Language`, so a shop hosting its own packs, or one with no route to `i18n.prestashop-project.org`, had no way to point them elsewhere. `Improve > International > Localization` now carries both, as URL templates with the `%version%` and `%locale%` placeholders the issue describes, and the constants stay the values a shop is installed with.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Open `Improve > International > Localization`, Advanced configuration: the two pack URLs are shown, filled with the shipped defaults. 2. Point them at a script of your own that logs what it receives, save, then install a language from `International > Translations`. The requests go to your URL, with `%version%` and `%locale%` replaced. 3. Clear both settings back to the defaults and install a language again: it downloads from `i18n.prestashop-project.org` as before. 4. Submitting a URL without `%locale%`, without an `http`/`https` scheme, or empty, is refused.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #28964
| Related PRs       | Rebuilds the abandoned #30887 by @FabienPapet
| Sponsor company   | None

### Credit

@FabienPapet wrote #30887 for this in January 2023. It was not rejected: the review comments were wording and a default-value suggestion, `CHANGES_REQUESTED` said only "There are some conflicts", and after `Waiting for rebase` and `Blocked` the author closed it himself in April. This is that work rebuilt on `develop`, with the two additions below.

### What is different from #30887

**Both packs.** #30887 made only `PACK_TYPE_SYMFONY` configurable and left `EMAILS_LANGUAGE_PACK_URL` hardcoded. @Progi1984 asked about exactly that on the diff. Configuring one and not the other sends a shop to its own server for translations and upstream for email translations.

**The `Url` constraint is not usable here.** These values are URL templates, and Symfony's `Url` constraint reads the `%ve` of `%version%` as a percent escape, so it rejects the shipped default. A test with a real validator catches it; the mock validator `ValidatorExtensionTrait` provides returns an empty violation list whatever is submitted, so a form test written the usual way passes while the field rejects everything at runtime. The fields are checked for an `http`/`https` scheme and for `%locale%` instead. The `%locale%` check matters because a URL without it downloads one archive for every language installed, and the response is still a valid zip, so nothing reports the mistake.

### Upgraded shops

No upgrade script is needed. `Configuration::get()` returns nothing for a shop upgraded from before these settings existed, so `downloadXLFLanguagePack()` falls back to the constants, and `AdvancedConfiguration::getConfiguration()` reads the constants too. Without that second fallback the page would render two empty required fields and refuse to save until both were retyped.

### Measured

On a 9.2 shop, both settings pointed at a local script that logs its query string, then `Language::downloadXLFLanguagePack()` called for `de-DE`:

| settings | requests observed |
| -------- | ----------------- |
| overridden | 3x `pack=translations&locale=de-DE&version=9.2.0`, 3x `pack=mails&locale=de-DE&version=9.2.0` |
| removed | none reach the local script, and the real `de-DE` pack downloads |

Three of each because the method retries three times. The second row is the constant fallback.

### Test

`tests/Unit/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationPackUrlTest.php`, five cases: a template with its placeholders is accepted, one without `%locale%` is refused, one with no scheme is refused, an empty one is refused, and a shop with no stored value reads the shipped defaults. Five mutations were checked: dropping either regex, dropping `NotBlank`, restoring the `Url` constraint, and removing the upgraded-shop fallback each fail exactly one case.

### Not included

`RemoteLanguagePackLoader::PACK_LINK`, the `available_languages.json` catalogue, is left alone. It uses a different placeholder, `%ps_version%`, and is consumed by a service rather than by `Language`, so whether the catalogue should follow the packs is a separate decision.
