### PR TITLE
Name the combination in cart errors that quote its quantity

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -384,7 +384,9 @@ class CartControllerCore extends FrontController
         if (!$product->id || !$product->active || !$product->checkAccess($this->context->cart->id_customer)) {
             $this->{$ErrorKey}[] = $this->trans(
                 'This product (%product%) is no longer available.',
-                ['%product%' => $product->name],
+                ['%product%' => $product->id
+                    ? Product::getProductName($this->id_product, $this->id_product_attribute)
+                    : $product->name],
                 'Shop.Notifications.Error'
             );
 
@@ -452,11 +454,17 @@ class CartControllerCore extends FrontController
         }
 
         // Check minimal_quantity
+        // WHY the name is resolved with the combination: the minimum below comes from the combination
+        // whenever one is selected, so naming only the product leaves the customer unable to tell which
+        // of several combinations of the same product in the cart the message is about.
         if (!$this->id_product_attribute) {
             if ($qty_to_check < $product->minimal_quantity) {
                 $this->errors[] = $this->trans(
                     'The minimum purchase order quantity for the product %product% is %quantity%.',
-                    ['%product%' => $product->name, '%quantity%' => $product->minimal_quantity],
+                    [
+                        '%product%' => Product::getProductName($this->id_product),
+                        '%quantity%' => $product->minimal_quantity,
+                    ],
                     'Shop.Notifications.Error'
                 );
 
@@ -467,7 +475,10 @@ class CartControllerCore extends FrontController
             if ($qty_to_check < $combination->minimal_quantity) {
                 $this->errors[] = $this->trans(
                     'The minimum purchase order quantity for the product %product% is %quantity%.',
-                    ['%product%' => $product->name, '%quantity%' => $combination->minimal_quantity],
+                    [
+                        '%product%' => Product::getProductName($this->id_product, $this->id_product_attribute),
+                        '%quantity%' => $combination->minimal_quantity,
+                    ],
                     'Shop.Notifications.Error'
                 );
 
@@ -669,7 +680,7 @@ class CartControllerCore extends FrontController
             return true;
         }
 
-        $productName = !empty($product['attributes']) ? $product['name'] . ' ' . $product['attributes'] : $product['name'];
+        $productName = $this->getCartProductName($product);
 
         if ($product['active'] && $product['quantity_available'] > 0) {
             return $this->trans(
@@ -690,6 +701,25 @@ class CartControllerCore extends FrontController
     }
 
     /**
+     * Name of a cart line, including its combination when it has one.
+     *
+     * WHY it reads the row instead of querying: every row returned by Cart::getProducts() and by
+     * Cart::checkQuantities() is merged with Cart::DEFAULT_ATTRIBUTES_KEYS, so 'attributes' is always
+     * present and is an empty string for a product without combinations. Resolving the name per row
+     * with a query would cost one query per cart line for something the row already carries.
+     *
+     * @param array $product a cart line as returned by Cart::getProducts() or Cart::checkQuantities()
+     */
+    private function getCartProductName(array $product): string
+    {
+        if (empty($product['attributes'])) {
+            return $product['name'];
+        }
+
+        return $product['name'] . ' ' . $product['attributes'];
+    }
+
+    /**
      * Check that minimal quantity conditions are respected for each product in the cart
      */
     private function checkCartProductsMinimalQuantities(): void
@@ -702,7 +732,7 @@ class CartControllerCore extends FrontController
                 $this->errors[] = $this->trans(
                     'The minimum purchase order quantity for the product %product% is %quantity%.',
                     [
-                        '%product%' => $product['name'],
+                        '%product%' => $this->getCartProductName($product),
                         '%quantity%' => $product['minimal_quantity'],
                     ],
                     'Shop.Notifications.Error'

--- a/tests/Integration/Classes/Controller/CartProductNameTest.php
+++ b/tests/Integration/Classes/Controller/CartProductNameTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes\Controller;
+
+use CartController;
+use ReflectionClass;
+use ReflectionMethod;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A cart error that quotes a quantity taken from a combination has to name that combination too.
+ * Several combinations of one product can sit in the same cart, and a message naming only the
+ * product does not say which line it is about.
+ */
+class CartProductNameTest extends KernelTestCase
+{
+    /**
+     * @dataProvider getCartLines
+     */
+    public function testACartLineIsNamedWithItsCombination(array $cartLine, string $expected, string $because): void
+    {
+        self::bootKernel();
+
+        self::assertSame($expected, $this->nameOf($cartLine), $because);
+    }
+
+    public static function getCartLines(): array
+    {
+        return [
+            'a combination' => [
+                ['name' => 'Hummingbird printed t-shirt', 'attributes' => 'Size : S, Color : Black'],
+                'Hummingbird printed t-shirt Size : S, Color : Black',
+                'the customer has to be able to tell this line from another combination of the same product',
+            ],
+            // Cart::getProducts() merges every row with Cart::DEFAULT_ATTRIBUTES_KEYS, so a product
+            // without combinations arrives with an empty string rather than no key at all.
+            'no combination' => [
+                ['name' => 'Mug The best is yet to come', 'attributes' => ''],
+                'Mug The best is yet to come',
+                'a product without combinations must not gain a trailing separator',
+            ],
+            'attributes key absent' => [
+                ['name' => 'Mug The best is yet to come'],
+                'Mug The best is yet to come',
+                'a row that never went through the attributes merge must not raise a notice',
+            ],
+        ];
+    }
+
+    private function nameOf(array $cartLine): string
+    {
+        $controller = (new ReflectionClass(CartController::class))->newInstanceWithoutConstructor();
+
+        $method = new ReflectionMethod(CartController::class, 'getCartProductName');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $cartLine);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The minimum a product may be bought from is taken from the selected combination, but the message quoting it names only the product. A cart holding several combinations of one product gives the customer no way to tell which line was refused. Name the combination wherever one is known.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23051
| Related PRs       | #42201 touches the same block and must land first; this one then rebases onto it.
| Sponsor company   | --

### Why

Reproduced on 9.2 over HTTP. Combination 2 of the demo t-shirt (`Size - S, Color - Black`) was given a
minimum of 5 and one unit was added to the cart:

```
The minimum purchase order quantity for the product Hummingbird printed t-shirt is 5.
```

The `5` is the **combination's** minimum, read from `Combination::$minimal_quantity` two lines above the
message. The name is the product's. With three sizes of the same shirt in a cart, nothing in the
sentence says which one is being refused. That is what this issue reports.

### What was already fixed, and what was left

Part of this issue has been repaired since 2021 and the remaining sites are the ones nobody came back
to. On 9.2 these already resolve the combination:

- `processChangeProductInCart()` availability messages, via `Product::getProductName($this->id_product, $this->id_product_attribute)`
- `areProductsAvailable()`, by reading `attributes` off the cart row

These did not:

| Site | Message |
|---|---|
| `processChangeProductInCart()`, product access check | `This product (%product%) is no longer available.` |
| `processChangeProductInCart()`, minimum quantity, both branches | `The minimum purchase order quantity for the product %product% is %quantity%.` |
| `checkCartProductsMinimalQuantities()` | the same message, for the whole cart |

The combination branch of the second one is the sharpest: it constructs `new Combination(...)`, takes
`minimal_quantity` from it, and then names the product.

### What it does

Each site follows whichever convention its own neighbours already use, rather than introducing a third:

- The request scoped checks resolve through `Product::getProductName()`, matching the two calls a few
  lines above them.
- The cart loop reads the row it already holds. `Cart::getProducts()` merges every row with
  `Cart::DEFAULT_ATTRIBUTES_KEYS`, so `attributes` is always present and is an empty string for a
  product without combinations. Resolving that with a query would cost one query per cart line for
  something the row already carries.

That row formatting existed once already, inline in `areProductsAvailable()`. It is now one private
helper with both callers, which is also what matks asked for on the earlier attempt at this issue
(#28467): "create a function to handle the stuff, so we dont repeat it".

### Measured, before and after, over HTTP

Each revert was confirmed by grepping the file inside the container before the run, not assumed.

**Adding a quantity below the combination's minimum**

```
before   ...for the product Hummingbird printed t-shirt is 5.
after    ...for the product Hummingbird printed t-shirt : Color - Black, Size - S is 5.
```

**The cart page warning, reached by raising the minimum after the line is already in the cart**

```
before   ...for the product Hummingbird printed t-shirt is 5.
after    ...for the product Hummingbird printed t-shirt Size: S - Color: Black is 5.
```

The two renderings differ because they come from different sources, and **both formats already ship in
this controller today** - `Product::getProductName()` produces `Name : Group - Value`, the cart row
produces `Group: Value - Group: Value`. This change does not introduce that inconsistency and does not
unify it either, since doing so would alter messages that already ship.

### Tests

`tests/Integration/Classes/Controller/CartProductNameTest.php`, 3 cases on the shared helper: a line
with a combination, a line whose `attributes` is the empty string that `DEFAULT_ATTRIBUTES_KEYS`
supplies, and a row with no `attributes` key at all. Neutering the helper to return the bare name fails
exactly the first, and leaves the other two passing, which is the correct discrimination.

```
php vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Classes/Controller/CartProductNameTest.php
```

The single `PHPUnit Deprecations: 1` is the repo-wide `@dataProvider` annotation: 46 files under
`tests/Integration` use it and none use the attribute, and an existing test (`Adapter/DatabaseTest.php`)
reports the same thing at the same rate.

### How to test

Give a combination of a product a minimum purchase quantity of 5, then try to add 1 of it to the cart.
The error names the combination. Then set the minimum back to 1, put the combination in the cart, raise
the minimum to 5 again and open the cart page: the warning names the combination too.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- Four earlier attempts at this issue exist and **all four were closed for inactivity, none on merit**:
  #23059, #23079, #23093 and #28467. #28467 was approved by matks and had its wording settled with
  Julievrz before it went stale. The `PR available` label on the issue is therefore misleading.
- This change is deliberately narrower than #28467, which also rewrote the wording of many messages.
  Wording changes need the product team; naming the combination does not.
