### PR TITLE
Stop mangling non Latin-1 text, and drop the deprecated utf8 functions

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1386,9 +1386,12 @@ class ToolsCore
         if (Tools::strlen($str) <= $max_length) {
             return $str;
         }
-        $str = utf8_decode($str);
 
-        return utf8_encode(substr($str, 0, $max_length - Tools::strlen($suffix)) . $suffix);
+        // WHY mb_substr and not substr: the previous implementation converted to ISO-8859-1 so that a
+        // byte offset would equal a character offset, then converted back. Every character outside
+        // Latin-1 does not survive that round trip and came back as "?", so truncating Cyrillic, Greek
+        // or CJK text destroyed it. mb_substr counts characters directly and needs no conversion.
+        return mb_substr($str, 0, $max_length - Tools::strlen($suffix)) . $suffix;
     }
 
     /* Copied from CakePHP String utility file */

--- a/classes/webservice/WebserviceSpecificManagementAttachments.php
+++ b/classes/webservice/WebserviceSpecificManagementAttachments.php
@@ -10,7 +10,9 @@ use PrestaShop\PrestaShop\Core\File\Exception\FileUploadException;
 use PrestaShop\PrestaShop\Core\File\Exception\MaximumSizeExceededException;
 use PrestaShop\PrestaShop\Core\File\FileUploader;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\String\UnicodeString;
 
 /**
  * This class is responsible for managing Attachement through webservice
@@ -101,7 +103,18 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
             // if displayFile is set, present the file (download)
             $this->getObjectOutput()->setHeaderParams('Content-Type', $this->displayFile['mime']);
             $this->getObjectOutput()->setHeaderParams('Content-Length', $this->displayFile['file_size']);
-            $this->getObjectOutput()->setHeaderParams('Content-Disposition', 'attachment; filename="' . utf8_decode($this->displayFile['file_name']) . '"');
+            // WHY HeaderUtils: the filename used to be pushed through utf8_decode(), which is deprecated
+            // since PHP 8.2 and which replaced every character outside Latin-1 with "?". makeDisposition
+            // emits the RFC 6266 pair - an ASCII fallback plus a UTF-8 filename* - so non Latin-1 names
+            // arrive intact instead of being mangled.
+            $this->getObjectOutput()->setHeaderParams(
+                'Content-Disposition',
+                HeaderUtils::makeDisposition(
+                    HeaderUtils::DISPOSITION_ATTACHMENT,
+                    (string) $this->displayFile['file_name'],
+                    (new UnicodeString((string) $this->displayFile['file_name']))->ascii()->toString()
+                )
+            );
 
             return file_get_contents($this->displayFile['file']);
         }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3677,7 +3677,21 @@ class AdminImportControllerCore extends AdminController
 
     public function utf8EncodeArray($array)
     {
-        return is_array($array) ? array_map('utf8_encode', $array) : utf8_encode($array);
+        return is_array($array)
+            ? array_map([self::class, 'utf8EncodeString'], $array)
+            : self::utf8EncodeString($array);
+    }
+
+    /**
+     * ISO-8859-1 to UTF-8, the conversion utf8_encode() performed before it was deprecated in PHP 8.2.
+     *
+     * @param string|null $string
+     *
+     * @return string
+     */
+    private static function utf8EncodeString($string)
+    {
+        return mb_convert_encoding((string) $string, 'UTF-8', 'ISO-8859-1');
     }
 
     protected function getNbrColumn($handle, $glue)

