### PR TITLE
Add a display hook on every product line of an order

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -461,6 +461,11 @@
       <title>Order detail</title>
       <description>This hook is displayed within the order's details in Front Office</description>
     </hook>
+    <hook id="displayOrderDetailProductLine">
+      <name>displayOrderDetailProductLine</name>
+      <title>Order detail product line</title>
+      <description>This hook is displayed on every product line of an order in Front Office. Receives the order, the order detail row and the product identifiers.</description>
+    </hook>
     <hook id="actionPaymentCCAdd">
       <name>actionPaymentCCAdd</name>
       <title>Payment CC added</title>
@@ -2150,6 +2155,11 @@
       <name>displayAdminOrderMainBottom</name>
       <title>Admin Order Main Column Bottom</title>
       <description>This hook displays content in the order view page at the bottom of the main column</description>
+    </hook>
+    <hook id="displayAdminOrderProductLine">
+      <name>displayAdminOrderProductLine</name>
+      <title>Admin Order Product Line</title>
+      <description>This hook displays content on every product line of the order view page. Receives the order, the order detail row and the product identifiers.</description>
     </hook>
     <hook id="displayAdminOrderTabLink">
       <name>displayAdminOrderTabLink</name>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -44,6 +44,11 @@
         <strong>{{ 'View pack content'|trans({}, 'Admin.Actions') }}</strong>
       </span>
     {% endif %}
+    {{ renderhook('displayAdminOrderProductLine', {
+      id_order: orderForViewing.id,
+      id_order_detail: product.orderDetailId,
+      id_product: product.id,
+    }) }}
   </td>
   <td class="cellProductUnitPrice">{{ product.unitPrice }}</td>
   <td class="cellProductQuantity text-center">

