### PR TITLE
Say which cart rule is which in the compatibility lists

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -93,7 +93,7 @@ class AdminCartRulesControllerCore extends AdminController
             if ($type == 'selected') {
                 $i = 1;
                 foreach ($cart_rules['selected'] as $cart_rule) {
-                    $html .= '<option value="' . (int) $cart_rule['id_cart_rule'] . '">&nbsp;' . Tools::safeOutput($cart_rule['name']) . '</option>';
+                    $html .= $this->renderCartRuleOption($cart_rule);
                     if ($i == $limit) {
                         break;
                     }
@@ -105,7 +105,7 @@ class AdminCartRulesControllerCore extends AdminController
             } else {
                 $i = 1;
                 foreach ($cart_rules['unselected'] as $cart_rule) {
-                    $html .= '<option value="' . (int) $cart_rule['id_cart_rule'] . '">&nbsp;' . Tools::safeOutput($cart_rule['name']) . '</option>';
+                    $html .= $this->renderCartRuleOption($cart_rule);
                     if ($i == $limit) {
                         break;
                     }
@@ -114,6 +114,62 @@ class AdminCartRulesControllerCore extends AdminController
             }
         }
         echo json_encode(['html' => $html, 'next_link' => $next_link]);
+    }
+
+    /**
+     * Builds one entry of the "Compatibility with other cart rules" lists.
+     *
+     * WHY the id and the state are shown: the two lists are the only place a merchant picks a cart rule
+     * out of every other cart rule in the shop, and they are not filtered - deliberately, because
+     * compatibility is a lasting relation and a rule that is disabled today can be enabled tomorrow. The
+     * name alone is not enough to choose with: nothing stops two rules sharing one, and an expired or
+     * disabled rule looks exactly like a live one. Every value used here comes from the row that is
+     * already selected, so this costs no extra query.
+     *
+     * @param array $cartRule
+     *
+     * @return string
+     */
+    protected function renderCartRuleOption(array $cartRule)
+    {
+        $label = sprintf('#%d - %s', (int) $cartRule['id_cart_rule'], $cartRule['name']);
+
+        if (!empty($cartRule['code'])) {
+            $label .= ' - ' . $cartRule['code'];
+        }
+
+        $state = $this->getCartRuleStateLabel($cartRule);
+        if (null !== $state) {
+            $label .= ' (' . $state . ')';
+        }
+
+        return '<option value="' . (int) $cartRule['id_cart_rule'] . '">&nbsp;' . Tools::safeOutput($label) . '</option>';
+    }
+
+    /**
+     * The reason a cart rule cannot be used right now, or null when it can.
+     *
+     * @param array $cartRule
+     *
+     * @return string|null
+     */
+    protected function getCartRuleStateLabel(array $cartRule)
+    {
+        if (!(bool) $cartRule['active']) {
+            return $this->trans('Disabled', [], 'Admin.Global');
+        }
+
+        $now = time();
+
+        if (!empty($cartRule['date_to']) && strtotime($cartRule['date_to']) < $now) {
+            return $this->trans('Expired', [], 'Admin.Catalog.Feature');
+        }
+
+        if (!empty($cartRule['date_from']) && strtotime($cartRule['date_from']) > $now) {
+            return $this->trans('Scheduled', [], 'Admin.Catalog.Feature');
+        }
+
+        return null;
     }
 
     public function setMedia($isNewTheme = false)

--- a/tests/Integration/Classes/Controller/CartRuleCompatibilityOptionTest.php
+++ b/tests/Integration/Classes/Controller/CartRuleCompatibilityOptionTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use AdminCartRulesController;
+use Context;
+use ControllerCore;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The two "Compatibility with other cart rules" lists are not filtered, on purpose: compatibility is a
+ * lasting relation and a rule disabled today can be enabled tomorrow. That makes the label the only
+ * thing a merchant has to tell one rule from another, and a name on its own is not enough - nothing
+ * stops two rules sharing one, and an expired rule looks exactly like a live one.
+ */
+class CartRuleCompatibilityOptionTest extends KernelTestCase
+{
+    private const DAY = 86400;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+    }
+
+    /**
+     * @dataProvider getCartRules
+     */
+    public function testTheOptionSaysWhichRuleItIs(array $cartRule, string $expected, string $because): void
+    {
+        self::assertSame($expected, strip_tags($this->renderOption($cartRule)), $because);
+    }
+
+    public static function getCartRules(): array
+    {
+        $past = date('Y-m-d H:i:s', time() - self::DAY);
+        $future = date('Y-m-d H:i:s', time() + self::DAY);
+
+        return [
+            'usable rule with a code' => [
+                ['id_cart_rule' => 7, 'name' => 'Spring sale', 'active' => '1', 'code' => 'SPRING', 'date_from' => $past, 'date_to' => $future],
+                '&nbsp;#7 - Spring sale - SPRING',
+                'a usable rule gets no state suffix',
+            ],
+            'automatic rule has no code to show' => [
+                ['id_cart_rule' => 8, 'name' => 'Free shipping', 'active' => '1', 'code' => '', 'date_from' => $past, 'date_to' => $future],
+                '&nbsp;#8 - Free shipping',
+                'an empty code must not leave a dangling separator',
+            ],
+            'disabled rule' => [
+                ['id_cart_rule' => 9, 'name' => 'Free shipping', 'active' => '0', 'code' => '', 'date_from' => $past, 'date_to' => $future],
+                '&nbsp;#9 - Free shipping (Disabled)',
+                'disabled outranks the dates, and this is the case the issue reports',
+            ],
+            'expired rule' => [
+                ['id_cart_rule' => 10, 'name' => 'Free shipping', 'active' => '1', 'code' => '', 'date_from' => date('Y-m-d H:i:s', time() - 2 * self::DAY), 'date_to' => $past],
+                '&nbsp;#10 - Free shipping (Expired)',
+                'an expired rule is active but unusable',
+            ],
+            'rule that has not started' => [
+                ['id_cart_rule' => 11, 'name' => 'Free shipping', 'active' => '1', 'code' => '', 'date_from' => $future, 'date_to' => date('Y-m-d H:i:s', time() + 2 * self::DAY)],
+                '&nbsp;#11 - Free shipping (Scheduled)',
+                'a rule that starts later is not usable yet either',
+            ],
+        ];
+    }
+
+    public function testTwoRulesSharingANameStayDistinguishable(): void
+    {
+        $common = ['name' => 'Free shipping', 'active' => '1', 'code' => '', 'date_from' => null, 'date_to' => null];
+
+        $first = $this->renderOption(['id_cart_rule' => 12] + $common);
+        $second = $this->renderOption(['id_cart_rule' => 13] + $common);
+
+        self::assertNotSame($first, $second, 'the whole point of the issue is that identical names must not render identically');
+    }
+
+    private function renderOption(array $cartRule): string
+    {
+        $controller = (new ReflectionClass(AdminCartRulesController::class))->newInstanceWithoutConstructor();
+
+        // The real controller receives its translator from the constructor, which needs a full request.
+        $translator = new ReflectionProperty(ControllerCore::class, 'translator');
+        $translator->setAccessible(true);
+        $translator->setValue($controller, Context::getContext()->getTranslator());
+
+        $method = new ReflectionMethod(AdminCartRulesController::class, 'renderCartRuleOption');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $cartRule);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The "Compatibility with other cart rules" lists show every other cart rule by name alone, so duplicates are indistinguishable and a disabled or expired rule looks like a live one. Show the id, the code, and why a rule cannot currently be used. The lists stay unfiltered, which is the conclusion the issue reached.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #22442
| Related PRs       | --
| Sponsor company   | --

