### PR TITLE
Let merchants order the contact list manually

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/contacts/ContactsPage.ts
+++ b/admin-dev/themes/new-theme/js/pages/contacts/ContactsPage.ts
@@ -14,6 +14,7 @@ export default class ContactsPage {
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(contactGrid));
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());

--- a/classes/Contact.php
+++ b/classes/Contact.php
@@ -25,6 +25,9 @@ class ContactCore extends ObjectModel
     /** @var bool */
     public $customer_service;
 
+    /** @var int Position in the contact list */
+    public $position = 0;
+
     /**
      * @see ObjectModel::$definition
      */
@@ -41,6 +44,10 @@ class ContactCore extends ObjectModel
             'customer_service' => [
                 'type' => self::TYPE_BOOL,
                 'validate' => 'isBool',
+            ],
+            'position' => [
+                'type' => self::TYPE_INT,
+                'validate' => 'isUnsignedInt',
             ],
 
             /* Lang fields */
@@ -77,7 +84,7 @@ class ContactCore extends ObjectModel
                 WHERE cl.`id_lang` = ' . (int) $idLang . '
                 AND contact_shop.`id_shop` IN (' . implode(', ', array_map('intval', $shopIds)) . ')
                 GROUP BY c.`id_contact`
-                ORDER BY `name` ASC';
+                ORDER BY c.`position` ASC, cl.`name` ASC';
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
     }
@@ -100,6 +107,71 @@ class ContactCore extends ObjectModel
             WHERE ct.customer_service = 1
             AND contact_shop.`id_shop` IN (' . implode(', ', array_map('intval', $shopIds)) . ')
             GROUP BY ct.`id_contact`
+            ORDER BY ct.`position` ASC, cl.`name` ASC
         ');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * A newly created contact is appended at the end of the list.
+     */
+    public function add($autoDate = true, $nullValues = false)
+    {
+        if ($this->position <= 0) {
+            $this->position = Contact::getHighestPosition() + 1;
+        }
+
+        return parent::add($autoDate, $nullValues);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Positions are compacted afterwards so the list keeps a gapless order.
+     */
+    public function delete()
+    {
+        return parent::delete() && Contact::cleanPositions();
+    }
+
+    /**
+     * Gets the highest contact position, or -1 when there is no contact yet.
+     */
+    public static function getHighestPosition(): int
+    {
+        $position = Db::getInstance()->getValue('SELECT MAX(`position`) FROM `' . _DB_PREFIX_ . 'contact`');
+
+        return is_numeric($position) ? (int) $position : -1;
+    }
+
+    /**
+     * Reorders contact positions consecutively, starting at 0.
+     * Called after deleting a contact.
+     */
+    public static function cleanPositions(): bool
+    {
+        $contacts = Db::getInstance()->executeS(
+            'SELECT `id_contact`
+             FROM `' . _DB_PREFIX_ . 'contact`
+             ORDER BY `position` ASC, `id_contact` ASC'
+        );
+
+        if ($contacts === false) {
+            return false;
+        }
+
+        $result = true;
+        $position = 0;
+
+        foreach ($contacts as $contact) {
+            $result = Db::getInstance()->execute(
+                'UPDATE `' . _DB_PREFIX_ . 'contact`
+                 SET `position` = ' . (int) $position++ . '
+                 WHERE `id_contact` = ' . (int) $contact['id_contact']
+            ) && $result;
+        }
+
+        return $result;
     }
 }

