### PR TITLE
Refuse duplicate order status and order return status names

### DIFF
--- a/classes/order/OrderReturnState.php
+++ b/classes/order/OrderReturnState.php
@@ -48,4 +48,27 @@ class OrderReturnStateCore extends ObjectModel
         LEFT JOIN `' . _DB_PREFIX_ . 'order_return_state_lang` orsl ON (ors.`id_order_return_state` = orsl.`id_order_return_state` AND orsl.`id_lang` = ' . (int) $id_lang . ')
         ORDER BY ors.`id_order_return_state` ASC');
     }
+
+    /**
+     * Check if a localized name is already used by another order return state.
+     *
+     * WHY: the name identifies the state everywhere it is displayed, so two states sharing one are
+     * indistinguishable in the back office lists and in the customer's return history.
+     *
+     * @param string $name
+     * @param int $idLang
+     * @param int|null $excludeIdOrderReturnState ID of the order return state excluded from the search
+     *
+     * @return bool
+     */
+    public static function existsLocalizedNameInDatabase(string $name, int $idLang, ?int $excludeIdOrderReturnState): bool
+    {
+        return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+            'SELECT COUNT(*) AS count' .
+            ' FROM ' . _DB_PREFIX_ . 'order_return_state_lang orsl' .
+            ' WHERE orsl.id_lang = ' . $idLang .
+            ' AND orsl.name = \'' . pSQL($name) . '\'' .
+            ($excludeIdOrderReturnState ? ' AND orsl.id_order_return_state != ' . $excludeIdOrderReturnState : '')
+        );
+    }
 }

--- a/src/Adapter/OrderReturnState/CommandHandler/AbstractOrderReturnStateHandler.php
+++ b/src/Adapter/OrderReturnState/CommandHandler/AbstractOrderReturnStateHandler.php
@@ -7,10 +7,14 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\OrderReturnState\CommandHandler;
 
+use Configuration;
+use Language;
 use OrderReturnState;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\DuplicateOrderReturnStateNameException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\MissingOrderReturnStateRequiredFieldsException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\ValueObject\Name;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\ValueObject\OrderReturnStateId;
 use PrestaShopException;
 
@@ -53,6 +57,39 @@ abstract class AbstractOrderReturnStateHandler
      * @throws OrderReturnStateException
      * @throws OrderReturnStateNotFoundException
      */
