### PR TITLE
Take the extra property logger through the core "logger" id instead of Psr\Log\LoggerInterface

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -15,6 +15,7 @@ use PrestaShop\PrestaShop\Core\Context\LegacyControllerContext;
 use PrestaShop\PrestaShop\Core\Exception\ContainerNotFoundException;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinition;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyRegistryInterface;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\ExtraPropertyException;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem;
 use PrestaShop\PrestaShop\Core\Module\Legacy\ModuleInterface;
 use PrestaShop\PrestaShop\Core\Module\ModuleOverrideChecker;
@@ -1236,16 +1237,16 @@ abstract class ModuleCore implements ModuleInterface
      * About BO label translations: store wording/domain pairs in the definition, and also call
      * $this->trans() in the module code so strings are discoverable by the BO translation UI.
      *
-     * Every failure throws (there is no false return): wrap the call in
-     * catch (PrestaShop\PrestaShop\Core\ExtraProperty\Exception\ExtraPropertyException $e)
-     * in module install code to handle all failure reasons — the exception message carries
-     * the reason. A failed registration persists nothing (no definition row, no column).
+     * A failure returns false and adds its reason to the module errors, so install code can
+     * simply test the returned value like it does for every other register* method. A failed
+     * registration persists nothing (no definition row, no column). Registry failures are also
+     * logged. Handle the reason codes of ExtraPropertyRegistryException by calling
+     * ExtraPropertyRegistryInterface::register() directly instead.
      *
      * @param ExtraPropertyDefinition $definition definition
      *
-     * @return bool always true — failures throw
-     *
-     * @throws PrestaShop\PrestaShop\Core\ExtraProperty\Exception\ExtraPropertyException on any failure: scope conflict, destructive schema change, invalid form options, missing base table, DDL or persistence failure (see the reason-code constants on ExtraPropertyRegistryException)
+     * @return bool false on any failure: scope conflict, destructive schema change, invalid form
+     *              options, missing base table, DDL or persistence failure
      */
     public function registerExtraProperty(ExtraPropertyDefinition $definition): bool
     {
@@ -1257,7 +1258,15 @@ abstract class ModuleCore implements ModuleInterface
         /** @var ExtraPropertyRegistryInterface $entityCustomFieldRegistry */
         $entityCustomFieldRegistry = $this->get(ExtraPropertyRegistryInterface::class);
 
-        $entityCustomFieldRegistry->register($definition);
+        try {
+            $entityCustomFieldRegistry->register($definition);
+        } catch (ExtraPropertyException $e) {
+            // The registry logged the reason already; carry it to whatever displays module errors
+            // (the module manager, and the shop installer through ModuleManager::getError()).
+            $this->_errors[] = $e->getMessage();
+
+            return false;
+        }
 
         return true;
     }
@@ -1271,9 +1280,8 @@ abstract class ModuleCore implements ModuleInterface
      * @param ExtraPropertyDefinition $definition Definition identifying the property to unregister
      * @param bool $dropData If true, also DROP the SQL column and its data from the *_extra table
      *
-     * @return bool always true — failures throw (no-op when nothing is registered)
-     *
-     * @throws PrestaShop\PrestaShop\Core\ExtraProperty\Exception\ExtraPropertyException when deleting the definition row or dropping the column fails — catch it in module uninstall code
+     * @return bool false when deleting the definition row or dropping the column fails, the reason
+     *              being added to the module errors (no-op, and true, when nothing is registered)
      */
     public function unregisterExtraProperty(ExtraPropertyDefinition $definition, bool $dropData = false): bool
     {
@@ -1284,7 +1292,13 @@ abstract class ModuleCore implements ModuleInterface
         /** @var ExtraPropertyRegistryInterface $entityCustomFieldRegistry */
         $entityCustomFieldRegistry = $this->get(ExtraPropertyRegistryInterface::class);
 
-        $entityCustomFieldRegistry->unregister($definition, $dropData);
+        try {
+            $entityCustomFieldRegistry->unregister($definition, $dropData);
+        } catch (ExtraPropertyException $e) {
+            $this->_errors[] = $e->getMessage();
+
+            return false;
+        }
 
         return true;
     }

