### PR TITLE
Keep remotely hosted assets out of the media server rewrite

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1112,7 +1112,11 @@ class FrontControllerCore extends Controller
         ];
         $params = array_merge($default_params, $params);
 
-        if (Tools::hasMediaServer() && !Configuration::get('PS_CSS_THEME_CACHE')) {
+        // WHY: the media server rewrite turns a path relative to the shop into a URL on the media
+        // server, which only makes sense for an asset served from this shop. A remote asset already
+        // carries an absolute URL, so getFullPath() cannot resolve it and the asset used to be
+        // dropped by the guard below.
+        if ('local' === $params['server'] && Tools::hasMediaServer() && !Configuration::get('PS_CSS_THEME_CACHE')) {
             $fullPath = $this->stylesheetManager->getFullPath($relativePath);
 
             if (!$fullPath) {
@@ -1147,7 +1151,8 @@ class FrontControllerCore extends Controller
         ];
         $params = array_merge($default_params, $params);
 
-        if (Tools::hasMediaServer() && !Configuration::get('PS_JS_THEME_CACHE')) {
+        // WHY: see registerStylesheet() above, a remote asset must keep the URL it was given.
+        if ('local' === $params['server'] && Tools::hasMediaServer() && !Configuration::get('PS_JS_THEME_CACHE')) {
             $fullPath = $this->javascriptManager->getFullPath($relativePath);
 
             if (!$fullPath) {

--- a/tests/Integration/Classes/controller/FrontControllerRemoteAssetTest.php
+++ b/tests/Integration/Classes/controller/FrontControllerRemoteAssetTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\controller;
+
+use Configuration;
+use FrontControllerCore;
+use JavascriptManager;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration as ConfigurationAdapter;
+use ReflectionProperty;
+use StylesheetManager;
+use Tools;
+
+/**
+ * A media server must not rewrite assets a module registered with 'server' => 'remote':
+ * their path is already an absolute URL, so it cannot be resolved on the local filesystem
+ * and the asset was silently dropped.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/34423
+ */
+class FrontControllerRemoteAssetTest extends TestCase
+{
+    private const REMOTE_JS = 'https://cdn.example.com/library.js';
+    private const REMOTE_CSS = 'https://cdn.example.com/library.css';
+
+    /** @var array<string, mixed> */
+    private array $backedUpConfiguration = [];
+
+    private ?int $backedUpMediaServerCache = null;
+
+    protected function setUp(): void
+    {
+        // The media server rewrite only runs when the theme cache is off
+        foreach (['PS_JS_THEME_CACHE', 'PS_CSS_THEME_CACHE'] as $key) {
+            $this->backedUpConfiguration[$key] = Configuration::get($key);
+            Configuration::updateValue($key, 0);
+        }
+
+        // Pretend one media server is configured, without touching the _MEDIA_SERVER_*_ constants
+        $this->backedUpMediaServerCache = $this->mediaServerCache()->getValue();
+        $this->mediaServerCache()->setValue(null, 1);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->backedUpConfiguration as $key => $value) {
+            Configuration::updateValue($key, $value);
+        }
+        $this->mediaServerCache()->setValue(null, $this->backedUpMediaServerCache);
+    }
+
+    public function testItKeepsTheUrlOfARemotelyHostedJavascript(): void
+    {
+        $controller = new TestAssetFrontController();
+        $controller->registerJavascript('remote-js', self::REMOTE_JS, ['server' => 'remote', 'position' => 'bottom']);
+
+        $asset = $this->findAsset($controller->getJavascriptList(), 'remote-js');
+
+        $this->assertNotNull($asset, 'the remotely hosted script was dropped');
+        $this->assertSame(self::REMOTE_JS, $asset['uri']);
+        $this->assertSame('remote', $asset['server']);
+    }
+
+    public function testItKeepsTheUrlOfARemotelyHostedStylesheet(): void
+    {
+        $controller = new TestAssetFrontController();
+        $controller->registerStylesheet('remote-css', self::REMOTE_CSS, ['server' => 'remote']);
+
+        $asset = $this->findAsset($controller->getStylesheetList(), 'remote-css');
+
+        $this->assertNotNull($asset, 'the remotely hosted stylesheet was dropped');
+        $this->assertSame(self::REMOTE_CSS, $asset['uri']);
+        $this->assertSame('remote', $asset['server']);
+    }
+
+    public function testItStillSendsLocalAssetsToTheMediaServer(): void
+    {
+        $controller = new TestAssetFrontController();
+        $controller->registerJavascript('local-js', '/js/jquery/jquery-3.7.1.min.js', ['position' => 'bottom']);
+
+        $asset = $this->findAsset($controller->getJavascriptList(), 'local-js');
+
+        $this->assertNotNull($asset, 'the local script was dropped');
+        $this->assertSame('remote', $asset['server'], 'a local asset must still be handed to the media server');
+    }
+
+    /**
+     * Stylesheets are listed as [type][id] and scripts as [position][type][id], so walk the
+     * nesting instead of assuming a depth.
+     *
+     * @param array<string, mixed> $list
+     *
+     * @return array<string, mixed>|null
+     */
+    private function findAsset(array $list, string $id): ?array
+    {
+        foreach ($list as $key => $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+            if ($key === $id && isset($value['id']) && $value['id'] === $id) {
+                return $value;
+            }
+            $found = $this->findAsset($value, $id);
+            if ($found !== null) {
+                return $found;
+            }
+        }
+
+        return null;
+    }
+
+    private function mediaServerCache(): ReflectionProperty
+    {
+        $property = new ReflectionProperty(Tools::class, '_cache_nb_media_servers');
+        $property->setAccessible(true);
+
+        return $property;
+    }
+}
+
+class TestAssetFrontController extends FrontControllerCore
+{
+    public function __construct()
+    {
+        // same directory list the real controller gives its managers
+        $directories = [_PS_THEME_URI_, _PS_PARENT_THEME_URI_, __PS_BASE_URI__];
+        $configuration = new ConfigurationAdapter();
+        $this->stylesheetManager = new StylesheetManager($directories, $configuration);
+        $this->javascriptManager = new JavascriptManager($directories, $configuration);
+    }
+
+    public function getJavascriptList(): array
+    {
+        return $this->javascriptManager->getList();
+    }
+
+    public function getStylesheetList(): array
+    {
+        return $this->stylesheetManager->getList();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `registerStylesheet()` and `registerJavascript()` convert an asset path into a URL on the media server whenever one is configured and the theme cache is off. That conversion assumes the path is relative to the shop, so an asset registered with `'server' => 'remote'`, whose path is already an absolute URL, cannot be resolved by `getFullPath()` and is dropped without notice. Before #41509 added that resolution guard the result was worse: the remote URL was concatenated behind the media server domain, so the browser requested an address that does not exist.<br><br>Both methods now only rewrite an asset that is actually served from this shop. The asset managers already handle `'remote'` correctly, so nothing downstream changes.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Register a remote asset from a module on `actionFrontControllerSetMedia`, for example `$this->context->controller->registerJavascript('x', 'https://cdn.example.com/x.js', ['server' => 'remote', 'position' => 'bottom'])`. Set `PS_MEDIA_SERVER_1` and turn the JS/CSS theme cache off. Before this change the tag is absent from the rendered page; after it, it is present with its original URL, while local assets still point at the media server. Covered by `tests/Integration/Classes/controller/FrontControllerRemoteAssetTest.php`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #34423, Fixes #36939, Fixes #36644
| Related PRs       | Supersedes #36645, whose guard this is
| Sponsor company   |

### Why `=== 'local'` and not `!== 'remote'`

The media server rewrite is only meaningful for an asset served from this shop, so anything that is not
explicitly local is left alone. That is fail-safe against an unexpected `server` value, where
`!== 'remote'` would still rewrite.

### Credit

@prestaalba proposed exactly this guard in #36645 for #36644. That branch predates merged #41509, which
replaced both blocks it patches, so it no longer applies; it also targets `develop` rather than the
lowest affected branch. Noted on all three threads before preparing this.

### Verification

Measured on 9.2.0 by rendering the front page with a module registering a remote script and stylesheet:

| condition | remote script | remote link | assets on the media server |
|---|---|---|---|
| no media server (control) | 1 | 1 | 0 |
| media server set, theme cache off | 0 | 0 | 91 |
| media server set, with this change | 1 | 1 | 91 |

RED/GREEN: reverting only `classes/controller/FrontController.php` fails the two remote cases and leaves
the local-asset case passing, which is the non-regression control in both directions.

### Note for reviewers, not part of this change

`tests/Integration/Classes/` contains both `controller/` and `Controller/`, which differ only in case and
would collide on a case-insensitive filesystem. This test goes in the lowercase directory next to
`AdminControllerTest.php`, matching `tests/Unit/Classes/controller/`. Worth consolidating separately.


### Credit

The guard is @prestaalba's, from #36645. That branch has not been rebasable since #41509 landed and targets `develop`; this is the same fix rebased onto `9.2.x`, the lowest affected branch, with an integration test. Opened here with their agreement on #36645.
