### PR TITLE
Let a dashboard widget in the third zone save its configuration

### DIFF
--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -5,7 +5,7 @@
  */
 class AdminDashboardControllerCore extends AdminController
 {
-    private const DASHBOARD_ALLOWED_HOOKS = ['dashboardData', 'dashboardZoneOne', 'dashboardZoneTwo', 'displayDashboardToolbarIcons', 'displayDashboardToolbarTopMenu', 'displayDashboardTop'];
+    private const DASHBOARD_ALLOWED_HOOKS = ['dashboardData', 'dashboardZoneOne', 'dashboardZoneThree', 'dashboardZoneTwo', 'displayDashboardToolbarIcons', 'displayDashboardToolbarTopMenu', 'displayDashboardTop'];
 
     public function __construct()
     {

--- a/tests/Integration/Controllers/AdminDashboardControllerCoreTest.php
+++ b/tests/Integration/Controllers/AdminDashboardControllerCoreTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Controllers;
+
+use AdminDashboardControllerCore;
+use ReflectionClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class AdminDashboardControllerCoreTest extends KernelTestCase
+{
+    /**
+     * The dashboard renders one widget zone per `dashboardZone*` hook it dispatches, and
+     * js/admin/dashboard.js sends the id of the enclosing zone container back when a widget
+     * saves its configuration. A zone missing from the allowed list therefore renders its
+     * widget but rejects the save, so the two lists have to agree.
+     */
+    public function testEveryDispatchedZoneHookMayAlsoSaveItsConfiguration(): void
+    {
+        $dispatched = $this->dispatchedZoneHooks();
+
+        // Guards against a regex that quietly matches nothing: the page has three zones.
+        self::assertGreaterThanOrEqual(
+            3,
+            count($dispatched),
+            'Failed to read the dispatched zone hooks out of the controller.'
+        );
+
+        $allowed = (new ReflectionClass(AdminDashboardControllerCore::class))
+            ->getConstant('DASHBOARD_ALLOWED_HOOKS');
+        self::assertIsArray($allowed);
+
+        foreach ($dispatched as $hook) {
+            self::assertContains(
+                $hook,
+                $allowed,
+                sprintf('Zone hook "%s" is rendered by the dashboard but cannot save its configuration.', $hook)
+            );
+        }
+    }
+
+    /**
+     * Replays what the browser sends: the zone container id, which is the hook name prefixed
+     * with "hook", against the check the controller applies to it.
+     */
+    public function testTheConfigurationGuardAcceptsWhatTheZoneContainersSend(): void
+    {
+        $allowed = (new ReflectionClass(AdminDashboardControllerCore::class))
+            ->getConstant('DASHBOARD_ALLOWED_HOOKS');
+
+        foreach ($this->dispatchedZoneHooks() as $hook) {
+            $containerId = 'hook' . ucfirst($hook);
+            self::assertContains(
+                lcfirst(str_replace('hook', '', $containerId)),
+                $allowed,
+                sprintf('The dashboard rejects a configuration save coming from container "%s".', $containerId)
+            );
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function dispatchedZoneHooks(): array
+    {
+        $source = file_get_contents(_PS_ROOT_DIR_ . '/controllers/admin/AdminDashboardController.php');
+        self::assertIsString($source);
+
+        preg_match_all("/Hook::exec\('(dashboardZone[A-Za-z]+)'/", $source, $matches);
+
+        return array_values(array_unique($matches[1]));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The dashboard dispatches three widget zones, and `js/admin/dashboard.js` sends the id of the enclosing zone container back when a widget saves its configuration. The list of hooks the controller accepts for that save was added two years after the third zone existed and does not include it, so a widget placed in the right sidebar renders normally but answers "This hook is not allowed here." when it tries to save. The third zone is a core-dispatched display hook of the same kind as the other two, so accepting it adds no surface that was not already permitted.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install any module that hooks on `dashboardZoneThree` and exposes a dashboard configuration form. On the Dashboard the widget appears in the right sidebar; open its configuration and save. Before this change the response is `{"has_errors":true,"errors":["This hook is not allowed here."]}` and nothing is stored; after it the configuration saves like it does for a widget in zone one or two. `tests/Integration/Controllers/AdminDashboardControllerCoreTest.php` covers it without needing a module.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Refs #10185
| Related PRs       | -
| Sponsor company   | -

## The defect

`AdminDashboardController` renders three zones (`AdminDashboardController.php:279-281`):

    'hookDashboardZoneOne'   => Hook::exec('dashboardZoneOne', $params),
    'hookDashboardZoneTwo'   => Hook::exec('dashboardZoneTwo', $params),
    'hookDashboardZoneThree' => Hook::exec('dashboardZoneThree', $params),

The template gives each one a container whose id is that key, and reflows zone two when zone three
has content (`admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:65-69`):

    <div class="col-md-8 col-lg-{if $hookDashboardZoneThree}7{else}9{/if}" id="hookDashboardZoneTwo">
    ...
    {if $hookDashboardZoneThree}
      <div class="col-md-12 col-lg-2" id="hookDashboardZoneThree">

`js/admin/dashboard.js:207` derives the `hook` parameter of a configuration save from that container:

    data = 'ajax=true&action=saveDashConfig&module='+widget_name+configs+'&hook='+$('#'+widget_name).closest('[id^=hook]').attr('id');

`ajaxProcessSaveDashConfig()` strips the prefix and checks the result against
`DASHBOARD_ALLOWED_HOOKS` (`AdminDashboardController.php:408`), which listed only zones one and two.
Evaluating exactly that expression for each container the page can produce:

    hookDashboardZoneOne     -> dashboardZoneOne     -> ALLOWED
    hookDashboardZoneTwo     -> dashboardZoneTwo     -> ALLOWED
    hookDashboardZoneThree   -> dashboardZoneThree   -> REJECTED (This hook is not allowed here.)
    hookDisplayDashboardTop  -> displayDashboardTop  -> ALLOWED

## It was an omission, not a deliberate exclusion

The two changes are two years apart, so the allowed list was written against a page that already
had three zones:

- `1ba0909c331`, 2021-10-13, "Add dashboardZoneThree for the dashboard right sidebar"
- `1b884c8b4a5`, 2023-07-25, "filter dashboard hooks" - introduces `DASHBOARD_ALLOWED_HOOKS`

The 2023 commit replaced `Validate::isHookName($hook)` with the fixed list and enumerated five hooks
plus `dashboardData`; zone three is the only rendered zone it left out.

## Why widening the list is safe

`dashboardZoneThree` is dispatched by the core controller itself, in the same statement group and with
the same parameters as zones one and two, and it reaches the same `$module_obj->$hook($params)` call
that zones one and two already reach. Nothing becomes callable that the page did not already render.

## Evidence

Test RED on `9.2.x` before the change, with the messages naming the zone:

    Zone hook "dashboardZoneThree" is rendered by the dashboard but cannot save its configuration.
    The dashboard rejects a configuration save coming from container "hookDashboardZoneThree".

GREEN after: 2 tests, 11 assertions. The whole `tests/Integration/Controllers` directory is 4 tests,
13 assertions, no regressions. php-cs-fixer and PHPStan clean on both files, the cs-fixer result
checked against a deliberately broken copy so a silent pass could not be mistaken for clean.

The test derives the zones from the `Hook::exec('dashboardZone...')` calls in the controller instead
of repeating them, and asserts it found at least three, so the regex cannot pass by matching nothing.
A fourth zone added without updating the list would fail the same way.

## Note for the reviewer

`displayDashboardToolbarIcons` is in `DASHBOARD_ALLOWED_HOOKS` and registered in
`install-dev/data/xml/hook.xml`, but it has no dispatch site anywhere in the repository. It is left
untouched here: removing an entry from an allowed list is a behaviour change for anyone who sends it,
and it is not what this fix is about.
