### PR TITLE
Pin the SQL manager to the all shops context and say why

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\RequestSqlFilters;
 use PrestaShop\PrestaShop\Core\SqlManager\Exporter\SqlRequestExporter;
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -44,6 +45,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 /**
  * Responsible of "Configure > Advanced Parameters > Database -> SQL Manager" page.
  */
+#[AllShopContext]
 class SqlManagerController extends PrestaShopAdminController
 {
     /**
@@ -82,6 +84,12 @@ class SqlManagerController extends PrestaShopAdminController
             'layoutTitle' => $this->trans('SQL manager', [], 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'multistoreInfoTip' => $this->trans(
+                'Note that this page is available in all shops context only, this is why your context has just switched.',
+                [],
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->getShopContext()->isMultiShopUsed() && $this->getShopContext()->getShopConstraint()->getShopId() !== null,
             'requestSqlSettingsForm' => $settingsForm->createView(),
             'requestSqlGrid' => $this->presentGrid($grid),
         ]);
@@ -158,7 +166,7 @@ class SqlManagerController extends PrestaShopAdminController
                 [],
                 'Admin.Notifications.Info'
             ),
-            'multistoreIsUsed' => $this->getShopContext()->isMultiShopUsed(),
+            'multistoreIsUsed' => $this->getShopContext()->isMultiShopUsed() && $this->getShopContext()->getShopConstraint()->getShopId() !== null,
         ]);
     }
 
@@ -205,6 +213,12 @@ class SqlManagerController extends PrestaShopAdminController
         return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/edit.html.twig', [
             'layoutTitle' => $this->trans('Editing SQL query %query%', ['%query%' => $sqlRequestForm->getData()['name']], 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
+            'multistoreInfoTip' => $this->trans(
+                'Note that this page is available in all shops context only, this is why your context has just switched.',
+                [],
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->getShopContext()->isMultiShopUsed() && $this->getShopContext()->getShopConstraint()->getShopId() !== null,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'requestSqlForm' => $sqlRequestForm->createView(),
             'dbTableNames' => $this->getDatabaseTables(),

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/edit.html.twig
@@ -6,6 +6,8 @@
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block content %}
+  {{ include('@PrestaShop/Admin/Common/multistore-infotip.html.twig') }}
+
   {% if requestSqlForm.vars.errors is not empty %}
     <div class="alert alert-danger">
       {% for error in requestSqlForm.vars.errors %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/index.html.twig
@@ -6,6 +6,8 @@
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block content %}
+  {{ include('@PrestaShop/Admin/Common/multistore-infotip.html.twig') }}
+
   {% block sql_manager_info_block %}
     <div class="alert alert-info" role="alert">
       <p class="alert-text">{{ 'How do I create a new SQL query?'|trans({}, 'Admin.Advparameters.Help') }}</p>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | SQL manager data has no shop dimension - `ps_request_sql` is keyed on `id_request_sql` alone, with no `id_shop` column and no association table, and the multi-statements setting is written into `config/defines_custom.inc.php`, a file shared by the whole installation. Editing any of it from a single shop context changes it everywhere with nothing on screen saying so. The other Advanced Parameters pages whose data is installation-wide already solve this with the `AllShopContext` attribute plus the multistore info tip (Security, Permissions, Profiles, Feature flags, Tags); this applies the same pattern instead of adding a third one. The pattern also turned out to be half applied here: `create` already included the tip, `index` and `edit` passed neither variable and included nothing, and no action carried the attribute - so the tip's text about the context "having just switched" was not true anywhere. `create` additionally showed the tip whenever multistore was in use, including in the all shops context where there is nothing to explain; its condition now matches the other pages.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With multistore on, switch the header context to a single shop and open Advanced Parameters > Database > SQL manager. The context switches to all shops and an info tip explains why. Same on the SQL query create and edit screens. In the all shops context no tip is shown. With multistore off nothing changes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #19356
| Related PRs       |
| Sponsor company   |

---

**Measured, base vs branch.** `ShopContextSubscriber` decides the constraint by reflecting on the
controller for `AllShopContext` (`src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php`,
lines 367-378). Running that same lookup:

| action | base | branch |
| --- | --- | --- |
| `indexAction` | class=0 method=0 -> `null`, context not forced | class=1 -> `ShopConstraint::allShops()` |
| `editAction` | class=0 method=0 -> `null` | class=1 -> `allShops()` |
| `createAction` | class=0 method=0 -> `null` | class=1 -> `allShops()` |

`SecurityController`, used as the reference, reports `class=1 -> allShops()` on both.

`php-cs-fixer` exit 0, `phpstan -c phpstan.neon.dist` OK, `lint:twig` OK on all 7 templates in the
directory.

**On tests:** none of the eight controllers that already carry `AllShopContext` has a per-controller
test for it; the behaviour lives in `ShopContextSubscriber`, which has its own unit test. Worth
flagging separately: `tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php`
currently reports 33 tests / 33 errors / 0 assertions **on an unmodified `9.2.x` checkout**, so that
file is already broken independently of this change.

**On the linked spec.** The issue asks for disabled fields with a hover message, per the multistore
special-cases spec. That shape fits a page where the rest of the content is shop-meaningful and only
some fields are not. Here nothing on the page is: the grid, the CRUD and the settings are all
installation-wide, which is why forcing the context is both simpler and more honest than leaving the
page open with three disabled fields on it.
