### PR TITLE
Accept Slovenian postcodes in their own format

### DIFF
--- a/install-dev/data/xml/country.xml
+++ b/install-dev/data/xml/country.xml
@@ -202,7 +202,7 @@
     <country id="RS" id_zone="Europe_out_E_U" iso_code="RS" call_prefix="381" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNNN" display_tax_label="1"/>
     <country id="SC" id_zone="Africa" iso_code="SC" call_prefix="248" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="SL" id_zone="Africa" iso_code="SL" call_prefix="232" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
-    <country id="SI" id_zone="Europe" iso_code="SI" call_prefix="386" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="C-NNNN" display_tax_label="1"/>
+    <country id="SI" id_zone="Europe" iso_code="SI" call_prefix="386" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNN" display_tax_label="1"/>
     <country id="SB" id_zone="Oceania" iso_code="SB" call_prefix="677" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="SO" id_zone="Africa" iso_code="SO" call_prefix="252" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="GS" id_zone="Central_America_Antilla" iso_code="GS" call_prefix="0" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="LLLL NLL" display_tax_label="1"/>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Slovenia ships with `zip_code_format="C-NNNN"`, which asks for the ISO country code, a dash and four digits. Slovenian postcodes are four digits and nothing else, so `Country::checkZipCode()` refused every real one and accepted only `SI-1000`, which is an international addressing convention rather than the postcode. Latvia and Moldova keep `C-NNNN` deliberately: their prefixes are part of the official format, so Slovenia was the only one of the three where it did not belong. This is the shipped default, so it applies to new installations; an existing shop keeps its value and can change it in Improve > International > Locations > Countries.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a fresh installation, Improve > International > Locations > Countries > Slovenia shows a zip/postal code format of `NNNN`. In the front office, place an order to a Slovenian address and enter `1000` - it is accepted, where before it produced "Invalid postcode". `SI-1000` is refused after the change, which is correct: it is not the postcode.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #16077
| Related PRs       |
| Sponsor company   |

## Measured on 9.2.x

`Country::checkZipCode()` against real Slovenian postcodes - Ljubljana, Maribor, Kranj, Izola,
Murska Sobota - and against values that must stay refused:

```
  format    real postcodes accepted   malformed accepted
  C-NNNN    0/5                       1/5   (SI-1000)
  NNNN      5/5                       0/5
```

The malformed set is `100`, `10000`, `ABCD`, `` and `SI-1000`.

## Why only Slovenia

Three countries carry `C-NNNN`: `LV` (line 138), `MD` (line 160) and `SI` (line 205). Checked all
three rather than assuming the reported one was the only wrong one:

- Latvia - the prefix is mandatory, "postal codes in Latvia are 4 digit numeric and use a mandatory
  ISO 3166-1 alpha-2 country code (LV) in front, i.e. the format is 'LV-NNNN'". Correct as shipped.
- Moldova - "consisting of the letters MD followed by a dash followed by four digits, e.g.
  Chisinau MD-2001". Correct as shipped.
- Slovenia - "The codes consist of four digits written without separator characters". Wrong as
  shipped.

So the class is exactly one member, and the other two are deliberately untouched.

## Scope

The value is defined once, in `install-dev/data/xml/country.xml`; nothing else in the repository
carries it. `tests/UI/data/xml/country.ts` builds its own countries with faker and does not
reference the shipped data, so it needs no matching change.

No test is added. Core asserts no individual country's fixture values anywhere, and a single
assertion for Slovenia would both break that convention and depend on the test database having been
reinstalled from the fixtures. The before/after measurement above is the evidence.

PrestaShop 9 has no `install-dev/upgrade/sql` directory - upgrades are carried by the autoupgrade
module - so nothing here changes an existing shop's stored value. That is also the safer behaviour:
a merchant who deliberately entered `SI-` addresses keeps working, and the report itself notes the
setting is easy to correct in the back office.
