### PR TITLE
Name the order's tax row after what it does to the prices beside it

### DIFF
--- a/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
@@ -147,7 +147,11 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
 
         return [
             'type' => 'tax',
-            'label' => $this->translator->trans('Tax', [], 'Shop.Theme.Checkout'),
+            // Same wording as the cart: the amount is informative when the prices around it already
+            // contain it, and an addition when they do not.
+            'label' => $this->includeTaxes
+                ? $this->translator->trans('Included taxes', [], 'Shop.Theme.Checkout')
+                : $this->translator->trans('Taxes', [], 'Shop.Theme.Checkout'),
             'amount' => $tax,
             'value' => $this->priceFormatter->format(
                 $tax,

--- a/tests/Integration/Adapter/Presenter/Order/OrderSubtotalTaxLabelTest.php
+++ b/tests/Integration/Adapter/Presenter/Order/OrderSubtotalTaxLabelTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Presenter\Order;
+
+use Configuration;
+use Db;
+use Group;
+use Order;
+use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderSubtotalLazyArray;
+use Product;
+use ReflectionProperty;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The order summary lists a tax amount next to prices that follow the customer group's price display
+ * method. Naming that row "Tax" leaves a tax-excluded group unable to tell whether the amount is
+ * already inside the prices above it or added to them.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/23784
+ */
+class OrderSubtotalTaxLabelTest extends KernelTestCase
+{
+    private static Order $order;
+
+    /** @var array<string, string> configuration values as found before this test class ran */
+    private static array $initialConfiguration = [];
+
+    private static int $groupId;
+
+    private static int $initialPriceDisplayMethod;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::bootKernel();
+        // The presenter resolves the translator through the legacy container finder.
+        global $kernel;
+        $kernel = self::$kernel;
+
+        // An order whose tax-included and tax-excluded totals differ, so the tax row has a value.
+        $orderId = (int) Db::getInstance()->getValue(
+            'SELECT MIN(`id_order`) FROM `' . _DB_PREFIX_ . 'orders` WHERE `total_paid_tax_incl` > `total_paid_tax_excl`'
+        );
+        self::$order = new Order($orderId);
+
+        foreach (['PS_TAX', 'PS_TAX_DISPLAY'] as $key) {
+            self::$initialConfiguration[$key] = (string) Configuration::get($key);
+            Configuration::updateValue($key, 1);
+        }
+
+        self::$groupId = (int) Group::getCurrent()->id;
+        self::$initialPriceDisplayMethod = Group::getPriceDisplayMethod(self::$groupId);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // PHPUnit shuts the kernel down between tests; the legacy container finder needs it back.
+        global $kernel;
+        $kernel = static::bootKernel();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::setPriceDisplayMethod(self::$initialPriceDisplayMethod);
+
+        foreach (self::$initialConfiguration as $key => $value) {
+            Configuration::updateValue($key, $value);
+        }
+
+        parent::tearDownAfterClass();
+    }
+
+    public function testTaxRowIsNamedAfterAnAdditionForATaxExcludedGroup(): void
+    {
+        self::setPriceDisplayMethod(PS_TAX_EXC);
+
+        $subtotals = new OrderSubtotalLazyArray(self::$order);
+
+        $this->assertGreaterThan(0, $subtotals['tax']['amount']);
+        $this->assertSame('Taxes', $subtotals['tax']['label']);
+    }
+
+    public function testTaxRowIsNamedAfterAnInclusionForATaxIncludedGroup(): void
+    {
+        self::setPriceDisplayMethod(PS_TAX_INC);
+
+        $subtotals = new OrderSubtotalLazyArray(self::$order);
+
+        $this->assertGreaterThan(0, $subtotals['tax']['amount']);
+        $this->assertSame('Included taxes', $subtotals['tax']['label']);
+    }
+
+    public function testTaxRowStaysEmptyWhenTheShopDoesNotDisplayItInTheCart(): void
+    {
+        Configuration::updateValue('PS_TAX_DISPLAY', 0);
+
+        try {
+            $subtotals = new OrderSubtotalLazyArray(self::$order);
+
+            $this->assertNull($subtotals['tax']['label']);
+        } finally {
+            Configuration::updateValue('PS_TAX_DISPLAY', 1);
+        }
+    }
+
+    /**
+     * Both the group's price display method and the derived tax calculation method are memoised in
+     * static properties that outlive a single request, so they have to be dropped alongside the write.
+     */
+    private static function setPriceDisplayMethod(int $priceDisplayMethod): void
+    {
+        Db::getInstance()->update('group', ['price_display_method' => $priceDisplayMethod], 'id_group = ' . self::$groupId);
+
+        $groupCache = new ReflectionProperty(Group::class, 'group_price_display_method');
+        $groupCache->setAccessible(true);
+        $groupCache->setValue(null, []);
+
+        $productCache = new ReflectionProperty(Product::class, '_taxCalculationMethod');
+        $productCache->setAccessible(true);
+        $productCache->setValue(null, null);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | With "Display tax in the shopping cart" on and a customer group set to "Tax excluded", the order summary lists a tax amount next to tax-excluded prices and a tax-excluded total, all under the single label "Tax". The cart already distinguishes the two cases as "Included taxes" / "Taxes"; the order summary and the order confirmation page now use the same pair.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23784
| Related PRs       | None
| Sponsor company   |

### Why

`OrderSubtotalLazyArray` builds every other row from the group's price display method
(`getProducts()`, `getShipping()`, `getGiftWrapping()` all branch on `$this->includeTaxes`), and
`OrderLazyArray::getAmounts()` picks `total_paid` or `total_paid_tax_excl` the same way. `getTax()` is the
one row that does not: it is emitted whenever `PS_TAX_DISPLAY` is on and always named "Tax".

For a tax-excluded group the page then reads `Subtotal 100.00 / Shipping 7.00 / Tax 22.00 / Total 107.00`.
Every number is correct - the total reflects the group's display method and the tax row is informational -
but nothing on the page says so, which is the "quite a mess" in the report and the "wrong total" in the
follow-up.

`CartLazyArray::getSubtotals()` already solved this for the cart: the same row is "Included taxes" when
the surrounding prices contain the tax and "Taxes" when they do not. The order presenter is a copy of the
cart's that never picked the distinction up.

### What it does

One label in `OrderSubtotalLazyArray::getTax()`, following `$this->includeTaxes`, reusing the two strings
the cart already uses. This also covers the order confirmation page, which renders
`$subtotals.tax.label` from the same presenter.

Nothing else changes: no amount moves, no row appears or disappears, no new translation key.

### How to test

```
php vendor/bin/phpunit -c tests/Integration/phpunit.xml \
  tests/Integration/Adapter/Presenter/Order/OrderSubtotalTaxLabelTest.php
```

On a shop: International > Taxes > enable "Display tax in the shopping cart"; Shop parameters > Customer
Settings > Groups > set the group's price display method; place an order and open it under My account >
Order history. The tax row reads "Taxes" for a tax-excluded group and "Included taxes" for a
tax-included one, matching what the cart said at checkout.

Reverting `OrderSubtotalLazyArray.php` fails both label tests.