+    /**
+     * Asserts that no other order return state already uses one of the given localized names.
+     *
+     * WHY: see AbstractOrderStateHandler::assertNameIsNotDuplicate() - every language is checked and
+     * not only the default one, because ObjectModel::formatFields() falls back to the default language
+     * value when a translation is left empty on a required field.
+     *
+     * @param int|null $excludeOrderReturnStateId order return state being edited, excluded from the search
+     *
+     * @throws DuplicateOrderReturnStateNameException
+     */
+    protected function assertNameIsNotDuplicate(OrderReturnState $orderReturnState, ?int $excludeOrderReturnStateId = null): void
+    {
+        $localizedNames = is_array($orderReturnState->name) ? $orderReturnState->name : [];
+        $defaultLangId = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        foreach (Language::getIDs(false) as $langId) {
+            $langId = (int) $langId;
+            $name = (string) ($localizedNames[$langId] ?? '');
+            if ('' === $name) {
+                $name = (string) ($localizedNames[$defaultLangId] ?? '');
+            }
+
+            if ('' === $name) {
+                continue;
+            }
+
+            if (OrderReturnState::existsLocalizedNameInDatabase($name, $langId, $excludeOrderReturnStateId)) {
+                throw new DuplicateOrderReturnStateNameException(new Name($name), sprintf('An order return state named "%s" already exists.', $name));
+            }
+        }
+    }
+
     protected function getOrderReturnState(OrderReturnStateId $orderReturnStateId): OrderReturnState
     {
         try {

--- a/src/Adapter/OrderReturnState/CommandHandler/AddOrderReturnStateHandler.php
+++ b/src/Adapter/OrderReturnState/CommandHandler/AddOrderReturnStateHandler.php
@@ -31,6 +31,7 @@ final class AddOrderReturnStateHandler extends AbstractOrderReturnStateHandler i
 
         $this->fillOrderReturnStateWithCommandData($orderReturnState, $command);
         $this->assertRequiredFieldsAreNotMissing($orderReturnState);
+        $this->assertNameIsNotDuplicate($orderReturnState);
 
         if (false === $orderReturnState->validateFields(false)) {
             throw new OrderReturnStateException('Order status contains invalid field values');

--- a/src/Adapter/OrderReturnState/CommandHandler/EditOrderReturnStateHandler.php
+++ b/src/Adapter/OrderReturnState/CommandHandler/EditOrderReturnStateHandler.php
@@ -34,6 +34,7 @@ final class EditOrderReturnStateHandler extends AbstractOrderReturnStateHandler 
         $this->updateOrderReturnStateWithCommandData($orderReturnState, $command);
 
         $this->assertRequiredFieldsAreNotMissing($orderReturnState);
+        $this->assertNameIsNotDuplicate($orderReturnState, $orderReturnStateId->getValue());
 
         if (false === $orderReturnState->validateFields(false)) {
             throw new OrderReturnStateException('OrderReturnState contains invalid field values');

--- a/src/Adapter/OrderState/CommandHandler/AbstractOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/AbstractOrderStateHandler.php
@@ -7,10 +7,14 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler;
 
+use Configuration;
+use Language;
 use OrderState;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\DuplicateOrderStateNameException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\MissingOrderStateRequiredFieldsException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\Name;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
 use PrestaShopException;
 
@@ -42,6 +46,40 @@ abstract class AbstractOrderStateHandler
             $missingFields = array_keys($errors);
 
             throw new MissingOrderStateRequiredFieldsException($missingFields, sprintf('One or more required fields for order state are missing. Missing fields are: %s', implode(',', $missingFields)));
+        }
+    }
+
+    /**
+     * Asserts that no other order state already uses one of the given localized names.
+     *
+     * WHY: a name is checked for every language and not only the default one, because
+     * ObjectModel::formatFields() falls back to the default language value when a translation is left
+     * empty on a required field, so the row that ends up in the database is not always the one the
+     * merchant typed. Checking the value that will actually be stored is what makes the rule hold.
+     *
+     * @param int|null $excludeOrderStateId order state being edited, excluded from the search
+     *
+     * @throws DuplicateOrderStateNameException
+     */
+    protected function assertNameIsNotDuplicate(OrderState $orderState, ?int $excludeOrderStateId = null): void
+    {
+        $localizedNames = is_array($orderState->name) ? $orderState->name : [];
+        $defaultLangId = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        foreach (Language::getIDs(false) as $langId) {
+            $langId = (int) $langId;
+            $name = (string) ($localizedNames[$langId] ?? '');
+            if ('' === $name) {
+                $name = (string) ($localizedNames[$defaultLangId] ?? '');
+            }
+
+            if ('' === $name) {
+                continue;
+            }
+
+            if (OrderState::existsLocalizedNameInDatabase($name, $langId, $excludeOrderStateId)) {
+                throw new DuplicateOrderStateNameException(new Name($name), sprintf('An order state named "%s" already exists.', $name));
+            }
         }
     }
 

--- a/src/Adapter/OrderState/CommandHandler/AddOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/AddOrderStateHandler.php
@@ -45,6 +45,7 @@ final class AddOrderStateHandler extends AbstractOrderStateHandler implements Ad
 
         $this->fillOrderStateWithCommandData($orderState, $command);
         $this->assertRequiredFieldsAreNotMissing($orderState);
+        $this->assertNameIsNotDuplicate($orderState);
 
         if (false === $orderState->validateFields(false)) {
             throw new OrderStateException('Order status contains invalid field values');

--- a/src/Adapter/OrderState/CommandHandler/EditOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/EditOrderStateHandler.php
@@ -49,6 +49,7 @@ final class EditOrderStateHandler extends AbstractOrderStateHandler implements E
         $this->updateOrderStateWithCommandData($orderState, $command);
 
         $this->assertRequiredFieldsAreNotMissing($orderState);
+        $this->assertNameIsNotDuplicate($orderState, $orderStateId->getValue());
 
         if (false === $orderState->validateFields(false)) {
             throw new OrderStateException('OrderState contains invalid field values');

--- a/src/Core/Domain/OrderReturnState/ValueObject/Name.php
+++ b/src/Core/Domain/OrderReturnState/ValueObject/Name.php
@@ -50,9 +50,13 @@ class Name
      */
     private function assertNameIsValid($name)
     {
-        $matchesFirstNamePattern = preg_match('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u', stripslashes($name));
+        // WHY: the pattern must be the one the name field itself accepts (Validate::isGenericName),
+        // otherwise this object rejects names the shop stores happily. It used to carry a person name
+        // pattern that forbids digits and most punctuation, so a status legitimately called "Status 2"
+        // could not be represented here at all.
+        $matchesGenericNamePattern = preg_match('/^[^<>{}]*$/u', stripslashes($name));
 
-        if (!$matchesFirstNamePattern) {
+        if (!$matchesGenericNamePattern) {
             throw new OrderReturnStateConstraintException(sprintf('Order return state name %s is invalid', var_export($name, true)), OrderReturnStateConstraintException::INVALID_NAME);
         }
     }

--- a/src/Core/Domain/OrderState/ValueObject/Name.php
+++ b/src/Core/Domain/OrderState/ValueObject/Name.php
@@ -50,9 +50,13 @@ class Name
      */
     private function assertNameIsValid($name)
     {
-        $matchesFirstNamePattern = preg_match('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u', stripslashes($name));
+        // WHY: the pattern must be the one the name field itself accepts (Validate::isGenericName),
+        // otherwise this object rejects names the shop stores happily. It used to carry a person name
+        // pattern that forbids digits and most punctuation, so a status legitimately called "Status 2"
+        // could not be represented here at all.
+        $matchesGenericNamePattern = preg_match('/^[^<>{}]*$/u', stripslashes($name));
 
-        if (!$matchesFirstNamePattern) {
+        if (!$matchesGenericNamePattern) {
             throw new OrderStateConstraintException(sprintf('Order state name %s is invalid', var_export($name, true)), OrderStateConstraintException::INVALID_NAME);
         }
     }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
@@ -11,6 +11,7 @@ use Exception;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\BulkDeleteOrderReturnStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\DeleteOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\DuplicateOrderReturnStateNameException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Query\GetOrderReturnStateForEditing;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\BulkDeleteOrderStateCommand;
@@ -460,6 +461,11 @@ class OrderStateController extends PrestaShopAdminController
             DuplicateOrderStateNameException::class => $this->trans(
                 'An order status with the same name already exists: %s',
                 [$e instanceof DuplicateOrderStateNameException ? $e->getName()->getValue() : ''],
+                'Admin.Shopparameters.Notification',
+            ),
+            DuplicateOrderReturnStateNameException::class => $this->trans(
+                'An order return status with the same name already exists: %s',
+                [$e instanceof DuplicateOrderReturnStateNameException ? $e->getName()->getValue() : ''],
                 'Admin.Shopparameters.Notification',
             ),
             OrderStateConstraintException::class => [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
@@ -35,8 +35,9 @@ class OrderReturnStateType extends TranslatorAwareType
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Status name', 'Admin.Shopparameters.Feature'),
                 'help' => sprintf(
-                    '%s %s %s',
+                    '%s %s %s %s',
                     $this->trans('Status name', 'Admin.Shopparameters.Feature'),
+                    $this->trans('The status name must be unique.', 'Admin.Shopparameters.Help'),
                     $this->trans('Invalid characters: numbers and', 'Admin.Shopparameters.Feature'),
                     static::NAME_CHARS
                 ),

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
@@ -119,8 +119,9 @@ class OrderStateType extends TranslatorAwareType
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Status name', 'Admin.Shopparameters.Feature'),
                 'help' => sprintf(
-                    '%s %s %s',
+                    '%s %s %s %s',
                     $this->trans('Order status (e.g. \'Pending\').', 'Admin.Shopparameters.Help'),
+                    $this->trans('The status name must be unique.', 'Admin.Shopparameters.Help'),
                     $this->trans('Invalid characters: numbers and', 'Admin.Shopparameters.Help'),
                     static::NAME_CHARS
                 ),

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderReturnStateFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderReturnStateFeatureContext.php
@@ -16,15 +16,31 @@ use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\DeleteOrderReturn
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\EditOrderReturnStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\BulkDeleteOrderReturnStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\DeleteOrderReturnStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\DuplicateOrderReturnStateNameException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Query\GetOrderReturnStateForEditing;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\QueryResult\EditableOrderReturnState;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\ValueObject\OrderReturnStateId;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
+use Tests\Resources\DatabaseDump;
 
 class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
 {
+    /**
+     * WHY: per scenario and not per feature, for the same reason as
+     * OrderStateFeatureContext::restoreOrderStatesTables() - the Background re-adds the same rows for
+     * every scenario and the names are unique.
+     *
+     * @BeforeScenario @restore-order-return-states-before-scenario
+     *
+     * @AfterFeature @restore-order-return-states-after-feature
+     */
+    public static function restoreOrderReturnStatesTables(): void
+    {
+        DatabaseDump::restoreTables(['order_return_state', 'order_return_state_lang']);
+    }
+
     /**
      * @Given I add a new order return state :orderReturnStateReference with the following details:
      *
@@ -117,6 +133,14 @@ class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
         } catch (BulkDeleteOrderReturnStateException $e) {
             $this->setLastException($e);
         }
+    }
+
+    /**
+     * @Then I should get an error that the order return state name is already used
+     */
+    public function assertLastErrorIsDuplicateOrderReturnStateName(): void
+    {
+        $this->assertLastErrorIs(DuplicateOrderReturnStateNameException::class);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderStateFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderStateFeatureContext.php
@@ -16,15 +16,31 @@ use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\DeleteOrderStateCommand
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\EditOrderStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\BulkDeleteOrderStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\DeleteOrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\DuplicateOrderStateNameException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Query\GetOrderStateForEditing;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\QueryResult\EditableOrderState;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
+use Tests\Resources\DatabaseDump;
 
 class OrderStateFeatureContext extends AbstractDomainFeatureContext
 {
+    /**
+     * WHY: per scenario and not per feature. The Background re-adds the same two order states for
+     * every scenario, and order state names are unique, so a feature scoped restore would make the
+     * second scenario collide with the rows the first one left behind.
+     *
+     * @BeforeScenario @restore-order-states-before-scenario
+     *
+     * @AfterFeature @restore-order-states-after-feature
+     */
+    public static function restoreOrderStatesTables(): void
+    {
+        DatabaseDump::restoreTables(['order_state', 'order_state_lang']);
+    }
+
     /**
      * @Given I add a new order state :orderStateReference with the following details:
      *
@@ -152,6 +168,14 @@ class OrderStateFeatureContext extends AbstractDomainFeatureContext
         } catch (BulkDeleteOrderStateException $e) {
             $this->setLastException($e);
         }
+    }
+
+    /**
+     * @Then I should get an error that the order state name is already used
+     */
+    public function assertLastErrorIsDuplicateOrderStateName(): void
+    {
+        $this->assertLastErrorIs(DuplicateOrderStateNameException::class);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/OrderReturnState/order_return_state.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/OrderReturnState/order_return_state.feature
@@ -1,4 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order_return_state
+@restore-order-return-states-before-scenario
 @restore-order-return-states-after-feature
 Feature: OrderState
   Background:
@@ -48,3 +49,28 @@ Feature: OrderState
     When I bulk delete order return states "order_return_state_1st,order_return_state_2nd"
     And the order return state "order_return_state_1st" shouldn't exist
     And the order return state "order_return_state_2nd" shouldn't exist
+
+  Scenario: Adding an order return state that reuses an existing name is refused
+    When I add a new order return state "order_return_state_duplicate" with the following details:
+      | name               | The 1st Order Return State |
+      | color              | #CDEF12                  |
+      | is_cancelling_return | 0                          |
+    Then I should get an error that the order return state name is already used
+
+  Scenario: Renaming an order return state to the name of another one is refused
+    When I update the order return state "order_return_state_2nd" with the following details:
+      | name               | The 1st Order Return State |
+    Then I should get an error that the order return state name is already used
+    And the order return state "order_return_state_2nd" should have the following details:
+      | name               | The 2nd Order Return State |
+      | color              | #7890AB                  |
+      | is_cancelling_return | 1                          |
+
+  Scenario: Saving an order return state while keeping its own name is accepted
+    When I update the order return state "order_return_state_1st" with the following details:
+      | name               | The 1st Order Return State |
+      | color              | #ABCDEF                  |
+    And the order return state "order_return_state_1st" should have the following details:
+      | name               | The 1st Order Return State |
+      | color              | #ABCDEF                  |
+      | is_cancelling_return | 0                          |

--- a/tests/Integration/Behaviour/Features/Scenario/OrderState/order_state.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/OrderState/order_state.feature
@@ -1,4 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order_state
+@restore-order-states-before-scenario
 @restore-order-states-after-feature
 Feature: OrderState
   Background:
@@ -94,3 +95,38 @@ Feature: OrderState
     And the order state "order_state_1st" should exist
     And the order state "order_state_2nd" should be deleted
     And the order state "order_state_2nd" should exist
+
+  Scenario: Adding an order state that reuses an existing name is refused
+    When I add a new order state "order_state_duplicate" with the following details:
+      | name            | The 1st Order State |
+      | color           | #CDEF12             |
+      | isLoggable      | 0                   |
+      | isInvoice       | 0                   |
+      | isHidden        | 0                   |
+      | hasSendMail     | 0                   |
+      | hasPdfInvoice   | 0                   |
+      | hasPdfDelivery  | 0                   |
+      | isShipped       | 0                   |
+      | isPaid          | 0                   |
+      | isDelivery      | 0                   |
+    Then I should get an error that the order state name is already used
+
+  Scenario: Renaming an order state to the name of another one is refused
+    When I update the order state "order_state_2nd" with the following details:
+      | name            | The 1st Order State |
+    Then I should get an error that the order state name is already used
+    And the order state "order_state_2nd" should have the following details:
+      | name            | The 2nd Order State |
+      | color           | #7890AB             |
+      | hasSendMail     | 0                   |
+      | template        |                     |
+
+  Scenario: Saving an order state while keeping its own name is accepted
+    When I update the order state "order_state_1st" with the following details:
+      | name            | The 1st Order State |
+      | color           | #ABCDEF             |
+    And the order state "order_state_1st" should have the following details:
+      | name            | The 1st Order State |
+      | color           | #ABCDEF             |
+      | hasSendMail     | 0                   |
+      | template        |                     |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The order status uniqueness rule merged as #23142 was lost when the Statuses page was migrated to Symfony. The migrated page kept the error message but not the check, so two order statuses can be given the same name again. Restore the check in the command handlers, for order statuses and for order return statuses.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23130
| Related PRs       | Touches `classes/order/OrderReturnState.php`, which #39210 also edits, and the two order status form types, which #39548 also edits. Different hunks in both cases, detail below.
| Sponsor company   | --

### Why

The issue asks to reword the duplicate name message and move it to the right translation domain. Both
halves are already done on `9.2.x`: `OrderStateController::getErrorMessages()` maps
`DuplicateOrderStateNameException` to `'An order status with the same name already exists: %s'` in
`Admin.Shopparameters.Notification`, which is the exact domain the issue asked for and it also names
the offending status.

That message is unreachable. The rule behind it is gone.

`OrderState::existsLocalizedNameInDatabase()` and the check that called it were merged as **#23142**
into `1.7.7.x` on 2021-02-24, in `classes/order/OrderState.php` and
`controllers/admin/AdminStatusesController.php`. The controller was deleted when the page moved to
Symfony. The helper survived and **has had no caller since**; the exception is mapped but is
**thrown nowhere**.

Derived rather than guessed: of the 10 `Duplicate*Exception` classes under `src/Core/Domain`, exactly
**two are never thrown**, and they are the two order status ones.

```
DuplicateCountryIsoCodeException            thrown
DuplicateCustomerEmailException             thrown
DuplicateOrderCartException                 thrown
DuplicateProductInOrderException            thrown
DuplicateProductInOrderInvoiceException     thrown
DuplicateFeatureValueAssociationException   thrown
DuplicateTagException                       thrown
DuplicateWebserviceKeyException             thrown
DuplicateOrderStateNameException            never
DuplicateOrderReturnStateNameException      never
```

Reproduced on a 9.2 shop through the command bus, which is what the Statuses page uses:

```
attempt 1: ACCEPTED, id=14
attempt 2: ACCEPTED, id=15
rows with that exact name in the default language: 2
existsLocalizedNameInDatabase() says: true
```

The orphaned helper answers correctly. Nothing asks it.

### What it does

The assert goes in the command handlers, next to the two asserts that are already there, so the
invariant holds for every entry point and not only for the form. That is what the three existing
uniqueness checks in the codebase do: `AddWebserviceKeyHandler` calls `WebserviceKey::keyExists()`,
`CountryValidator` calls `Country::getByIso()`, `AddCustomerHandler` uses `Customer::getByEmail()`.

- `AbstractOrderStateHandler::assertNameIsNotDuplicate()` and the same on
  `AbstractOrderReturnStateHandler`, throwing the two exceptions that already existed. Called from the
  add and the edit handler of each domain, with the edited id excluded.
- `OrderReturnState::existsLocalizedNameInDatabase()` mirrors the order status helper. The return
  status table has no `deleted` column, so the query is the simpler one.
- `DuplicateOrderReturnStateNameException` gets a message in `getErrorMessages()`. It had none, so
  throwing it would have produced the generic fallback.
- The help text the issue asked for, on both name fields.

**Every language is checked, not only the default one.** `ObjectModel::formatFields()` falls back to
the default language value when a translation is left empty on a required field, and `name` is
required on both models, so the row that is stored is not always the one that was typed. Measured:
storing `''` for language 2 produced `'ZZ Blank Probe'` in language 2. A check that tested the empty
string would pass and then write a duplicate. This is what the deleted controller did too, and this
is why.

### Two things found while building it, both required for the fix to work

**The `Name` value objects rejected names the field accepts.** Both carried
`/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u` under a variable named `$matchesFirstNamePattern` - a person name
pattern, forbidding digits and most punctuation - while the field itself validates with
`Validate::isGenericName()`, `/^[^<>{}]*$/u`. Measured:

```
"The 1st Order State"   Name VO: invalid    isGenericName: true
"Status 2"              Name VO: invalid    isGenericName: true
"Pending"               Name VO: valid      isGenericName: true
```

Both value objects were unused, so this never surfaced. It surfaces immediately here, because the
exception carries the duplicate name: a status called "Status 2" would have reported "the Name field
is invalid" instead of "already exists". Aligned with the field's own pattern.

**The Behat restore tags were declared but never implemented.** `@restore-order-states-after-feature`
and `@restore-order-return-states-after-feature` appear on the two feature files and no hook matched
them, so the tables were never restored. The local test database had accumulated **16** leftover
order statuses from previous runs. This was harmless while duplicates were allowed. It is not
harmless now, so the hooks are implemented, per scenario rather than per feature, because the
Background re-adds the same rows for every scenario.

### How to test

```
php vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order_state
php vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order_return_state
```

In the back office, Shop parameters > Order settings > Statuses: create a status, then create a second
one with the same name. It is refused and the message names the status. Editing a status without
changing its name still saves. Both also apply to the Return statuses tab.

### Measured

```
                        base            with this change
order_state             6 passed        9 passed (70 steps)
order_return_state      4 passed        7 passed (54 steps)
php-cs-fixer            0 of 14 files can be fixed
phpstan                 [OK] No errors
```

Three mutations, each with the revert verified by grep before the run, not assumed:

| Mutation | Result |
|---|---|
| remove the two order status call sites | exactly the 2 new order status refusal scenarios fail, other 7 pass |
| remove the two order return status call sites | exactly the 2 new return status refusal scenarios fail, order_state stays 9/9 |
| restore the old person name regex in both `Name` value objects | the same 4 refusal scenarios fail, because the wrong exception is thrown |

The third scenario of each pair, "saving while keeping its own name is accepted", passes under every
mutation. It is there because the exclusion of the edited id is the way this change could break a
merchant who only edits a colour, and the pre-existing "Edit order state" scenarios cover the same
ground independently.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- Overlaps, both checked by hunk, neither the same fix:
  - #39210 (draft, `develop`, PostgreSQL support) rewrites the body of
    `OrderReturnState::getOrderReturnStates()` at `@@ -44,8`; the new helper is appended at
    `@@ -48,4`. If that PR lands first, the new helper is one more place wanting
    `Db::quoteIdentifier()`; it already avoids backtick quoting.
  - #39548 (`develop`) adds `: void` to `buildForm()` and `configureOptions()` in both form types, at
    `@@ -113,7` and `@@ -248,7`; the help text change is at `@@ -119,8` inside the `name` field. The
    changed lines are different lines.
- `translations/default/*.xlf` is deliberately untouched: the default catalogue is refreshed by
  separate "Update default catalog" commits, not by code pull requests.
- Not changed, reported instead: `existsLocalizedNameInDatabase()` reads through
  `Db::getInstance(_PS_USE_SQL_SLAVE_)`. On a shop with configured replicas a uniqueness check
  immediately preceding a write wants read-your-writes. It cannot be verified on a single server shop,
  so it is left alone rather than changed blind.
