### PR TITLE
Multistore: required multilang fields are validated against the wrong language because ObjectModel::validateField() caches PS_LANG_DEFAULT in a static

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1146,10 +1146,12 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
      */
     public function validateField($field, $value, $id_lang = null, $skip = [], $human_errors = false)
     {
-        static $ps_lang_default = null;
+        // The default language depends on the shop context, which can change during the request
+        static $ps_lang_default = [];
 
-        if ($ps_lang_default === null) {
-            $ps_lang_default = Configuration::get('PS_LANG_DEFAULT');
+        $id_shop = (int) Shop::getContextShopID(true);
+        if (!isset($ps_lang_default[$id_shop])) {
+            $ps_lang_default[$id_shop] = Configuration::get('PS_LANG_DEFAULT');
         }
 
         $this->cacheFieldsRequiredDatabase();
@@ -1157,7 +1159,7 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
 
         // Check if field is required
         $required_fields = $this->getCachedFieldsRequiredDatabase();
-        if (!$id_lang || $id_lang == $ps_lang_default) {
+        if (!$id_lang || $id_lang == $ps_lang_default[$id_shop]) {
             if (!in_array('required', $skip) && (!empty($data['required']) || in_array($field, $required_fields))) {
                 if (Tools::isEmpty($value)) {
                     if ($human_errors) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
⚠️ SECURITY WARNING — READ BEFORE OPENING THIS PULL REQUEST ⚠️

If this pull request fixes or relates to a SECURITY vulnerability, DO NOT open
it here. Public pull requests disclose the vulnerability to everyone, including
attackers, before a fix is released.

Please report security issues privately by contacting
security-core@prestashop.com instead.
------------------------------------------------------------------------------>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `ObjectModel::validateField()` cached `PS_LANG_DEFAULT` in a function level static. It is a configuration value that depends on the shop context, so caching it for the whole request freezes whichever shop context happened to be active when the method was first called. In a multistore back office that makes the required language check disagree with `AdminController::validateRules()`, which resolves the value fresh: the form accepts a translatable field filled in the shop's default language, and the save then rejects it as empty. The value is now read on each call.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Multistore on, with a shop whose default language differs from the global `PS_LANG_DEFAULT`. Switch the back office context to that shop, go to Customers > Groups > Add new group, fill "Name" only in that shop's default language, and save. Before this change the save fails with `Property Group->name is empty`. After it, the group is saved normally.
| UI Tests          | MySQL: https://github.com/SGP97/ga.tests.ui.pr/actions/runs/34345327687 / MariaDB: https://github.com/SGP97/ga.tests.ui.pr/actions/runs/34345361303
| Fixed issue or discussion?     | n/a
| Related PRs       |
| Sponsor company   |

## Why not keep the cache?

  `Configuration::get()` already serves from an in-memory cache once `loadConfiguration()` has run, so the static was not saving a query, only a couple of array lookups, and in exchange it froze a value that depends on the shop
  context.