### PR TITLE
Make module version checks in UI tests resilient to module releases

### DIFF
--- a/tests/UI/campaigns/functional/API/02_endpoints/module/10_putModulesBulkUninstall.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/module/10_putModulesBulkUninstall.ts
@@ -4,6 +4,7 @@ import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer'
 import {installModule} from '@commonTests/BO/modules/moduleManager';
 
 import {expect} from 'chai';
+import semver from 'semver';
 import {
   type APIRequestContext,
   boDashboardPage,
@@ -170,7 +171,12 @@ describe('API : PUT /modules/bulk-uninstall', async () => {
 
           const moduleInfo = await boModuleManagerPage.getModuleInformationNth(page, 1);
           expect(moduleInfo.technicalName).to.equal(module.tag);
-          expect(module.versionCurrent).to.contains(moduleInfo.version);
+          // The module is no longer on disk: the card is built from the Distribution API listing,
+          // whose version can be ahead of the one bundled in the core
+          expect(
+            semver.gte(moduleInfo.version, module.versionCurrent),
+            `Module version ${moduleInfo.version} should be at least ${module.versionCurrent}`,
+          ).to.eq(true);
           expect(moduleInfo.enabled).to.equal(false);
           expect(moduleInfo.installed).to.equal(false);
         }

--- a/tests/UI/campaigns/modules/10_ps_cashondelivery/01_installation/01_upgradeModule.ts
+++ b/tests/UI/campaigns/modules/10_ps_cashondelivery/01_installation/01_upgradeModule.ts
@@ -1,5 +1,6 @@
 import testContext from '@utils/testContext';
 import {expect} from 'chai';
+import semver from 'semver';
 
 // Import commonTests
 import {installModule, uninstallModule} from '@commonTests/BO/modules/moduleManager';
@@ -159,7 +160,12 @@ describe('Cash on delivery (COD) module: Upgrade module', async () => {
       expect(isModuleVisible).to.eq(true);
 
       const moduleInfo = await boModuleManagerPage.getModuleInformationNth(page, 1);
-      expect(dataModules.psCashOnDelivery.versionCurrent).to.contains(moduleInfo.version);
+      // The upgrade installs the latest release published on the Distribution API, which may be
+      // ahead of the version referenced by the ui-testing-library: only check the module got newer
+      expect(
+        semver.gt(moduleInfo.version, dataModules.psCashOnDelivery.versionOld),
+        `Module version ${moduleInfo.version} should be greater than ${dataModules.psCashOnDelivery.versionOld}`,
+      ).to.eq(true);
     });
 
     it('should go to \'Shop parameters > General\' page', async function () {
@@ -345,7 +351,12 @@ describe('Cash on delivery (COD) module: Upgrade module', async () => {
       expect(isModuleVisible).to.eq(true);
 
       const moduleInfo = await boModuleManagerPage.getModuleInformationNth(page, 1);
-      expect(dataModules.psCashOnDelivery.versionCurrent).to.contains(moduleInfo.version);
+      // The upgrade installs the latest release published on the Distribution API, which may be
+      // ahead of the version referenced by the ui-testing-library: only check the module got newer
+      expect(
+        semver.gt(moduleInfo.version, dataModules.psCashOnDelivery.versionOld),
+        `Module version ${moduleInfo.version} should be greater than ${dataModules.psCashOnDelivery.versionOld}`,
+      ).to.eq(true);
     });
 
     it('should go to the front office', async function () {

--- a/tests/UI/campaigns/modules/29_ps_newproducts/01_installation/01_upgradeModule.ts
+++ b/tests/UI/campaigns/modules/29_ps_newproducts/01_installation/01_upgradeModule.ts
@@ -5,6 +5,7 @@ import testContext from '@utils/testContext';
 import {installModule, uninstallModule} from '@commonTests/BO/modules/moduleManager';
 
 import {expect} from 'chai';
+import semver from 'semver';
 import {
   boDashboardPage,
   boLoginPage,
@@ -148,7 +149,12 @@ describe('New products block module: Upgrade module', async () => {
       expect(isModuleVisible).to.eq(true);
 
       const moduleInfo = await boModuleManagerPage.getModuleInformationNth(page, 1);
-      expect(dataModules.psNewProducts.versionCurrent).to.contains(moduleInfo.version);
+      // The upgrade installs the latest release published on the Distribution API, which may be
+      // ahead of the version referenced by the ui-testing-library: only check the module got newer
+      expect(
+        semver.gt(moduleInfo.version, dataModules.psNewProducts.versionOld),
+        `Module version ${moduleInfo.version} should be greater than ${dataModules.psNewProducts.versionOld}`,
+      ).to.eq(true);
     });
 
     it('should go to \'Shop parameters > General\' page', async function () {
@@ -266,7 +272,12 @@ describe('New products block module: Upgrade module', async () => {
       expect(isModuleVisible).to.eq(true);
 
       const moduleInfo = await boModuleManagerPage.getModuleInformationNth(page, 1);
-      expect(dataModules.psNewProducts.versionCurrent).to.contains(moduleInfo.version);
+      // The upgrade installs the latest release published on the Distribution API, which may be
+      // ahead of the version referenced by the ui-testing-library: only check the module got newer
+      expect(
+        semver.gt(moduleInfo.version, dataModules.psNewProducts.versionOld),
+        `Module version ${moduleInfo.version} should be greater than ${dataModules.psNewProducts.versionOld}`,
+      ).to.eq(true);
     });
 
     it('should go to the front office', async function () {

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -16,7 +16,8 @@
         "dotenv": "^17.4.1",
         "mocha": "^11.7.6",
         "mochawesome": "^7.1.4",
-        "mysql2": "^3.22.5"
+        "mysql2": "^3.22.5",
+        "semver": "^7.8.5"
       },
       "devDependencies": {
         "@types/chai": "^5.2.3",
@@ -24,6 +25,7 @@
         "@types/mocha": "^10.0.10",
         "@types/mochawesome": "^6.2.5",
         "@types/node": "^26.1.0",
+        "@types/semver": "^7.8.0",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.62.1",
         "babel-eslint": "^10.1.0",
@@ -810,6 +812,13 @@
       "dependencies": {
         "undici-types": "~8.3.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -5705,7 +5714,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.2",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -118,7 +118,8 @@
     "dotenv": "^17.4.1",
     "mocha": "^11.7.6",
     "mochawesome": "^7.1.4",
-    "mysql2": "^3.22.5"
+    "mysql2": "^3.22.5",
+    "semver": "^7.8.5"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",
@@ -126,6 +127,7 @@
     "@types/mocha": "^10.0.10",
     "@types/mochawesome": "^6.2.5",
     "@types/node": "^26.1.0",
+    "@types/semver": "^7.8.0",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.62.1",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Since `ps_cashondelivery` v3.0.0 was released, the UI campaigns `modules:10-19` and `functional:API` fail on every PR with `AssertionError: expected 'v2.0.1' to include '3.0.0'`. The tests compare the version shown in the Module Manager with the hard-coded `versionCurrent` of `dataModules` in `@prestashop-core/ui-testing`, which follows `composer.lock`. But two flows take their version from the Distribution API instead: the "Upgrade" action of the Module Manager (`ps_distributionapiclient` hooks `actionBeforeUpgradeModule` and installs the latest published release when no source is given), and the card of a native module deleted from disk (built from the Distribution API listing). Both can be ahead of `composer.lock`, so every module release breaks these tests. This PR replaces the strict equality with a `semver` comparison in the affected assertions: after an upgrade the displayed version must be greater than the version installed before (`versionOld`), and a deleted native module must show at least the version bundled in the core (`versionCurrent`). The same change is applied to the `ps_newproducts` upgrade scenario, which would break at its next release. Assertions on versions coming from a pinned zip (keycloak, `upload-source` in the upgrade API test) are unchanged. `semver` (already a transitive dependency of the ui-testing-library) is declared explicitly in `tests/UI/package.json` with its types.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the UI campaigns `modules:10-19` and `functional:API` on this PR: they must be green while the Distribution API serves `ps_cashondelivery` 3.0.0 and the ui-testing-library still references v2.0.1. Locally, in `tests/UI`: `TEST_PATH='modules/10_*/01*/01*' npm run test:specific`, the step "should reload the page" after the upgrade passes with the module at 3.0.0. `npm run lint` and `npm run check:typescript` pass.
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/34334596535
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