--- a/tests/Unit/PrestaShopBundle/Twig/RenderHookDeclarationTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/RenderHookDeclarationTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A hook a back office template renders has to be declared in the install data as well, or a fresh
+ * shop never creates the row for it and the hook does not appear where a merchant positions modules.
+ */
+class RenderHookDeclarationTest extends TestCase
+{
+    private const VIEWS_DIRECTORY = '/src/PrestaShopBundle/Resources/views';
+    private const HOOK_FILE = '/install-dev/data/xml/hook.xml';
+
+    public function testEveryHookRenderedByATemplateIsDeclaredInTheInstallData(): void
+    {
+        $declared = $this->getDeclaredHookNames();
+        $this->assertNotEmpty($declared, 'No hook is declared in ' . self::HOOK_FILE . '.');
+
+        $rendered = $this->getRenderedHookNames();
+        $this->assertNotEmpty($rendered, 'No template renders a hook, so this test would pass vacuously.');
+
+        $this->assertSame([], array_values(array_diff($rendered, $declared)));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getDeclaredHookNames(): array
+    {
+        $hooks = simplexml_load_file(_PS_ROOT_DIR_ . self::HOOK_FILE);
+        $this->assertNotFalse($hooks, self::HOOK_FILE . ' cannot be parsed.');
+
+        $names = [];
+        foreach ($hooks->entities->hook as $hook) {
+            $names[] = (string) $hook->name;
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getRenderedHookNames(): array
+    {
+        $directory = new \RecursiveDirectoryIterator(_PS_ROOT_DIR_ . self::VIEWS_DIRECTORY);
+        $names = [];
+
+        /** @var \SplFileInfo $file */
+        foreach (new \RecursiveIteratorIterator($directory) as $file) {
+            if ($file->getExtension() !== 'twig') {
+                continue;
+            }
+
+            $template = file_get_contents($file->getPathname());
+            if ($template === false) {
+                continue;
+            }
+
+            // A hook name built from a variable cannot be checked here and is left out on purpose.
+            preg_match_all('/renderhook(?:s?Array)?\(\s*[\'"]([A-Za-z0-9_]+)[\'"]/', $template, $matches);
+            $names = array_merge($names, $matches[1]);
+        }
+
+        return array_values(array_unique($names));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | An order product line has no extension point in the back office or the front office. Declare a display hook for each and render the back office one on every row of the order view.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23245
| Related PRs       | PrestaShop/hummingbird#TBD and PrestaShop/classic-theme#TBD render `displayOrderDetailProductLine`. Touches `install-dev/data/xml/hook.xml`, which my #42559, #42742 and #42779 also edit - all in different parts of the file.
| Sponsor company   | --

### Why

PierreRambaud answered the question on the issue in 2021 - "AFAIK there is no hook to do it right
now" - and that is still true on 9.2. The order view has fourteen `displayAdminOrder*` hooks and the
front office has `displayOrderDetail`, but every one of them is page level or column level. Nothing
receives one product line, so a module cannot put information, or an input, next to a single product
of an order.

The confirmation email is the exception and needs no change. `PaymentModule` already runs
`actionPaymentModuleProductVarTplAfter` once per row with `product_var_tpl` passed **by reference**,
so a module can add data to one line, and `mails/_partials/order_conf_product_list.tpl` already
calls `{hook h='displayProductPriceBlock' product=$product type="unit_price"}` inside the row, so
there is already a render point as well. That covers the third surface the issue asks for.

### Decisions taken here

The issue is labelled `Needs Specs` and no product answer ever came, so these are mine.

- **Two hooks, not one.** The back office row is an `OrderProductForViewing` in a Twig table and the
  front office row is a presented array in a Smarty template. A single name would arrive with two
  different parameter shapes, which is the thing that makes a hook hard to use.
- **Identifiers only**, `id_order`, `id_order_detail` and `id_product`. This matches
  `displayAdminOrderTop` and `displayOrderPreview`, and it keeps the hook independent of the shape of
  a query result or of a presenter, both of which change between versions. A module loads what it
  needs from the ids.
- **Rendered at the end of the product cell**, where the reference, the MPN, the supplier reference
  and the shipment number already are. A new column would have to be added to the header of every
  table and to every colspan in it; the product cell is where per line information already lives, and
  it needs no geometry change at all.
- **A listener must be idempotent and must not emit fixed ids.** The hook can be called more than
  once for the same order line: classic renders every line twice, once in a `hidden-sm-down` table
  and once in a `hidden-md-up` list, so a listener fires twice per line there and once on
  hummingbird. That is why classic already prefixes its own element ids with `_desktop_` and
  `_mobile_`, and a module rendering into this hook has to do the same. A listener that counts, logs
  a row or emits a fixed `id` or `name` attribute will do it twice per line on classic.
- **`displayOrderDetailProductLine` is declared here and called by the two theme branches.** A
  declaration is what makes a hook appear where a merchant positions modules;
  `Hook::registerHook()` creates the row on the fly for a name it does not know, so a module or a
  third party theme can use it either way.

### How to test

```
php vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter RenderHookDeclarationTest
php bin/console lint:twig src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
```

Then, with a module that registers on `displayAdminOrderProductLine` and returns some markup from
`hookDisplayAdminOrderProductLine($params)`, open any order in Orders > view. The markup appears
under the product name of every line, and `$params` carries the three identifiers of that line.

### Measured on a running 9.2 shop

A probe module returning `<!--PROBE-BO id_order=... id_order_detail=... id_product=...-->` was
installed and registered on both names.

```
Hook::exec('displayAdminOrderProductLine', [1, 2, 3])   <!--PROBE-BO id_order=1 id_order_detail=2 id_product=3-->
Hook::exec('displayOrderDetailProductLine', [4, 5, 6])  <!--PROBE-FO id_order=4 id_order_detail=5 id_product=6-->
lint:twig                                               OK, 1 file
```

The front office hook was then measured end to end through the real page - see the two theme bodies,
where the probe output appears once per product line with the right identifiers on all twelve render
sites of the two shipped themes.

**What was NOT exercised, stated plainly:** `renderhook` itself, in the back office page. It goes
through `HookDispatcher::dispatchRenderingWithParameters`, and a kernel booted from the CLI does not
dispatch rendering hooks at all. The control for that is `displayAdminOrderTop`, which already ships
in core and is already rendered by `renderhook` on this very page, so it demonstrably works in
production. With the probe registered on both names in the same run:

```
renderhook('displayAdminOrderProductLine')    0 bytes
renderhook('displayAdminOrderTop')            0 bytes      <- ships in core, works in the back office
Hook::exec('displayAdminOrderProductLine')    <!--PROBE-NEW-->
Hook::exec('displayAdminOrderTop')            <!--PROBE-EXISTING-->
```

A hook that works in production returns nothing through the same call from the CLI, so the empty
result is the harness and not a property of the new name. The back office page needs an employee
session, which is out of scope here. What is established is that
the name resolves and the module receives the three identifiers, that the call site compiles, that
the call is unconditional inside the product cell, and that all three code paths rendering
`product.html.twig` pass `orderForViewing` (the page, and the two AJAX actions in
`OrderController` at the add-product and update-product handlers).

### Mutations

`tests/Unit/PrestaShopBundle/Twig/RenderHookDeclarationTest.php` asserts that every hook name a
back office template renders is declared in the install data - the rule #36742 exists to repair
retroactively, and it had no guard. Removing the two declarations while keeping the call makes it
fail and name `displayAdminOrderProductLine`. It scans 32 hook names across the bundle's templates
and all 32 are declared on `develop`, so it is green before this change and stays green after it.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- **Order matters**: this declares the front office hook, the two theme branches call it. Land this
  first, the same way the #23659 pair was sequenced.
- `install-dev/data/xml/hook.xml` collisions with my own open PRs, all checked by hunk: #42559 at
  lines 138 and 5385, #42742 at 4788, #42779 at the end of the file (5938). The two entries here go
  in at 460 and 2124, next to `displayOrderDetail` and inside the `displayAdminOrder*` cluster, on
  purpose - appending at the end would have collided with #42779.
- `product.html.twig` is also edited by my #42526, whose hunk is `@@ -167,7 +167,7 @@`; this one is
  at line 44. No overlap.
- A module's output lands inside a `<td>` in the back office and inside a `<span>` or a `<td>`
  depending on the theme in the front office, so inline level markup is the safe assumption for
  module authors. Worth stating in the devdocs entry.
