### PR TITLE
Write a UTF-8 BOM from back office CSV exports, and skip one on import

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1065,6 +1065,8 @@ class AdminControllerCore extends Controller
         header('Content-disposition: attachment; filename="' . $this->table . '_' . date('Y-m-d_His') . '.csv"');
 
         $fd = fopen('php://output', 'wb');
+        // Spreadsheets have no other way to know the stream is UTF-8, see Utf8Bom.
+        fwrite($fd, PrestaShop\PrestaShop\Core\Util\File\Utf8Bom::SEQUENCE);
         $headers = [];
         foreach ($this->fields_list as $key => $datas) {
             if ('PDF' === $datas['title']) {

--- a/classes/module/ModuleGraph.php
+++ b/classes/module/ModuleGraph.php
@@ -234,6 +234,8 @@ abstract class ModuleGraphCore extends Module
         }
         header('Content-Type: application/octet-stream');
         header('Content-Disposition: attachment; filename="' . $this->displayName . ' - ' . time() . '.csv"');
+        // Spreadsheets have no other way to know the file is UTF-8, see Utf8Bom.
+        echo PrestaShop\PrestaShop\Core\Util\File\Utf8Bom::SEQUENCE;
         echo $this->_csv;
         exit;
     }

--- a/classes/module/ModuleGrid.php
+++ b/classes/module/ModuleGrid.php
@@ -171,6 +171,8 @@ abstract class ModuleGridCore extends Module
         }
         header('Content-Type: application/octet-stream');
         header('Content-Disposition: attachment; filename="' . $this->displayName . ' - ' . time() . '.csv"');
+        // Spreadsheets have no other way to know the file is UTF-8, see Utf8Bom.
+        echo PrestaShop\PrestaShop\Core\Util\File\Utf8Bom::SEQUENCE;
         echo $this->_csv;
         exit;
     }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -848,10 +848,7 @@ class AdminImportControllerCore extends AdminController
         if (!is_resource($handle)) {
             return false;
         }
-        rewind($handle);
-        if (($bom = fread($handle, 3)) != "\xEF\xBB\xBF") {
-            rewind($handle);
-        }
+        PrestaShop\PrestaShop\Core\Util\File\Utf8Bom::skip($handle);
     }
 
     protected static function getBoolean($field)

--- a/src/Core/Export/FileWriter/ExportCsvFileWriter.php
+++ b/src/Core/Export/FileWriter/ExportCsvFileWriter.php
@@ -10,6 +10,7 @@ use Exception;
 use PrestaShop\PrestaShop\Core\Export\Data\ExportableDataInterface;
 use PrestaShop\PrestaShop\Core\Export\Exception\FileWritingException;
 use PrestaShop\PrestaShop\Core\Export\ExportDirectory;
+use PrestaShop\PrestaShop\Core\Util\File\Utf8Bom;
 use SplFileInfo;
 use SplFileObject;
 
@@ -46,6 +47,8 @@ final class ExportCsvFileWriter implements FileWriterInterface
             );
         }
 
