### PR TITLE
Keep a category's own values when a CSV row only updates some of them

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1149,15 +1149,19 @@ class AdminImportControllerCore extends AdminController
 
             return;
         }
-        AdminImportController::setDefaultValues($info);
-
         if (!$force_ids) {
             unset($info['id']);
         }
 
         if ($force_ids && isset($info['id']) && (int) $info['id'] && Category::existsInDatabase((int) $info['id'], 'category')) {
+            // An existing category keeps every column the file did not mention. The
+            // default values describe a NEW category, so applying them here would
+            // silently rewrite what was not asked for: a file carrying only a rewritten
+            // URL would reparent the category to Home, reactivate it if it was
+            // disabled, and drop its URL - none of which the row asked for.
             $category = new Category((int) $info['id']);
         } else {
+            AdminImportController::setDefaultValues($info);
             $category = new Category();
         }
 
@@ -1276,8 +1280,11 @@ class AdminImportControllerCore extends AdminController
                 $category->id_parent
             );
 
-            // If category already in base, get id category back
-            if ($category_already_created['id_category']) {
+            // If category already in base, get id category back.
+            // getRow() returns false when nothing matches, which is the normal case for
+            // a category the file is creating - indexing that directly warns on every
+            // new row.
+            if (!empty($category_already_created['id_category'])) {
                 $cat_moved[$category->id] = (int) $category_already_created['id_category'];
                 $category->id = (int) $category_already_created['id_category'];
                 if (Validate::isDate($category_already_created['date_add'])) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `categoryImportOne()` applies the entity default values (`parent` = Home, `active` = 1, `link_rewrite` = '') before deciding whether the row creates or updates a category. With Force IDs on, an update therefore receives those defaults on top of the loaded category and writes them back: a row carrying only an id and a rewritten URL moves the category to Home and re-enables it if it had been disabled. The defaults describe a **new** category, so they are now applied only on the branch that creates one; an existing category keeps whatever the row does not carry, which is how every other column in this importer already behaves. The same function's lookup a few lines below is also guarded: `Category::searchByNameAndParentCategoryId()` returns `false` when nothing matches - the normal case for a category being created - and the result was indexed directly, so every new row emitted a PHP warning.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a category under a parent other than Home and disable it. Advanced Parameters > Import > Categories, with "Force IDs" enabled, import a file whose only columns are `id` and `link_rewrite`, pointing at that category. Before: it is moved under Home and re-enabled. After: it keeps its parent and stays disabled, and only the URL changes. Importing a file that creates categories behaves as before, without the warning it used to emit for each new row.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #17696
| Related PRs       |
| Sponsor company   |

---

**Measured, base vs branch.** A category created under a fixture parent, disabled, then run through the
real `categoryImportOne()` with `['id' => X, 'link_rewrite' => 'renamed']` and Force IDs on:

| | base | branch |
| --- | --- | --- |
| `id_parent` | fixture parent -> **2 (Home)** | kept |
| `active` | 0 -> **1** | kept at 0 |
| `link_rewrite` | updated | updated |
| PHP warning | `Trying to access array offset on value of type bool` | none |

Creating a new category through the same method still works and no longer warns.

The `active` reset is not in the report and is the more damaging half: a URL-only import silently
publishes every disabled category it touches.

---

**On the 2020 exchange.** The first answer on the issue was that this is normal behaviour, because the
default parent applies when the column is absent. The reporter's counter is the one this follows: "all
other data (like active, descriptions, metas, images...) are not updated when it isn't specified in CSV
file. So why parent category is?" - and the same maintainer then agreed, "I think it could be a good
improvement", and asked the product team, who did not reply. The measurement above shows the premise of
the original answer was also incomplete: `active` is reset too, so the behaviour was not consistent with
the rest of the importer even on its own terms.
