### PR TITLE
Add a button to send an order invoice to the customer

### DIFF
--- a/mails/themes/classic/core/invoice.html.twig
+++ b/mails/themes/classic/core/invoice.html.twig
@@ -1,0 +1,50 @@
+{% extends '@MailThemes/classic/components/layout.html.twig' %}
+
+{% block content %}
+<tr>
+  <td align="center" class="titleblock">
+    <font size="2" face="{{ languageDefaultFont }}Open-sans, sans-serif" color="#555454">
+      <span class="title">{{ 'Hi {firstname} {lastname},'|trans({}, 'Emails.Body', locale) }}</span>
+    </font>
+  </td>
+</tr>
+<tr>
+  <td class="space_footer">&nbsp;</td>
+</tr>
+<tr>
+  <td class="box" style="border:1px solid #D6D4D4;">
+    <table class="table">
+      <tr>
+        <td width="10">&nbsp;</td>
+        <td>
+          <font size="2" face="{{ languageDefaultFont }}Open-sans, sans-serif" color="#555454">
+            {% if templateType == 'html' %}
+
+              <p style="border-bottom:1px solid #D6D4D4;">
+                {{ 'Order {order_name}'|trans({}, 'Emails.Body', locale) }}&nbsp;-&nbsp;{{ 'Invoice'|trans({}, 'Emails.Body', locale)|raw }}
+              </p>
+
+{% endif %}
+            <span>
+              {{ 'Please find attached the invoice for your order with the reference [1]{order_name}[/1].'|trans({'[1]': '<span><strong>', '[/1]': '</strong></span>'}, 'Emails.Body', locale)|raw }}
+            </span>
+          </font>
+        </td>
+        <td width="10">&nbsp;</td>
+      </tr>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td class="space_footer">&nbsp;</td>
+</tr>
+<tr>
+  <td class="linkbelow">
+    <font size="2" face="{{ languageDefaultFont }}Open-sans, sans-serif" color="#555454">
+      <span>
+        {{ 'You can also find it on our store, in the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
+      </span>
+    </font>
+  </td>
+</tr>
+{% endblock %}

--- a/mails/themes/modern/core/invoice.html.twig
+++ b/mails/themes/modern/core/invoice.html.twig
@@ -1,0 +1,295 @@
+{% extends '@MailThemes/modern/components/layout.html.twig' %}
+        
+{% block title %}{{ 'Invoice'|trans({}, 'Emails.Body', locale) }}{% endblock %}
+
+{% block content %}
+<!--[if mso | IE]><tr><td class="" width="604px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:604px;" width="604" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:604px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:{{ direction }};font-size:0px;padding:0 25px;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:554px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:{{ align_left }};direction:{{ direction }};display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="vertical-align:top;padding:0;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
+                                    <tbody>
+                                      <!-- TITLE BEGINING -->
+                                      <tr>
+                                        <td align="{{ align_left }}" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:20px;word-break:break-word;">
+                                          <div style="font-family:Open sans, arial, sans-serif;font-size:20px;font-weight:600;line-height:25px;text-align:{{ align_left }};color:#363A41;">{{ 'Hi {firstname} {lastname},'|trans({}, 'Emails.Body', locale) }}</div>
+                                        </td>
+                                      </tr>
+                                      <!-- TITLE ENDING -->
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
+              <!-- BORDER BEGINING -->
+              <!--[if mso | IE]><tr><td class="" width="604px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:604px;" width="604" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:604px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:{{ direction }};font-size:0px;padding:0 50px 40px;text-align:{{ align_left }};">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:25px;" ><![endif]-->
+                        <div class="mj-column-px-25 mj-outlook-group-fix" style="font-size:0px;text-align:{{ align_left }};direction:{{ direction }};display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" class="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-right:0;padding-left:0;word-break:break-word;">
+                                  <p style="border-top:solid 3px #505050;font-size:1px;margin:0px auto;width:25px;">
+                                  </p>
+                                  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 3px #505050;font-size:1px;margin:0px auto;width:25px;" role="presentation" width="25px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
+              <!-- BORDER ENDING -->
+              <!-- SUBTITLE BEGINING -->
+              <!--[if mso | IE]><tr><td class="" width="604px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:604px;" width="604" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:604px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:{{ direction }};font-size:0px;padding:0 25px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:554px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:{{ align_left }};direction:{{ direction }};display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="vertical-align:top;padding:0;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
+                                    <tbody>
+                                      <tr>
+                                        <td align="{{ align_left }}" style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:0px;word-break:break-word;">
+                                          <div style="font-family:Open sans, arial, sans-serif;font-size:16px;font-weight:600;line-height:25px;text-align:{{ align_left }};color:#363A41;">{{ 'Order ID {order_name}'|trans({}, 'Emails.Body', locale) }} - {{ 'Invoice'|trans({}, 'Emails.Body', locale)|raw }}</div>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
+              <!-- SUBTITLE ENDING -->
+              <!-- BOX BEGINING -->
+              <!--[if mso | IE]><tr><td class="" width="604px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:604px;" width="604" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:604px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:{{ direction }};font-size:0px;padding:15px 50px 40px;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:{{ align_left }};direction:{{ direction }};display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="background-color:#fefefe;border:1px solid #DFDFDF;vertical-align:top;padding:20px 0;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
+                                    <tbody>
+                                      <tr>
+                                        <td align="{{ align_left }}" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                          <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:{{ align_left }};color:#363A41;">{{ 'Please find attached the invoice for your order with the reference [1]{order_name}[/1].'|trans({'[1]': '<span class="label">', '[/1]': '</span>'}, 'Emails.Body', locale)|raw }}</div>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
+              <!-- BOX ENDING -->
+              <!-- FIRST TEXT BEGINING -->
+              <!--[if mso | IE]><tr><td class="" width="604px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:604px;" width="604" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:604px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:{{ direction }};font-size:0px;padding:0 25px 30px;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:554px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:{{ align_left }};direction:{{ direction }};display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="{{ align_left }}" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:{{ align_left }};color:#363A41;">{{ 'You can also find it on our store, in the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
+              <!-- FIRST TEXT ENDING -->
+              
+
+{% endblock %}
+
+{% block styles %}
+<style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+        <noscript>
+        <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        </noscript>
+        <![endif]-->
+  <!--[if lte mso 11]>
+        <style type="text/css">
+          .mj-outlook-group-fix { width:100% !important; }
+        </style>
+        <![endif]-->
+  <!--[if !mso]><!-->
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700);
+    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i);
+  </style>
+  <!--<![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+
+      .mj-column-px-25 {
+        width: 25px !important;
+        max-width: 25px;
+      }
+    }
+  </style>
+  <style media="screen and (min-width:480px)">
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+
+    .moz-text-html .mj-column-px-25 {
+      width: 25px !important;
+      max-width: 25px;
+    }
+  </style>
+  <style type="text/css">
+  </style>
+  <style type="text/css">
+    .shadow {
+      box-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.1);
+    }
+
+    .label {
+      font-weight: 700;
+    }
+
+    .warning {
+      font-weight: 700;
+      font-size: 16px;
+    }
+
+    a {
+      color: #25B9D7;
+      text-decoration: underline;
+      font-weight: 600;
+    }
+
+    a.light {
+      font-weight: 400;
+    }
+
+    span.strong {
+      font-weight: 600;
+    }
+
+    @media only screen and (max-width: 480px) {
+
+      body,
+      .no-bg {
+        background-color: #fff !important;
+      }
+
+      .left p {
+        text-align: left;
+        display: inline-block
+      }
+    }
+  </style>
+
+{% endblock %}

