### PR TITLE
Say on the customer page that the customer is deleted

### DIFF
--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -169,7 +169,8 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
             $customerShop->name,
             $customerLanguage->name,
             $customerSubscriptions,
-            (bool) $customer->active
+            (bool) $customer->active,
+            (bool) $customer->deleted
         );
     }
 

--- a/src/Core/Domain/Customer/QueryResult/PersonalInformation.php
+++ b/src/Core/Domain/Customer/QueryResult/PersonalInformation.php
@@ -82,6 +82,11 @@ class PersonalInformation
     private $isActive;
 
     /**
+     * @var bool
+     */
+    private $isDeleted;
+
+    /**
      * @param string $firstName
      * @param string $lastName
      * @param string $email
@@ -111,7 +116,8 @@ class PersonalInformation
         $shopName,
         $languageName,
         Subscriptions $subscriptions,
-        $isActive
+        $isActive,
+        $isDeleted = false
     ) {
         $this->firstName = $firstName;
         $this->lastName = $lastName;
@@ -127,6 +133,7 @@ class PersonalInformation
         $this->languageName = $languageName;
         $this->subscriptions = $subscriptions;
         $this->isActive = $isActive;
+        $this->isDeleted = $isDeleted;
     }
 
     /**
@@ -239,5 +246,16 @@ class PersonalInformation
     public function isActive()
     {
         return $this->isActive;
+    }
+
+    /**
+     * A soft deleted customer keeps its row, and its `active` flag keeps whatever value it had, so
+     * the two are independent and both are needed to describe the account.
+     *
+     * @return bool
+     */
+    public function isDeleted()
+    {
+        return $this->isDeleted;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/personal_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/personal_information.html.twig
@@ -160,6 +160,13 @@
             {{ 'Inactive'|trans({}, 'Admin.Global') }}
           {% endif %}
         </span>
+
+        {% if customerInformation.personalInformation.deleted %}
+          <span class="customer-deleted-status badge badge-danger rounded">
+            <i class="material-icons">delete</i>
+            {{ 'Deleted'|trans({}, 'Admin.Global') }}
+          </span>
+        {% endif %}
       </div>
     </div>
 

--- a/tests/Integration/Adapter/Customer/QueryHandler/DeletedCustomerIsMarkedTest.php
+++ b/tests/Integration/Adapter/Customer/QueryHandler/DeletedCustomerIsMarkedTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Customer\QueryHandler;
+
+use Configuration;
+use Context;
+use Currency;
+use Customer;
+use PrestaShop\PrestaShop\Core\Crypto\Hashing;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\ViewableCustomer;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A soft deleted customer is hidden from the Customers grid but its view page stays reachable, because
+ * the handler only checks that the record loads. The page therefore has to say the account is deleted:
+ * `deleted` and `active` are independent columns, so without it the page reports a deleted customer as
+ * Active, which is worse than saying nothing.
+ */
+class DeletedCustomerIsMarkedTest extends KernelTestCase
+{
+    private ?Customer $customer = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        // The handler formats cart totals, which needs a currency on the context; a bare kernel has none.
+        $context = Context::getContext();
+        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->container = self::getContainer();
+    }
+
+    protected function tearDown(): void
+    {
+        if (null !== $this->customer && $this->customer->id) {
+            $this->customer->delete();
+            $this->customer = null;
+        }
+
+        parent::tearDown();
+    }
+
+    public function testADeletedCustomerIsReportedAsDeletedWhileStayingActive(): void
+    {
+        $customer = $this->createCustomer();
+
+        self::assertFalse($this->view($customer)->getPersonalInformation()->isDeleted(), 'a fresh customer is not deleted');
+
+        $customer->deleted = true;
+        $customer->update();
+
+        $personalInformation = $this->view($customer)->getPersonalInformation();
+
+        self::assertTrue($personalInformation->isDeleted(), 'the view has to report the deletion');
+        self::assertTrue(
+            $personalInformation->isActive(),
+            'deleted and active are independent columns, so deleting must not be inferred from active'
+        );
+    }
+
+    private function view(Customer $customer): ViewableCustomer
+    {
+        return self::getContainer()
+            ->get('prestashop.core.query_bus')
+            ->handle(new GetCustomerForViewing((int) $customer->id));
+    }
+
+    private function createCustomer(): Customer
+    {
+        $customer = new Customer();
+        $customer->firstname = 'Deleted';
+        $customer->lastname = 'Probe';
+        $customer->email = sprintf('deleted-probe-%s@example.com', uniqid());
+        // the column stores a hash, not a password: Customer::$definition validates it with isHashedPassword
+        $customer->passwd = (new Hashing())->hash('probe-password');
+        $customer->active = true;
+        $customer->add();
+
+        return $this->customer = $customer;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A soft deleted customer is hidden from the Customers grid but its view page stays reachable, and that page never mentioned the deletion. Worse, because `deleted` and `active` are independent columns, it showed a green Active badge. Carry the flag to the view model and show it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #22958
| Related PRs       | --
| Sponsor company   | --

### Why

`CustomerQueryBuilder` selects `c.deleted = 0`, so a soft deleted customer disappears from the
Customers list. Its view page does not disappear with it: `GetCustomerForViewingHandler` asserts only
that the record loaded (`if (!$customer->id)`), and a soft deleted row still loads. The page is
reachable from an order, from a search, or from a bookmarked URL.

Neither `ViewableCustomer` nor `PersonalInformation` carried anything about deletion, so the page could
not mention it even if the template wanted to.

Measured by dispatching `GetCustomerForViewing` against a customer with `deleted = 1`:

```
VIEW SERVED for a deleted customer
  isActive   : true
  isGuest    : true
  methods mentioning 'delet' on PersonalInformation : NONE
  methods mentioning 'delet' on ViewableCustomer    : NONE
```

That `isActive: true` is the part that turns an omission into a contradiction. `deleted` and `active`
are independent columns and deleting a customer does not clear `active`, so the page shows a green
**Active** badge for an account that was deleted, while the Customers list refuses to show it at all.

### What it does

`PersonalInformation` gains an `isDeleted` flag, the handler passes `(bool) $customer->deleted`, and the
template shows a Deleted badge next to the existing status badge.

The new constructor argument is **optional and last**, so any existing caller that builds a
`PersonalInformation` keeps working. That is why the table above says no BC break.

### The second half of the issue is moot

The report also asks for a `$deleted` parameter on `Customer::getCustomers()`. That method has **no
callers at all** in `src`, `classes` or `controllers` on 9.2. Adding a parameter to code nothing calls
buys nothing, and it stays public, so nothing is removed either. Said on the issue rather than done.

### Tests

`tests/Integration/Adapter/Customer/QueryHandler/DeletedCustomerIsMarkedTest.php` creates a customer,
asserts it is not reported as deleted, soft deletes it, and asserts the view reports the deletion **and
still reports it as active** - the second assertion is the one that pins the independence of the two
columns, which is the whole point. Removing the handler's new argument fails it with `the view has to
report the deletion`.

```
php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Adapter/Customer/QueryHandler/DeletedCustomerIsMarkedTest.php
```

Two things the fixture needs, both pre-existing traits of the code under test rather than of this
change: `Customer::$passwd` is validated with `isHashedPassword`, so the fixture hashes; and
`GetCustomerForViewingHandler` formats cart totals through the context currency, which a bare kernel
does not set, so the test sets one.

### How to test

Delete a customer from the Customers list, then open that customer from one of their orders. The page
shows a Deleted badge beside the status. A customer that has not been deleted looks exactly as before.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- `Deleted` is a new string in `Admin.Global`, which is where its neighbours `Active` and `Inactive`
  already live. `translations/default/` is deliberately untouched: that catalogue is refreshed by
  separate "Update default catalog" commits, not by code pull requests.
- `GetCustomerForViewingHandler.php` is also edited by my #42148, at `@@ -33` and `@@ -341`; this change
  is at the `new PersonalInformation(` call around line 158. Different hunks.
