### PR TITLE
Let a form ask for its entity search input to be initialised automatically

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.ts
@@ -30,6 +30,7 @@ import TinyMCEEditor from '@js/components/tinymce-editor';
 import TranslatableField from '@js/components/translatable-field';
 import TranslatableInput from '@js/components/translatable-input';
 import EntitySearchInput from '@js/components/entity-search-input';
+import AutoEntitySearchInput from '@components/form/auto-entity-search-input';
 import MultipleZoneChoice from '@js/components/form/multiple-zone-choice';
 import ToggleChildrenChoice from '@js/components/form/toggle-children-choice';
 import FilterLinkGroup from '@components/filter/filter-link-group';
@@ -147,6 +148,7 @@ const initPrestashopComponents = (): void => {
     TranslatableField,
     TranslatableInput,
     EntitySearchInput,
+    AutoEntitySearchInput,
     EmailInput,
     MultipleZoneChoice,
     ToggleChildrenChoice,

--- a/admin-dev/themes/new-theme/js/components/components-map.ts
+++ b/admin-dev/themes/new-theme/js/components/components-map.ts
@@ -52,6 +52,8 @@ export default {
     specificLocale: (selectedLocale: string): string => `.nav-item a[data-locale="${selectedLocale}"]`,
   },
   entitySearchInput: {
+    // Only set on containers whose form type asked for automatic initialisation
+    autoInitSelector: '.js-entity-search-input',
     searchInputSelector: '.entity-search-input',
     entitiesContainerSelector: '.entities-list',
     listContainerSelector: '.entities-list-container',

--- a/admin-dev/themes/new-theme/js/components/form/auto-entity-search-input.ts
+++ b/admin-dev/themes/new-theme/js/components/form/auto-entity-search-input.ts
@@ -1,0 +1,37 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+import ComponentsMap from '@components/components-map';
+import EntitySearchInput from '@js/components/entity-search-input';
+
+const {$} = window;
+
+/**
+ * Initialises every entity search input that asked for it in its form type, so a page does not have
+ * to instantiate them one by one.
+ *
+ * EntitySearchInput itself stays a one container component: it builds a remote source and an
+ * autocomplete widget per container, so the loop belongs here rather than in the component. Every
+ * setting is already carried by the data attributes the widget template renders, and
+ * EntitySearchInput reads options in the order input, data attribute, default, so an empty object
+ * is all this has to pass.
+ */
+export default class AutoEntitySearchInput {
+  private readonly entitySearchInputs: EntitySearchInput[];
+
+  constructor(selector: string = ComponentsMap.entitySearchInput.autoInitSelector) {
+    this.entitySearchInputs = $(selector)
+      .toArray()
+      .map((container: HTMLElement) => new EntitySearchInput($(container), {}));
+  }
+
+  /**
+   * The created components, in document order, for a page that needs to reach one of them after
+   * automatic initialisation.
+   */
+  getEntitySearchInputs(): EntitySearchInput[] {
+    return this.entitySearchInputs;
+  }
+}

--- a/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
@@ -71,6 +71,11 @@ class EntitySearchInputType extends CollectionType
             'limit' => 0,
             // Min length before suggestions start getting rendered
             'min_length' => 2,
+            // Let initComponents(['AutoEntitySearchInput']) build the javascript component for this
+            // widget, instead of the page instantiating EntitySearchInput itself. Off by default:
+            // a page that already instantiates it would otherwise end up with two components on
+            // the same container.
+            'auto_init' => false,
             // Search input attributes (if needed to be customized)
             'search_attr' => [],
             // List container attributes (if needed to be customized)
@@ -99,6 +104,7 @@ class EntitySearchInputType extends CollectionType
             'suggestion_field' => 'name',
         ]);
         $resolver->setAllowedTypes('allow_search', ['bool']);
+        $resolver->setAllowedTypes('auto_init', ['bool']);
         $resolver->setAllowedTypes('search_attr', ['array']);
         $resolver->setAllowedTypes('list_attr', ['array']);
         $resolver->setAllowedTypes('placeholder', ['string']);
@@ -154,6 +160,7 @@ class EntitySearchInputType extends CollectionType
 
         $view->vars = array_replace($view->vars, [
             'allow_search' => $options['allow_search'],
+            'auto_init' => $options['auto_init'],
             'remote_url' => $options['remote_url'],
             'limit' => $options['limit'],
             'min_length' => $options['min_length'],

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
@@ -19,6 +19,10 @@
     'data-suggestion-field': form.vars.suggestion_field,
   }) -%}
   {%- set attr = attr|merge({class: (attr.class|default('') ~ ' entity-search-widget')|trim}) -%}
