### PR TITLE
Do not fail the email preview on an order without a usable cart

### DIFF
--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -350,7 +350,16 @@ final class MailPreviewVariablesBuilder
     {
         $cart = new Cart($order->id_cart);
         $packageList = $cart->getPackageList();
-        $package = current(current($packageList));
+
+        // The preview picks the most recent order, whose cart may no longer resolve to a deliverable
+        // package - an emptied cart, or products removed since. There is then nothing to list, which is
+        // not a reason to fail the whole preview.
+        $addressPackages = current($packageList);
+        $package = is_array($addressPackages) ? current($addressPackages) : false;
+        if (!is_array($package) || !isset($package['product_list'])) {
+            return [];
+        }
+
         $productList = $package['product_list'];
 
         $productTemplateList = [];

--- a/tests/Integration/Adapter/MailTemplate/MailPreviewOrderLayoutTest.php
+++ b/tests/Integration/Adapter/MailTemplate/MailPreviewOrderLayoutTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\MailTemplate;
+
+use Doctrine\DBAL\Connection;
+use PrestaShop\PrestaShop\Adapter\MailTemplate\MailPreviewVariablesBuilder;
+use PrestaShop\PrestaShop\Core\MailTemplate\Layout\Layout;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Integration\Utility\ContextMocker;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * The order_conf preview is built from the most recent order. Not every order has a usable cart -
+ * an order created without one carries id_cart = 0 - and then Cart::getPackageList() is empty.
+ * getProductList() read current(current($packageList)) unguarded, so the whole preview died with
+ * "current(): Argument #1 ($array) must be of type array, bool given" instead of simply having no
+ * product list to show.
+ */
+class MailPreviewOrderLayoutTest extends KernelTestCase
+{
+    private const TABLES_TO_RESTORE = ['orders'];
+
+    private Connection $connection;
+    private string $dbPrefix;
+    private ?ContextMocker $contextMocker = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->dbPrefix = self::getContainer()->getParameter('database_prefix');
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+        $this->contextMocker = (new ContextMocker())->mockContext();
+    }
+
+    protected function tearDown(): void
+    {
+        DatabaseDump::restoreTables(self::TABLES_TO_RESTORE);
+
+        if (null !== $this->contextMocker) {
+            $this->contextMocker->resetContext();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testOrderConfirmationPreviewSurvivesAnOrderWithoutACart(): void
+    {
+        // getOrdersWithInformations() orders by date_add DESC, and ties resolve arbitrarily, so make
+        // one order unambiguously the newest and strip its cart.
+        $targetOrderId = (int) $this->connection->executeQuery(
+            'SELECT id_order FROM ' . $this->dbPrefix . 'orders ORDER BY id_order DESC LIMIT 1'
+        )->fetchOne();
+        $this->assertGreaterThan(0, $targetOrderId, 'The fixture needs at least one order.');
+
+        $this->connection->executeStatement(
+            'UPDATE ' . $this->dbPrefix . 'orders SET id_cart = 0, date_add = NOW() WHERE id_order = :id',
+            ['id' => $targetOrderId]
+        );
+
+        $builder = self::getContainer()->get(MailPreviewVariablesBuilder::class);
+        $variables = $builder->buildTemplateVariables(new Layout('order_conf', '', ''));
+
+        // Reaching this line at all is the regression: without the guard the builder throws.
+        $this->assertArrayHasKey('{shop_name}', $variables);
+        // The order branch was entered rather than skipped - the product list is simply empty.
+        $this->assertArrayHasKey('{products}', $variables);
+        $this->assertStringNotContainsString('id_product', (string) $variables['{products}']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Design > Email Theme > preview of the `order_conf` layout builds its product list from the most recent order's cart. Not every order has one - an order created without a cart carries `id_cart = 0` - and `Cart::getPackageList()` is then empty, so `current(current($packageList))` in `MailPreviewVariablesBuilder::getProductList()` throws `current(): Argument #1 ($array) must be of type array, bool given` and the whole preview fails. A cart that resolves to no deliverable package now means an empty product list; the rest of the preview still renders.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make the shop's most recent order carry `id_cart = 0` (or delete its cart) and open Design > Email Theme > preview on the `order_conf` layout. Before the change the page fails with the TypeError above; after it the preview renders with an empty product list. `tests/Integration/Adapter/MailTemplate/MailPreviewOrderLayoutTest.php` forces exactly that state.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | (add the issue reference before publishing)
| Related PRs       | Shares `MailPreviewVariablesBuilder.php` with `fix/mail-preview-extra-template-vars-24923`, at a different method (`getProductList()` vs `buildTemplateVariables()`), so the two do not conflict.
| Sponsor company   |

### How it was found and pinned

It surfaced as a TypeError while writing the #24923 test. The first attempt to reproduce it was wrong:
emptying `cart_product` for the order's cart changed nothing, because `getPackageList()` still returns a
structure. Probing the fixture directly gave the real cause - the newest order is `id_order=30` with
**`id_cart = 0`**, so `getPackageList()` returns `[]`, `current([])` is `false`, and the outer `current()`
rejects it.

`Order::getOrdersWithInformations(1)` sorts by `date_add DESC` with ties resolved arbitrarily and a shop
restriction applied, so which order the preview picks is not stable. The test therefore forces one order
to be unambiguously the newest and strips its cart, instead of relying on the fixture's ordering.

### Verification

- Mutation - restore the unguarded `current(current($packageList))`: the test errors with the exact
  original message, `TypeError: current(): Argument #1 ($array) must be of type array, bool given`.
- The test asserts `{products}` is still present, so the order branch is entered rather than skipped -
  the guard makes the product list empty, it does not bypass the branch.
- PHPStan `[OK]`, php-cs-fixer clean.
