### PR TITLE
Check the PHP version against the range the release supports

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -3,6 +3,9 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+
+use PrestaShop\PrestaShop\Core\Requirement\PhpVersionRequirement;
+
 class ConfigurationTestCore
 {
     public static $test_files = [
@@ -80,7 +83,6 @@ class ConfigurationTestCore
     public static function getDefaultTestsOp()
     {
         return [
-            'new_phpversion' => false,
             'gz' => false,
             'mbstring' => false,
             'dom' => false,
@@ -117,9 +119,14 @@ class ConfigurationTestCore
         return 'fail';
     }
 
-    public static function test_phpversion()
+    /**
+     * @param int|null $versionId a PHP_VERSION_ID to test instead of the running one. ConfigurationTest::run()
+     *                            passes the test's own configuration value here, which is `false` for this
+     *                            test, so anything that is not an id is ignored
+     */
+    public static function test_phpversion($versionId = null)
     {
-        return version_compare(PHP_VERSION, '7.1.3', '>=');
+        return PhpVersionRequirement::isVersionSupported(is_int($versionId) ? $versionId : PHP_VERSION_ID);
     }
 
     public static function test_apache_mod_rewrite()
@@ -132,6 +139,10 @@ class ConfigurationTestCore
         return in_array('mod_rewrite', apache_get_modules());
     }
 
+    /**
+     * @deprecated since 9.2.0, use test_phpversion() instead. It answers the same question, and this one
+     *             is no longer part of getDefaultTestsOp() because it reported the same failure twice.
+     */
     public static function test_new_phpversion()
     {
         return static::test_phpversion();

--- a/src/Adapter/Requirement/CheckRequirements.php
+++ b/src/Adapter/Requirement/CheckRequirements.php
@@ -7,6 +7,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Requirement;
 
 use ConfigurationTest;
+use PrestaShop\PrestaShop\Core\Requirement\PhpVersionRequirement;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -71,7 +72,15 @@ class CheckRequirements
     private function getErrorMessages()
     {
         return [
-            'phpversion' => $this->translator->trans('Update your PHP version.', [], 'Admin.Advparameters.Notification'),
+            'phpversion' => $this->translator->trans(
+                'Your server runs PHP %current%. PrestaShop runs on PHP %minimum% to PHP %maximum%.',
+                [
+                    '%current%' => PHP_VERSION,
+                    '%minimum%' => PhpVersionRequirement::MINIMUM_VERSION,
+                    '%maximum%' => PhpVersionRequirement::MAXIMUM_VERSION,
+                ],
+                'Admin.Advparameters.Notification'
+            ),
             'upload' => $this->translator->trans('Configure your server to allow file uploads.', [], 'Admin.Advparameters.Notification'),
             'system' => $this->translator->trans('Configure your server to allow the creation of directories and files with write permissions.', [], 'Admin.Advparameters.Notification'),
             'curl' => $this->translator->trans('Enable the CURL extension on your server.', [], 'Admin.Advparameters.Notification'),
@@ -104,7 +113,6 @@ class CheckRequirements
             'fopen' => $this->translator->trans('Allow the PHP fopen() function on your server.', [], 'Admin.Advparameters.Notification'),
             'gz' => $this->translator->trans('Enable GZIP compression on your server.', [], 'Admin.Advparameters.Notification'),
             'files' => $this->translator->trans('Some PrestaShop files are missing from your server.', [], 'Admin.Advparameters.Notification'),
-            'new_phpversion' => $this->translator->trans('You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.6. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.6 now!', ['%s' => PHP_VERSION], 'Admin.Advparameters.Notification'),
             'apache_mod_rewrite' => $this->translator->trans('Enable the Apache mod_rewrite module', [], 'Admin.Advparameters.Notification'),
         ];
     }

--- a/src/Core/Requirement/PhpVersionRequirement.php
+++ b/src/Core/Requirement/PhpVersionRequirement.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Requirement;
+
+/**
+ * The range of PHP versions this release runs on.
+ *
+ * The installer cannot use this class: it checks the PHP version before Composer's autoloader is
+ * reachable, so it carries the same numbers in install-dev/install_version.php. PhpVersionRequirementTest
+ * fails if the two ever disagree.
+ */
+final class PhpVersionRequirement
+{
+    public const MINIMUM_VERSION_ID = 80100;
+    public const MAXIMUM_VERSION_ID = 80599;
+
+    public const MINIMUM_VERSION = '8.1';
+    public const MAXIMUM_VERSION = '8.5';
+
+    // This class should not be instantiated
+    private function __construct()
+    {
+    }
+
+    public static function isVersionSupported(int $versionId = PHP_VERSION_ID): bool
+    {
+        return $versionId >= self::MINIMUM_VERSION_ID && $versionId <= self::MAXIMUM_VERSION_ID;
+    }
+}

--- a/tests/Unit/Classes/ConfigurationTestPhpVersionTest.php
+++ b/tests/Unit/Classes/ConfigurationTestPhpVersionTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use ConfigurationTest;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Requirement\PhpVersionRequirement;
+
+class ConfigurationTestPhpVersionTest extends TestCase
+{
+    /**
+     * The System information page runs this test and prints an error when it fails, so it has to answer
+     * for the release it ships with rather than for a version bound left behind by an older branch.
+     */
+    public function testItAnswersForTheVersionRangeTheReleaseSupports(): void
+    {
+        $this->assertSame(PhpVersionRequirement::isVersionSupported(), ConfigurationTest::test_phpversion());
+    }
+
+    /**
+     * Driven with explicit ids rather than with the running interpreter: on a supported one every wrong
+     * bound returns true, including the 7.1.3 this replaced, so that assertion could not fail.
+     *
+     * @dataProvider provideVersionIds
+     */
+    public function testItRejectsVersionsOutsideTheRange(int $versionId, bool $expected): void
+    {
+        $this->assertSame($expected, ConfigurationTest::test_phpversion($versionId));
+    }
+
+    public function provideVersionIds(): iterable
+    {
+        yield 'PHP 7.4, below the range' => [70433, false];
+        yield 'PHP 8.0, below the range' => [80030, false];
+        yield 'PHP 8.1, the minimum' => [80100, true];
+        yield 'PHP 8.5, the maximum' => [80599, true];
+        yield 'PHP 8.6, above the range' => [80600, false];
+    }
+
+    /**
+     * ConfigurationTest::run() hands the test its configuration value, `false` for this one, and that
+     * must not be read as a version id.
+     */
+    public function testItFallsBackToTheRunningVersion(): void
+    {
+        $this->assertSame(PhpVersionRequirement::isVersionSupported(), ConfigurationTest::run('phpversion', false) === 'ok');
+    }
+
+    /**
+     * new_phpversion has always delegated to phpversion, so leaving it in the optional list reported the
+     * same failure twice on the page.
+     */
+    public function testTheOptionalListNoLongerRepeatsThePhpVersionTest(): void
+    {
+        $this->assertArrayNotHasKey('new_phpversion', ConfigurationTest::getDefaultTestsOp());
+        $this->assertArrayHasKey('phpversion', ConfigurationTest::getDefaultTests());
+    }
+}

--- a/tests/Unit/Core/Requirement/PhpVersionRequirementTest.php
+++ b/tests/Unit/Core/Requirement/PhpVersionRequirementTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Requirement;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Requirement\PhpVersionRequirement;
+
+class PhpVersionRequirementTest extends TestCase
+{
+    /**
+     * @dataProvider provideVersionIds
+     */
+    public function testItAcceptsOnlyTheSupportedRange(int $versionId, bool $expected): void
+    {
+        $this->assertSame($expected, PhpVersionRequirement::isVersionSupported($versionId));
+    }
+
+    public function provideVersionIds(): iterable
+    {
+        yield 'below the minimum' => [PhpVersionRequirement::MINIMUM_VERSION_ID - 1, false];
+        yield 'the minimum itself' => [PhpVersionRequirement::MINIMUM_VERSION_ID, true];
+        yield 'inside the range' => [PhpVersionRequirement::MINIMUM_VERSION_ID + 1, true];
+        yield 'the maximum itself' => [PhpVersionRequirement::MAXIMUM_VERSION_ID, true];
+        yield 'above the maximum' => [PhpVersionRequirement::MAXIMUM_VERSION_ID + 1, false];
+    }
+
+    /**
+     * The installer checks the PHP version before the autoloader is reachable, so it cannot use this
+     * class and repeats the range in install-dev/install_version.php. Parsed rather than required:
+     * that file defines constants, and another test may already have loaded it.
+     *
+     * @dataProvider provideConstantPairs
+     */
+    public function testItStaysInStepWithTheInstaller(string $installerConstant, $expected): void
+    {
+        $installVersion = file_get_contents(__DIR__ . '/../../../../install-dev/install_version.php');
+        $this->assertIsString($installVersion);
+
+        $matched = preg_match(
+            "/define\('" . preg_quote($installerConstant, '/') . "', '?([^')]+)'?\)/",
+            $installVersion,
+            $matches
+        );
+
+        $this->assertSame(1, $matched, sprintf('%s is not defined by the installer', $installerConstant));
+        $this->assertSame((string) $expected, $matches[1]);
+    }
+
+    public function provideConstantPairs(): iterable
+    {
+        yield ['_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', PhpVersionRequirement::MINIMUM_VERSION_ID];
+        yield ['_PS_INSTALL_MAXIMUM_PHP_VERSION_ID_', PhpVersionRequirement::MAXIMUM_VERSION_ID];
+        yield ['_PS_INSTALL_MINIMUM_PHP_VERSION_', PhpVersionRequirement::MINIMUM_VERSION];
+        yield ['_PS_INSTALL_MAXIMUM_PHP_VERSION_', PhpVersionRequirement::MAXIMUM_VERSION];
+    }
+}

--- a/translations/default/AdminAdvparametersNotification.xlf
+++ b/translations/default/AdminAdvparametersNotification.xlf
@@ -987,11 +987,6 @@
         <target>Unknown tax rule group ID. You need to create a group with this ID first.</target>
         <note>File: src/Adapter/Import/Handler/ProductImportHandler.php [Line: 470]</note>
       </trans-unit>
-      <trans-unit id="4f32e16f17a3ba8527cd8160ad85de37">
-        <source>Update your PHP version.</source>
-        <target>Update your PHP version.</target>
-        <note>File: src/Adapter/Requirement/CheckRequirements.php [Line: 74]</note>
-      </trans-unit>
       <trans-unit id="b5871613cbf4ab8b21d528ff2576fcbf">
         <source>Updated files</source>
         <target>Updated files</target>
@@ -1031,11 +1026,6 @@
         <source>You are about to enable a feature that is not stable yet. This should only be done in a test environment or in full knowledge of the potential risks.</source>
         <target>You are about to enable a feature that is not stable yet. This should only be done in a test environment or in full knowledge of the potential risks.</target>
         <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/FeatureFlag/index.html.twig [Line: 64]</note>
-      </trans-unit>
-      <trans-unit id="e567554b1238bc9e85e38b01e6b198e9">
-        <source>You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.6. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.6 now!</source>
-        <target>You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.6. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.6 now!</target>
-        <note>File: src/Adapter/Requirement/CheckRequirements.php [Line: 107]</note>
       </trans-unit>
       <trans-unit id="5bb701014490e33a37ecdc43ce578404">
         <source>You can't put this menu inside itself. </source>
@@ -1091,6 +1081,11 @@
         <source>Your file has been successfully imported into your shop. Don't forget to re-build the products' search index.</source>
         <target>Your file has been successfully imported into your shop. Don't forget to re-build the products' search index.</target>
         <note>File: controllers/admin/AdminImportController.php [Line: 548]</note>
+      </trans-unit>
+      <trans-unit id="4eb6efb26e37e7af6a1d63064406fccf">
+        <source>Your server runs PHP %current%. PrestaShop runs on PHP %minimum% to PHP %maximum%.</source>
+        <target>Your server runs PHP %current%. PrestaShop runs on PHP %minimum% to PHP %maximum%.</target>
+        <note>File: src/Adapter/Requirement/CheckRequirements.php [Line: 74]</note>
       </trans-unit>
       <trans-unit id="95fdb0ead4798ff27cce78fac3fd3c11">
         <source>[1]%percentage%[/1]% validated</source>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The Information page's PHP version check compares against 7.1.3, a bound left behind by the 1.7 branch, so a shop running a PHP version 9.2 does not support is told its requirements are fine.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23551
| Related PRs       |
| Sponsor company   |

### Possible impacts

Three. (1) Advanced parameters > Information starts reporting an error on shops whose PHP is outside 8.1 to 8.5 - the point of the change, but a new red line for merchants who have drifted off a supported version. (2) `ConfigurationTest::getDefaultTestsOp()` no longer contains `new_phpversion`, so a caller enumerating the optional list gets one key fewer. (3) `ConfigurationTest::test_new_phpversion()` is deprecated.

Deprecation: `ConfigurationTest::test_new_phpversion()`.

### Why

The thread converged in 2023. matks argued a runtime check cannot be relied on, since an unsupported PHP
often means a blank page rather than a page carrying a warning; Hlavtox called a runtime check overkill;
kpodemski thought the issue could be closed as already done. MatShir had the last word, on 2023-08-23:
"The check is done on the information page, we could highlight it there when the version is not
correct."

The check is indeed there - `SystemInformationController` injects `CheckRequirements`, whose summary the
page renders as a list of failing requirements, and `phpversion` is in
`ConfigurationTest::getDefaultTests()`. It just cannot fail. `ConfigurationTest::test_phpversion()` was

```php
return version_compare(PHP_VERSION, '7.1.3', '>=');
```

while 9.2 installs on 8.1 to 8.5 (`install-dev/install_version.php`). Measured:

```
PHP 7.1.3    test_phpversion()=ok   supported by 9.2 (8.1-8.5)=no
PHP 7.4.33   test_phpversion()=ok   supported by 9.2 (8.1-8.5)=no
PHP 8.0.30   test_phpversion()=ok   supported by 9.2 (8.1-8.5)=no
PHP 8.1.0    test_phpversion()=ok   supported by 9.2 (8.1-8.5)=yes
PHP 8.5.0    test_phpversion()=ok   supported by 9.2 (8.1-8.5)=yes
PHP 8.6.0    test_phpversion()=ok   supported by 9.2 (8.1-8.5)=no
```

Four of six wrong, in both directions. So this is not the feature the issue asked for; it is a check
that stopped matching its release, which is why nobody's PHP has ever been flagged.

### What it does

- `PhpVersionRequirement` carries the supported range. The installer cannot use it - it checks the PHP
  version before Composer's autoloader is reachable - so it keeps its own copy in
  `install-dev/install_version.php`, and a test fails if the two ever disagree.
- `ConfigurationTest::test_phpversion()` asks that class. It also takes an optional version id, because
  otherwise it can only be exercised against the interpreter the suite happens to run on, where every
  wrong bound returns true. `ConfigurationTest::run()` passes the test's configuration value, `false`
  for this one, so anything that is not an id is ignored.
- The message changes. "Update your PHP version." is wrong in one of the two directions the check now
  catches, so it names the running version and the supported range instead.
- `new_phpversion` leaves `getDefaultTestsOp()`. It has always delegated to `test_phpversion()`, so with
  a working check it would have printed the same failure twice on one page - once under Required
  parameters, once under Optional. The method stays, deprecated. Its message, which still recommended
  upgrading to PHP 5.6, is gone.

### Callers, enumerated

`ConfigurationTest` is driven from two places, and both are safe:

- `PrestaShopBundle\Install\System::checkRequiredTests()` / `checkOptionalTests()` - the installer's
  requirements screen. It is a namespaced, Composer-autoloaded class, and `install-dev/index.php`
  requires `autoload.php` before anything reaches it, so `PhpVersionRequirement` is always loadable
  there. The same `index.php` also hard-gates the PHP range against its own standalone constants and
  sends an out-of-range interpreter to `missing_requirement.php` before the screen runs, so the newly
  failing states are unreachable from the installer and its own minimum-only wording
  ("PHP %version% or later is not enabled") is never shown for the above-maximum case.
- `Adapter\Requirement\CheckRequirements` - the Information page, which is the surface this fixes.

`new_phpversion` has no other reference anywhere in the repository: no installer message, no UI test, no
module. Removing it from the optional list orphans nothing.

### How to test

```
php vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter 'ConfigurationTestPhpVersionTest|PhpVersionRequirementTest'
```

In the back office, Advanced parameters > Information: on a supported PHP, "Required parameters: OK", as
before. On PHP 8.0 or 8.6 the page lists "Your server runs PHP 8.0.30. PrestaShop runs on PHP 8.1 to PHP
8.5." under Required parameters, and lists it once.

### Mutations

- restore the `7.1.3` comparison: 3 of the version cases fail (7.4, 8.0, 8.6).
- drop the upper bound from `isVersionSupported()`: 2 fail.
- put `new_phpversion` back in the optional list: 1 fails.
- change `MAXIMUM_VERSION_ID` to 80699: the installer drift test fails.

php-cs-fixer clean, PHPStan clean, the xlf parses and stays sorted with every id equal to
`md5(<source>)`.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- The drift test parses `install-dev/install_version.php`, a file the release tooling edits - but
  `ReleaseCreator::setInstallDevInstallVersionConstants()` only rewrites `_PS_INSTALL_VERSION_`, not the
  four PHP constants, so a release does not move the guard. `9.2.x` merges up into `develop`, where that
  file differs only in `_PS_INSTALL_VERSION_` (9.2.0 vs 9.3.0), which the test does not read.
- Only `translations/default/` is touched; the locale catalogues are Crowdin's, which is what the
  previous string change on this repo did.
- The UI campaign `BO/14_advancedParameters/01_informations` addresses blocks by their `data-block`
  attributes and asserts no requirement text, so it is unaffected.
- **Deliberately NOT built**: the highlight of the PHP version line in the Server information block. I
  had it written before finding `CheckRequirements`, and it would have put a second indicator for the
  same fact on the same page. The requirements list already says it.

