### PR TITLE
Default the installer SSL option to the scheme the installer is served over

### DIFF
--- a/install-dev/controllers/http/configure.php
+++ b/install-dev/controllers/http/configure.php
@@ -206,6 +206,19 @@ class InstallControllerHttpConfigure extends InstallControllerHttp implements Ht
             }
         }
 
+        // Default SSL to the scheme the installer is itself being served over. A shop
+        // configured for HTTP behind a host that force-redirects to HTTPS ends up in a
+        // redirect loop, and mirroring the installer's own scheme is the least surprising
+        // default. The merchant can still switch it off on this same screen.
+        //
+        // WHY isset() rather than the falsy check used for the country just below: `false`
+        // is a legitimate stored answer here, so `!$this->session->enable_ssl` would be true
+        // both when the question has never been asked AND when the merchant answered "No" -
+        // re-applying the default on every redisplay and silently overwriting that answer.
+        if (!isset($this->session->enable_ssl)) {
+            $this->session->enable_ssl = Tools::usingSecureMode();
+        }
+
         // Try to detect default country
         if (!$this->session->shop_country) {
             $detect_language = $this->language->detectLanguage();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | On step 4 the "Enable SSL" radio always started on **No**, whatever scheme the installer itself was reached over. On a host that force-redirects HTTP to HTTPS this leaves the finished shop configured for HTTP and the merchant lands in a redirect loop. The radio now starts on the value the installer is actually running under, detected with the existing `Tools::usingSecureMode()` so proxy and load-balancer setups (`X-Forwarded-Proto`) are covered too. It is a default, not a lock: the merchant changes it on the same screen. The default is applied only when the question has not been answered yet - guarded with `isset()`, not with the falsy check used for the country default a few lines below, because `false` is a legitimate stored answer and a falsy check would re-apply the default on every redisplay and silently overwrite an explicit "No". CLI install is untouched: it has no request scheme, so `datas.php` keeps `'default' => 0`.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Serve the installer over HTTPS (or over HTTP through a proxy sending `X-Forwarded-Proto: https`) and open step 4 "Shop information": "Enable SSL" is preselected to **Yes**. Reach the same step over plain HTTP: it is **No**, as before. Then answer **No** on an HTTPS install, navigate back to step 4: it stays **No** and is not silently flipped back to Yes.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #19991
| Related PRs       |
| Sponsor company   |

---

**Measured, base vs fixed** (real `InstallSession` + real `Tools::usingSecureMode()`, reading the
condition the template uses at `install-dev/theme/views/configure.php:57`):

| Scenario | base | fixed |
|---|---|---|
| plain HTTP, first display | No | No |
| `HTTPS=on`, first display | **No** | **Yes** |
| `X-Forwarded-Proto: https`, first display | **No** | **Yes** |
| `HTTPS=on`, merchant answered No | No | **No** |
| `HTTPS=on`, merchant answered Yes | Yes | Yes |
| plain HTTP, merchant answered Yes | Yes | Yes |

Three negative controls hold: no change on plain HTTP, and an explicit merchant answer survives in
both directions. `php -l`, `php-cs-fixer` (exit 0, 0 fixes) and `phpstan -c phpstan.neon.dist` (OK, no
errors - `install-dev` is in the scanned paths) all clean on the touched file.

**Thread context:** #19791 added the "Enable SSL" option itself; Progi1984 then restated the remaining
ask precisely - "you would like that option would be selected on Yes for Enable SSL only if the
installer is in HTTPS. Right?" - and the reporter confirmed. This implements exactly that.
