### PR TITLE
Warn that a quantity discount on a product covers all its combinations

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
@@ -10,6 +10,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
 use DateTime;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DateRange;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
@@ -27,6 +28,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -55,6 +57,16 @@ class SpecificPriceType extends TranslatorAwareType
     private $combinationNameBuilder;
 
     /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
      * @var int
      */
     private $languageId;
@@ -66,7 +78,9 @@ class SpecificPriceType extends TranslatorAwareType
         AttributeRepository $attributeRepository,
         EventSubscriberInterface $specificPriceCombinationListener,
         CombinationNameBuilderInterface $combinationNameBuilder,
-        int $contextLanguageId
+        int $contextLanguageId,
+        ConfigurationInterface $configuration,
+        RouterInterface $router
     ) {
         parent::__construct($translator, $locales);
         $this->productRepository = $productRepository;
@@ -74,6 +88,8 @@ class SpecificPriceType extends TranslatorAwareType
         $this->specificPriceCombinationListener = $specificPriceCombinationListener;
         $this->combinationNameBuilder = $combinationNameBuilder;
         $this->languageId = $contextLanguageId;
+        $this->configuration = $configuration;
+        $this->router = $router;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -100,6 +116,7 @@ class SpecificPriceType extends TranslatorAwareType
             $builder->add('combination_id', ChoiceType::class, [
                 'label' => $this->trans('Combination', 'Admin.Global'),
                 'required' => false,
+                'help' => $this->getCombinationHelp(),
                 'choices' => $this->getSelectedChoices($builder),
                 'attr' => [
                     // select2 jQuery component is added in javascript manually for this ChoiceType
@@ -169,6 +186,34 @@ class SpecificPriceType extends TranslatorAwareType
      *
      * @return array<string, int>
      */
+    /**
+     * Warns that picking a combination here has no effect while quantity discounts are
+     * computed per product.
+     *
+     * With "Quantity discounts based on" set to Products, SpecificPrice sums the quantities of
+     * every combination of the product, so a specific price entered for one combination starts
+     * applying as soon as the total reaches the threshold - which is not what choosing a single
+     * combination in this dropdown looks like it does. The setting is the thing to change, so
+     * the message links to it.
+     *
+     * @return string|null null when discounts already work per combination and there is nothing to warn about
+     */
+    private function getCombinationHelp(): ?string
+    {
+        if ((bool) $this->configuration->get('PS_QTY_DISCOUNT_ON_COMBINATION')) {
+            return null;
+        }
+
+        return $this->trans(
+            'Note that if you want to base a quantity discount on a product, it will apply to all of its combinations. Go to [1]Shop Parameters > Product Settings[/1] to modify it.',
+            'Admin.Catalog.Help',
+            [
+                '[1]' => '<a href="' . $this->router->generate('admin_product_preferences') . '#configuration_fieldset_products">',
+                '[/1]' => '</a>',
+            ]
+        );
+    }
+
     private function getSelectedChoices(FormBuilderInterface $builder): array
     {
         $combinationIdValue = $builder->getData()['combination_id'] ?? NoCombinationId::NO_COMBINATION_ID;

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -492,6 +492,7 @@ services:
       $attributeRepository: '@PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository'
       $specificPriceCombinationListener: '@PrestaShopBundle\Form\Admin\Sell\Product\EventListener\SpecificPriceCombinationListener'
       $combinationNameBuilder: '@PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder'
+      $configuration: '@prestashop.adapter.legacy.configuration'
 
   PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPricePriorityType:
     arguments:

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceTypeCombinationHelpTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceTypeCombinationHelpTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
+
+use Configuration;
+use Db;
+use PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPriceType;
+use Tests\Integration\PrestaShopBundle\Form\AbstractFormTester;
+
+class SpecificPriceTypeCombinationHelpTest extends AbstractFormTester
+{
+    private const SETTING = 'PS_QTY_DISCOUNT_ON_COMBINATION';
+
+    /** @var mixed */
+    private $initialSetting;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->initialSetting = Configuration::get(self::SETTING);
+    }
+
+    protected function tearDown(): void
+    {
+        Configuration::updateValue(self::SETTING, $this->initialSetting);
+        Configuration::loadConfiguration();
+        parent::tearDown();
+    }
+
+    public function testItWarnsWhenQuantityDiscountsAreBasedOnProducts(): void
+    {
+        $help = $this->combinationHelpWithSetting(0);
+
+        $this->assertNotNull($help, 'the combination field must carry the warning');
+        $this->assertStringContainsString('it will apply to all of its combinations', $help);
+        // The message is only useful if it points at the setting that causes it.
+        $this->assertStringContainsString('<a href="', $help);
+        $this->assertStringContainsString('#configuration_fieldset_products', $help);
+    }
+
+    public function testItStaysSilentWhenQuantityDiscountsAreBasedOnCombinations(): void
+    {
+        $this->assertNull(
+            $this->combinationHelpWithSetting(1),
+            'nothing to warn about once discounts are already computed per combination'
+        );
+    }
+
+    /**
+     * @param int $settingValue 0 = Products, 1 = Combinations
+     */
+    private function combinationHelpWithSetting(int $settingValue): ?string
+    {
+        Configuration::updateValue(self::SETTING, $settingValue);
+        Configuration::loadConfiguration();
+
+        // The builder is enough and is the narrower subject: buildForm() runs here, while
+        // getForm() would additionally resolve the impact sub-form, which needs data this
+        // test has no reason to supply.
+        $builder = $this->createFormBuilder(SpecificPriceType::class, [], ['product_id' => $this->combinationProductId()]);
+
+        // The field only exists for a product that has combinations, which is the whole point
+        // of the message - fail loudly rather than silently skipping the assertion.
+        $this->assertTrue($builder->has('combination_id'), 'fixture product must be a combinations product');
+
+        return $builder->get('combination_id')->getOption('help');
+    }
+
+    private function combinationProductId(): int
+    {
+        $id = (int) Db::getInstance()->getValue(
+            'SELECT p.id_product FROM ' . _DB_PREFIX_ . 'product p
+             WHERE p.product_type = "combinations"
+               AND EXISTS (SELECT 1 FROM ' . _DB_PREFIX_ . 'product_attribute pa WHERE pa.id_product = p.id_product)'
+        );
+
+        if (!$id) {
+            $this->markTestSkipped('no product with combinations in the fixtures');
+        }
+
+        return $id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Choosing a combination while adding a specific price looks like it limits the discount to that combination, and it does not while `Quantity discounts based on` is set to Products: `SpecificPrice` then sums the quantities of every combination of the product, so the price starts applying once the total reaches the threshold whichever combinations made it up. This puts the explanation under the dropdown that suggests otherwise and links to the setting that decides it, so the merchant can change the behaviour rather than only read about it. Nothing is shown when discounts are already computed per combination. The wording and the placement are the ones agreed on the issue - the text was settled with the PM and marionf asked for it to sit under the drop-down - and the link reuses the pattern `CombinationAvailabilityType` already uses to point at the same settings page.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shop Parameters > Product Settings, set `Quantity discounts based on` to `Products` (the default). Open a product that has combinations, Pricing tab, add a specific price: the combination dropdown now carries the note underneath, and the link opens Product Settings at the right card. Switch the setting to `Combinations` and reopen the form - the note is gone, because the dropdown then does what it looks like it does.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #12363
| Related PRs       |
| Sponsor company   |

## Why this shape

The issue carries a `SPECS` block written by the PM and `Wording ✔️` since 2019-08-23, so the text
is not mine to choose:

> Note that if you want to base a quantity discount on a product, it will apply to all of its
> combinations. Go to Shop Parameters > Product Settings to modify it

marionf added "This new wording should be under the drop-down", which is what Symfony's `help`
option does - it renders in `form_help`, directly under the widget - so no template change is
needed. `Waiting for UX` was removed in 2023 and the issue is labelled `Ready`, `Quickwin` and
`Hacktoberfest`.

The underlying pricing behaviour is deliberate and configurable, so it is not touched. The defect
the reporter hit is that the form gives no hint the setting exists.

## Rendered output, read from the built form rather than from the source

```
Note that if you want to base a quantity discount on a product, it will apply to all of its
combinations. Go to <a href="/configure/shop/product-preferences/?_token=#configuration_fieldset_products">Shop
Parameters > Product Settings</a> to modify it.
```

`#configuration_fieldset_products` is the card that holds `Quantity discounts based on`
(`Blocks/product_preferences_general.html.twig:10`). PrestaShop renders help through
`{{ help|raw_purified }}`, so the anchor survives without `help_html`.

## Tests

`SpecificPriceTypeCombinationHelpTest` (2 tests, 7 assertions), built against the real container:

- setting = Products: the field carries the note, and the note contains a link to the settings card;
- setting = Combinations: `help` is null.

Both assert the fixture product really is a combinations product first, so the case cannot pass by
the field being absent. The test drives the form **builder** rather than the finished form on
purpose - `buildForm()` runs there, while `getForm()` would additionally resolve the impact
sub-form, which needs data unrelated to this change.

Mutation check: removing the `'help' => $this->getCombinationHelp()` line fails the first test and
leaves the second green; restoring it puts both back.

## Gate

- `php -l`: clean on both PHP files
- php-cs-fixer: exit 0 on both
- `bin/console lint:yaml` on the changed service file: OK
- PHPStan level 5 with `phpstan.neon.dist`: no errors

One thing worth flagging for review: `ConfigurationInterface` declares only `get()` and `set()`, so
the check is `(bool) $this->configuration->get(...)` as in `SEOType`, not `getBoolean()` - that
method exists on the adapter, not on the interface, and `php -l` will not tell you.
