### PR TITLE
Silence PHPStan 2 on the intentionally invalid render() argument

### DIFF
--- a/tests/Unit/Core/ExtraProperty/Constraint/ExtraPropertyConstraintRendererTest.php
+++ b/tests/Unit/Core/ExtraProperty/Constraint/ExtraPropertyConstraintRendererTest.php
@@ -540,7 +540,7 @@ final class ExtraPropertyConstraintRendererTest extends TestCase
             Constraint::class
         ));
 
-        ExtraPropertyConstraintRenderer::render([new Assert\NotBlank(), 'Email']);
+        ExtraPropertyConstraintRenderer::render([new Assert\NotBlank(), 'Email']); // @phpstan-ignore-line intentionally invalid: a non-Constraint item to trigger the refusal
     }
 
     public function testAKeyedArrayOfConstraintsIsRefused(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PHP Static Analysis` fails on every PHP version on the `9.2.x` into `develop` merge PR, on a single error in `ExtraPropertyConstraintRendererTest`. The test file is byte-identical between the two branches; the analyser is not: PHPStan 1.12.12 on `9.2.x`, 2.2.12 on `develop`. PHPStan 2 reports the deliberately wrong argument of a negative test, which 1.12 let through. This annotates the call so the analyser stops at it, without touching what the test asserts.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" below.
| UI Tests          | N/A, a unit test annotation only
| Fixed issue or discussion?     | Fixes #42817
| Related PRs       | Unblocks #42816
| Sponsor company   | @PrestaShopCorp

## What changes

`testANonConstraintItemIsRefused()` passes a string where a `Constraint` is expected, which is exactly what it asserts `render()` refuses:

```php
ExtraPropertyConstraintRenderer::render([new Assert\NotBlank(), 'Email']);
```

The line now carries the same annotation the keyed-array case two tests below already has:

```php
ExtraPropertyConstraintRenderer::render([new Assert\NotBlank(), 'Email']); // @phpstan-ignore-line intentionally invalid: a non-Constraint item to trigger the refusal
```

That case already had it because PHPStan 1.12 reported it; this one is only caught by 2.x, which is why it surfaces on the merge and not here.

## Why 9.2.x and not develop

The file does not exist on `develop` yet, it arrives with the merge, so the fix cannot be applied there. `reportUnmatchedIgnoredErrors` is `false` in `phpstan.neon.dist`, so the annotation stays silent under PHPStan 1.12 on this branch and only takes effect once the file reaches `develop`.

## How to test

The error only reproduces under PHPStan 2, so this branch alone cannot show it. Either read the failing jobs on #42816, or merge this branch into a local `develop` and run:

```
php ./vendor/bin/phpstan analyse -c phpstan.neon.dist
```

Before: `Found 1 error`, `argument.type` on `ExtraPropertyConstraintRendererTest.php:543`.
After: no error.

On this branch, `PHP Static Analysis` must stay green, which is what confirms the annotation does not become an unmatched ignore under PHPStan 1.12.

The behaviour under test is unchanged: `phpunit -c tests/Unit/phpunit.xml --filter ExtraPropertyConstraintRenderer` still passes, the test still expects `InvalidExtraPropertyConstraintException`.
