### PR TITLE
Keep the PDO connection attributes, and allow TLS to the database

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -49,21 +49,32 @@ class DbPDOCore extends Db
          * replacements are the new Pdo\Mysql:: constants, introduced in PHP 8.4. Unfortunately, we don't
          * have one solution that fits all supported PHP versions.
          */
+        /*
+         * These are assigned rather than merged: PDO attributes are integer constants, and
+         * array_merge() renumbers integer keys, so merging replaced every attribute with a
+         * meaningless one and PDO fell back to its own defaults.
+         */
         if (PHP_VERSION_ID >= 80500) {
-            $options = array_merge($options, [
-                /* @phpstan-ignore-next-line */
-                Pdo\Mysql::ATTR_USE_BUFFERED_QUERY => true,
-                /* @phpstan-ignore-next-line */
-                Pdo\Mysql::ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
-                /* @phpstan-ignore-next-line */
-                Pdo\Mysql::ATTR_MULTI_STATEMENTS => _PS_ALLOW_MULTI_STATEMENTS_QUERIES_,
-            ]);
+            /* @phpstan-ignore-next-line */
+            $options[Pdo\Mysql::ATTR_USE_BUFFERED_QUERY] = true;
+            /* @phpstan-ignore-next-line */
+            $options[Pdo\Mysql::ATTR_INIT_COMMAND] = 'SET NAMES utf8mb4';
+            /* @phpstan-ignore-next-line */
+            $options[Pdo\Mysql::ATTR_MULTI_STATEMENTS] = _PS_ALLOW_MULTI_STATEMENTS_QUERIES_;
         } else {
-            $options = array_merge($options, [
-                PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
-                PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
-                PDO::MYSQL_ATTR_MULTI_STATEMENTS => _PS_ALLOW_MULTI_STATEMENTS_QUERIES_,
-            ]);
+            $options[PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = true;
+            $options[PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES utf8mb4';
+            $options[PDO::MYSQL_ATTR_MULTI_STATEMENTS] = _PS_ALLOW_MULTI_STATEMENTS_QUERIES_;
+        }
+
+        foreach (self::getSslOptions(
+            _PS_DB_SSL_CA_,
+            _PS_DB_SSL_CERT_,
+            _PS_DB_SSL_KEY_,
+            _PS_DB_SSL_VERIFY_SERVER_CERT_,
+            PHP_VERSION_ID >= 80500
+        ) as $attribute => $value) {
+            $options[$attribute] = $value;
         }
 
         return new PDO(
@@ -72,6 +83,67 @@ class DbPDOCore extends Db
             $password,
             $options
         );
+    }
+
+    /**
+     * PDO options for a TLS connection, or an empty array when none of the paths is configured.
+     *
+     * Naming the certificate authority is the right answer wherever it is possible. Verification is
+     * nonetheless made switchable, because a server presenting a certificate that cannot match the
+     * host it is reached on, which is what MySQL's own auto generated certificates do, refuses the
+     * connection outright even when the authority is correct. Without the switch TLS would be
+     * unusable against a stock MySQL, and encryption without authentication still removes passive
+     * eavesdropping, so it is offered rather than pretended not to exist.
+     *
+     * @param string $ca path to the certificate authority bundle
+     * @param string $cert path to the client certificate, for a server that asks for one
+     * @param string $key path to the client certificate's key
+     * @param bool $verifyServerCert whether the server's certificate has to match the host
+     * @param bool $useModernConstants whether the Pdo\Mysql constants are available, PHP 8.4 and up
+     *
+     * @return array<int, mixed>
+     */
+    protected static function getSslOptions($ca, $cert, $key, $verifyServerCert, $useModernConstants)
+    {
+        $options = [];
+
+        /*
+         * PHP 8.5 deprecated the driver specific PDO:: prefixed constants, as above, so the same
+         * split applies here.
+         */
+        if ($useModernConstants) {
+            /* @phpstan-ignore-next-line */
+            $keys = [
+                'ca' => Pdo\Mysql::ATTR_SSL_CA,
+                'cert' => Pdo\Mysql::ATTR_SSL_CERT,
+                'key' => Pdo\Mysql::ATTR_SSL_KEY,
+            ];
+        } else {
+            $keys = [
+                'ca' => PDO::MYSQL_ATTR_SSL_CA,
+                'cert' => PDO::MYSQL_ATTR_SSL_CERT,
+                'key' => PDO::MYSQL_ATTR_SSL_KEY,
+            ];
+        }
+
+        foreach (['ca' => $ca, 'cert' => $cert, 'key' => $key] as $name => $path) {
+            if (is_string($path) && '' !== $path) {
+                $options[$keys[$name]] = $path;
+            }
+        }
+
+        // Only meaningful alongside TLS material, and only worth sending when it turns the check
+        // off, so a shop that configures nothing keeps PDO's own behaviour untouched.
+        if ([] !== $options && !$verifyServerCert) {
+            // Resolved here rather than alongside the others because the Pdo\Mysql polyfill below
+            // PHP 8.4 declares several feature detected variants and only one carries this one.
+            $verifyAttribute = $useModernConstants
+                ? constant('Pdo\\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')
+                : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+            $options[$verifyAttribute] = false;
+        }
+
+        return $options;
     }
 
     /**

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -54,6 +54,33 @@ if (!defined('_PS_ALLOW_MULTI_STATEMENTS_QUERIES_')) {
     define('_PS_ALLOW_MULTI_STATEMENTS_QUERIES_', false);
 }
 
+/*
+ * TLS material for the database connection, for a shop whose database is not on the same host.
+ * Each one is a path, read from the environment so a deployment can set it without editing files,
+ * and definable in config/defines_custom.inc.php like every other define here. Leaving them empty,
+ * which is the default, connects exactly as before.
+ */
+if (!defined('_PS_DB_SSL_CA_')) {
+    define('_PS_DB_SSL_CA_', getenv('PS_DB_SSL_CA') ?: '');
+}
+if (!defined('_PS_DB_SSL_CERT_')) {
+    define('_PS_DB_SSL_CERT_', getenv('PS_DB_SSL_CERT') ?: '');
+}
+if (!defined('_PS_DB_SSL_KEY_')) {
+    define('_PS_DB_SSL_KEY_', getenv('PS_DB_SSL_KEY') ?: '');
+}
+/*
+ * Whether the server's certificate has to match the host being connected to. Leave it alone unless
+ * the database presents a certificate that cannot match, which is what MySQL's own auto generated
+ * certificates do; turning it off keeps the connection encrypted but stops it proving who answered.
+ */
+if (!defined('_PS_DB_SSL_VERIFY_SERVER_CERT_')) {
+    define(
+        '_PS_DB_SSL_VERIFY_SERVER_CERT_',
+        !in_array(strtolower((string) getenv('PS_DB_SSL_VERIFY_SERVER_CERT')), ['0', 'false', 'off', 'no'], true)
+    );
+}
+
 $currentDir = dirname(__FILE__);
 
 if (!defined('_PS_ROOT_DIR_') && (getenv('_PS_ROOT_DIR_') || getenv('REDIRECT__PS_ROOT_DIR_'))) {
@@ -62,19 +89,19 @@ if (!defined('_PS_ROOT_DIR_') && (getenv('_PS_ROOT_DIR_') || getenv('REDIRECT__P
 
 /* Directories */
 if (!defined('_PS_ROOT_DIR_')) {
-    define('_PS_ROOT_DIR_', realpath($currentDir.'/..'));
+    define('_PS_ROOT_DIR_', realpath($currentDir . '/..'));
 }
 
 if (!defined('_PS_CORE_DIR_')) {
-    define('_PS_CORE_DIR_', realpath($currentDir.'/..'));
+    define('_PS_CORE_DIR_', realpath($currentDir . '/..'));
 }
 
 if (!defined('_PS_ALL_THEMES_DIR_')) {
-    define('_PS_ALL_THEMES_DIR_', _PS_ROOT_DIR_.'/themes/');
+    define('_PS_ALL_THEMES_DIR_', _PS_ROOT_DIR_ . '/themes/');
 }
 /* BO THEMES */
 if (defined('_PS_ADMIN_DIR_')) {
-    define('_PS_BO_ALL_THEMES_DIR_', _PS_ADMIN_DIR_.'/themes/');
+    define('_PS_BO_ALL_THEMES_DIR_', _PS_ADMIN_DIR_ . '/themes/');
 }
 
 // Find if we are running under a Symfony command
@@ -92,7 +119,7 @@ if ((defined('_PS_IN_TEST_') && _PS_IN_TEST_)
 ) {
     define('_PS_ENV_', 'test');
 } else {
-    define('_PS_ENV_', _PS_MODE_DEV_ ? 'dev': 'prod');
+    define('_PS_ENV_', _PS_MODE_DEV_ ? 'dev' : 'prod');
 }
 
 // This legacy const is used in many legacy components (smarty, parameters caching, ...) We don't change this one
@@ -100,62 +127,62 @@ if ((defined('_PS_IN_TEST_') && _PS_IN_TEST_)
 // (dev, prod, test) will contain some cache folder common to all the kernels, it simplifies the cache clearing
 // for legacy codes since they only need to clear one cache and not three
 if (!defined('_PS_CACHE_DIR_')) {
-    define('_PS_CACHE_DIR_', _PS_ROOT_DIR_.'/var/cache/' . _PS_ENV_ . DIRECTORY_SEPARATOR);
+    define('_PS_CACHE_DIR_', _PS_ROOT_DIR_ . '/var/cache/' . _PS_ENV_ . DIRECTORY_SEPARATOR);
 }
 
-define('_PS_CONFIG_DIR_', _PS_CORE_DIR_.'/config/');
-define('_PS_CUSTOM_CONFIG_FILE_', _PS_CONFIG_DIR_.'settings_custom.inc.php');
-define('_PS_CLASS_DIR_', _PS_CORE_DIR_.'/classes/');
+define('_PS_CONFIG_DIR_', _PS_CORE_DIR_ . '/config/');
+define('_PS_CUSTOM_CONFIG_FILE_', _PS_CONFIG_DIR_ . 'settings_custom.inc.php');
+define('_PS_CLASS_DIR_', _PS_CORE_DIR_ . '/classes/');
 if (!defined('_PS_DOWNLOAD_DIR_')) {
     $dir = (defined('_PS_IN_TEST_') && _PS_IN_TEST_) ? '/tests/Resources/download/' : '/download/';
-    define('_PS_DOWNLOAD_DIR_', _PS_ROOT_DIR_.$dir);
+    define('_PS_DOWNLOAD_DIR_', _PS_ROOT_DIR_ . $dir);
 }
-define('_PS_MAIL_DIR_', _PS_CORE_DIR_.'/mails/');
+define('_PS_MAIL_DIR_', _PS_CORE_DIR_ . '/mails/');
 if (!defined('_PS_MODULE_DIR_')) {
-    define('_PS_MODULE_DIR_', _PS_ROOT_DIR_.'/modules/');
+    define('_PS_MODULE_DIR_', _PS_ROOT_DIR_ . '/modules/');
 }
 if (!defined('_PS_OVERRIDE_DIR_')) {
-    define('_PS_OVERRIDE_DIR_', _PS_ROOT_DIR_.'/override/');
+    define('_PS_OVERRIDE_DIR_', _PS_ROOT_DIR_ . '/override/');
 }
-define('_PS_PDF_DIR_', _PS_CORE_DIR_.'/pdf/');
-define('_PS_TRANSLATIONS_DIR_', _PS_ROOT_DIR_.'/translations/');
+define('_PS_PDF_DIR_', _PS_CORE_DIR_ . '/pdf/');
+define('_PS_TRANSLATIONS_DIR_', _PS_ROOT_DIR_ . '/translations/');
 if (!defined('_PS_UPLOAD_DIR_')) {
-    define('_PS_UPLOAD_DIR_', _PS_ROOT_DIR_.'/upload/');
+    define('_PS_UPLOAD_DIR_', _PS_ROOT_DIR_ . '/upload/');
 }
-define('_PS_CONTROLLER_DIR_', _PS_CORE_DIR_.'/controllers/');
-define('_PS_ADMIN_CONTROLLER_DIR_', _PS_CORE_DIR_.'/controllers/admin/');
-define('_PS_FRONT_CONTROLLER_DIR_', _PS_CORE_DIR_.'/controllers/front/');
+define('_PS_CONTROLLER_DIR_', _PS_CORE_DIR_ . '/controllers/');
+define('_PS_ADMIN_CONTROLLER_DIR_', _PS_CORE_DIR_ . '/controllers/admin/');
+define('_PS_FRONT_CONTROLLER_DIR_', _PS_CORE_DIR_ . '/controllers/front/');
 
-define('_PS_TOOL_DIR_', _PS_CORE_DIR_.'/tools/');
+define('_PS_TOOL_DIR_', _PS_CORE_DIR_ . '/tools/');
 if (!defined('_PS_GEOIP_DIR_')) {
-    define('_PS_GEOIP_DIR_', _PS_CORE_DIR_.'/app/Resources/geoip/');
+    define('_PS_GEOIP_DIR_', _PS_CORE_DIR_ . '/app/Resources/geoip/');
 }
 if (!defined('_PS_GEOIP_CITY_FILE_')) {
     define('_PS_GEOIP_CITY_FILE_', 'GeoLite2-City.mmdb');
 }
 
-define('_PS_VENDOR_DIR_', _PS_CORE_DIR_.'/vendor/');
+define('_PS_VENDOR_DIR_', _PS_CORE_DIR_ . '/vendor/');
 
-define('_PS_IMG_SOURCE_DIR_', _PS_ROOT_DIR_.'/img/');
+define('_PS_IMG_SOURCE_DIR_', _PS_ROOT_DIR_ . '/img/');
 if (!defined('_PS_IMG_DIR_')) {
     $dir = (defined('_PS_IN_TEST_') && _PS_IN_TEST_) ? '/tests/Resources/img/' : '/img/';
-    define('_PS_IMG_DIR_', _PS_ROOT_DIR_.$dir);
+    define('_PS_IMG_DIR_', _PS_ROOT_DIR_ . $dir);
 }
 
-define('_PS_CORE_IMG_DIR_', _PS_CORE_DIR_.'/img/');
-define('_PS_CAT_IMG_DIR_', _PS_IMG_DIR_.'c/');
-define('_PS_COL_IMG_DIR_', _PS_IMG_DIR_.'co/');
-define('_PS_EMPLOYEE_IMG_DIR_', _PS_IMG_DIR_.'e/');
-define('_PS_GENDERS_DIR_', _PS_IMG_DIR_.'genders/');
-define('_PS_LANG_IMG_DIR_', _PS_IMG_DIR_.'l/');
-define('_PS_MANU_IMG_DIR_', _PS_IMG_DIR_.'m/');
-define('_PS_ORDER_STATE_IMG_DIR_', _PS_IMG_DIR_.'os/');
+define('_PS_CORE_IMG_DIR_', _PS_CORE_DIR_ . '/img/');
+define('_PS_CAT_IMG_DIR_', _PS_IMG_DIR_ . 'c/');
+define('_PS_COL_IMG_DIR_', _PS_IMG_DIR_ . 'co/');
+define('_PS_EMPLOYEE_IMG_DIR_', _PS_IMG_DIR_ . 'e/');
+define('_PS_GENDERS_DIR_', _PS_IMG_DIR_ . 'genders/');
+define('_PS_LANG_IMG_DIR_', _PS_IMG_DIR_ . 'l/');
+define('_PS_MANU_IMG_DIR_', _PS_IMG_DIR_ . 'm/');
+define('_PS_ORDER_STATE_IMG_DIR_', _PS_IMG_DIR_ . 'os/');
 define('_PS_PRODUCT_IMG_DIR_', _PS_IMG_DIR_ . 'p/');
-define('_PS_PROFILE_IMG_DIR_', _PS_IMG_DIR_.'pr/');
-define('_PS_SHIP_IMG_DIR_', _PS_IMG_DIR_.'s/');
-define('_PS_STORE_IMG_DIR_', _PS_IMG_DIR_.'st/');
-define('_PS_SUPP_IMG_DIR_', _PS_IMG_DIR_.'su/');
-define('_PS_TMP_IMG_DIR_', _PS_IMG_DIR_.'tmp/');
+define('_PS_PROFILE_IMG_DIR_', _PS_IMG_DIR_ . 'pr/');
+define('_PS_SHIP_IMG_DIR_', _PS_IMG_DIR_ . 's/');
+define('_PS_STORE_IMG_DIR_', _PS_IMG_DIR_ . 'st/');
+define('_PS_SUPP_IMG_DIR_', _PS_IMG_DIR_ . 'su/');
+define('_PS_TMP_IMG_DIR_', _PS_IMG_DIR_ . 'tmp/');
 
 /* Settings php */
 define('_PS_TRANS_PATTERN_', '(.*[^\\\\])');
@@ -185,7 +212,7 @@ define('_PS_USE_SQL_SLAVE_', false);
 define('_PS_ADMIN_PROFILE_', 1);
 
 /* Cache */
-define('_PS_CACHEFS_DIRECTORY_', _PS_ROOT_DIR_.'/cache/cachefs/');
+define('_PS_CACHEFS_DIRECTORY_', _PS_ROOT_DIR_ . '/cache/cachefs/');
 
 /* Geolocation */
 define('_PS_GEOLOCATION_NO_CATALOG_', 0);
@@ -196,4 +223,4 @@ define('_PS_SMARTY_NO_COMPILE_', 0);
 define('_PS_SMARTY_CHECK_COMPILE_', 1);
 define('_PS_SMARTY_FORCE_COMPILE_', 2);
 
-define('_PS_CACHE_CA_CERT_FILE_', _PS_CACHE_DIR_.'cacert.pem');
+define('_PS_CACHE_CA_CERT_FILE_', _PS_CACHE_DIR_ . 'cacert.pem');

--- a/tests/Unit/Classes/Db/DbPDOSslOptionsTest.php
+++ b/tests/Unit/Classes/Db/DbPDOSslOptionsTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Db;
+
+use DbPDO;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * A shop whose database is on another host had no way to require TLS for it. The paths are now
+ * defines, read from the environment, and they turn into PDO options here.
+ *
+ * A shop that configures none of them must connect exactly as before, which is what most of these
+ * cases pin.
+ */
+class DbPDOSslOptionsTest extends TestCase
+{
+    public function testNothingConfiguredAddsNoOptions(): void
+    {
+        $this->assertSame([], $this->options('', '', ''));
+    }
+
+    public function testTheAuthorityAloneIsEnough(): void
+    {
+        $this->assertSame([PDO::MYSQL_ATTR_SSL_CA => '/etc/ssl/ca.pem'], $this->options('/etc/ssl/ca.pem', '', ''));
+    }
+
+    public function testAClientCertificateIsPassedWithItsKey(): void
+    {
+        $this->assertSame(
+            [
+                PDO::MYSQL_ATTR_SSL_CA => '/ca.pem',
+                PDO::MYSQL_ATTR_SSL_CERT => '/client.pem',
+                PDO::MYSQL_ATTR_SSL_KEY => '/client.key',
+            ],
+            $this->options('/ca.pem', '/client.pem', '/client.key')
+        );
+    }
+
+    public function testAnEmptyPathIsNotPassedAsAnEmptyOption(): void
+    {
+        // An empty string reaching PDO as an SSL path is a connection error, not "no TLS".
+        $options = $this->options('/ca.pem', '', '');
+
+        $this->assertArrayNotHasKey(PDO::MYSQL_ATTR_SSL_CERT, $options);
+        $this->assertArrayNotHasKey(PDO::MYSQL_ATTR_SSL_KEY, $options);
+    }
+
+    public function testVerificationIsOnlySentWhenItIsBeingTurnedOff(): void
+    {
+        $verifying = $this->options('/ca.pem', '', '', true);
+        $notVerifying = $this->options('/ca.pem', '', '', false);
+
+        $this->assertArrayNotHasKey(PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT, $verifying);
+        $this->assertFalse($notVerifying[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]);
+    }
+
+    public function testVerificationIsNotSentWithoutAnyTlsMaterial(): void
+    {
+        // Nothing to verify against, so a shop that only sets the flag connects as it always did.
+        $this->assertSame([], $this->options('', '', '', false));
+    }
+
+    public function testBothConstantFamiliesProduceTheSameOptions(): void
+    {
+        // The method has two branches only because PHP 8.5 deprecated the PDO:: prefixed constants;
+        // the Pdo\Mysql ones are aliases of the same integers, which is what makes the branch safe.
+        // Exercising both branches pins that, without naming either class here: PHP resolves class
+        // names case insensitively but the autoloader does not, and the constants live in a polyfill
+        // below PHP 8.4, so a literal reference in a test is a portability problem of its own.
+        $this->assertSame(
+            $this->options('/ca.pem', '/client.pem', '/client.key', true, false),
+            $this->options('/ca.pem', '/client.pem', '/client.key', true, true)
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function options(
+        string $ca,
+        string $cert,
+        string $key,
+        bool $verify = true,
+        bool $modern = false
+    ): array {
+        $method = new ReflectionMethod(DbPDO::class, 'getSslOptions');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $ca, $cert, $key, $verify, $modern);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `DbPDO::getPDO()` assembled its PDO options with `array_merge()`. PDO attributes are integer constants and `array_merge()` renumbers integer keys, so every attribute after the first arrived under a meaningless number and PDO used its own defaults: the timeout, the buffered query flag, the init command and the multi statements flag were all discarded. They are now assigned into the array. On top of that, a shop whose database is on another host can require TLS for it through three new path defines, read from the environment.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Attributes: give the connection an init command of `SET @probe = 42` and read `SELECT @probe` back. Before this change it is `NULL`, after it is `42`. 2. TLS: set `PS_DB_SSL_CA` to your server's authority and `PS_DB_SSL_VERIFY_SERVER_CERT=false` if its certificate cannot match the host, then check `SHOW STATUS LIKE 'Ssl_cipher'` on the shop's own connection: it names a cipher instead of being empty. 3. Setting none of the three connects exactly as before, with `Ssl_cipher` empty.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #27438
| Related PRs       | None
| Sponsor company   | None

### The attributes were never arriving

```php
$options = [PDO::ATTR_TIMEOUT => $timeout];              // key 2
$options = array_merge($options, [
    PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,          // key 1000
    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4', // key 1002
    ...
]);
```

`array_merge()` preserves string keys and renumbers integer ones, so the keys come out as `0, 1, 2, 3`. PDO is handed nothing at 1000 or 1002, and `ATTR_TIMEOUT`, which is 2, receives the init command string.

Measured with an init command of `SET @probe = 42`, then reading `SELECT @probe`:

| | `@probe` |
| --- | --- |
| through `array_merge()` | `NULL` |
| through assignment | `42` |

Both branches of the PHP 8.5 constant split had it, so this was the same on every supported version. The init command's own effect was masked because the DSN already carries `;charset=utf8mb4`.

### TLS

Three paths, as defines in `config/defines.inc.php` next to `_PS_ALLOW_MULTI_STATEMENTS_QUERIES_`, each defaulting from an environment variable so a deployment can set them without editing files, and overridable in `config/defines_custom.inc.php` like every other define there. Configuring none of them is the default and connects exactly as before.

### Why verification is switchable

Naming the authority ought to be enough, and a switch to stop checking the server's certificate looks like a footgun. Measuring it says otherwise: a stock MySQL presents its own auto generated certificate, whose subject cannot match the host it is reached on, so PDO refuses the connection even when the authority is correct.

| | result |
| --- | --- |
| real authority, verification on | `SQLSTATE[HY000] [2002] Cannot connect to MySQL using SSL` |
| real authority, verification off | connected, `Ssl_cipher = TLS_AES_256_GCM_SHA384` |

Without the switch, TLS would be unusable against a default MySQL, which is most self hosted shops. It defaults to verifying, is only sent to PDO when it is being turned off, and only when TLS material is configured at all.

### Test

`tests/Unit/Classes/Db/DbPDOSslOptionsTest.php` covers the option building: nothing configured adds nothing, the authority alone is enough, a client certificate goes with its key, an empty path is not passed as an empty option, verification is only sent when it is being turned off, it is not sent without TLS material, and both constant families produce the same options.

That last one deliberately does not name either class. PHP resolves class names case insensitively but the autoloader does not, and `Pdo\Mysql` comes from `symfony/polyfill-php84` below PHP 8.4 in several feature detected variants, only one of which carries `ATTR_SSL_VERIFY_SERVER_CERT`. The production code resolves that one constant only when it is actually used, for the same reason.