### Why

`AdminCartRulesController::ajaxProcessLoadCartRules()` builds every entry of both lists as

```php
'<option value="' . (int) $cart_rule['id_cart_rule'] . '">&nbsp;' . Tools::safeOutput($cart_rule['name']) . '</option>'
```

Name and nothing else. Measured on a shop with five cart rules, two of them deliberately sharing a name:

```
before                          after
ZZ Probe disabled               #17 - ZZ Probe disabled - ZZOFF (Disabled)
ZZ Probe expired                #18 - ZZ Probe expired (Expired)
ZZ Probe scheduled              #19 - ZZ Probe scheduled (Scheduled)
ZZ Probe live                   #20 - ZZ Probe live - ZZDUP
```

### The decision, which was already made on the issue

The title asks to **offer only** active or valid vouchers. The thread concluded the opposite, and it is
right: MatShir pointed out that compatibility is a lasting relation, so "if you activate an older cart
rule, how will the new cart rules interact with it?". Filtering the list would silently drop a relation
the merchant cannot then restore. prestascott's design answer was a Description column.

So this labels rather than filters. The state is shown for exactly the rules the reporter could not
tell apart, and nothing is hidden.

Precedence is deliberate: `Disabled` outranks the dates, because a disabled rule is unusable whatever
its period says.

### Cost

Nothing is queried that was not already fetched. `CartRule::getAssociatedRestrictions()` runs
`SELECT t.*, tl.*`, so `active`, `code`, `date_from` and `date_to` are already on every row the loop
walks.

All three state words already exist in the catalogues - `Disabled` in `Admin.Global`, `Expired` and
`Scheduled` in `Admin.Catalog.Feature` - so there are no new strings, and
`translations/default/` is untouched.

### Worth knowing before this is reviewed: the surface is scheduled to disappear

The new discount system replaces this page, and it does **not** carry this feature forward.
`DiscountFormDataHandler` sets `setCompatibleDiscountTypeIds(...)` - compatibility by discount **type**,
not the per rule list this issue is about. So when `FEATURE_FLAG_DISCOUNT` becomes the default, the
lists this fixes stop existing.

That flag is `state="0"` and `stability="beta"` in `install-dev/data/xml/feature_flag.xml`, so today
every shop is on the legacy page. This is a small change to the page merchants actually use, not an
investment in the replacement, and it should be judged on that basis.

### Tests

`tests/Integration/Classes/Controller/CartRuleCompatibilityOptionTest.php`, 6 cases: a usable rule with
a code, an automatic rule with no code (the empty-code case that would otherwise leave a dangling
separator), disabled, expired, not yet started, and two rules sharing a name asserted to render
differently - which is the issue restated as an assertion.

Two mutations, each with the revert grep-verified inside the container first:

| Mutation | Result |
|---|---|
| drop the state suffix | 3 failures, exactly the three state cases |
| drop the `#id -` prefix | 5 failures, including the shared-name case |

### How to test

Create several cart rules with `cart_rule_restriction` on, including two with the same name, one
disabled, one whose end date has passed and one whose start date is in the future. Edit any cart rule
and open Conditions > Compatibility with other cart rules. Each entry now reads
`#id - name - code (state)`, with the code and the state present only when they apply.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- The `Stale` label was added by the bot on 2026-09-04; the issue is `PM ✔️` and `To Do` since 2021.
- One other open core PR touches `AdminCartRulesController.php`: my own #42752, at `@@ -729`
  inside `renderForm()`. This change is at `@@ -93`, `@@ -105` and `@@ -116`. No overlap. Checked by
  hunk over all 755 open core PRs, full coverage.