--- a/config/services/common.yml
+++ b/config/services/common.yml
@@ -16,10 +16,11 @@ services:
         public: true
 
     # This file is loaded by the hand-built legacy containers only (front, webservice), which have no
-    # Monolog: services taking Psr\Log\LoggerInterface (the extra property definition repository, for
-    # instance) get the legacy logger there, writing ps_log. The Symfony kernels never import this file
-    # and keep Monolog behind the interface.
-    Psr\Log\LoggerInterface:
+    # Monolog: services taking "@logger" (the extra property definition repository, for instance) get
+    # the legacy logger there, writing ps_log. The Symfony kernels never import this file and keep
+    # Monolog behind "logger". Deliberately not the Psr\Log\LoggerInterface id: modules redefine that
+    # id in the shared containers.
+    logger:
         alias: prestashop.adapter.legacy.logger
 
     PrestaShop\PrestaShop\Core\Crypto\Hashing: ~

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -210,6 +210,23 @@ class LegacyContext
     }
 
     /**
+     * Returns the language the current employee last selected in a translatable form, if any.
+     *
+     * Read through this adapter rather than straight from the cookie in the container bindings:
+     * the legacy cookie is only set by config/config.inc.php, so it is absent from the installer
+     * context, where form types are nevertheless built (an extra property definition validates
+     * its form options when it is registered by a module install).
+     *
+     * @return int|string|null the raw cookie value, null when there is no legacy cookie
+     */
+    public function getEmployeeFormLanguageId()
+    {
+        $cookie = $this->getContext()->cookie;
+
+        return null !== $cookie ? $cookie->employee_form_lang : null;
+    }
+
+    /**
      * Returns Currency set for the current employee.
      *
      * @return Currency|null

--- a/src/Core/ExtraProperty/Definition/ExtraPropertyRegistry.php
+++ b/src/Core/ExtraProperty/Definition/ExtraPropertyRegistry.php
@@ -182,7 +182,15 @@ class ExtraPropertyRegistry implements ExtraPropertyRegistryInterface
             $definition->getFormOptions()
         );
         if ([] !== $formOptionErrors) {
-            $message = sprintf('Invalid extra property form options: %s', implode(' ', $formOptionErrors));
+            // The property is named like in every other refusal of this method: a module install
+            // registers many definitions in a row, and the stack trace alone does not tell which
+            // one the container refused.
+            $message = sprintf(
+                'Invalid extra property form options for %s.%s: %s',
+                $entityName,
+                $propertyName,
+                implode(' ', $formOptionErrors)
+            );
             $this->logger->error($message);
 
             throw new ExtraPropertyRegistryException($message, ExtraPropertyRegistryException::INVALID_FORM_OPTIONS, errors: $formOptionErrors);

--- a/src/Core/ExtraProperty/Value/ExtraPropertyReader.php
+++ b/src/Core/ExtraProperty/Value/ExtraPropertyReader.php
@@ -35,8 +35,7 @@ class ExtraPropertyReader implements ExtraPropertyReaderInterface
         protected readonly string $prefix,
         protected readonly ShopListResolverInterface $shopListResolver,
         protected readonly ExtraPropertyDefinitionShopFilterInterface $definitionShopFilter,
-        // Optional: the hand-built FO legacy container has no logger service.
-        protected readonly ?LoggerInterface $logger = null,
+        protected readonly LoggerInterface $logger,
     ) {
     }
 
@@ -215,12 +214,10 @@ class ExtraPropertyReader implements ExtraPropertyReaderInterface
         } catch (Throwable $e) {
             // Reads must never break the page that displays them (FO especially), but a
             // failing query is a schema/definition bug: trace it instead of hiding it.
-            $message = sprintf('Extra property read failed on table %s: %s', $extraTableName, $e->getMessage());
-            if (null !== $this->logger) {
-                $this->logger->error($message, ['exception' => $e]);
-            } else {
-                error_log($message);
-            }
+            $this->logger->error(
+                sprintf('Extra property read failed on table %s: %s', $extraTableName, $e->getMessage()),
+                ['exception' => $e]
+            );
 
             return $result;
         }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -24,7 +24,7 @@ services:
       $isTaxEnabled: "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_TAX')"
       $defaultShopLanguageId: "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
       $saveFormLocaleChoice: "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_BO_ALLOW_EMPLOYEE_FORM_LANG')"
-      $defaultFormLanguageId: "@=service('prestashop.adapter.legacy.context').getContext().cookie.employee_form_lang"
+      $defaultFormLanguageId: "@=service('prestashop.adapter.legacy.context').getEmployeeFormLanguageId()"
       $isDebug: '%kernel.debug%'
       $multiStoreFeature: '@prestashop.adapter.feature.multistore'
       $contextShopId: '@=service("prestashop.adapter.legacy.context").getContext().shop.id'

--- a/src/PrestaShopBundle/Resources/config/services/extra_property/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/extra_property/common.yml
@@ -14,15 +14,18 @@ services:
 
   # ─── Repository ──────────────────────────────────────────────────────────────
 
-  # The logger is taken through its interface on purpose: in the Symfony kernels (back office,
-  # Admin API) Psr\Log\LoggerInterface is Monolog, which writes to var/logs and never touches the
-  # database. The hand-built front-office container has no Monolog and aliases the interface to the
-  # legacy logger (ps_log) in config/services/front/services_prod.yml.
+  # The logger is taken through the core "logger" id, not through Psr\Log\LoggerInterface: module
+  # service files are merged into the Symfony containers and a module can redefine that interface id
+  # (ps_checkout does, with a factory that instantiates the module; its constructor calls $this->trans(),
+  # which needs the translator this repository is being built for -> circular reference). In the Symfony
+  # kernels "logger" is Monolog, which writes to var/logs and never touches the database. The hand-built
+  # legacy containers have no Monolog and alias "logger" to the legacy logger (ps_log) in
+  # config/services/common.yml.
   PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepository:
     arguments:
       $connection: '@doctrine.dbal.default_connection'
       $prefix: '%database_prefix%'
-      $logger: '@Psr\Log\LoggerInterface'
+      $logger: '@logger'
 
   # Note: the definition WRITER interface (ExtraPropertyDefinitionWriterInterface) is intentionally NOT aliased
   # here. Writing definitions (register/unregister) is a back-office-only concern, so the alias lives in
@@ -80,8 +83,7 @@ services:
       $prefix: '%database_prefix%'
       $shopListResolver: '@PrestaShop\PrestaShop\Core\Shop\ShopListResolverInterface'
       $definitionShopFilter: '@PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionShopFilterInterface'
-      # Optional on purpose: absent from the hand-built FO legacy container.
-      $logger: '@?logger'
+      $logger: '@logger'
 
   PrestaShop\PrestaShop\Core\ExtraProperty\Value\ExtraPropertyReaderInterface:
     alias: 'PrestaShop\PrestaShop\Core\ExtraProperty\Value\ExtraPropertyReader'

--- a/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
+++ b/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
@@ -199,6 +199,18 @@ describe('API : Check endpoints', async () => {
     // @todo: add tests
     '/employees/send-password-reset-email: POST',
     // @todo: add tests
+    '/extra-property-definitions/bulk-delete: DELETE',
+    // @todo: add tests
+    '/extra-property-definitions/{extraPropertyDefinitionId}: DELETE',
+    // @todo: add tests
+    '/extra-property-definitions/{extraPropertyDefinitionId}: GET',
+    // @todo: add tests
+    '/extra-property-definitions/{extraPropertyDefinitionId}: PATCH',
+    // @todo: add tests
+    '/extra-property-definitions: GET',
+    // @todo: add tests
+    '/extra-property-definitions: POST',
+    // @todo: add tests
     '/features/bulk-delete: DELETE',
     // @todo: add tests
     '/features/values/bulk-delete: DELETE',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The back office of a 9.2.x shop with ps_checkout (v9) installed answers 500 as soon as it is opened, in prod and in dev mode: `Circular reference detected for service "Symfony\Contracts\Translation\TranslatorInterface", path: "Symfony\Contracts\Translation\TranslatorInterface -> Symfony\Contracts\Translation\TranslatorInterface"`. The extra property definition repository, which sits in the translator loader chain, takes its logger through the `Psr\Log\LoggerInterface` id, and ps_checkout redefines that id in the shared container (details below). The extra property services now take the core `logger` id, which is Monolog in the Symfony kernels and is aliased to the legacy logger in the hand-built legacy containers. Since every container now provides `logger`, the `ExtraPropertyReader` logger becomes required. <br><br> Also backports to 9.2.x the update of the expected Admin API endpoint list (`tests/UI/campaigns/functional/API/02_checkEndpoints.ts`) made on develop in #42816: 9.2.x already ships the extra property definition endpoints through `ps_apiresources`, so the API UI campaign needs them listed. <br><br> Also fixes a second, unrelated failure of the same feature, this time during **shop installation**: a module registering a LANG-scoped extra property with an explicit form type could not be installed by the installer, which aborted the whole installation. The definition is validated by building a throwaway form, LANG scope wraps it in `TranslatableType`, and that type was given the employee's last selected form language by reading the legacy cookie directly — a cookie the installer never sets. The binding now goes through `LegacyContext`, which returns `null` when there is no cookie. Refusals raised by the form options also name the property, a module install registering many definitions in a row. <br><br> While at it, `Module::registerExtraProperty()` and `Module::unregisterExtraProperty()` are made to honour their `bool` signature: they could only return `true`, every failure leaving through an `ExtraPropertyException` that escaped the module install. They now catch it, return `false` and add the reason to the module errors, which `ModuleManager::getError()` already surfaces in the module manager and in the installer.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no (the extra property feature and the `Psr\Log\LoggerInterface` alias of the legacy containers are new in 9.2, only `9.2.0-beta.1` is tagged)
| Deprecations?     | no
| How to test?      | See "How to test" below.
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/34529967822
| Fixed issue or discussion?     | No issue opened, found while testing the Classic edition build of 9.2.x (ps_checkout 9.5.5.3 among the bundled modules).
| Related PRs       | None. A scoped logger id should also be requested on https://github.com/PrestaShopCorp/ps_checkout (see below).
| Sponsor company   | PrestaShop

### How to test

1. On `9.2.x` without this PR, install ps_checkout v9 (`ps9` directory of https://github.com/PrestaShopCorp/ps_checkout/tree/main/ps9, or take the Classic edition build) and open the back office: 500, the error above is in the web server error log. Dev mode shows the same exception on the Symfony error page.
2. Apply this PR, clear `var/cache`, open the back office again: login and dashboard load.
3. Check the other containers still compile: front office pages, `/api/` (webservice, 401 without key), `/admin-api/`.
4. `bin/console debug:container logger --env=prod` resolves to `monolog.logger`; `var/cache/<env>/FrontContainer.php` and `WebserviceContainer.php` contain `'logger' => 'prestashop.adapter.legacy.logger'`.
5. `vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/Core/ExtraProperty/` passes.

For the installation fix:

6. Put a module registering a LANG-scoped extra property with an explicit form type in `modules/` — `demoextrafield` of https://github.com/PrestaShop/example-modules does it with `product.video_link` (`scope: LANG`, `formType: UrlType::class`) — and install a shop from scratch: `php install-dev/index_cli.php --language=en --country=fr --domain=<domain> --base_uri=/ --db_server=127.0.0.1 --db_user=root --db_name=<db> --db_create=1 --name=<shop> --email=<email> --password=<password>`.
7. Without this PR the install stops on `Cannot install module demoextrafield` / `Attempt to read property "employee_form_lang" on null`, leaving a shop without fixtures. With it the install completes, and the module's definitions are in `ps_extra_property_definition` with their storage columns.
8. Check the language selector of a translatable form still preselects the language the employee last used: open a product, switch the language of a translatable field, save, reopen it.
9. Check the failure path of a registration: add an unknown option to a definition of the module used above (`formOptions: ['nope' => true]`) and install it. The install fails with `Cannot install module <module>`, followed by the message the module itself puts in its errors and by the reason coming from the registry, and nothing is left uncaught.

### Where the installation bug comes from: no legacy cookie during an install

`Context::getContext()->cookie` is set by `config/config.inc.php`, so every normal entry point has one, and by `Install::initializeTestContext()`, used by `tests/bin/create-test-db.php`. A real installation has none: `InstallControllerConsoleProcess::initializeContext()` sets the shop, language, country, currency, cart, employee and smarty, but no cookie. The binding read that cookie:

```yaml
$defaultFormLanguageId: "@=service('prestashop.adapter.legacy.context').getContext().cookie.employee_form_lang"
```

`TranslatableType` and `TranslateType` consume it. Since #41422's save-time validation, `ExtraPropertyRegistry::register()` validates a definition by building a throwaway form through `FormOptionsValidator`, and a LANG-scoped definition is always wrapped in `TranslatableType`. Registering such a definition during an install therefore dereferenced a null cookie:

```
demoextrafield->install()
  → Module::registerExtraProperty()  →  ExtraPropertyRegistry::register()
  → FormOptionsValidator::validate()  →  form factory builds TranslatableType
  → $defaultFormLanguageId  →  Context::cookie->employee_form_lang  →  cookie is null
  → Warning caught as a refusal: "Invalid extra property form options"
  → ExtraPropertyRegistryException escapes the module install and aborts the installation
```

Only definitions that declare a `formType` or `formOptions` are affected: the validator returns early otherwise, which is why a bare LANG definition installs fine.

It stayed unnoticed because the installer is the only path without a cookie. It auto-installs everything in `modules/` (`getModulesOnDisk()`), so the module has to be on disk *before* the install to be caught; installing it afterwards from the back office, from `bin/console prestashop:module install` or from `ps-install-module` always runs with a cookie. `tests/bin/create-test-db.php` even makes the very same `installModules(array_keys($install->getModulesOnDisk()))` call, but right after `initializeTestContext()`, which sets a cookie.

### Registering an extra property now returns false instead of throwing

The refusal above aborted the whole installation rather than failing this one module, and that is a second problem. `Module::registerExtraProperty()` and `Module::unregisterExtraProperty()` are typed `: bool`, but the only value they could return was `true`: every failure left through an `ExtraPropertyException`, which `Install::executeAction()` does not catch since it only guards against `PrestaShopException`. Install code testing the returned value, the way it does for `registerHook()` and the other `register*` methods, was therefore testing a condition that could never be met.

Both methods now catch `ExtraPropertyException`, add its message to the module errors and return `false`:

```php
try {
    $entityCustomFieldRegistry->register($definition);
} catch (ExtraPropertyException $e) {
    $this->_errors[] = $e->getMessage();

    return false;
}
```

`ModuleManager::getError()` already builds its message from `$module->getInstance()->getErrors()`, so the reason now reaches the module manager and the installer, where an empty error array otherwise produced "Unfortunately, the module %module% did not return additional details.". The registry still logs every refusal before throwing, and a caller that needs the reason codes of `ExtraPropertyRegistryException` can call `ExtraPropertyRegistryInterface::register()` directly.

### Where the bug comes from: ps_checkout redefines `Psr\Log\LoggerInterface`

ps_checkout v9 declares its logger in [`ps9/config/shared/logger.yml`](https://github.com/PrestaShopCorp/ps_checkout/blob/main/ps9/config/shared/logger.yml) under `_defaults: public: true`, and uses the PSR interface FQCN as the **service id**:

```yaml
  PsCheckout\Infrastructure\Logger\LoggerFactory:
    arguments:
      - '@=service("ps_checkout.module").name'
      - '@Monolog\Handler\HandlerInterface'

  Psr\Log\LoggerInterface:
    class: 'Psr\Log\LoggerInterface'
    factory: ['@PsCheckout\Infrastructure\Logger\LoggerFactory', "build"]
```

(`Monolog\Handler\HandlerInterface` is redefined the same way.)

Module service files are merged into the core Symfony containers. A module definition with the id `Psr\Log\LoggerInterface` therefore **replaces the core alias** (`Psr\Log\LoggerInterface` → Monolog) for the whole container: every service that references the interface id, core or module, explicitly with `@Psr\Log\LoggerInterface` or implicitly through autowiring of a `LoggerInterface $logger` argument, now receives ps_checkout's logger. That is already the case for `EmployeeSessionSubscriber` for instance: core log lines end up in ps_checkout's log files. The module logger also needs the module instance (`service("ps_checkout.module").name`), so resolving the logger instantiates `Ps_Checkout`, whose constructor calls `$this->trans()`.

With 9.2 the extra property definition repository joined the translator's loader chain and took its logger through the interface id, which turned the silent leak into a crash:

```
TranslatorInterface (being built)
  → prestashop.translation.loader.extra_property
  → prestashop.translation.extractor.extra_property
  → ExtraPropertyDefinitionRepository  ($logger: '@Psr\Log\LoggerInterface')
  → PsCheckout\Infrastructure\Logger\LoggerFactory
  → ps_checkout.module  →  Ps_Checkout::__construct()  →  $this->trans()
  → Context::getTranslator()  →  $container->get(TranslatorInterface::class)
  → translator built a second time → same chain → constructor called a second time
  → $container->get(TranslatorInterface::class) → ServiceCircularReferenceException
```

The message names the translator and not the logger because Symfony's runtime circular detection only tracks ids fetched through the public `Container::get()` (here, twice, from `Context::getTranslator()`); the logger, the factory and the module service are resolved internally by the compiled container and never appear in the path. The compile-time check cannot see the loop either: the edge from `ps_checkout.module` back to the translator lives in PHP (`Module::getInstanceByName()` → constructor → `trans()`), not in the service definitions.

### Why a core fix, and why it is only a quick, temporary one

This change is made out of courtesy and efficiency: switching the extra property services to `@logger` unblocks every 9.2.x shop that ships ps_checkout without waiting for a module release. It is not where the fix belongs. The core should not have to adapt to a service predefined by a module with such a wide impact, and this PR does not protect the other core services that take `Psr\Log\LoggerInterface`: they still receive ps_checkout's logger.

The real problem is on the module side: registering `Psr\Log\LoggerInterface` (or any vendor / core FQCN) as a public service id in a container shared with the core and with every other module goes too far. It replaces the logger of the whole application, not only of the module, wherever the interface is used with autowiring, and it ties the resolution of a core service to the instantiation of the module. A module should keep its services scoped: a module-prefixed id (for instance `ps_checkout.logger`) referenced explicitly, or `_defaults: bind` / named arguments limited to its own service files, so that nothing leaks into the other containers and nothing in the core changes behaviour because a module is installed. Once ps_checkout scopes its logger, the core can go back to the interface, and a longer-term guard against modules redefining core ids in the shared containers can be discussed separately.


