### PR TITLE
Add the out of stock behavior to the products bulk actions

### DIFF
--- a/src/Adapter/Product/Stock/CommandHandler/BulkUpdateProductOutOfStockTypeHandler.php
+++ b/src/Adapter/Product/Stock/CommandHandler/BulkUpdateProductOutOfStockTypeHandler.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Stock\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AbstractBulkHandler;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Update\ProductStockProperties;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Update\ProductStockUpdater;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\BulkUpdateProductOutOfStockTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\CommandHandler\BulkUpdateProductOutOfStockTypeHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+
+/**
+ * Applies one out of stock behavior to every selected product.
+ */
+#[AsCommandHandler]
+class BulkUpdateProductOutOfStockTypeHandler extends AbstractBulkHandler implements BulkUpdateProductOutOfStockTypeHandlerInterface
+{
+    public function __construct(
+        private readonly ProductStockUpdater $productStockUpdater,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(BulkUpdateProductOutOfStockTypeCommand $command): void
+    {
+        $this->handleBulkAction($command->getProductIds(), $command);
+    }
+
+    /**
+     * WHY this delegates instead of writing the field: the behavior is stored twice, on
+     * `product.out_of_stock` and on `stock_available.out_of_stock`, and the front office reads the
+     * second one - `Product::loadStockData()` overwrites the product's copy with it. ProductStockUpdater
+     * already writes both and already resolves the shop constraint to the right stock rows, so the bulk
+     * action stays exactly as correct as editing one product in the Stock tab.
+     *
+     * @param BulkUpdateProductOutOfStockTypeCommand $command
+     */
+    protected function handleSingleAction(ProductId $productId, $command = null): void
+    {
+        $this->productStockUpdater->update(
+            $productId,
+            new ProductStockProperties(null, $command->getOutOfStockType()),
+            $command->getShopConstraint()
+        );
+    }
+}

--- a/src/Core/Domain/Product/Stock/Command/BulkUpdateProductOutOfStockTypeCommand.php
+++ b/src/Core/Domain/Product/Stock/Command/BulkUpdateProductOutOfStockTypeCommand.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+/**
+ * Sets the behavior applied when several products run out of stock.
+ */
+class BulkUpdateProductOutOfStockTypeCommand
+{
+    /**
+     * @var ProductId[]
+     */
+    private $productIds;
+
+    /**
+     * @var OutOfStockType
+     */
+    private $outOfStockType;
+
+    /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
+     * @param int[] $productIds
+     *
+     * @throws ProductConstraintException
+     */
+    public function __construct(
+        array $productIds,
+        int $outOfStockType,
+        ShopConstraint $shopConstraint
+    ) {
+        foreach ($productIds as $productId) {
+            $this->productIds[] = new ProductId($productId);
+        }
+        $this->outOfStockType = new OutOfStockType($outOfStockType);
+        $this->shopConstraint = $shopConstraint;
+    }
+
+    /**
+     * @return ProductId[]
+     */
+    public function getProductIds(): array
+    {
+        return $this->productIds;
+    }
+
+    public function getOutOfStockType(): OutOfStockType
+    {
+        return $this->outOfStockType;
+    }
+
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
+    }
+}

--- a/src/Core/Domain/Product/Stock/CommandHandler/BulkUpdateProductOutOfStockTypeHandlerInterface.php
+++ b/src/Core/Domain/Product/Stock/CommandHandler/BulkUpdateProductOutOfStockTypeHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Stock\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\BulkUpdateProductOutOfStockTypeCommand;
+
+interface BulkUpdateProductOutOfStockTypeHandlerInterface
+{
+    public function handle(BulkUpdateProductOutOfStockTypeCommand $command): void;
+}

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Employee\ContextEmployeeProviderInterface;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
@@ -663,6 +664,7 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
             $bulkDisableRoute = 'admin_products_bulk_disable_shop';
             $bulkDuplicateRoute = 'admin_products_bulk_duplicate_shop';
             $bulkDeleteRoute = 'admin_products_bulk_delete_from_shop';
+            $bulkOutOfStockRoute = 'admin_products_bulk_set_out_of_stock_type_shop';
             $routeParams = [
                 'shopId' => $this->shopConstraintContext->getShopConstraint()->getShopId()->getValue(),
             ];
@@ -682,6 +684,7 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
             $bulkDisableRoute = 'admin_products_bulk_disable_shop_group';
             $bulkDuplicateRoute = 'admin_products_bulk_duplicate_shop_group';
             $bulkDeleteRoute = 'admin_products_bulk_delete_from_shop_group';
