### PR TITLE
Accept any front container translator in the checkout process provider

### DIFF
--- a/src/Adapter/Order/Checkout/CheckoutProcessProviderInterface.php
+++ b/src/Adapter/Order/Checkout/CheckoutProcessProviderInterface.php
@@ -10,7 +10,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\Checkout;
 
 use CheckoutProcess;
 use CheckoutSession;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 
 /**
  * Contract for modules that provide their own checkout process.
@@ -30,6 +30,6 @@ interface CheckoutProcessProviderInterface
      */
     public function buildCheckoutProcess(
         CheckoutSession $session,
-        TranslatorComponent $translator
+        TranslatorInterface $translator
     ): CheckoutProcess;
 }

--- a/src/Adapter/Order/Checkout/CheckoutProcessProviderResolver.php
+++ b/src/Adapter/Order/Checkout/CheckoutProcessProviderResolver.php
@@ -11,7 +11,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\Checkout;
 use CheckoutProcess;
 use CheckoutSession;
 use Hook;
-use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 
 /**
  * Resolves the checkout process provided by modules through the checkout hook.
@@ -23,11 +23,11 @@ class CheckoutProcessProviderResolver
      * or null to keep the native checkout.
      *
      * @param CheckoutSession $session
-     * @param TranslatorComponent $translator
+     * @param TranslatorInterface $translator
      *
      * @return CheckoutProcess|null
      */
-    public function resolve(CheckoutSession $session, TranslatorComponent $translator): ?CheckoutProcess
+    public function resolve(CheckoutSession $session, TranslatorInterface $translator): ?CheckoutProcess
     {
         $providers = $this->getValidProviders();
         $providersCount = count($providers);

--- a/tests/Unit/Adapter/Order/Checkout/CheckoutProcessProviderResolverTest.php
+++ b/tests/Unit/Adapter/Order/Checkout/CheckoutProcessProviderResolverTest.php
@@ -13,7 +13,10 @@ use CheckoutSession;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Order\Checkout\CheckoutProcessProviderInterface;
 use PrestaShop\PrestaShop\Adapter\Order\Checkout\CheckoutProcessProviderResolver;
+use PrestaShopBundle\Translation\DataCollectorTranslator;
+use PrestaShopBundle\Translation\Translator;
 use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShopBundle\Translation\TranslatorInterface;
 
 class StubCheckoutProcessProvider implements CheckoutProcessProviderInterface
 {
@@ -30,7 +33,7 @@ class StubCheckoutProcessProvider implements CheckoutProcessProviderInterface
 
     public function buildCheckoutProcess(
         $session,
-        TranslatorComponent $translator
+        TranslatorInterface $translator
     ): CheckoutProcess {
         return $this->checkoutProcess;
     }
@@ -91,6 +94,35 @@ class CheckoutProcessProviderResolverTest extends TestCase
         );
 
         $this->assertNull($resolvedProcess);
+    }
+
+    /**
+     * The front controller hands over whatever the container registered as the translator: that is
+     * Translator in prod and DataCollectorTranslator in dev, and neither of them extends
+     * TranslatorComponent. A signature naming that class fails while binding the argument, before
+     * the method body runs, which is what broke the order page under the new front container.
+     *
+     * @dataProvider provideTranslatorsTheContainerCanReturn
+     *
+     * @param class-string<TranslatorInterface> $translatorClass
+     */
+    public function testResolveAcceptsEveryTranslatorTheContainerCanReturn(string $translatorClass): void
+    {
+        $resolver = new TestableCheckoutProcessProviderResolver();
+
+        $resolvedProcess = $resolver->resolve(
+            $this->createMock(CheckoutSession::class),
+            $this->createMock($translatorClass)
+        );
+
+        $this->assertNull($resolvedProcess);
+    }
+
+    public function provideTranslatorsTheContainerCanReturn(): iterable
+    {
+        yield 'prod front container' => [Translator::class];
+        yield 'dev front container' => [DataCollectorTranslator::class];
+        yield 'the class the signature used to name' => [TranslatorComponent::class];
     }
 
     private function createProvider(bool $enabled, ?CheckoutProcess $checkoutProcess = null): CheckoutProcessProviderInterface


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `CheckoutProcessProviderResolver::resolve()` and `CheckoutProcessProviderInterface::buildCheckoutProcess()` type their translator argument as `PrestaShopBundle\Translation\TranslatorComponent`. That is one of three sibling translator classes, and it is not the one the Symfony container returns. With `PS_FF_FRONT_CONTAINER_V2` enabled the order page fatals with a `TypeError` while binding argument #2. Both signatures now name `PrestaShopBundle\Translation\TranslatorInterface`, which all three implement.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set `PS_FF_FRONT_CONTAINER_V2=true` in `.env` (it ships as `false`), clear the cache, put a product in the cart and open the order page. On 9.2.x the page fatals with `CheckoutProcessProviderResolver::resolve(): Argument #2 ($translator) must be of type PrestaShopBundle\Translation\TranslatorComponent, PrestaShopBundle\Translation\DataCollectorTranslator given`. With this change the checkout renders. With the flag off (the default) the page is unaffected either way. `tests/Unit/Adapter/Order/Checkout/CheckoutProcessProviderResolverTest.php` covers both concrete classes the container can return.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | None
| Related PRs       | None
| Sponsor company   | None

