### PR TITLE
Let a single-shop group still change its customer and order sharing

### DIFF
--- a/classes/shop/ShopGroup.php
+++ b/classes/shop/ShopGroup.php
@@ -110,6 +110,34 @@ class ShopGroupCore extends ObjectModel
      *
      * @return bool
      */
+    /**
+     * Whether the customer or order sharing flags of a group must stay read-only.
+     *
+     * Turning sharing on moves these records from the scope of one shop to the scope of the
+     * whole group, so it is refused once the group already holds them: the flip would show
+     * one shop's customers and orders to another shop without warning.
+     *
+     * That reasoning needs a second shop to be true. While the group holds at most one shop
+     * the two scopes are the same set of shops, so the flag decides nothing and there is
+     * nobody to expose the data to. Without this, the first order a single-shop merchant
+     * takes locks the option for good, and the only way back is to build a second group and
+     * move the shop into it - which the sharing check in AdminShopController then refuses in
+     * turn once quantities are shared.
+     *
+     * @param int $id_shop_group Shop group identifier
+     * @param string $check 'all', 'customer' or 'order'
+     *
+     * @return bool
+     */
+    public static function isSharingLocked($id_shop_group, $check = 'all')
+    {
+        if (count(Shop::getShops(false, (int) $id_shop_group, true) ?: []) <= 1) {
+            return false;
+        }
+
+        return static::hasDependency($id_shop_group, $check);
+    }
+
     public static function hasDependency($id_shop_group, $check = 'all')
     {
         $list_shops = Shop::getShops(false, $id_shop_group, true);

--- a/controllers/admin/AdminShopGroupController.php
+++ b/controllers/admin/AdminShopGroupController.php
@@ -193,7 +193,7 @@ class AdminShopGroupControllerCore extends AdminController
                     'required' => true,
                     'class' => 't',
                     'is_bool' => true,
-                    'disabled' => ($this->id_object && $this->display == 'edit' && ShopGroup::hasDependency($this->id_object, 'customer')) ? true : false,
+                    'disabled' => ($this->id_object && $this->display == 'edit' && ShopGroup::isSharingLocked($this->id_object, 'customer')) ? true : false,
                     'values' => [
                         [
                             'id' => 'share_customer_on',
@@ -232,7 +232,7 @@ class AdminShopGroupControllerCore extends AdminController
                     'required' => true,
                     'class' => 't',
                     'is_bool' => true,
-                    'disabled' => ($this->id_object && $this->display == 'edit' && ShopGroup::hasDependency($this->id_object, 'order')) ? true : false,
+                    'disabled' => ($this->id_object && $this->display == 'edit' && ShopGroup::isSharingLocked($this->id_object, 'order')) ? true : false,
                     'values' => [
                         [
                             'id' => 'share_order_on',

--- a/tests/Integration/Classes/shop/ShopGroupSharingLockTest.php
+++ b/tests/Integration/Classes/shop/ShopGroupSharingLockTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\shop;
+
+use Configuration;
+use Customer;
+use PHPUnit\Framework\TestCase;
+use Shop;
+use ShopGroup;
+
+class ShopGroupSharingLockTest extends TestCase
+{
+    /** @var int[] */
+    private $shopIds = [];
+
+    /** @var int|null */
+    private $groupId;
+
+    /** @var int|null */
+    private $customerId;
+
+    protected function tearDown(): void
+    {
+        if ($this->customerId) {
+            (new Customer($this->customerId))->delete();
+        }
+        foreach ($this->shopIds as $id) {
+            $shop = new Shop($id);
+            $shop->deleted = true;
+            $shop->update();
+        }
+        if ($this->groupId) {
+            $group = new ShopGroup($this->groupId);
+            $group->deleted = true;
+            $group->update();
+        }
+        Shop::cacheShops(true);
+    }
+
+    public function testAGroupHoldingOneShopStaysEditableEvenWithCustomers(): void
+    {
+        $this->givenAGroupWithOneShopAndACustomer();
+
+        // The data really is there - this is what the old condition looked at on its own.
+        $this->assertTrue(
+            ShopGroup::hasDependency($this->groupId, 'customer'),
+            'the fixture is meant to have a customer, otherwise the test proves nothing'
+        );
+
+        // ...but with a single shop in the group there is no second shop to expose it to.
+        $this->assertFalse(
+            ShopGroup::isSharingLocked($this->groupId, 'customer'),
+            'a group holding one shop must keep the sharing flags editable'
+        );
+    }
+
+    public function testASecondShopInTheGroupLocksTheFlags(): void
+    {
+        $this->givenAGroupWithOneShopAndACustomer();
+        $this->shopIds[] = $this->createShop('Probe16804 shop B');
+        Shop::cacheShops(true);
+
+        $this->assertCount(2, Shop::getShops(false, $this->groupId, true));
+        $this->assertTrue(
+            ShopGroup::isSharingLocked($this->groupId, 'customer'),
+            'once the group holds a second shop the customer data may not be re-scoped'
+        );
+    }
+
+    public function testAnEmptyGroupIsNeverLocked(): void
+    {
+        $this->groupId = $this->createGroup();
+        $this->shopIds[] = $this->createShop('Probe16804 shop A');
+        Shop::cacheShops(true);
+
+        $this->assertFalse(ShopGroup::isSharingLocked($this->groupId, 'customer'));
+        $this->assertFalse(ShopGroup::isSharingLocked($this->groupId, 'order'));
+    }
+
+    private function givenAGroupWithOneShopAndACustomer(): void
+    {
+        $this->groupId = $this->createGroup();
+        $shopId = $this->createShop('Probe16804 shop A');
+        $this->shopIds[] = $shopId;
+        Shop::cacheShops(true);
+
+        $customer = new Customer();
+        $customer->firstname = 'Probe';
+        $customer->lastname = 'Sharing';
+        $customer->email = 'probe16804@example.com';
+        // Customer::$definition validates this with isHashedPassword, which insists on a
+        // 32 or 60 character string, so a plain literal is rejected.
+        $customer->passwd = password_hash('probe16804', PASSWORD_BCRYPT);
+        $customer->id_shop = $shopId;
+        $customer->id_shop_group = $this->groupId;
+        $customer->add();
+        $this->customerId = (int) $customer->id;
+    }
+
+    private function createGroup(): int
+    {
+        $group = new ShopGroup();
+        $group->name = 'Probe16804 group';
+        $group->active = true;
+        $group->add();
+
+        return (int) $group->id;
+    }
+
+    private function createShop(string $name): int
+    {
+        $shop = new Shop();
+        $shop->name = $name;
+        $shop->id_shop_group = $this->groupId;
+        $shop->id_category = (int) Configuration::get('PS_HOME_CATEGORY');
+        $shop->theme_name = _THEME_NAME_;
+        $shop->active = true;
+        $shop->add();
+
+        return (int) $shop->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | "Share customers" and "Share orders" were disabled on a shop group as soon as `ShopGroup::hasDependency()` found a single customer or order in it. The guard exists because turning sharing on moves those records from the scope of one shop to the scope of the whole group, and doing that to existing data would show one shop's customers and orders to another shop with no warning. That reasoning needs a second shop: while a group holds at most one shop the two scopes are the same set of shops, the flag decides nothing, and there is nobody to expose the data to. As shipped, the first order a single-shop merchant takes locks the option permanently - the documented way out is to create a second group and move the shop into it, which `AdminShopController` then refuses once quantities are shared, so a live shop has no way back at all. The form now asks `ShopGroup::isSharingLocked()`, which adds the shop count the guard was missing. `hasDependency()` keeps answering the question it is named for, because `AdminShopController:453` uses it to decide whether a shop may be moved into a sharing group - there the data really would become visible to another shop, and that call site is deliberately untouched.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable multistore on a shop that has at least one customer or order and only one shop in its default group. Advanced Parameters > Multistore, edit the default group: before this change "Share customers" and "Share orders" are greyed out for good; after it they can be changed. Then add a second shop to that group and edit it again - both fields must be locked once more, which is the case the guard is actually for. `tests/Integration/Classes/shop/ShopGroupSharingLockTest.php` covers all three states.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #16804
| Related PRs       |
| Sponsor company   |

## Measured on develop

That the flags are a no-op while the group holds one shop is measured, not argued. Flipping all
three on the default group of a shop with one shop, 2 customers and 60039 orders, and counting
through `Shop::addSqlRestriction()` in `CONTEXT_SHOP`:

```
                        customers   orders
  sharing OFF                   2    60039
  sharing ON                    2    60039
```

Identical, so nothing becomes visible or invisible. The flags were restored afterwards.

The guard's own state on that installation, which is what the form reads:

```
  group 1 (Default): shops=1  hasDependency(customer)=true  hasDependency(order)=true  -> both fields locked
```

## Tests

`ShopGroupSharingLockTest` (3 tests, 6 assertions):

- a group with one shop and a customer: `hasDependency()` is still true - asserted, so the fixture
  cannot silently stop having data - while `isSharingLocked()` is false;
- the same group after a second shop is added: locked again;
- a group with one shop and no data: never locked.

Mutation check: dropping the shop-count condition from `isSharingLocked()`, so it delegates
straight to `hasDependency()` as before, fails the first test and leaves the other two green. With
the condition restored all three pass.

## Gate

- `php -l` on all three files: clean
- php-cs-fixer: exit 0 (it moved a `\Configuration` reference to a `use` import; applied)
- PHPStan level 5 with `phpstan.neon.dist`: no errors. Verified the run was real by temporarily
  calling an undefined function in the touched method - PHPStan reported it, so the OK is not a
  no-op.
- Integration suite for the new test: 3/3 green

## Not changed on purpose

`AdminShopController:453` still calls `hasDependency()`. Moving an existing shop into a group that
already shares and already holds data is the case where records genuinely would cross a shop
boundary, so that check has to stay as strict as it is.
