### PR TITLE
Require a customer name to carry at least one letter

### DIFF
--- a/src/Core/ConstraintValidator/CustomerNameValidator.php
+++ b/src/Core/ConstraintValidator/CustomerNameValidator.php
@@ -16,7 +16,12 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class CustomerNameValidator extends ConstraintValidator
 {
-    public const PATTERN_NAME = '/^(?!\s*$)(?:[^0-9!<>,;?=+()\/\\\\@#"°*`{}_^$%:¤\[\]|\.。]|[。\.](?:\s|$))*$/u';
+    /**
+     * The leading lookahead requires one letter, in any script, so a name made only of punctuation is
+     * rejected while a one or two letter name is not. It also covers the blank case it replaced: a
+     * string of spaces carries no letter either.
+     */
+    public const PATTERN_NAME = '/^(?=\P{L}*\p{L})(?:[^0-9!<>,;?=+()\/\\\\@#"°*`{}_^$%:¤\[\]|\.。]|[。\.](?:\s|$))*$/u';
     public const PATTERN_DOT_SPACED = '/[\.。](\s{1}[^\ ]|$)/';
 
     /**

--- a/tests/Unit/Core/ConstraintValidator/CustomerNameValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/CustomerNameValidatorTest.php
@@ -31,6 +31,59 @@ class CustomerNameValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * A name has to carry a letter. Everything here is punctuation the pattern allows inside a name but
+     * which says nothing on its own, which is how an account named "-" could be created.
+     *
+     * @return array
+     */
+    public function getNamesWithoutALetter()
+    {
+        return [
+            ['-'], ['--'], ['- -'], ["'"], ["''"], ["-'-"], ['  -  '],
+        ];
+    }
+
+    /**
+     * The counter-examples raised when this was discussed: one and two letter names exist, and a name
+     * may legitimately carry a hyphen, an apostrophe or a non-latin script. None of these may regress.
+     *
+     * @return array
+     */
+    public function getShortAndInternationalNames()
+    {
+        return [
+            ['E'], ['Li'], ['Xu Li'], ["O'Brien"], ['Jean-Luc'], ['Ann-Marie'],
+            ['李'], ['Þór'], ['van der Berg'],
+        ];
+    }
+
+    /**
+     * @dataProvider getNamesWithoutALetter
+     *
+     * @param string $name
+     */
+    public function testItFailsWhenTheNameCarriesNoLetter($name)
+    {
+        $this->validator->validate($name, new CustomerName());
+
+        $this->buildViolation((new CustomerName())->message)
+            ->assertRaised()
+        ;
+    }
+
+    /**
+     * @dataProvider getShortAndInternationalNames
+     *
+     * @param string $name
+     */
+    public function testItAcceptsShortAndNonLatinNames($name)
+    {
+        $this->validator->validate($name, new CustomerName());
+
+        $this->assertNoViolation();
+    }
+
+    /**
      * @return array
      */
     public function getValidCharactersWithSpaces()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A customer account can be created with "-" as both the first and the last name. The name validator never requires anything to be present, so a name made only of the punctuation it allows passes.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23446
| Related PRs       |
| Sponsor company   |

### Possible impacts

A name consisting only of punctuation is rejected from now on. A shop that already stores one keeps it, but the record fails validation the next time it is saved, in the back office or by the customer.

### Why

`CustomerNameValidator::PATTERN_NAME` is a blacklist. It excludes digits and a set of punctuation and
refuses a value that is only whitespace, but it never asks for anything to be present, so `-`, `--`,
`'` and `  -  ` are all accepted names.

The thread rejected the reporter's own proposal, a three character minimum, and was right to: Hlavtox
and matks pointed out that one and two letter names exist ("what if my name is Li E?") and that the
hyphen has to stay allowed because names carry it. The reporter agreed. That left the issue with an
agreed problem and no agreed rule, which is where it sat from 2021.

Requiring **one letter, in any script** separates the two cases without a length rule at all. It is also
the rule the field already claims: the back office help under both name fields reads "Only letters and
the dot (.) character, followed by a space, are allowed."

### What it does

One lookahead at the front of the pattern, `(?=\P{L}*\p{L})`. It also subsumes the `(?!\s*$)` guard it
replaces, since a string of spaces carries no letter either. `\P{L}*\p{L}` rather than `.*\p{L}`: it
cannot backtrack, and it does not change behaviour for a value containing a newline.

### How to test

```
php vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter CustomerNameValidatorTest
```

Front office, Create an account: `-` for both names is refused, `Li` and `E` are accepted (measured,
see below).

The back office reaches the same validator: `CustomerType` attaches the `CustomerName` constraint to
both `first_name` and `last_name` (src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php,
lines 176 and 202), and form validation runs before the command is built, so Customers > Add new
customer rejects the same values. That path was read in the form type, not exercised.

### Measured on a running 9.2 shop

Registration through the front office form, before and after, with the row checked in the database
rather than the page believed:

```
before, firstname=- lastname=-     redirected to /            ps_customer row created (id 18)
after,  firstname=- lastname=-     stayed on /registration    no row, invalid-message rendered
after,  firstname=Li lastname=E    redirected to /            ps_customer row created (id 19)
```

The last line is the control: it is the exact name raised against a length rule on the issue.

Probe accounts and their `ps_customer_group`, `ps_customer_session`, `ps_guest`, `ps_cart` and
`ps_psgdpr_log` rows were deleted afterwards, and the deployed file restored to its `9.2.x` md5.

### Mutations

Restoring the original pattern fails 7 of the new cases (`-`, `--`, `- -`, `'`, `''`, `-'-`, `  -  `).
All 69 tests in the file pass with the change, so the existing cases - including the whitespace-only one
whose guard was replaced - do not regress.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- florine2623 said on 2025-02-13 that PrestaShop SA would not fix this and invited a community PR, and
  the issue is labelled `Ready`. The stale bot fired on 2026-08-15 with a 30 day grace period, so this
  should go out before that expires or the issue closes under it.
- **Interacts with my own open PR #42151** ("Describe the customer name rules accurately in the field
  help"), which edits the same test file at `@@ -142,4 +142,28 @@`, the end. The additions here sit near
  the top of the file, so the hunks do not touch - but #42151's new help text reads "Letters, spaces,
  hyphens (-) and apostrophes (') are allowed. Numbers are not, and a dot (.) must be followed by a
  space." Whichever lands second has to add the new clause to that sentence, because after this change a
  name must also contain a letter.
- `FirstName` / `LastName` (src/Core/Domain/Customer/ValueObject/) carry a **second, looser** pattern of
  their own, `/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u`, with no letter requirement. Every UI path goes
  through the form constraint first, so this change covers the reported symptom; a caller that dispatches
  `AddCustomerCommand` directly - a module, a script - still gets `-` accepted. Unifying the two patterns
  is a separate change, and it collides with my open #42147, which is already editing those two value
  objects. #42147 adds trimming there: if it lands first, `" - "` arrives as `"-"` and this pattern
  rejects it either way, so the order does not matter for behaviour.
- `Validate::isName()` (classes/Validate.php) is a separate, looser blacklist used for other entities and
  is deliberately untouched: widening this rule to every named entity is not what the issue asked for and
  changes validation on records that have nothing to do with customers.

