### PR TITLE
Repeat the product table header on every page of a PDF document

### DIFF
--- a/pdf/delivery-slip.product-tab.tpl
+++ b/pdf/delivery-slip.product-tab.tpl
@@ -19,14 +19,14 @@
 				{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 				<tr class="product {$bgcolor_class}">
 
-					<td class="product left">
+					<td class="product left" width="25%">
 						{if empty($order_detail.product_reference)}
 							---
 						{else}
 							{$order_detail.product_reference}
 						{/if}
 					</td>
-					<td class="product left">
+					<td class="product left" width="65%">
 						{if $display_product_images}
 							<table width="100%">
 								<tr>
@@ -45,7 +45,7 @@
 							{$order_detail.product_name}
 						{/if}
 					</td>
-					<td class="product center">
+					<td class="product center" width="10%">
 						{$order_detail.product_quantity-$order_detail.product_quantity_refunded}
 					</td>
 

--- a/pdf/delivery-slip.tpl
+++ b/pdf/delivery-slip.tpl
@@ -32,14 +32,14 @@
 		<td colspan="12" height="20">&nbsp;</td>
 	</tr>
 
-	<!-- Products -->
-	<tr>
-		<td colspan="12">
+</table>
 
-		{$product_tab}
+{* The product table is rendered outside this layout table on purpose. TCPDF only repeats a
+   <thead> across a page break for a table that is not nested, so a document longer than one
+   page would lose its column headers. *}
+{$product_tab}
 
-		</td>
-	</tr>
+<table width="100%" id="body-end" border="0" cellpadding="0" cellspacing="0" style="margin:0;">
 
 	<tr>
 		<td colspan="12" height="20">&nbsp;</td>

--- a/pdf/invoice-b2b.tpl
+++ b/pdf/invoice-b2b.tpl
@@ -33,14 +33,14 @@
 		<td colspan="12" height="20">&nbsp;</td>
 	</tr>
 
-	<!-- Product -->
-	<tr>
-		<td colspan="12">
+</table>
 
-			{$product_tab}
+{* The product table is rendered outside this layout table on purpose. TCPDF only repeats a
+   <thead> across a page break for a table that is not nested, so a document longer than one
+   page would lose its column headers. *}
+{$product_tab}
 
-		</td>
-	</tr>
+<table width="100%" id="body-end" border="0" cellpadding="0" cellspacing="0" style="margin:0;">
 
 	<tr>
 		<td colspan="12" height="10">&nbsp;</td>

--- a/pdf/invoice.product-tab.tpl
+++ b/pdf/invoice.product-tab.tpl
@@ -39,10 +39,10 @@
     {cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
     <tr class="product {$bgcolor_class}">
 
-      <td class="product center">
+      <td class="product center" width="{$layout.reference.width}%">
         {$order_detail.product_reference}
       </td>
-      <td class="product left">
+      <td class="product left" width="{$widthColProduct}%">
         {if $display_product_images}
           <table width="100%">
             <tr>
@@ -63,13 +63,13 @@
 
       </td>
       {if $isTaxEnabled}
-        <td class="product center">
+        <td class="product center" width="{$layout.tax_code.width}%">
           {$order_detail.order_detail_tax_label}
         </td>
       {/if}
 
       {if isset($layout.before_discount)}
-        <td class="product center">
+        <td class="product center" width="{$layout.unit_price_tax_excl.width}%">
           {if isset($order_detail.unit_price_tax_excl_before_specific_price)}
             {displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_excl_before_specific_price}
           {else}
@@ -78,17 +78,17 @@
         </td>
       {/if}
 
-      <td class="product right">
+      <td class="product right" width="{$layout.unit_price_tax_excl.width}%">
         {displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_excl_including_ecotax}
         {if $order_detail.ecotax_tax_excl > 0}
           <br>
           <small>{{displayPrice currency=$order->id_currency price=$order_detail.ecotax_tax_excl}|string_format:{l s='ecotax: %s' d='Shop.Pdf' pdf='true'}}</small>
         {/if}
       </td>
-      <td class="product center">
+      <td class="product center" width="{$layout.quantity.width}%">
         {$order_detail.product_quantity}
       </td>
-      <td  class="product right">
+      <td class="product right" width="{$layout.total_tax_excl.width}%">
         {displayPrice currency=$order->id_currency price=$order_detail.total_price_tax_excl_including_ecotax}
       </td>
     </tr>

--- a/pdf/invoice.tpl
+++ b/pdf/invoice.tpl
@@ -33,14 +33,14 @@
         <td colspan="12" height="20">&nbsp;</td>
     </tr>
 
-    <!-- Product -->
-    <tr>
-        <td colspan="12">
+</table>
 
-            {$product_tab}
+{* The product table is rendered outside this layout table on purpose. TCPDF only repeats a
+   <thead> across a page break for a table that is not nested, so a document longer than one
+   page would lose its column headers. *}
+{$product_tab}
 
-        </td>
-    </tr>
+<table width="100%" id="body-end" border="0" cellpadding="0" cellspacing="0" style="margin:0;">
 
     <tr>
         <td colspan="12" height="10">&nbsp;</td>

--- a/pdf/order-return.product-tab.tpl
+++ b/pdf/order-return.product-tab.tpl
@@ -17,17 +17,17 @@
 		{foreach $products as $product}
 			{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 			<tr class="product {$bgcolor_class}">
-				<td class="product left">
+				<td class="product left" width="60%">
 					{$product.product_name}
 				</td>
-				<td class="product left">
+				<td class="product left" width="20%">
 					{if empty($product.product_reference)}
 						---
 					{else}
 						{$product.product_reference}
 					{/if}
 				</td>
-				<td class="product center">
+				<td class="product center" width="20%">
 					{$product.product_quantity}
 				</td>
 			</tr>

--- a/pdf/order-return.tpl
+++ b/pdf/order-return.tpl
@@ -33,14 +33,14 @@
 		<td colspan="12" height="20">&nbsp;</td>
 	</tr>
 
-	<!-- Product -->
-	<tr>
-		<td colspan="12">
+</table>
 
-			{$product_tab}
+{* The product table is rendered outside this layout table on purpose. TCPDF only repeats a
+   <thead> across a page break for a table that is not nested, so a document longer than one
+   page would lose its column headers. *}
+{$product_tab}
 
-		</td>
-	</tr>
+<table width="100%" id="body-end" border="0" cellpadding="0" cellspacing="0" style="margin:0;">
 
 	<tr>
 		<td colspan="12" height="20">&nbsp;</td>

--- a/pdf/order-slip.product-tab.tpl
+++ b/pdf/order-slip.product-tab.tpl
@@ -16,8 +16,8 @@
 
 	<tbody>
 		{if !isset($order_details) || count($order_details) == 0}
-			<tr class="product" colspan="4">
-				<td class="product center">
+			<tr class="product">
+				<td class="product center" colspan="4">
 					{l s='No details' d='Shop.Pdf' pdf='true'}
 				</td>
 			</tr>
@@ -25,20 +25,20 @@
 			{foreach $order_details as $order_detail}
 				{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 				<tr class="product {$bgcolor_class}">
-					<td class="product left">
+					<td class="product left" width="60%">
 						{$order_detail.product_name}
 					</td>
-					<td class="product center">
+					<td class="product center" width="10%">
 						{$order_detail.product_quantity}
 					</td>
-					<td class="product right">
+					<td class="product right" width="15%">
 						{if $tax_excluded_display}
 							- {displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_excl}
 						{else}
 							- {displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_incl}
 						{/if}
 					</td>
-					<td class="product right">
+					<td class="product right" width="15%">
 						{if $tax_excluded_display}
 							- {displayPrice currency=$order->id_currency price=$order_detail.total_price_tax_excl}
 						{else}
@@ -68,9 +68,9 @@
 								</td></tr></table>
 							</td>
 
-							<td class="center">({$customization.quantity})</td>
-							<td class="product"></td>
-							<td class="product"></td>
+							<td class="center" width="10%">({$customization.quantity})</td>
+							<td class="product right" width="15%"></td>
+							<td class="product right" width="15%"></td>
 						</tr>
 					{/foreach}
 				{/foreach}

--- a/pdf/order-slip.tpl
+++ b/pdf/order-slip.tpl
@@ -33,14 +33,14 @@
 		<td colspan="12" height="20">&nbsp;</td>
 	</tr>
 
-	<!-- Product -->
-	<tr>
-		<td colspan="12">
+</table>
 
-			{$product_tab}
+{* The product table is rendered outside this layout table on purpose. TCPDF only repeats a
+   <thead> across a page break for a table that is not nested, so a document longer than one
+   page would lose its column headers. *}
+{$product_tab}
 
-		</td>
-	</tr>
+<table width="100%" id="body-end" border="0" cellpadding="0" cellspacing="0" style="margin:0;">
 
 	<tr>
 		<td colspan="12" height="10">&nbsp;</td>

--- a/pdf/shipment-delivery-slip.product-tab.tpl
+++ b/pdf/shipment-delivery-slip.product-tab.tpl
@@ -19,14 +19,14 @@
 				{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 				<tr class="product {$bgcolor_class}">
 
-					<td class="product left">
+					<td class="product left" width="25%">
 						{if empty($product.product_reference)}
 							---
 						{else}
 							{$product.product_reference}
 						{/if}
 					</td>
-					<td class="product left">
+					<td class="product left" width="65%">
 						{if $display_product_images}
 							<table width="100%">
 								<tr>
@@ -45,7 +45,7 @@
 							{$product.product_name}
 						{/if}
 					</td>
-					<td class="product center">
+					<td class="product center" width="10%">
 						{$product.product_quantity-$product.product_quantity_refunded}
 					</td>
 

--- a/pdf/supply-order.product-tab.tpl
+++ b/pdf/supply-order.product-tab.tpl
@@ -25,31 +25,31 @@
 	{foreach $supply_order_details as $supply_order_detail}
 		{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 		<tr class="product {$bgcolor_class}">
-			<td class="product left">
+			<td class="product left" width="14%">
 				{$supply_order_detail->supplier_reference}
 			</td>
-			<td class="product left">
+			<td class="product left" width="21%">
 				{$supply_order_detail->name}
 			</td>
-			<td  class="product right">
+			<td class="product right" width="5%">
 				{$supply_order_detail->quantity_expected}
 			</td>
-			<td  class="product right">
+			<td class="product right" width="10%">
 				{$currency->prefix} {$supply_order_detail->unit_price_te} {$currency->suffix}
 			</td>
-			<td  class="product right">
+			<td class="product right" width="11%">
 				{$currency->prefix} {$supply_order_detail->price_te} {$currency->suffix}
 			</td>
-			<td  class="product right">
+			<td class="product right" width="9%">
 				{$supply_order_detail->discount_rate}
 			</td>
-			<td  class="product right">
+			<td class="product right" width="11%">
 				{$currency->prefix} {$supply_order_detail->price_with_discount_te} {$currency->suffix}
 			</td>
-			<td  class="product right">
+			<td class="product right" width="9%">
 				{$supply_order_detail->tax_rate}
 			</td>
-			<td  class="product right">
+			<td class="product right" width="10%">
 				{$currency->prefix} {$supply_order_detail->price_ti} {$currency->suffix}
 			</td>
 		</tr>

--- a/pdf/supply-order.tpl
+++ b/pdf/supply-order.tpl
@@ -20,14 +20,14 @@
 		<td colspan="12" height="30">&nbsp;</td>
 	</tr>
 
-	<!-- Product -->
-	<tr>
-		<td colspan="12">
+</table>
 
-			{$product_tab}
+{* The product table is rendered outside this layout table on purpose. TCPDF only repeats a
+   <thead> across a page break for a table that is not nested, so a document longer than one
+   page would lose its column headers. *}
+{$product_tab}
 
-		</td>
-	</tr>
+<table width="100%" id="body-end" border="0" cellpadding="0" cellspacing="0" style="margin:0;">
 
 
 	<tr>

--- a/tests/Unit/Pdf/PdfProductTableTest.php
+++ b/tests/Unit/Pdf/PdfProductTableTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Pdf;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * TCPDF repeats a <thead> on every page a table spans, but only for a table that is not nested in
+ * another one. The product table of every PDF document therefore has to be rendered outside the
+ * layout table of the document it belongs to, or its column headers disappear from the second page on.
+ */
+class PdfProductTableTest extends TestCase
+{
+    /**
+     * @return array<array{string}>
+     */
+    public function getDocumentTemplates(): array
+    {
+        return [
+            ['delivery-slip.tpl'],
+            ['invoice-b2b.tpl'],
+            ['invoice.tpl'],
+            ['order-return.tpl'],
+            ['order-slip.tpl'],
+            ['supply-order.tpl'],
+        ];
+    }
+
+    /**
+     * @return array<array{string}>
+     */
+    public function getProductTemplates(): array
+    {
+        return [
+            ['delivery-slip.product-tab.tpl'],
+            ['invoice.product-tab.tpl'],
+            ['order-return.product-tab.tpl'],
+            ['order-slip.product-tab.tpl'],
+            ['shipment-delivery-slip.product-tab.tpl'],
+            ['supply-order.product-tab.tpl'],
+        ];
+    }
+
+    /**
+     * @dataProvider getDocumentTemplates
+     */
+    public function testProductTabIsRenderedOutsideAnyTable(string $template): void
+    {
+        $content = $this->getTemplateContent($template);
+        $position = strpos($content, '{$product_tab}');
+
+        $this->assertIsInt($position, sprintf('%s does not render the product tab.', $template));
+
+        $before = substr($content, 0, $position);
+        $depth = preg_match_all('/<table[\s>]/', $before) - preg_match_all('/<\/table>/', $before);
+
+        $this->assertSame(0, $depth, sprintf(
+            '%s renders the product tab inside %d table(s). TCPDF does not repeat the header of a nested table.',
+            $template,
+            $depth
+        ));
+    }
+
+    /**
+     * @dataProvider getProductTemplates
+     */
+    public function testEveryProductCellCarriesAWidth(string $template): void
+    {
+        $content = $this->getTemplateContent($template);
+
+        $this->assertStringContainsString('<thead>', $content, sprintf(
+            '%s has no header rows to repeat.',
+            $template
+        ));
+
+        // Without a width of its own a body cell is sized independently of the header, which TCPDF
+        // prints as a table of its own once it has to repeat it. Only the cells that carry the
+        // "product" class are checked: those are the ones that set the column geometry. A cell
+        // spanning several columns declares a colspan instead and is skipped.
+        preg_match('/<tbody>(.*)<\/tbody>/s', $content, $body);
+        $this->assertNotEmpty($body, sprintf('%s has no product rows.', $template));
+
+        preg_match_all('/<td(?![^>]*\b(?:width|colspan)=)[^>]*class="product[^"]*"[^>]*>/', $body[1], $withoutWidth);
+
+        $this->assertSame([], $withoutWidth[0], sprintf(
+            '%s has product cells without a width.',
+            $template
+        ));
+    }
+
+    private function getTemplateContent(string $template): string
+    {
+        $path = _PS_ROOT_DIR_ . '/pdf/' . $template;
+        $content = file_get_contents($path);
+
+        $this->assertIsString($content, sprintf('%s cannot be read.', $path));
+
+        return $content;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A PDF document longer than one page loses the column headers of its product table from the second page on. It affects the invoice, the delivery slip, the credit slip, the return slip and the supply order form.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23366
| Related PRs       | Touches `pdf/invoice.product-tab.tpl`, which #35356 also edits, and `pdf/shipment-delivery-slip.product-tab.tpl`, which #42773 also edits. Neither overlaps the lines changed here except #42773, see the notes below.
| Sponsor company   | --

### Why

The templates already declare a `<thead>`, and TCPDF does repeat a `<thead>` on every page a table
spans - but only for a table that is not nested in another one. `getHtmlDomArray()` strips the header
section out of any table it has marked `nested="true"`:

```php
// remove thead sections from nested tables
$dom[...]['content'] = str_replace('<thead>', '', $dom[...]['content']);
```

Every document template wraps all of its tabs in a single layout table, `<table width="100%" id="body">`,
so the product table was always the nested one and its header never reached that mechanism.

### What it does

Two changes per document.

1. The product tab is rendered outside the layout table. The wrapper is closed before it and reopened
   after it, so nothing else about the page layout moves: the surrounding spacer rows, the `colspan`
   arrangement of the tax/total blocks and the hook row all stay where they were.

2. Every product cell gets the width its header cell already declares. This is required, not cosmetic:
   once TCPDF has a header to repeat it prints that header as a table of its own, so the body rows no
   longer inherit the `<th width>` values and a cell without a width of its own is auto-sized. Without
   this the Product column collapsed and every product name wrapped over three lines.

Two adjacent slips in `order-slip.product-tab.tpl` came out of the same work: the "No details" row
carried its `colspan` on the `<tr>` instead of the `<td>`, so it was a one-column row in a four-column
table, and the two trailing cells of the customization row had no width either.

### How to test

```
php vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter PdfProductTableTest
```

Then, on a shop, place an order with enough lines to fill more than one page (about 20 with the
default theme) and print each document from the order page: Documents > Invoice, Delivery slip,
Credit slip, the merchandise return slip from Customer Service > Merchandise Returns, and a supply
order form from Stock > Supply Orders. Every page after the first should carry the same column
headers as the first, aligned with the columns below them.

### Measured on a running 9.2 shop

Order 1 padded to 32 lines, each document rendered before and after through its real template class
and read back out of the PDF:

```
document        before                        after
invoice         p2 starts at a product row    p2 starts with Reference / Product / Tax Rate / Unit Price / Qty / Total
delivery slip   p2 starts at a product row    p2 starts with Reference / Product / Qty
credit slip     p2 starts at a product row    p2 starts with Product / Reference / Qty / Unit price / Price
return slip     p2 starts at a product row    p2 starts with Items to be returned / Reference / Qty
supply order    p2 starts at a product row    p2 starts with all nine columns
```

Page one is unchanged: rendered at 90 dpi, the delivery slip's first page is identical pixel for pixel
before and after, and the invoice's differs only in fitting one more row.

Branches of the product table that the first fixture never reached were forced and measured
separately, all against a reverted baseline:

```
PS_PDF_IMG_INVOICE=1     image cell and product name keep their position and size
has_discount             the seven column layout with "Base price" keeps its widths, header repeats
cart_rules               the Discounts block still spans the table, the value stays in the last column
customizedDatas          the customization rows render as before under the repeated header
```

Every probe row was removed afterwards - the 30 filler `order_detail` rows, the `order_cart_rule`,
`order_slip`, `order_slip_detail`, `order_return`, `order_return_detail`, `customization` and
`customized_data` rows and the `PS_PDF_IMG_INVOICE` configuration row - and the invoice regenerated
to the same 466084 bytes as before the experiment.

### Mutations

`tests/Unit/Pdf/PdfProductTableTest.php` covers both halves of the fix over all six document
templates: the product tab must sit at table nesting depth 0, and no product cell may be missing a
width. Each half was reverted on its own, so the two assertions are shown to be independent:

```
reverted                     failures
pdf/ entirely                12 of 12
the six wrappers only         6 - exactly the nesting cases, all width cases green
the six product tabs only     6 - exactly the width cases, all nesting cases green
nothing                       0
```

The width assertion checks the cells carrying the `product` class, the ones that set the column
geometry, and skips a cell that declares a `colspan`.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- **Rebase against my own #42773** before publishing, or publish after it: #42773 edits
  `pdf/shipment-delivery-slip.product-tab.tpl` at `@@ -46,7 +46,7 @@`, and the width added here lands
  on the `<td>` two lines above it, inside the same hunk. The resolution is mechanical - keep both.
- #35356 (tswfi, base `develop`) collapses the multi-line `<th>` tags of `invoice.product-tab.tpl`
  onto single lines. It is a different fix in the same file and its hunk stops at `</thead>`, while
  everything changed here is below `<tbody>`, so the two do not touch. Do not restate its fix.
- PrestaShop regenerates a document PDF on every print rather than storing it, so a reprinted
  historical invoice can paginate one row differently after this change. Worth stating in
  *Possible impacts?* if a maintainer asks.
- Left out on purpose, both pre-existing and unrelated to the header:
  - `{assign var=end value=($layout._colCount-3)}` with an inclusive `{for $var=0 to $end}` makes the
    invoice customization row emit `_colCount + 1` cells, and `_colCount` does not account for the
    tax column being dropped when tax is disabled.
  - `order-slip.product-tab.tpl` iterates `{foreach $customization.datas as $customization_types}`
    over a key that `OrderSlip::getOrdersSlipProducts()` never sets, which raises
    "Undefined array key datas" for a credit slip that contains a customized product.
- No theme ships a `pdf/` directory (checked `hummingbird` 2.x and `classic-theme` develop), so the
  core templates are what every shop renders.