+            $bulkOutOfStockRoute = 'admin_products_bulk_set_out_of_stock_type_shop_group';
             $routeParams = [
                 'shopGroupId' => $this->shopConstraintContext->getShopConstraint()->getShopGroupId()->getValue(),
             ];
@@ -694,6 +697,7 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
             $bulkDisableRoute = 'admin_products_bulk_disable_all_shops';
             $bulkDuplicateRoute = 'admin_products_bulk_duplicate_all_shops';
             $bulkDeleteRoute = 'admin_products_bulk_delete_from_all_shops';
+            $bulkOutOfStockRoute = 'admin_products_bulk_set_out_of_stock_type_all_shops';
             $routeParams = [];
             $bulkEnableLabel = $this->trans('Activate selection for associated stores', [], 'Admin.Actions');
             $bulkDisableLabel = $this->trans('Deactivate selection for associated stores', [], 'Admin.Actions');
@@ -737,6 +741,36 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                 $this->trans('Deleting %done% / %total% products', [], 'Admin.Actions'),
                 'delete',
                 $routeParams
+            ))
+            // The three out of stock behaviors are separate entries rather than one action with a
+            // value picker, because a bulk action posts the selection and nothing else. The labels are
+            // the ones the Stock tab already uses for the same setting.
+            ->add($this->buildAjaxBulkAction(
+                'bulk_deny_orders_ajax',
+                $bulkOutOfStockRoute,
+                $this->trans('Deny orders when out of stock for selection', [], 'Admin.Actions'),
+                $this->trans('Updating %total% products', [], 'Admin.Actions'),
+                $this->trans('Updating %done% / %total% products', [], 'Admin.Actions'),
+                'remove_shopping_cart',
+                $routeParams + ['outOfStockType' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE]
+            ))
+            ->add($this->buildAjaxBulkAction(
+                'bulk_allow_orders_ajax',
+                $bulkOutOfStockRoute,
+                $this->trans('Allow orders when out of stock for selection', [], 'Admin.Actions'),
+                $this->trans('Updating %total% products', [], 'Admin.Actions'),
+                $this->trans('Updating %done% / %total% products', [], 'Admin.Actions'),
+                'add_shopping_cart',
+                $routeParams + ['outOfStockType' => OutOfStockType::OUT_OF_STOCK_AVAILABLE]
+            ))
+            ->add($this->buildAjaxBulkAction(
+                'bulk_default_out_of_stock_ajax',
+                $bulkOutOfStockRoute,
+                $this->trans('Use the default out of stock behavior for selection', [], 'Admin.Actions'),
+                $this->trans('Updating %total% products', [], 'Admin.Actions'),
+                $this->trans('Updating %done% / %total% products', [], 'Admin.Actions'),
+                'settings_backup_restore',
+                $routeParams + ['outOfStockType' => OutOfStockType::OUT_OF_STOCK_DEFAULT]
             ))
         ;
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProductsForAssociation
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForAssociation;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Exception\SpecificPriceConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\BulkUpdateProductOutOfStockTypeCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
@@ -1431,6 +1432,69 @@ class ProductController extends PrestaShopAdminController
      *
      * @return JsonResponse
      */