### Why the front container changes which class arrives

`Context::getTranslator()` has two branches:

```php
if ($isInstaller || null === $sfContainer) {
    $this->translator = $this->getTranslatorFromLocale($this->language->locale);
} else {
    $this->translator = $sfContainer->get(TranslatorInterface::class);
}
```

`getTranslatorFromLocale()` builds a `TranslatorComponent` - `classes/Context.php` imports it as
`use PrestaShopBundle\Translation\TranslatorComponent as Translator;`, so the `@return Translator`
docblock there is the alias, not `PrestaShopBundle\Translation\Translator`. That is the branch the
front office takes today, and it is why the current signature works and the bug is not visible by
default.

`index.php` only boots a `FrontKernel` when `PS_FF_FRONT_CONTAINER_V2` is set, so
`SymfonyContainer::getInstance()` is null without it. With the flag on, the else branch runs and
resolves the `PrestaShopBundle\Translation\TranslatorInterface` alias, which points at `translator`:
`PrestaShopBundle\Translation\Translator` in prod, `PrestaShopBundle\Translation\DataCollectorTranslator`
in dev.

Measured on 9.2.x, replaying `Context::getTranslator()` under both container states:

| `SymfonyContainer::getInstance()` | `getTranslator()` returns | accepted by the current signature |
| --- | --- | --- |
| null (flag off, default) | `TranslatorComponent` | yes |
| present (flag on) | `DataCollectorTranslator` (dev), `Translator` (prod) | no - `TypeError` |

The three classes are siblings, not a hierarchy: `TranslatorComponent` extends Symfony's component
`Translator`, `Translator` extends the FrameworkBundle one, `DataCollectorTranslator` extends the
component's data collector. Their only common PrestaShop ancestor is `TranslatorInterface`.

### Why the interface, and not a union or the concrete container class

The resolver never calls a method on the translator - it passes it straight to the module's
`buildCheckoutProcess()`. The dependency this seam actually has is the interface, so naming the
interface is both the narrowest correct type and the one that survives the container returning a
fourth implementation later. A union type would have to be revisited each time; naming
`PrestaShopBundle\Translation\Translator` instead would fix prod and leave dev broken.

`controllers/front/OrderController.php` carried the same wrong type in the `@param` of its own
`buildCheckoutProcess()` (the parameter itself is untyped), and its `TranslatorComponent` import
existed only for that docblock. Both are corrected in the same commit.

### On the BC cell

`CheckoutProcessProviderInterface` is module-facing, and widening a parameter type on an interface
is a break for implementors that name the narrower type. It is answered `no` because the interface
was added on 2026-07-04 and `git tag --contains` puts it in `9.2.0-beta.1` only - it has never
shipped in a stable release. An implementor typed `TranslatorComponent` could not be called
successfully through the container path anyway, which is the defect being fixed.