+        // Spreadsheets have no other way to know the file is UTF-8, see Utf8Bom.
+        $exportFile->fwrite(Utf8Bom::SEQUENCE);
         $exportFile->fputcsv($data->getTitles(), $separator, '"', '');
 
         foreach ($data->getRows() as $row) {

--- a/src/Core/Import/File/CsvFileReader.php
+++ b/src/Core/Import/File/CsvFileReader.php
@@ -8,6 +8,7 @@ namespace PrestaShop\PrestaShop\Core\Import\File;
 
 use PrestaShop\PrestaShop\Core\Import\Exception\UnreadableFileException;
 use PrestaShop\PrestaShop\Core\Import\File\DataRow\DataRow;
+use PrestaShop\PrestaShop\Core\Util\File\Utf8Bom;
 use SplFileInfo;
 
 /**
@@ -72,6 +73,9 @@ final class CsvFileReader implements FileReaderInterface
 
         $convertToUtf8 = !mb_check_encoding(file_get_contents($file), 'UTF-8');
         $handle = $this->fileOpener->open($file);
+        // Excel's "CSV UTF-8" writes a BOM, and so do our own exports; without this the
+        // three bytes land in the first header cell and that column stops matching.
+        Utf8Bom::skip($handle);
 
         while ($row = fgetcsv($handle, $this->length, $this->delimiter, $this->enclosure, $this->escape)) {
             if ($convertToUtf8) {

--- a/src/Core/Util/File/Utf8Bom.php
+++ b/src/Core/Util/File/Utf8Bom.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Util\File;
+
+/**
+ * The UTF-8 byte order mark, and the one place that knows its byte sequence.
+ *
+ * WHY it is written to back office CSV exports: the files are UTF-8 but carry no
+ * encoding declaration a spreadsheet can see. Excel on Windows therefore reads them in
+ * the system codepage and mangles every non-ASCII character - a currency symbol becomes
+ * mojibake. The BOM is the only in-band signal Excel honours; an HTTP charset header
+ * does not survive the download.
+ *
+ * WHY it is also skipped on import: PrestaShop is not the only producer of the files it
+ * reads. Excel's own "CSV UTF-8" writes a BOM, so a reader that does not skip one puts
+ * those three bytes into the first column of the header row and the column stops
+ * matching.
+ */
+final class Utf8Bom
+{
+    public const SEQUENCE = "\xEF\xBB\xBF";
+
+    /**
+     * Move an open handle past a leading BOM, leaving it at the first real byte.
+     *
+     * Rewinds either way, so it is safe to call on a handle that has already been read.
+     *
+     * Deliberately typed as mixed rather than resource: the legacy import path passes
+     * whatever it was handed, and a no-op on a non-resource is the useful behaviour
+     * there. The guard below is the contract.
+     *
+     * @param mixed $handle
+     */
+    public static function skip($handle): void
+    {
+        if (!is_resource($handle)) {
+            return;
+        }
+
+        rewind($handle);
+
+        if (fread($handle, strlen(self::SEQUENCE)) !== self::SEQUENCE) {
+            rewind($handle);
+        }
+    }
+}

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -8,6 +8,7 @@ namespace PrestaShopBundle\Component;
 
 use InvalidArgumentException;
 use LogicException;
+use PrestaShop\PrestaShop\Core\Util\File\Utf8Bom;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -322,6 +323,9 @@ class CsvResponse extends StreamedResponse
      */
     private function dumpFile($handle)
     {
+        // Spreadsheets have no other way to know the stream is UTF-8, see Utf8Bom.
+        echo Utf8Bom::SEQUENCE;
+
         fseek($handle, 0);
 
         while (!feof($handle)) {

--- a/tests/Unit/Core/Util/File/Utf8BomTest.php
+++ b/tests/Unit/Core/Util/File/Utf8BomTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Util\File;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Util\File\Utf8Bom;
+
+class Utf8BomTest extends TestCase
+{
+    public function testItIsTheThreeByteUtf8Signature(): void
+    {
+        $this->assertSame("\xEF\xBB\xBF", Utf8Bom::SEQUENCE);
+        $this->assertSame(3, strlen(Utf8Bom::SEQUENCE));
+    }
+
+    public function testItSkipsALeadingBom(): void
+    {
+        $handle = $this->handleContaining(Utf8Bom::SEQUENCE . "first;second\nrow\n");
+
+        Utf8Bom::skip($handle);
+
+        $this->assertSame("first;second\n", fgets($handle));
+    }
+
+    /**
+     * The reason skip() rewinds rather than seeking forward unconditionally: most files
+     * have no BOM, and swallowing their first three bytes would silently corrupt the
+     * header row instead of the encoding.
+     */
+    public function testItLeavesAFileWithoutABomUntouched(): void
+    {
+        $handle = $this->handleContaining("first;second\nrow\n");
+
+        Utf8Bom::skip($handle);
+
+        $this->assertSame("first;second\n", fgets($handle));
+    }
+
+    public function testItDoesNotSwallowBytesThatOnlyLookLikeABom(): void
+    {
+        $handle = $this->handleContaining("\xEF\xBBfirst\n");
+
+        Utf8Bom::skip($handle);
+
+        $this->assertSame("\xEF\xBBfirst\n", fgets($handle));
+    }
+
+    public function testItIsSafeToCallOnAHandleThatHasAlreadyBeenRead(): void
+    {
+        $handle = $this->handleContaining(Utf8Bom::SEQUENCE . "first;second\n");
+        fgets($handle);
+
+        Utf8Bom::skip($handle);
+
+        $this->assertSame("first;second\n", fgets($handle));
+    }
+
+    public function testItIgnoresANonResource(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        Utf8Bom::skip(null);
+        Utf8Bom::skip('not a handle');
+    }
+
+    /**
+     * @return resource
+     */
+    private function handleContaining(string $contents)
+    {
+        $handle = fopen('php://memory', 'r+');
+        fwrite($handle, $contents);
+        rewind($handle);
+
+        return $handle;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Back office CSV exports are UTF-8 but carry no signal a spreadsheet can see, so Excel on Windows reads them in the system codepage and mangles every non-ASCII character - the reported mojibake currency symbol. All five emitters now write the BOM through one shared constant: `ExportCsvFileWriter`, `CsvResponse` (its `dumpFile()` funnel covers both process methods), `AdminController::processExport`, `ModuleGrid::_displayCsv` and `ModuleGraph::_displayCsv`. The last two are the ones the report actually needs - Best categories, Best vouchers and Best-selling products are stats modules going through them, and they build the CSV by hand rather than through any Core writer. The import side is fixed in the same change because otherwise this would break it: `CsvFileReader` had no BOM handling, so a BOM'd file (including Excel's own "CSV UTF-8") put three bytes into the first header cell and that column stopped matching. It now skips one, which the legacy importer already did in `rewindBomAware()`; that method delegates to the same helper so the byte sequence lives in one place.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | BO > Stats > Best-selling products > CSV Export, with a currency whose symbol is non-ASCII. Open the file in Excel on Windows: the symbol is correct, with no import wizard and no manual codepage choice. Same for Best categories and Best vouchers, and for a grid export from any BO listing. Then Advanced Parameters > Import a CSV saved by Excel as "CSV UTF-8": the first column header matches instead of being rejected.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #19807
| Related PRs       |
| Sponsor company   |

---

**Measured, base vs branch** - first three bytes actually produced by each emitter, read from
its own output (the two module ones `echo` and `exit`, so that is stdout of a separate process):

| emitter | base | branch |
| --- | --- | --- |
| `ModuleGrid::_displayCsv` (Best-selling products) | `63 6f 6c` | `ef bb bf` |
| `ModuleGraph::_displayCsv` | `63 6f 6c` | `ef bb bf` |
| `ExportCsvFileWriter::write` | `63 6f 6c` | `ef bb bf` |
| `CsvResponse::dumpFile` | `63 6f 6c` | `ef bb bf` |

Import, same measurement on the first header cell:

| input | base | branch |
| --- | --- | --- |
| CSV **with** BOM | `ef bb bf 69` - header is `\xEF\xBB\xBFid`, column does not match | `69 64` - `id` |
| CSV **without** BOM | `69 64` | `69 64`, unchanged |

`tests/Unit/Core/Util/File/Utf8BomTest.php`: 6 tests, 6 assertions, green. Mutating the constant to a
two-byte sequence turns two of them red, so they discriminate. `php-cs-fixer` exit 0 and `phpstan -c
phpstan.neon.dist` OK on all nine files.

---

**On the design question this issue stalled on in 2022.** #27495 carried three approvals and was closed
in 2023 for staleness only, after a disagreement about whether the BOM should be optional
(@davidglezz: "the BOM has always been a source of issues... reading the csv with a PHP script will no
longer be as easy"). This writes it unconditionally, deliberately:

- these are merchant-facing downloads whose realistic consumer is a spreadsheet; a parser-friendly feed
  is what the webservice and the Admin API are for;
- there is no existing CSV or export encoding setting to hang a toggle on, so making it optional means a
  new Configuration key, a back office field, a translation, and threading it through five emitters -
  more surface than the fix;
- the one in-product consumer that a BOM would have broken is the CSV import, and this change fixes that
  rather than leaving it as the reason not to act.

`classes/CSV.php` also emits CSV headers but has no callers anywhere in the codebase, so it is left
alone. `modules/psgdpr` has its own exporter and belongs to its own repository.