+    /**
+     * Set the out of stock behavior of products in bulk action, for all associated stores.
+     */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_products_index', message: 'You do not have permission to edit this.', jsonResponse: true)]
+    public function bulkSetOutOfStockTypeAllShopsAction(Request $request, int $outOfStockType): JsonResponse
+    {
+        $shopConstraint = ShopConstraint::allShops();
+        if (!$this->hasAuthorizationByShopConstraint($shopConstraint)) {
+            throw new MultiShopAccessDeniedException($shopConstraint);
+        }
+
+        return $this->bulkUpdateProductOutOfStockType($request, $outOfStockType, $shopConstraint);
+    }
+
+    /**
+     * Set the out of stock behavior of products in bulk action, for one store.
+     */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_products_index', message: 'You do not have permission to edit this.', jsonResponse: true)]
+    public function bulkSetOutOfStockTypeShopAction(Request $request, int $shopId, int $outOfStockType): JsonResponse
+    {
+        $shopConstraint = ShopConstraint::shop($shopId);
+        if (!$this->hasAuthorizationByShopConstraint($shopConstraint)) {
+            throw new MultiShopAccessDeniedException($shopConstraint);
+        }
+
+        return $this->bulkUpdateProductOutOfStockType($request, $outOfStockType, $shopConstraint);
+    }
+
+    /**
+     * Set the out of stock behavior of products in bulk action, for one store group.
+     */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_products_index', message: 'You do not have permission to edit this.', jsonResponse: true)]
+    public function bulkSetOutOfStockTypeShopGroupAction(Request $request, int $shopGroupId, int $outOfStockType): JsonResponse
+    {
+        $shopConstraint = ShopConstraint::shopGroup($shopGroupId);
+        if (!$this->hasAuthorizationByShopConstraint($shopConstraint)) {
+            throw new MultiShopAccessDeniedException($shopConstraint);
+        }
+
+        return $this->bulkUpdateProductOutOfStockType($request, $outOfStockType, $shopConstraint);
+    }
+
+    private function bulkUpdateProductOutOfStockType(Request $request, int $outOfStockType, ShopConstraint $shopConstraint): JsonResponse
+    {
+        try {
+            $this->dispatchCommand(
+                new BulkUpdateProductOutOfStockTypeCommand(
+                    $this->getBulkActionIds($request, self::BULK_PRODUCT_IDS_KEY),
+                    $outOfStockType,
+                    $shopConstraint
+                )
+            );
+        } catch (Exception $e) {
+            if ($e instanceof BulkProductException) {
+                return $this->jsonBulkErrors($e);
+            }
+
+            return $this->json(['error' => $this->getErrorMessageForException($e, $this->getErrorMessages())], Response::HTTP_BAD_REQUEST);
+        }
+
+        return $this->json(['success' => true]);
+    }
+
     private function bulkUpdateProductStatus(Request $request, bool $newStatus, ShopConstraint $shopConstraint): JsonResponse
     {
         try {

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/product.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/product.yml
@@ -342,6 +342,41 @@ admin_products_bulk_enable_shop_group:
   options:
     expose: true
 
+admin_products_bulk_set_out_of_stock_type_all_shops:
+  path: /bulk-set-out-of-stock-type-all-shops/{outOfStockType}
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::bulkSetOutOfStockTypeAllShopsAction
+    _legacy_controller: AdminProducts
+  requirements:
+    outOfStockType: \d+
+  options:
+    expose: true
+
+admin_products_bulk_set_out_of_stock_type_shop:
+  path: /bulk-set-out-of-stock-type-shop/{shopId}/{outOfStockType}
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::bulkSetOutOfStockTypeShopAction
+    _legacy_controller: AdminProducts
+  requirements:
+    shopId: \d+
+    outOfStockType: \d+
+  options:
+    expose: true
+
+admin_products_bulk_set_out_of_stock_type_shop_group:
+  path: /bulk-set-out-of-stock-type-shop-group/{shopGroupId}/{outOfStockType}
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::bulkSetOutOfStockTypeShopGroupAction
+    _legacy_controller: AdminProducts
+  requirements:
+    shopGroupId: \d+
+    outOfStockType: \d+
+  options:
+    expose: true
+
 admin_products_bulk_disable_all_shops:
   path: /bulk-disable-for-all-shops
   methods: [ POST ]

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -273,6 +273,11 @@ services:
     arguments:
       $productUpdatablePropertyFiller: '@PrestaShop\PrestaShop\Adapter\Product\Update\Filler\ProductFiller'
 
+  PrestaShop\PrestaShop\Adapter\Product\Stock\CommandHandler\BulkUpdateProductOutOfStockTypeHandler:
+    autowire: true
+    public: false
+    autoconfigure: true
+
   PrestaShop\PrestaShop\Adapter\Product\Stock\CommandHandler\UpdateProductStockAvailableHandler:
     autowire: true
     public: false

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
@@ -11,6 +11,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 use Behat\Gherkin\Node\TableNode;
 use Cache;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\BulkUpdateProductOutOfStockTypeCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\UpdateProductStockAvailableCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopCollection;
@@ -19,6 +20,40 @@ use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class UpdateStockFeatureContext extends AbstractProductFeatureContext
 {
+    /**
+     * @When /^I bulk change out of stock type to be "(default|available|not_available)" for following products:$/
+     */
+    public function bulkUpdateOutOfStockTypeForDefaultShop(string $outOfStockType, TableNode $productsList): void
+    {
+        $this->bulkUpdateOutOfStockType($outOfStockType, $productsList, ShopConstraint::shop($this->getDefaultShopId()));
+    }
+
+    /**
+     * @When /^I bulk change out of stock type to be "(default|available|not_available)" for following products for all shops:$/
+     */
+    public function bulkUpdateOutOfStockTypeForAllShops(string $outOfStockType, TableNode $productsList): void
+    {
+        $this->bulkUpdateOutOfStockType($outOfStockType, $productsList, ShopConstraint::allShops());
+    }
+
+    private function bulkUpdateOutOfStockType(string $outOfStockType, TableNode $productsList, ShopConstraint $shopConstraint): void
+    {
+        $productIds = [];
+        foreach ($productsList->getColumnsHash() as $productInfo) {
+            $productIds[] = $this->getSharedStorage()->get($productInfo['reference']);
+        }
+
+        try {
+            $this->getCommandBus()->handle(new BulkUpdateProductOutOfStockTypeCommand(
+                $productIds,
+                $this->convertOutOfStockToInt($outOfStockType),
+                $shopConstraint
+            ));
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+
     /**
      * @When I update product :productReference stock with following information:
      */

--- a/tests/Integration/Behaviour/Features/Scenario/Product/bulk_update_product_out_of_stock_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/bulk_update_product_out_of_stock_type.feature
@@ -1,0 +1,65 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags bulk-update-out-of-stock-type
+@restore-products-before-feature
+@clear-cache-before-feature
+@bulk-product
+@bulk-update-out-of-stock-type
+Feature: Bulk update product out of stock type from BO (Back Office)
+  As an employee I must be able to set the out of stock behavior of several products at once
+
+  Background:
+    Given language with iso code "en" is the default one
+    And I add product "product1" with following information:
+      | name[en-US] | Bulk out of stock poster nr. 1 |
+      | type        | standard                       |
+    And I add product "product2" with following information:
+      | name[en-US] | Bulk out of stock poster nr. 2 |
+      | type        | standard                       |
+    And I add product "product3" with following information:
+      | name[en-US] | Bulk out of stock poster nr. 3 |
+      | type        | standard                       |
+
+  Scenario: I deny orders when out of stock for a selection
+    When I bulk change out of stock type to be "not_available" for following products:
+      | reference |
+      | product1  |
+      | product2  |
+      | product3  |
+    Then product "product1" should have following stock information:
+      | out_of_stock_type | not_available |
+    And product "product2" should have following stock information:
+      | out_of_stock_type | not_available |
+    And product "product3" should have following stock information:
+      | out_of_stock_type | not_available |
+
+  Scenario: I allow orders when out of stock for a selection
+    Given I bulk change out of stock type to be "not_available" for following products:
+      | reference |
+      | product1  |
+      | product2  |
+    And product "product1" should have following stock information:
+      | out_of_stock_type | not_available |
+    When I bulk change out of stock type to be "available" for following products:
+      | reference |
+      | product1  |
+      | product2  |
+    Then product "product1" should have following stock information:
+      | out_of_stock_type | available |
+    And product "product2" should have following stock information:
+      | out_of_stock_type | available |
+
+  Scenario: A product left out of the selection keeps its own behavior
+    Given I bulk change out of stock type to be "available" for following products:
+      | reference |
+      | product1  |
+      | product2  |
+      | product3  |
+    When I bulk change out of stock type to be "not_available" for following products:
+      | reference |
+      | product1  |
+      | product2  |
+    Then product "product1" should have following stock information:
+      | out_of_stock_type | not_available |
+    And product "product2" should have following stock information:
+      | out_of_stock_type | not_available |
+    And product "product3" should have following stock information:
+      | out_of_stock_type | available |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The behavior applied when a product runs out of stock can only be set one product at a time. Add it to the products bulk actions, one entry per behavior, reusing the labels the Stock tab already uses.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #22906
| Related PRs       | --
| Sponsor company   | --

### Why

The issue is approved on both sides and has been waiting since 2021: `PM ✔️` after prestascott wrote
"It's a go for me concerning this issue", `UX ✔️` on hibatallahAouadni's mockup, then `To Do`. The
`Old Products Page` label was removed in November 2025, so it applies to the current grid.

On `develop` the products grid offers four bulk actions - activate, deactivate, duplicate, delete - and
nothing for stock behavior. Changing it for a brand or a season means opening every product.

### What it does

Three bulk actions, one per behavior, using the same labels as the Stock tab
(`OutOfStockTypeChoiceProvider`): deny orders, allow orders, use the default.

They are separate entries rather than one action with a value picker because a bulk action posts the
selection and nothing else. The behavior travels as a **route parameter**, so the three entries share
one route per shop scope - three routes in total rather than nine.

### The decision that matters, and why it is delegation rather than a write

The behavior is stored **twice**: on `product.out_of_stock` and on `stock_available.out_of_stock`. The
front office reads the second one, and `Product::loadStockData()` overwrites the product's copy with it.
Writing the field directly in the handler would have been the obvious thing and would have been wrong
in a way that is invisible until a customer hits a product page.

So the handler delegates to `ProductStockUpdater`, which the Stock tab already uses. That gives the bulk
action the same correctness as editing one product, for free: both columns, and the shop constraint
resolved to the right stock rows including the all-shops fan-out.

Measured on a running shop, dispatching the command for three products with `ShopConstraint::shop(1)`:

```
before   6: product_col=2  stock_col=2      7: 2/2      8: 2/2
after    6: product_col=2  stock_col=1      7: 2/1      8: 2/1
```

`stock_available.out_of_stock` is what changed, which is the value the front office consults.
`product.out_of_stock` is not kept in step by the platform's own stock path either - on an **untouched**
shop 3 of 19 products already have the two columns disagreeing, and on the other shop
`product.out_of_stock` is uniformly `2` for all 85 products while `stock_available.out_of_stock` holds
0, 1 and 2. The bulk action therefore leaves the data in exactly the shape single product editing does.

### Wiring, proven rather than assumed

```
debug:router      admin_products_bulk_set_out_of_stock_type_all_shops   POST  .../bulk-set-out-of-stock-type-all-shops/{outOfStockType}
                  admin_products_bulk_set_out_of_stock_type_shop        POST  .../bulk-set-out-of-stock-type-shop/{shopId}/{outOfStockType}
                  admin_products_bulk_set_out_of_stock_type_shop_group  POST  .../bulk-set-out-of-stock-type-shop-group/{shopGroupId}/{outOfStockType}
debug:messenger   BulkUpdateProductOutOfStockTypeCommand handled by
                  ...Adapter\Product\Stock\CommandHandler\BulkUpdateProductOutOfStockTypeHandler (when method=handle)
php-cs-fixer      clean
phpstan           [OK] No errors
```

The handler is declared in `services/adapter/product.yml` like every sibling: `#[AsCommandHandler]`
only configures services that already exist, and `src/Adapter` is not registered by a PSR-4 resource, so
the attribute alone leaves a handler silently unregistered.

### Tests

`tests/Integration/Behaviour/Features/Scenario/Product/bulk_update_product_out_of_stock_type.feature`,
three scenarios modelled on `bulk_update_product_status.feature`: setting deny for a selection, changing
a selection from allow to deny, and a product left out of the selection keeping its own behavior. The
third is the one that would catch a handler applying the change to the wrong set.

**These could not be run locally, and the reason is the environment, not the test.** The product Behat
suite needs a test database matching the branch, and `ps_feature_product_attribute` is in develop's
`db_structure.sql` but exists in none of the local install databases. The control is decisive: the
**existing** `bulk-update-status` feature skips all four of its scenarios with the identical
`Cannot find dump for table ps_feature_product_attribute` failure. So the suite cannot run here for any
product feature, mine included. What was verified instead is the direct dispatch above, against a real
database.

### How to test

In Catalog > Products, tick several products, open Bulk actions and pick one of the three out of stock
entries. Every selected product's Stock tab shows the new behavior and the others are untouched.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- New feature, so `develop`.
- Three new strings in `Admin.Actions`. `translations/default/` is untouched on purpose - that catalogue
  is refreshed by separate "Update default catalog" commits.
- The issue also collects a wider idea from MatShir and Hlavtox - a general bulk edit modal for many
  product properties. That is a different feature and is deliberately not attempted here; this delivers
  the one the reporter called mandatory and the one PM and UX signed off.
- Overlaps, checked by hunk over all 755 open core PRs, none the same feature: `ProductController.php`
  with #37846, #42218, #42480 (hunks at 729 and 822-839 vs mine at 37 and 1431) and
  `products/product.yml` with my #42717 (150/163/173 vs mine at 342).


## Update 2026-09-21

- The three `admin_products_bulk_set_out_of_stock_type_*` routes are `expose: true` but were missing from the
  committed `admin-dev/themes/new-theme/js/fos_js_routes.json`, which the back office JS builds its URLs from, so
  `router.generate` threw. Added, identical to a live `fos:js-routing:dump` for those entries.
- The route values are cast to string: the JS router treats a numeric `0` in the last path segment as empty and
  moves it to the query string, so "Deny orders" (0) matched no route.
- `_legacy_link` added on the three routes for the legacy-link lint.