--- a/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
@@ -15,8 +15,10 @@ use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\PositionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
@@ -87,6 +89,16 @@ final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
             )
             ->add(
+                (new PositionColumn('position'))
+                    ->setName($this->trans('Position', [], 'Admin.Global'))
+                    ->setOptions([
+                        'id_field' => 'id_contact',
+                        'position_field' => 'position',
+                        'update_method' => 'POST',
+                        'update_route' => 'admin_contacts_update_position',
+                    ])
+            )
+            ->add(
                 (new ActionColumn('actions'))
                     ->setName($this->trans('Actions', [], 'Admin.Global'))
                     ->setOptions([
@@ -147,7 +159,10 @@ final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
                     ->setAssociatedColumn('description')
             )
-
+            ->add(
+                (new Filter('position', ReorderPositionsButtonType::class))
+                    ->setAssociatedColumn('position')
+            )
             ->add(
                 (new Filter('actions', SearchAndResetType::class))
                     ->setTypeOptions([

--- a/src/Core/Grid/Query/ContactQueryBuilder.php
+++ b/src/Core/Grid/Query/ContactQueryBuilder.php
@@ -58,12 +58,17 @@ final class ContactQueryBuilder extends AbstractDoctrineQueryBuilder
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
         $qb
-            ->select('c.id_contact, c.email, cl.name, cl.description, c.customer_service')
+            ->select('c.id_contact, c.email, cl.name, cl.description, c.customer_service, c.position')
             ->groupBy('c.id_contact');
 
         $this->searchCriteriaApplicator
             ->applySorting($searchCriteria, $qb)
             ->applyPagination($searchCriteria, $qb);
+
+        // Always sort by id as the second sorting condition: positions can be equal on shops upgraded from a
+        // version that never maintained them, and the position update handler re-indexes rows by the order they
+        // are read in, so an ambiguous order would make a drag and drop land on the wrong row.
+        $qb->addOrderBy('c.id_contact', 'ASC');
 
         return $qb;
     }

--- a/src/Core/Search/Filters/ContactFilters.php
+++ b/src/Core/Search/Filters/ContactFilters.php
@@ -27,7 +27,7 @@ final class ContactFilters extends Filters
         return [
             'limit' => 10,
             'offset' => 0,
-            'orderBy' => 'id_contact',
+            'orderBy' => 'position',
             'sortOrder' => 'asc',
             'filters' => [],
         ];

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -14,6 +14,8 @@ use PrestaShop\PrestaShop\Core\Domain\Exception\DomainConstraintException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Position\Exception\PositionUpdateException;
+use PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition;
 use PrestaShop\PrestaShop\Core\Search\Filters\ContactFilters;
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
@@ -148,6 +150,25 @@ class ContactsController extends PrestaShopAdminController
                 'success',
                 $this->trans('Successful deletion', [], 'Admin.Notifications.Success')
             );
+        }
+
+        return $this->redirectToRoute('admin_contacts_index');
+    }
+
+    #[DemoRestricted(redirectRoute: 'admin_contacts_index')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_contacts_index', message: 'You do not have permission to edit this.')]
+    public function updatePositionAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.core.grid.contact.position_definition')]
+        PositionDefinition $positionDefinition,
+    ): RedirectResponse {
+        try {
+            $this->updateGridPosition($positionDefinition, [
+                'positions' => $request->request->all('positions'),
+            ]);
+            $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
+        } catch (PositionUpdateException $e) {
+            $this->addFlashErrors([$e->toArray()]);
         }
 
         return $this->redirectToRoute('admin_contacts_index');

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/contacts.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/contacts.yml
@@ -44,6 +44,13 @@ admin_contacts_delete:
   requirements:
     contactId: \d+
 
+admin_contacts_update_position:
+  path: /update-position
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\ContactsController::updatePositionAction'
+    _legacy_controller: AdminContacts
+
 admin_contacts_delete_bulk:
   path: /delete/bulk
   methods: [ POST ]

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
@@ -40,6 +40,13 @@ services:
       $idField: 'id_attribute_group'
       $positionField: 'position'
 
+  prestashop.core.grid.contact.position_definition:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition'
+    arguments:
+      $table: 'contact'
+      $idField: 'id_contact'
+      $positionField: 'position'
+
   prestashop.core.grid.carrier.position_definition:
     class: 'PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition'
     arguments:

--- a/tests/Integration/Classes/ContactPositionTest.php
+++ b/tests/Integration/Classes/ContactPositionTest.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Contact;
+use Db;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Contact\Command\AddContactCommand;
+use PrestaShop\PrestaShop\Core\Domain\Contact\ValueObject\ContactId;
+use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Presenter\GridPresenterInterface;
+use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
+use PrestaShop\PrestaShop\Core\Search\Filters\ContactFilters;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * Contacts are listed in the order the merchant arranged them, the name is only a tie-breaker.
+ */
+class ContactPositionTest extends KernelTestCase
+{
+    private static int $langId;
+
+    /**
+     * Positions as they were before this test class ran, id_contact => position.
+     *
+     * @var array<int, int>
+     */
+    private static array $initialPositions = [];
+
+    /**
+     * @var int[]
+     */
+    private array $createdContactIds = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::bootKernel();
+
+        self::$langId = (int) Configuration::get('PS_LANG_DEFAULT');
+        self::$initialPositions = self::readPositions();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        foreach (self::$initialPositions as $contactId => $position) {
+            Db::getInstance()->update('contact', ['position' => $position], 'id_contact = ' . $contactId);
+        }
+
+        parent::tearDownAfterClass();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdContactIds as $contactId) {
+            $contact = new Contact($contactId);
+
+            if ($contact->id) {
+                $contact->delete();
+            }
+        }
+        $this->createdContactIds = [];
+
+        parent::tearDown();
+    }
+
+    public function testNewContactIsAppendedAtTheEndOfTheList(): void
+    {
+        $highestPosition = Contact::getHighestPosition();
+
+        $contact = $this->createContact('Zulu');
+
+        $this->assertSame($highestPosition + 1, (int) $contact->position);
+    }
+
+    /**
+     * The back office creates contacts through the command bus, not through the ObjectModel directly.
+     */
+    public function testContactAddedThroughTheCommandBusIsAppendedAtTheEndOfTheList(): void
+    {
+        // No HTTP request ran, so nothing initialized the language context the command bus needs.
+        $languageContextBuilder = self::getContainer()->get(LanguageContextBuilder::class);
+        $languageContextBuilder->setLanguageId(self::$langId);
+        $languageContextBuilder->setDefaultLanguageId(self::$langId);
+
+        $highestPosition = Contact::getHighestPosition();
+
+        $command = new AddContactCommand([self::$langId => 'Zulu'], false);
+        $command->setShopAssociation([(int) Configuration::get('PS_SHOP_DEFAULT')]);
+
+        /** @var ContactId $contactId */
+        $contactId = self::getContainer()->get('prestashop.core.command_bus')->handle($command);
+        $this->createdContactIds[] = $contactId->getValue();
+
+        $this->assertSame($highestPosition + 1, (int) (new Contact($contactId->getValue()))->position);
+    }
+
+    public function testGetContactsIsOrderedByPositionAndNotByName(): void
+    {
+        // Created in reverse alphabetical order, so the position order and the name order disagree.
+        $zulu = $this->createContact('Zulu');
+        $mike = $this->createContact('Mike');
+        $alpha = $this->createContact('Alpha');
+
+        $this->assertSame(
+            [(int) $zulu->id, (int) $mike->id, (int) $alpha->id],
+            $this->listedContactIds()
+        );
+    }
+
+    public function testContactsSharingAPositionFallBackOnTheirName(): void
+    {
+        $zulu = $this->createContact('Zulu');
+        $alpha = $this->createContact('Alpha');
+
+        Db::getInstance()->update('contact', ['position' => 500], 'id_contact IN (' . (int) $zulu->id . ', ' . (int) $alpha->id . ')');
+
+        $this->assertSame(
+            [(int) $alpha->id, (int) $zulu->id],
+            $this->listedContactIds()
+        );
+    }
+
+    public function testDeletingAContactCompactsThePositionsOfTheOthers(): void
+    {
+        $zulu = $this->createContact('Zulu');
+        $mike = $this->createContact('Mike');
+        $alpha = $this->createContact('Alpha');
+
+        $mike->delete();
+        $this->createdContactIds = array_values(array_diff($this->createdContactIds, [(int) $mike->id]));
+
+        $positions = self::readPositions();
+
+        $this->assertSame(range(0, count($positions) - 1), array_values($positions));
+        $this->assertSame([(int) $zulu->id, (int) $alpha->id], $this->listedContactIds());
+    }
+
+    /**
+     * The drag handle is only added by the grid presenter when the grid is sorted on the
+     * position column, so the default sort order is what makes reordering reachable at all.
+     */
+    public function testContactsGridIsSortedOnPositionSoTheDragHandleIsRendered(): void
+    {
+        $this->assertSame('position', ContactFilters::getDefaults()['orderBy']);
+
+        $columnTypes = array_column($this->presentDefaultGrid()['columns'], 'type', 'id');
+
+        $this->assertSame('position', $columnTypes['position'] ?? null);
+        $this->assertSame('position_handle', $columnTypes['position_handle'] ?? null);
+    }
+
+    /**
+     * Shops upgraded from a version that never maintained the column have every contact at position 0.
+     * Sorting on the position alone leaves their order up to the database, and the position update handler
+     * re-indexes the rows it is given by the order they come back in. Asserted on the query rather than on
+     * an observed row order: with equal sort keys the server is free to return any order, so a run that
+     * happens to come back by id proves nothing.
+     */
+    public function testContactsGridQueryIsUnambiguouslyOrdered(): void
+    {
+        /** @var DoctrineQueryBuilderInterface $queryBuilder */
+        $queryBuilder = self::getContainer()->get('prestashop.core.grid.query_builder.contact');
+        $sql = $queryBuilder->getSearchQueryBuilder(new ContactFilters(ContactFilters::getDefaults()))->getSQL();
+
+        $this->assertMatchesRegularExpression('/ORDER BY [^)]*\bc\.id_contact ASC/i', $sql);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function presentDefaultGrid(): array
+    {
+        // The grid factory reads the filter form from the session; a kernel test has no request.
+        $request = new Request();
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $requestStack = self::getContainer()->get('request_stack');
+        $requestStack->push($request);
+
+        /** @var GridFactoryInterface $gridFactory */
+        $gridFactory = self::getContainer()->get('prestashop.core.grid.factory.contacts');
+        /** @var GridPresenterInterface $gridPresenter */
+        $gridPresenter = self::getContainer()->get(GridPresenterInterface::class);
+
+        try {
+            return $gridPresenter->present($gridFactory->getGrid(new ContactFilters(ContactFilters::getDefaults())));
+        } finally {
+            $requestStack->pop();
+        }
+    }
+
+    /**
+     * Contact ids created by the current test, in the order Contact::getContacts() returns them.
+     *
+     * @return int[]
+     */
+    private function listedContactIds(): array
+    {
+        $listedIds = array_map(
+            static fn (array $contact): int => (int) $contact['id_contact'],
+            Contact::getContacts(self::$langId)
+        );
+
+        return array_values(array_intersect($listedIds, $this->createdContactIds));
+    }
+
+    private function createContact(string $name): Contact
+    {
+        $contact = new Contact();
+        $contact->name = [self::$langId => $name];
+        $contact->email = 'position-test@prestashop.com';
+        $contact->customer_service = false;
+
+        $contact->add();
+        $contact->associateTo((int) Configuration::get('PS_SHOP_DEFAULT'));
+
+        $this->createdContactIds[] = (int) $contact->id;
+
+        return $contact;
+    }
+
+    /**
+     * @return array<int, int> id_contact => position, ordered by position
+     */
+    private static function readPositions(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT `id_contact`, `position` FROM `' . _DB_PREFIX_ . 'contact` ORDER BY `position` ASC, `id_contact` ASC'
+        );
+
+        $positions = [];
+        foreach ($rows as $row) {
+            $positions[(int) $row['id_contact']] = (int) $row['position'];
+        }
+
+        return $positions;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The front-office contact form always listed its subjects alphabetically. `ps_contact` already had a `position` column, but it was absent from the ObjectModel definition and no query read it. Contacts become reorderable by drag and drop in Shop parameters > Contact, and `Contact::getContacts()` orders by position with the name as tie-breaker.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23990
| Related PRs       | None
| Sponsor company   |

### Why

`Contact::getContacts()` ended on `ORDER BY name ASC`, so the `<select name="id_contact">` the
`contactform` module renders was alphabetical and the merchant had no way to change it. The column that
would carry a manual order - `ps_contact.position`, present in `install-dev/data/db_structure.sql` - was
never declared on the ObjectModel and never read, so it stayed at 0 on every row.

### What it does

Wires that dead column up the same way `carrier` does. Carrier is the right precedent rather than
attribute group: `ps_carrier` has the same shape as `ps_contact`, a shop association table next to a
**global** position column, so position is shared across shops in both.

- `classes/Contact.php` - `position` joins the definition; `add()` appends at `getHighestPosition() + 1`;
  `delete()` compacts the remaining positions; `getContacts()` and `getCategoriesContacts()` order by
  `position ASC, name ASC`.
- Contacts grid - `PositionColumn` plus the `Rearrange` button, `c.position` in the query builder's
  select, and `ContactFilters::getDefaults()['orderBy'] = 'position'`. That default is load-bearing:
  `GridPresenter::getColumns()` only prepends the drag handle when the grid is sorted on the position
  column.
- `ContactsController::updatePositionAction` + `admin_contacts_update_position`, delegating to the
  existing `GridPositionUpdater` through `prestashop.core.grid.contact.position_definition`.
- `ContactsPage.ts` registers `PositionExtension`.
- `ContactQueryBuilder` sorts on `c.id_contact` as a second condition, the same way
  `ProductCombinationQueryBuilder` does.

No schema change and no data migration: the column already exists, and every existing row keeps
`position = 0`, where the `name` tie-breaker reproduces today's alphabetical order exactly. An upgraded
shop sees no change until the merchant drags something.

The secondary sort is what makes that safe. Ordering the grid on an all-zero `position` alone leaves the
row order to the server, and `GridPositionUpdater::getNewPositions()` re-indexes rows by the order they
come back in rather than by the values stored - so a grid the merchant sees in one order and a handler
that reads it in another would land a drag on the wrong row. Adding `id_contact` fixes both to the order
the listing has today. The install fixtures need nothing either: `XmlLoader` creates contacts through
`$object->add()`, so a fresh install gets 1 and 2.

Because `position` joins the ObjectModel definition, the `contacts` webservice resource exposes it too,
so an integration can set the order without going through the back office. Every deletion path
(`ContactDeleter` for the single and bulk back-office actions, `DELETE /api/contacts/{id}`) goes through
`Contact::delete()`, so positions are compacted whichever one is used.

### How to test

```
php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/ContactPositionTest.php
```

In the back office, Shop parameters > Contact: drag a contact to another row, then reload the
front-office contact page - the subject dropdown follows the new order. Measured on a 9.2 shop:
with both contacts at position 0 the dropdown reads `Customer service, Webmaster` (alphabetical);
after setting Webmaster to position 0 it reads `Webmaster, Customer service`.

Reverting `classes/Contact.php` fails 4 of the 7 tests; reverting `ContactFilters` alone, or
`ContactGridDefinitionFactory` alone, fails the grid column test; reverting the `addOrderBy` fails
`testContactsGridQueryIsUnambiguouslyOrdered` with `ORDER BY position asc LIMIT 10`.

That last test asserts the generated SQL, not an observed row order. The behavioural version of it
passed with the fix reverted: with every sort key equal InnoDB hands the rows back in primary-key order
anyway, so the run agreed with the assertion while the guarantee was missing.