--- a/src/Core/Import/File/CsvFileReader.php
+++ b/src/Core/Import/File/CsvFileReader.php
@@ -75,7 +75,13 @@ final class CsvFileReader implements FileReaderInterface
 
         while ($row = fgetcsv($handle, $this->length, $this->delimiter, $this->enclosure, $this->escape)) {
             if ($convertToUtf8) {
-                $row = array_map('utf8_encode', $row);
+                // utf8_encode() is deprecated since PHP 8.2; this is the conversion it performed.
+                $row = array_map(
+                    static function (?string $cell): string {
+                        return mb_convert_encoding((string) $cell, 'UTF-8', 'ISO-8859-1');
+                    },
+                    $row
+                );
             }
 
             yield DataRow::createFromArray($row);

--- a/tests/Unit/Classes/ToolsTest.php
+++ b/tests/Unit/Classes/ToolsTest.php
@@ -16,6 +16,48 @@ class ToolsTest extends TestCase
 {
     use ExtendedTestCaseMethodsTrait;
 
+    /**
+     * Truncating used to convert to ISO-8859-1 so a byte offset would match a character offset, then
+     * convert back. Anything outside Latin-1 does not survive that round trip, so a Cyrillic or CJK
+     * string came back as question marks.
+     *
+     * @dataProvider getStringsToTruncate
+     */
+    public function testTruncateKeepsCharactersOutsideLatin1(string $input, int $maxLength, string $expected, string $because): void
+    {
+        $this->assertSame($expected, Tools::truncate($input, $maxLength), $because);
+    }
+
+    public static function getStringsToTruncate(): array
+    {
+        return [
+            'shorter than the limit is returned untouched' => [
+                'Short', 20, 'Short',
+                'nothing is truncated below the limit, so nothing can be mangled',
+            ],
+            'latin text truncates as before' => [
+                'Ceci est une phrase assez longue', 20, 'Ceci est une phra...',
+                'the behaviour for Latin-1 text must not change',
+            ],
+            'cyrillic survives' => [
+                'Товары со скидкой в нашем магазине', 20, 'Товары со скидкой...',
+                'this used to come back as question marks',
+            ],
+            'greek survives' => [
+                'Ελληνικό κείμενο εδώ', 15, 'Ελληνικό κεί...',
+                'same round trip loss for Greek',
+            ],
+            'a string exactly at the limit is untouched' => [
+                'Ελληνικό κείμενο εδώ', 20, 'Ελληνικό κείμενο εδώ',
+                'the length check counts characters, so an exactly sized string is not truncated',
+            ],
+            'accented latin survives' => [
+                'Chaussures élégantes pour homme', 20, 'Chaussures élégan...',
+                'accented characters are inside Latin-1 and must stay correct too',
+            ],
+        ];
+    }
+
     private const PS_ROUND_UP = 0;
     private const PS_ROUND_DOWN = 1;
     private const PS_ROUND_HALF_UP = 2;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Tools::truncate()` converts to ISO-8859-1 to truncate and back, which replaces every character outside Latin-1 with a question mark, so truncating Cyrillic, Greek or CJK text destroys it. The same deprecated pair of functions is used in four other places. Replace them.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     |
| Related PRs       | #41722 fixes the fifth call site, in the front office `AttachmentController`, and is deliberately left to it.
| Sponsor company   | --

### The bug

`Tools::truncate()`:

```php
$str = utf8_decode($str);

return utf8_encode(substr($str, 0, $max_length - Tools::strlen($suffix)) . $suffix);
```

The round trip through ISO-8859-1 exists so that a byte offset lines up with a character offset. Every
character that does not exist in Latin-1 does not survive it. Measured:

```
in : Товары со скидкой в нашем магазине
now: ?????? ?? ???????...
mb : Товары со скидкой...

in : 日本語のテキストはここにあります
now: ????????????????...
mb : 日本語のテキストはここにあります...
```

`Tools::strlen()` is already multibyte aware, so the length check was right and only the cut was wrong.
`mb_substr` counts characters directly and needs no conversion.

`Tools::truncate()` has **no callers in core** - its own comment says "CAUTION : Use it only on module
hookEvents" - so this is public API used by modules and themes, which is exactly where a shop in Russian,
Greek, Hebrew or Japanese would meet it.

### The rest of the class

`utf8_encode()` and `utf8_decode()` have been **deprecated since PHP 8.2**, and this branch requires
`>=8.1` with CI running to 8.5. Derived from the branch rather than assumed - the six occurrences on
`9.2.x`, and what each is:

| Site | What it is | Change |
|---|---|---|
| `classes/Tools.php` x2 | the truncate round trip above | `mb_substr` |
| `controllers/admin/AdminImportController.php` | `utf8EncodeArray()`, 10 call sites, converts a declared ISO-8859-1 CSV line | `mb_convert_encoding(..., 'UTF-8', 'ISO-8859-1')` |
| `src/Core/Import/File/CsvFileReader.php` | the same conversion in the legacy reader | same |
| `classes/webservice/WebserviceSpecificManagementAttachments.php` | attachment filename in `Content-Disposition` | `HeaderUtils::makeDisposition` |
| `controllers/front/AttachmentController.php` | the front office twin of the above | **left alone, #41722 fixes it** |

`mb_convert_encoding($s, 'UTF-8', 'ISO-8859-1')` is exactly what `utf8_encode()` did, so the two import
paths keep their behaviour. `develop` already carries that identical replacement in `CsvFileReader`
(marked `@deprecated since 9.3`), so the merge upward is trivial.

The webservice filename is the one place the swap would have preserved a bug: `utf8_decode` on a
filename loses the same characters. `HeaderUtils::makeDisposition()` emits the RFC 6266 pair - an ASCII
fallback plus a UTF-8 `filename*` - which is what #41722 does for the front office twin, so the two
attachment paths end up consistent.

### Tests

`Tools::truncate()` had no test. Six cases added to `tests/Unit/Classes/ToolsTest.php`: below the limit,
Latin text unchanged, Cyrillic, Greek, accented Latin, and a string exactly at the limit. Restoring the
old implementation fails two of them (Cyrillic and Greek) and leaves the Latin ones green, which is the
correct discrimination - the old code was only ever wrong outside Latin-1.

```
                    tests  assertions  PHPUnit deprecations
ToolsTest before      403         527                    21
ToolsTest after       409         533                    21
```

The 21 deprecations are the file's own `@dataProvider` annotations and are unchanged by this addition -
measured on the pristine file as a control.

### How to test

```
php vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/Classes/ToolsTest.php
```

For the import paths: import a CSV saved as ISO-8859-1 with accented characters and check the imported
values, which must be unchanged from before. For the webservice: fetch an attachment whose filename has
non Latin-1 characters and check the `Content-Disposition` header now carries both a plain `filename`
and a `filename*`.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- No linked issue. It was found while checking `AttachmentController` for #22634, which is a different
  request (an inline PDF viewer). ps-jarvis will ask for one; the `Fixed issue` cell is left empty
  rather than pointing at an issue this does not fix.
- 26 open core PRs touch one of these files, `Tools.php` and `AdminImportController.php` being the
  contended ones. None of them touches these lines: the only overlap of substance is #41722, and that is
  the call site deliberately excluded here.