+  {# The class AutoEntitySearchInput selects on, so only the widgets that asked for it are built #}
+  {%- if auto_init -%}
+    {%- set attr = attr|merge({class: (attr.class ~ ' js-entity-search-input')|trim}) -%}
+  {%- endif -%}
 
   {# We use widget_container_attributes in this widget because we do not want the name property #}
   <div {{ block('widget_container_attributes') }}>

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Type/EntitySearchInputAutoInitTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Type/EntitySearchInputAutoInitTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Type;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Form\Admin\Type\EntitySearchInputType;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The javascript component is built per container, so a widget that both asks for automatic
+ * initialisation and is instantiated by its page would end up with two of them on the same input.
+ * That is what keeps the option off unless a form asks for it, and this pins it.
+ */
+class EntitySearchInputAutoInitTest extends TestCase
+{
+    public function testAutomaticInitialisationIsOffUnlessAFormAsksForIt(): void
+    {
+        $this->assertFalse($this->resolve([])['auto_init']);
+    }
+
+    public function testAFormCanAskForAutomaticInitialisation(): void
+    {
+        $this->assertTrue($this->resolve(['auto_init' => true])['auto_init']);
+    }
+
+    public function testTheOptionOnlyAcceptsABoolean(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $this->resolve(['auto_init' => 'yes']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resolve(array $options): array
+    {
+        $resolver = new OptionsResolver();
+        (new EntitySearchInputType($this->createMock(TranslatorInterface::class)))->configureOptions($resolver);
+
+        return $resolver->resolve($options);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `EntitySearchInput` is already listed in the component map that `initComponents` reads, but that entry could never be used: `initComponents` constructs with `new Component()` and no arguments, while the constructor needs the container it works on. Every page therefore instantiates the component by hand, which is the work module developers have to repeat. A new `auto_init` option on `EntitySearchInputType` marks the widget container with a class, and a new `AutoEntitySearchInput` component builds one `EntitySearchInput` per marked container, so a page or a module only has to call `initComponents(['AutoEntitySearchInput'])`.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Add `'auto_init' => true` to an `EntitySearchInputType` field and call `window.prestashop.component.initComponents(['AutoEntitySearchInput'])` on that page, with no explicit `new EntitySearchInput(...)`. The search field autocompletes, selects and removes entities exactly as a hand-instantiated one does. 2. Leave the option out on another field on the same page: it gets no class, no component, and behaves as before. 3. The five pages that instantiate the component themselves are untouched and keep working.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #29252
| Related PRs       | None
| Sponsor company   | None

### The three open questions in the issue

The description leaves three choices open. Each is answered by what the other components in the same registry already do.

**A new component, or a nullable first parameter on `EntitySearchInput`.** A new component. `DisablingSwitch` is already exactly this shape: a no-argument component whose whole body composes another component with a `ComponentsMap` selector. The alternative would make one class both a single-container component and a multi-container manager, and no other class in the registry carries two responsibilities.

**Whether `EntitySearchInput` needs a refactor to handle several elements.** It does not. The components that cover many elements from one instance, `TextWithLengthCounter` and `DeltaQuantityInput`, do it with delegated `$(document).on(...)` handlers scoped by a container selector, which works because they only react to events. `EntitySearchInput` builds a remote source and an autocomplete widget per container in its constructor, so it needs one instance per container and the loop belongs in the initializer.

**Whether automatic initialisation should be the default.** No, and this one is not a preference. `pages/discount/form/create-free-gift-discount.ts`, `pages/discount/form/specific-products.ts`, `pages/product/edit/manager/attachments-manager.ts`, `pages/product/edit/manager/redirect-option-manager.ts` and `pages/category/edit/manager/redirect-option-manager.ts` construct the component themselves and keep the instance to call `setValues()` and friends. Defaulting the option on would give each of those containers a second component and a second autocomplete widget on the same input.

### No configuration is passed

`AutoEntitySearchInput` constructs each component with an empty options object. That is enough because the widget template already renders every setting as a `data-` attribute on the container, and `EntitySearchInput::buildOptions()` resolves each option in the order input, data attribute, default. A page that needs a callback, `onSelectedContent` for instance, is not a candidate for automatic initialisation and keeps instantiating the component itself.

`ComponentsMap.entitySearchInput` gained an `autoInitSelector`; it previously held only the selectors internal to a widget, because the container was always supplied by the caller.

### Test

`tests/Unit/PrestaShopBundle/Form/Admin/Type/EntitySearchInputAutoInitTest.php` pins the option contract: off unless a form asks, settable to true, and rejected when it is not a boolean. Two mutations were checked - defaulting the option to `true` fails the first case, and dropping the `bool` type constraint fails the third.

The class the option adds is one guarded line in the widget template, and the loop it feeds is four lines of the new component. `eslint` reports nothing on the three touched TypeScript files, and `tsc --noEmit` reports the same 22 errors with and without this change, measured against a clean `develop` tree, so it adds none.
