### PR TITLE
Rewrite .htaccess when the media servers change

### DIFF
--- a/src/Adapter/Media/MediaServerConfiguration.php
+++ b/src/Adapter/Media/MediaServerConfiguration.php
@@ -7,6 +7,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Media;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
 
 /**
@@ -19,9 +20,15 @@ class MediaServerConfiguration implements DataConfigurationInterface
      */
     private $configuration;
 
-    public function __construct(Configuration $configuration)
+    /**
+     * @var Tools
+     */
+    private $tools;
+
+    public function __construct(Configuration $configuration, Tools $tools)
     {
         $this->configuration = $configuration;
+        $this->tools = $tools;
     }
 
     /**
@@ -48,6 +55,10 @@ class MediaServerConfiguration implements DataConfigurationInterface
             $serverTwo = $configuration['media_server_two'];
             $serverThree = $configuration['media_server_three'];
 
+            $hasChanged = $serverOne !== $this->configuration->get('PS_MEDIA_SERVER_1')
+                || $serverTwo !== $this->configuration->get('PS_MEDIA_SERVER_2')
+                || $serverThree !== $this->configuration->get('PS_MEDIA_SERVER_3');
+
             $this->configuration->set('PS_MEDIA_SERVER_1', $serverOne);
             $this->configuration->set('PS_MEDIA_SERVER_2', $serverTwo);
             $this->configuration->set('PS_MEDIA_SERVER_3', $serverThree);
@@ -56,6 +67,17 @@ class MediaServerConfiguration implements DataConfigurationInterface
                 $this->configuration->set('PS_MEDIA_SERVERS', 1);
             } else {
                 $this->configuration->set('PS_MEDIA_SERVERS', 0);
+            }
+
+            // .htaccess carries a RewriteCond per media server, so the file has to be
+            // rewritten for the setting to take effect. Without this the value is stored
+            // and shown in the back office while the server it names is never used.
+            if ($hasChanged && !$this->tools->generateHtaccess()) {
+                $errors[] = [
+                    'key' => 'Before being able to use this tool, you need to:[1][2]Create a blank .htaccess in your root directory.[/2][2]Give it write permissions (CHMOD 666 on Unix system).[/2][/1]',
+                    'domain' => 'Admin.Advparameters.Notification',
+                    'parameters' => [],
+                ];
             }
         } else {
             $errors = $isValid;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -80,7 +80,9 @@ services:
 
   prestashop.adapter.media_servers.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Media\MediaServerConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+      - '@PrestaShop\PrestaShop\Adapter\Tools'
 
   prestashop.adapter.caching.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Cache\CachingConfiguration'

--- a/tests/Unit/Adapter/Media/MediaServerConfigurationTest.php
+++ b/tests/Unit/Adapter/Media/MediaServerConfigurationTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Media;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Media\MediaServerConfiguration;
+use PrestaShop\PrestaShop\Adapter\Tools;
+
+class MediaServerConfigurationTest extends TestCase
+{
+    /**
+     * @var Configuration|MockObject
+     */
+    private $configuration;
+
+    /**
+     * @var Tools|MockObject
+     */
+    private $tools;
+
+    protected function setUp(): void
+    {
+        $this->configuration = $this->createMock(Configuration::class);
+        $this->tools = $this->createMock(Tools::class);
+    }
+
+    public function testItRewritesHtaccessWhenAServerChanges(): void
+    {
+        $this->givenStoredServers('', '', '');
+        $this->tools->expects($this->once())->method('generateHtaccess')->willReturn(true);
+
+        $errors = $this->configurator()->updateConfiguration($this->submit('localhost'));
+
+        $this->assertSame([], $errors);
+    }
+
+    /**
+     * Saving the form without touching the fields must not rewrite the file: the page
+     * is shared with other settings, so an unchanged save would rewrite .htaccess on
+     * every visit that presses Save.
+     */
+    public function testItLeavesHtaccessAloneWhenNothingChanged(): void
+    {
+        $this->givenStoredServers('localhost', '', '');
+        $this->tools->expects($this->never())->method('generateHtaccess');
+
+        $errors = $this->configurator()->updateConfiguration($this->submit('localhost'));
+
+        $this->assertSame([], $errors);
+    }
+
+    public function testItReportsAnUnwritableHtaccess(): void
+    {
+        $this->givenStoredServers('', '', '');
+        $this->tools->method('generateHtaccess')->willReturn(false);
+
+        $errors = $this->configurator()->updateConfiguration($this->submit('localhost'));
+
+        $this->assertCount(1, $errors);
+        $this->assertSame('Admin.Advparameters.Notification', $errors[0]['domain']);
+    }
+
+    /**
+     * An invalid value never reaches the configuration, so there is nothing to
+     * regenerate either.
+     */
+    public function testItDoesNotRewriteHtaccessWhenTheValueIsRejected(): void
+    {
+        $this->tools->expects($this->never())->method('generateHtaccess');
+        $this->configuration->expects($this->never())->method('set');
+
+        $errors = $this->configurator()->updateConfiguration($this->submit('not a domain at all'));
+
+        $this->assertNotEmpty($errors);
+    }
+
+    private function configurator(): MediaServerConfiguration
+    {
+        return new MediaServerConfiguration($this->configuration, $this->tools);
+    }
+
+    /**
+     * `localhost` rather than a realistic CDN name on purpose: the class validates a
+     * media server with `gethostbyname()`, so any name used here has to resolve, and a
+     * unit test must not depend on the machine having DNS.
+     */
+    private function submit(string $one, string $two = '', string $three = ''): array
+    {
+        return [
+            'media_server_one' => $one,
+            'media_server_two' => $two,
+            'media_server_three' => $three,
+        ];
+    }
+
+    private function givenStoredServers(string $one, string $two, string $three): void
+    {
+        // A callback rather than willReturnMap: the map matches on the full argument
+        // list, and Configuration::get() carries optional parameters, so the entry has
+        // to mirror the call shape exactly to match. The callback does not care.
+        $stored = [
+            'PS_MEDIA_SERVER_1' => $one,
+            'PS_MEDIA_SERVER_2' => $two,
+            'PS_MEDIA_SERVER_3' => $three,
+        ];
+        $this->configuration->method('get')->willReturnCallback(
+            static fn ($key) => $stored[$key] ?? null
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `.htaccess` carries a `RewriteCond %{HTTP_HOST} ^<server>$ [OR]` per media server, generated from `PS_MEDIA_SERVER_1..3` (`Tools::generateHtaccess()`). Saving those values stored them and displayed them back in the back office, but never rewrote the file, so the servers were configured and unused. The workaround on the issue is to rename `.htaccess`, then disable and re-enable friendly URLs, which regenerates it as a side effect. The values are now written and the file regenerated in the same save, the way `CombineCompressCacheConfiguration` already does for the other `.htaccess`-affecting settings, and an unwritable file reports the same error it reports. Regeneration is skipped when none of the three values changed, so pressing Save on an unrelated part of that form does not rewrite the file.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Advanced Parameters > Performance, set a media server and save. `.htaccess` gains a `RewriteCond %{HTTP_HOST} ^<your server>$ [OR]` line immediately, with no rename-and-toggle-friendly-URLs dance. Clear the field and save: the line goes. Save the page again without touching the media servers: `.htaccess` is not rewritten.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #16447
| Related PRs       |
| Sponsor company   |

---

**Measured, base vs branch**, counting `RewriteCond %{HTTP_HOST} ^localhost$ [OR]` lines in `.htaccess`
around a save through the same configurator the form uses:

| step | base | branch |
| --- | --- | --- |
| before | 0 | 0 |
| after saving a media server | **0** | **9** |
| after an explicit `Tools::generateHtaccess()` | 9 | 9 |

Negative control: saving the identical values a second time leaves `.htaccess` mtime unchanged on the
branch. The service also resolves through the real container with the `Tools` dependency injected.

Unit test: 4 tests, 9 assertions. Removing the changed-values guard reddens one, removing the
regeneration call reddens two.

`php-cs-fixer` exit 0 and `phpstan -c phpstan.neon.dist` OK on both changed PHP files; `lint:yaml` OK on
the service definition. `lint:container` fails on this branch and on an unmodified `9.2.x` alike, for an
unrelated Monolog `RotatingFileHandler` type error.

**One thing worth knowing for the test file:** the validator resolves a media server with
`gethostbyname()`, so any hostname in a test has to resolve. The test uses `localhost` for that reason
rather than a realistic CDN name.

**On the 2019 exchange:** the first answer described the rename-and-toggle workaround, and the same
person then reproduced it across `1.7.5.0`, `1.7.6.1`, `1.7.6.2build1` and `develop` and asked the
product team whether the process should be improved. It was left there. The behaviour is not a process
question: the value is stored and the artefact that consumes it is not updated, which is the same
inconsistency the neighbouring settings on that page already avoid.