--- a/src/Adapter/Order/CommandHandler/SendOrderInvoiceEmailHandler.php
+++ b/src/Adapter/Order/CommandHandler/SendOrderInvoiceEmailHandler.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
+
+use Customer;
+use Mail;
+use PrestaShop\PrestaShop\Adapter\PDF\OrderInvoicePdfGenerator;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\SendOrderInvoiceEmailCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\SendOrderInvoiceEmailHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderEmailSendException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Sends the invoices of an order to its customer on demand.
+ *
+ * WHY this exists next to ResendOrderEmailCommand: that one replays a status email, so an invoice can
+ * only be sent by moving the order through a status configured to attach one. A merchant who simply
+ * corrected a customer's email address, or who was asked for the invoice again, has no reason to
+ * change the order's status to do it.
+ *
+ * @internal
+ */
+#[AsCommandHandler]
+final class SendOrderInvoiceEmailHandler extends AbstractOrderCommandHandler implements SendOrderInvoiceEmailHandlerInterface
+{
+    public function __construct(
+        private readonly OrderInvoicePdfGenerator $invoicePdfGenerator,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    public function handle(SendOrderInvoiceEmailCommand $command): void
+    {
+        $order = $this->getOrder($command->getOrderId());
+
+        if (!$order->hasInvoice()) {
+            throw new OrderException(sprintf('Order with id "%d" has no invoice to send.', $order->id));
+        }
+
+        $customer = new Customer((int) $order->id_customer);
+        if (empty($customer->email)) {
+            throw new OrderException(sprintf('Customer of order with id "%d" has no email address.', $order->id));
+        }
+
+        $generatedPdf = $this->invoicePdfGenerator->generatePDFForResponse([(int) $order->id]);
+
+        $orderLanguage = $order->getAssociatedLanguage();
+
+        $sent = Mail::Send(
+            (int) $orderLanguage->getId(),
+            'invoice',
+            $this->translator->trans(
+                'Invoice for your order',
+                [],
+                'Emails.Subject',
+                $orderLanguage->locale
+            ),
+            [
+                '{lastname}' => $customer->lastname,
+                '{firstname}' => $customer->firstname,
+                '{id_order}' => $order->id,
+                '{order_name}' => $order->getUniqReference(),
+            ],
+            $customer->email,
+            $customer->firstname . ' ' . $customer->lastname,
+            null,
+            null,
+            [
+                'invoice' => [
+                    'content' => $generatedPdf->getContent(),
+                    'name' => $generatedPdf->getFileName(),
+                    'mime' => 'application/pdf',
+                ],
+            ],
+            null,
+            _PS_MAIL_DIR_,
+            true,
+            (int) $order->id_shop
+        );
+
+        if (!$sent) {
+            throw new OrderEmailSendException('Failed to send the invoice email.', OrderEmailSendException::FAILED_SEND_INVOICE);
+        }
+    }
+}

--- a/src/Core/Domain/Order/Command/SendOrderInvoiceEmailCommand.php
+++ b/src/Core/Domain/Order/Command/SendOrderInvoiceEmailCommand.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+
+/**
+ * Sends the invoices of an order to its customer, without changing the order status.
+ */
+class SendOrderInvoiceEmailCommand
+{
+    /**
+     * @var OrderId
+     */
+    private $orderId;
+
+    public function __construct(int $orderId)
+    {
+        $this->orderId = new OrderId($orderId);
+    }
+
+    public function getOrderId(): OrderId
+    {
+        return $this->orderId;
+    }
+}

--- a/src/Core/Domain/Order/CommandHandler/SendOrderInvoiceEmailHandlerInterface.php
+++ b/src/Core/Domain/Order/CommandHandler/SendOrderInvoiceEmailHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\SendOrderInvoiceEmailCommand;
+
+interface SendOrderInvoiceEmailHandlerInterface
+{
+    public function handle(SendOrderInvoiceEmailCommand $command): void;
+}

--- a/src/Core/Domain/Order/Exception/OrderEmailSendException.php
+++ b/src/Core/Domain/Order/Exception/OrderEmailSendException.php
@@ -20,4 +20,9 @@ class OrderEmailSendException extends OrderException
      * When order process email sending failed
      */
     public const FAILED_SEND_PROCESS_ORDER = 2;
+
+    /**
+     * When sending the order invoice to the customer failed
+     */
+    public const FAILED_SEND_INVOICE = 3;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -29,6 +29,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCom
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\DeleteCartRuleFromOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\DuplicateOrderCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ResendOrderEmailCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\SendOrderInvoiceEmailCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\SendProcessOrderEmailCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\SetInternalOrderNoteCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand;
@@ -1868,6 +1869,28 @@ class OrderController extends PrestaShopAdminController
             $this->addFlash(
                 'success',
                 $this->trans('The message was successfully sent to the customer.', [], 'Admin.Orderscustomers.Notification')
+            );
+        } catch (Exception $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        }
+
+        return $this->redirectToRoute('admin_orders_view', [
+            'orderId' => $orderId,
+        ]);
+    }
+
+    /**
+     * Sends the order's invoices to the customer without changing the order status.
+     */
+    #[AdminSecurity("is_granted('update', 'AdminOrders')", redirectRoute: 'admin_orders_view', redirectQueryParamsToKeep: ['orderId'], message: 'You do not have permission to edit this.')]
+    public function sendInvoiceAction(int $orderId): RedirectResponse
+    {
+        try {
+            $this->dispatchCommand(new SendOrderInvoiceEmailCommand($orderId));
+
+            $this->addFlash(
+                'success',
+                $this->trans('The invoice was successfully sent to the customer.', [], 'Admin.Orderscustomers.Notification')
             );
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
@@ -185,6 +185,14 @@ admin_orders_resend_email:
     orderHistoryId: \d+
     orderStatusId: \d+
 
+admin_orders_send_invoice:
+  path: /{orderId}/send-invoice
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Order\OrderController::sendInvoiceAction
+  requirements:
+    orderId: \d+
+
 admin_orders_preview:
   path: /{orderId}/preview
   methods: [ GET ]

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -194,6 +194,13 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\ResendOrderEmailHandler
     autoconfigure: true
 
+  prestashop.adapter.order.command_handler.send_order_invoice_email_handler:
+    class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\SendOrderInvoiceEmailHandler
+    autoconfigure: true
+    arguments:
+      - '@prestashop.adapter.pdf.order_invoice_pdf_generator'
+      - '@translator'
+
   prestashop.adapter.order.query_handler.get_order_preview_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Order\QueryHandler\GetOrderPreviewHandler'
     autoconfigure: true

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
@@ -87,6 +87,12 @@
                 {{ 'Edit note'|trans({}, 'Admin.Orderscustomers.Feature') }}
               </button>
             {% endif %}
+            <form method="POST" class="d-inline-block"
+                  action="{{ path('admin_orders_send_invoice', {orderId: orderForViewing.id}) }}">
+              <button type="submit" class="btn btn-primary btn-sm">
+                {{ 'Send to customer'|trans({}, 'Admin.Orderscustomers.Feature') }}
+              </button>
+            </form>
           {% endif %}
         </td>
       </tr>

--- a/tests/Unit/Core/MailTemplate/CoreMailThemeParityTest.php
+++ b/tests/Unit/Core/MailTemplate/CoreMailThemeParityTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\MailTemplate;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A core mail is only usable if every shipped theme can render it. Themes are discovered by scanning
+ * folders, so a template added to one theme and forgotten in the other produces no error at all: the
+ * mail simply cannot be generated for a shop using the other theme.
+ */
+class CoreMailThemeParityTest extends TestCase
+{
+    private const THEMES_DIR = _PS_ROOT_DIR_ . '/mails/themes';
+
+    public function testEveryCoreMailTemplateExistsInEveryTheme(): void
+    {
+        $templatesByTheme = $this->getCoreTemplatesByTheme();
+
+        self::assertGreaterThan(1, count($templatesByTheme), 'Expected more than one mail theme to compare.');
+
+        $allTemplates = array_unique(array_merge(...array_values($templatesByTheme)));
+        sort($allTemplates);
+
+        self::assertNotEmpty($allTemplates, 'No core mail templates were found, the test would pass vacuously.');
+
+        foreach ($templatesByTheme as $theme => $templates) {
+            self::assertSame(
+                $allTemplates,
+                $templates,
+                sprintf('Mail theme "%s" is missing core templates that another theme provides.', $theme)
+            );
+        }
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    private function getCoreTemplatesByTheme(): array
+    {
+        $templatesByTheme = [];
+
+        foreach (glob(self::THEMES_DIR . '/*', GLOB_ONLYDIR) ?: [] as $themeDir) {
+            $coreDir = $themeDir . '/core';
+            if (!is_dir($coreDir)) {
+                continue;
+            }
+
+            $templates = array_map(
+                'basename',
+                glob($coreDir . '/*.html.twig') ?: []
+            );
+            sort($templates);
+
+            $templatesByTheme[basename($themeDir)] = $templates;
+        }
+
+        return $templatesByTheme;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | An invoice can only reach a customer by moving the order through a status configured to attach one. Add a "Send to customer" button next to the existing invoice actions, backed by a command that leaves the order status alone.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23048
| Related PRs       | --
| Sponsor company   | --

### Why

The only way to email an invoice today is to move the order through a status whose configuration
attaches one. That was the answer given on the issue in 2021, and the reporter's objection to it still
stands: an order status is a statement about the order, not a way to send a document. A merchant who
corrects a customer's email address, or who is simply asked for the invoice again, has no reason to
change the order's status.

Confirmed on `develop`: `ResendOrderEmailCommand` replays a **status** email
(`OrderHistory::sendEmail()`), which attaches the invoice only when the status carries `pdf_invoice`.
The Documents block offers download, enter payment, add/edit note and generate invoice, and nothing
that sends one.

The issue is labelled `PM ✔️`, and MatShir, who worked on the order page, wrote: "We have two missing
features (resend the order and the resend the invoice) when the merchant change the email address of a
customer. So a contribution is very welcome". Resending the order landed; resending the invoice did not.

### What it does

A `Send to customer` button on each invoice row, posting to `admin_orders_send_invoice`, dispatching
`SendOrderInvoiceEmailCommand(orderId)`.

The PDF is produced by `OrderInvoicePdfGenerator`, the same service the download button uses, so
`actionPDFInvoiceRender` fires exactly as it does for a download and modules that decorate the invoice
keep working. The command takes the order rather than a single invoice id, which matches the
neighbouring download button: `admin_orders_generate_invoice_pdf` is also per order and renders all of
the order's invoices into one document.

The handler refuses two states rather than sending something useless: an order with no invoice, and a
customer with no email address.

A new `invoice` mail template is added to **both** shipped themes.

### Two things the environment proved that reading would not have

**The handler was silently unregistered.** `#[AsCommandHandler]` only configures services that already
exist, and `src/Adapter` is not registered by a PSR-4 resource - every sibling handler is declared in
`services/adapter/order.yml`. With only the attribute, `debug:messenger` listed
`ResendOrderEmailCommand` and `SendProcessOrderEmailCommand` and **not** the new one, with no error
anywhere. Declaring the service fixed it. `OrderInvoicePdfGenerator` also has no autowiring alias, so
its argument is passed explicitly, as `OrderController::generateInvoicePdfAction()` does.

**The guard is not theoretical.** Order 1 of the demo data carries `invoice_number = 1` on `ps_orders`
and has **zero** rows in `ps_order_invoice`, so `Order::hasInvoice()` is false. Without the check that
order would have produced an empty PDF and mailed it.

### Measured end to end

The command was dispatched against a real order and the mail captured at the SMTP server:

```
subject     [PrestaShop] Invoice for your order
to          the order's customer
attachments invoices.pdf  application/pdf  469812 bytes
```

Body, fully substituted, no placeholder left unresolved in either the text or the HTML part:

```
Hi John DOE,
Order ID OHSATSERP#1 - Invoice
Please find attached the invoice for your order with the reference OHSATSERP#1.
You can also find it on our store, in the [Order history](.../order-history) section of your customer account.
```

`prestashop:mail:generate modern en-US` produced `invoice.html` (27 KB) and `invoice.txt` from the new
sources, so the templates integrate with the theme generator rather than only looking right.

```
debug:router      admin_orders_send_invoice  POST  /sell/orders/{orderId}/send-invoice
debug:messenger   SendOrderInvoiceEmailCommand handled by
                  prestashop.adapter.order.command_handler.send_order_invoice_email_handler
lint:twig         3 files valid          lint:yaml  2 files valid
php-cs-fixer      0 of 5 files
phpstan           OK on the new files
```

`OrderController.php` reports 3 phpstan errors about the `Currency` namespace both with and without this
change - the pristine `develop` file emits the same three, at lines 9/2226/2227 against 9/2249/2250 here,
the difference being this change's 23 added lines.

### Tests

`tests/Unit/Core/MailTemplate/CoreMailThemeParityTest.php` asserts every core mail template exists in
every shipped theme. Themes are discovered by folder scan, so a template added to one theme and
forgotten in the other produces no error at all - the mail simply cannot be generated for shops on the
other theme, which is precisely the mistake this change could have made. 35 templates per theme, 4
assertions. Removing the classic copy of the new template fails it with
`Mail theme "classic" is missing core templates that another theme provides.`

### How to test

Open an order that has an invoice, in Orders > view > Documents. Press `Send to customer`. The customer
receives the invoice as a PDF attachment and the order status is unchanged. On an order with no invoice
the button is not shown, and dispatching the command for one is refused.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- New feature, so `develop`.
- Delivery slips and credit slips are deliberately out of scope. Credit slips already have their own
  mail, sent when one is created; a delivery slip has no template at all. The seam added here takes
  either later without change.
- `mails/{iso}/*.html` is generated, not shipped (`.gitignore` has `mails/*` with `!mails/themes/`), so
  only the two theme sources are in the diff. Existing shops pick the new mail up the same way they pick
  up any other new core mail.
