### PR TITLE
Hide the payment details panel when there are no card details

### DIFF
--- a/src/Core/Domain/Order/QueryResult/OrderPaymentForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderPaymentForViewing.php
@@ -187,6 +187,23 @@ class OrderPaymentForViewing
     /**
      * @return string|null
      */
+    /**
+     * Whether this payment carries any of the card details the order page can show.
+     *
+     * WHY: the four card columns are only ever written by a payment module that has card data to
+     * record. For a bank wire, a cheque or a cash on delivery there is nothing to put in them, and the
+     * details panel then shows four rows of "Not defined", which is what PrestaShop/PrestaShop#22120
+     * reports. Asking the payment whether it has anything to show keeps that decision in one place
+     * instead of repeating four emptiness checks in the template.
+     */
+    public function hasCardDetails(): bool
+    {
+        return '' !== $this->cardNumber
+            || '' !== $this->cardBrand
+            || '' !== $this->cardExpiration
+            || '' !== $this->cardHolder;
+    }
+
     public function getEmployeeName(): ?string
     {
         return $this->employeeName;

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig
@@ -38,11 +38,16 @@
           <td data-role="invoice-column">{% if payment.invoiceNumber %}{{ payment.invoiceNumber }}{% endif %}</td>
           <td data-role="invoice-column">{% if payment.employeeName %}{{ payment.employeeName }}{% else %}-{% endif %}</td>
           <td class="text-right">
-            <button class="btn btn-sm btn-outline-secondary js-payment-details-btn">
-              {{ 'Details'|trans({}, 'Admin.Global') }}
-            </button>
+            {# A payment with no card data has nothing to show, so the button would only ever open
+               a panel of "Not defined" rows. #}
+            {% if payment.hasCardDetails %}
+              <button class="btn btn-sm btn-outline-secondary js-payment-details-btn">
+                {{ 'Details'|trans({}, 'Admin.Global') }}
+              </button>
+            {% endif %}
           </td>
         </tr>
+        {% if payment.hasCardDetails %}
         <tr class="d-none" data-role="payment-details">
           <td colspan="6">
             <p class="mb-0">
@@ -79,6 +84,7 @@
             </p>
           </td>
         </tr>
+        {% endif %}
       {% endfor %}
       <tr class="d-print-none">
         {{ form_start(addOrderPaymentForm, {action: path('admin_orders_add_payment', {orderId: orderForViewing.id})}) }}

--- a/tests/Unit/Core/Domain/Order/QueryResult/OrderPaymentForViewingCardDetailsTest.php
+++ b/tests/Unit/Core/Domain/Order/QueryResult/OrderPaymentForViewingCardDetailsTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Order\QueryResult;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderPaymentForViewing;
+
+/**
+ * The order page offers a Details button on every payment row and fills the panel behind it with the
+ * four card columns. Those columns are only written by a payment module that has card data, so for a
+ * bank wire or a cheque the panel is four rows of "Not defined".
+ */
+class OrderPaymentForViewingCardDetailsTest extends TestCase
+{
+    /**
+     * @dataProvider getPayments
+     */
+    public function testAPaymentKnowsWhetherItHasCardDetails(
+        string $cardNumber,
+        string $cardBrand,
+        string $cardExpiration,
+        string $cardHolder,
+        bool $expected,
+        string $because
+    ): void {
+        $payment = new OrderPaymentForViewing(
+            1,
+            new DateTimeImmutable(),
+            'Bank wire',
+            '',
+            '10.00',
+            null,
+            $cardNumber,
+            $cardBrand,
+            $cardExpiration,
+            $cardHolder
+        );
+
+        self::assertSame($expected, $payment->hasCardDetails(), $because);
+    }
+
+    public static function getPayments(): array
+    {
+        return [
+            'nothing recorded' => [
+                '', '', '', '', false,
+                'a bank wire or a cheque records none of these, so there is nothing to show',
+            ],
+            'only the number' => [
+                '1234', '', '', '', true,
+                'one field is enough to make the panel worth opening',
+            ],
+            'only the brand' => [
+                '', 'Visa', '', '', true,
+                'the check must not look at the number alone',
+            ],
+            'only the expiration' => [
+                '', '', '10/30', '', true,
+                'the check must not look at the number alone',
+            ],
+            'only the holder' => [
+                '', '', '', 'John Doe', true,
+                'the check must not look at the number alone',
+            ],
+            'everything recorded' => [
+                '1234', 'Visa', '10/30', 'John Doe', true,
+                'the normal card payment case',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Every payment row on the order page offers a Details button, and the panel behind it always lists the four card fields. Those are only written by a payment module that has card data, so for a bank wire or a cheque the merchant reads "Not defined" four times. Show neither the button nor the panel when there is nothing to show.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #22120
| Related PRs       | --
| Sponsor company   | --

### Scope, and what is deliberately left out

The issue asks for two things. This delivers the second one only, and does not attempt the first:

1. **Replace the four `card_*` columns with one universal `payment_details` field.** Not attempted. It
   is a schema change on `order_payment`, and the thread does not agree on it - Hlavtox proposed a
   `displayBackofficePaymentDetails` hook, Matt75 pointed out that payment modules already display their
   own details through `displayAdminOrderLeft` and `displayAdminOrderMainBottom` and that it is not worth
   it "until a real refactor of the native Payment block". That disagreement is a product decision.
2. **"These 4 rows, along with the details button, should be hidden for payments which don't have these
   fields filled in."** That is uncontroversial, needs no schema change, and is what this does.

### Why

`payments.html.twig` renders the Details button for **every** payment row unconditionally, and the panel
behind it prints each of the four card fields with `{% else %}Not defined{% endif %}`. So a shop that
takes bank transfers and cheques offers a button on every payment whose only content is four rows of
"Not defined". Confirmed on 9.2, and on a test shop every `order_payment` row has all four columns empty
regardless of the payment method.

### What it does

`OrderPaymentForViewing::hasCardDetails()` answers whether any of the four fields is set, and the
template renders the button and the panel only when it is true. The check lives on the view model rather
than as four emptiness tests in Twig, so the rule is stated once.

Nothing is removed: a card payment that does record the fields is displayed exactly as before, including
the per-field "Not defined" fallback for a payment that fills some but not all of them.

### Tests

`tests/Unit/Core/Domain/Order/QueryResult/OrderPaymentForViewingCardDetailsTest.php`, 6 cases: nothing
recorded, each of the four fields alone, and all four. The four single-field cases are the point -
narrowing the check to the card number alone (the tempting shortcut) fails exactly three of them.

```
php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/Domain/Order/QueryResult/OrderPaymentForViewingCardDetailsTest.php
```

### How to test

Place an order paid by bank wire or cheque and open it in the back office. The Payment block shows the
row with no Details button. Then set any one of `card_number`, `card_brand`, `card_expiration` or
`card_holder` on that `order_payment` row and reload: the button returns and opens the panel as before.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- No other open core PR touches these files - checked by file-set intersection over all 755 open core
  PRs, full coverage, zero hits.
- The comment on the issue also records tswfi's separate 2023 observation, that
  `order_payment.payment_method` stores the module's display name rather than an identifier, which is
  measurable on a live shop ("Bank wire", "Payments by check"). That belongs to the part of the issue
  this PR does not attempt.
