### PR TITLE
Bind the new guest to the logged-in customer in Guest::setNewGuest()

### DIFF
--- a/classes/Guest.php
+++ b/classes/Guest.php
@@ -231,8 +231,17 @@ class GuestCore extends ObjectModel
      */
     public static function setNewGuest($cookie)
     {
-        $guest = new Guest(isset($cookie->id_customer) ? (int) Guest::getFromCustomer((int) $cookie->id_customer) : null);
+        $idCustomer = isset($cookie->id_customer) ? (int) $cookie->id_customer : 0;
+        // Guest::getFromCustomer(0) matches any anonymous guest, so only look one up for a real customer
+        $guest = new Guest($idCustomer ? (int) Guest::getFromCustomer($idCustomer) : null);
         $guest->userAgent();
+
+        // A logged-in customer with no guest yet gets a new one, and it has to carry the customer:
+        // otherwise the visit stays anonymous and its connections are unreachable from the customer
+        if ($idCustomer) {
+            $guest->id_customer = $idCustomer;
+        }
+
         $guest->save();
         $cookie->id_guest = (int) $guest->id;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `Guest::setNewGuest()` looks up the logged-in customer's guest, but when the customer has none yet it silently creates an **anonymous** one. `Guest::getFromCustomer()` returns `false`, `(int) false === 0`, so `new Guest(0)` loads nothing and `save()` falls through to `add()` with `id_customer` left at 0. `Context::updateCustomer()` calls it (`classes/Context.php:363`) while `$this->cookie->id_customer` is already set (line 332), so a customer logging in without a visit identifier gets a guest that is not theirs. The new id is then written to the cookie, so `setNewGuest()` is never called again for that visitor and every `ps_connections` row keeps landing on a guest whose `id_customer` is 0 — the back office "Last visit" (`src/Core/Grid/Query/CustomerQueryBuilder.php:150` and `Customer::getStats()`) resolves customer → `ps_guest.id_customer` → `ps_connections`, so it stays empty for good. This patch assigns the customer the method already has in hand. It also guards the lookup: `Guest::getFromCustomer(0)` passes `Validate::isUnsignedId()` and runs `WHERE id_customer = 0`, which matches an arbitrary *other* visitor's anonymous guest.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run — the change is not covered by a UI campaign (the visitor/guest linkage is only observable in the database and in the back office "Last visit" column). Happy to launch one if you'd like.
| Fixed issue or discussion?     | Fixes #42819
| Related PRs       | –
| Sponsor company   | Evolutive

### How to test

`statsdata` masks this on the two login paths that fire `actionAuthentication` / `actionCustomerAccountAdd`, so reproduce through a path that fires neither — the password reset:

1. Make sure `statsdata` is installed and enabled (default).
2. Create a customer account, log out, clear cookies.
3. Browse the front office anonymously. A `ps_guest` row appears with `id_customer = 0` plus one `ps_connections` row — note the `id_guest`.
4. Use "Forgot your password?" for that customer, open the emailed link, set a new password. You are logged in via `PasswordController::processReset` → `Context::updateCustomer()`, which fires no hook `statsdata` listens to.
5. Keep browsing while logged in.

**Before this patch:** `SELECT * FROM ps_guest WHERE id_customer = <id>` returns 0 rows, the guest from step 3 still has `id_customer = 0`, and the back office "Last visit" is empty for that customer in both the grid and the detail page — while `ps_cart` holds a row with both their `id_customer` and that `id_guest`, proving the session was theirs.

**After this patch:** the same reproduction on a *fresh* visitor (no `id_guest` cookie yet — e.g. log in from a cleared browser) creates the guest with `id_customer` already set, so "Last visit" shows the real date.

Note that this patch fixes the *creation* of the anonymous guest. It does not retro-link guests already orphaned in existing databases, and it does not by itself cover the case where an anonymous guest is already in the cookie when one of the hookless paths logs the customer in — `setNewGuest()` is not called there. Issue #42819 describes that second half; binding the guest inside `Context::updateCustomer()` (the funnel all four login paths share) would close it, but that is a larger change and I kept this PR to the single clear defect.
