### PR TITLE
Align the legacy mail template listing with the way core resolves templates

### DIFF
--- a/src/Core/Email/LegacyEmailTemplateLister.php
+++ b/src/Core/Email/LegacyEmailTemplateLister.php
@@ -32,14 +32,15 @@ class LegacyEmailTemplateLister
     {
         $templates = [];
 
-        $corePath = $this->mailsDir . '/' . $isoCode . '/';
+        $corePath = rtrim($this->mailsDir, '/') . '/' . $isoCode . '/';
         if (is_dir($corePath)) {
-            $templates = array_merge($templates, $this->scanDirectory($corePath, '', true));
+            $templates = $this->scanDirectory($corePath, '', true);
         }
 
-        $templates = array_merge($templates, $this->scanModuleTemplates($isoCode));
-
-        return $templates;
+        // Mail::getTemplateBasePath() searches the theme and core mail directories before it walks
+        // the modules, so when a module ships a template of the same name the core one is what gets
+        // sent. The union keeps that core entry instead of letting the module overwrite it.
+        return $templates + $this->scanModuleTemplates($isoCode);
     }
 
     private function scanDirectory(string $path, string $moduleName, bool $isCore = false): array
@@ -51,26 +52,32 @@ class LegacyEmailTemplateLister
         }
 
         $finder = new Finder();
-        $finder->files()->in($path)->depth(0)->name('*.html');
+        $finder->files()->in($path)->depth(0)->name(['*.html', '*.txt']);
 
         /** @var SplFileInfo $file */
         foreach ($finder as $file) {
-            $templateName = $file->getBasename('.html');
+            $templateName = $file->getBasename('.' . $file->getExtension());
 
-            if ($templateName[0] === '.') {
+            if ($templateName === '' || $templateName[0] === '.') {
                 continue;
             }
 
+            if (isset($templates[$templateName])) {
+                continue;
+            }
+
+            // A template counts as present when either half is, which is the rule
+            // Mail::getTemplateBasePath() already applies; PS_MAIL_TYPE then decides which half
+            // is required at send time, and TYPE_BOTH_AUTOMATIC_TEXT needs no .txt at all.
+            $htmlFile = $path . $templateName . '.html';
             $txtFile = $path . $templateName . '.txt';
 
-            if (file_exists($txtFile)) {
-                $templates[$templateName] = [
-                    'module' => $moduleName,
-                    'is_core' => $isCore,
-                    'html_path' => $file->getPathname(),
-                    'txt_path' => $txtFile,
-                ];
-            }
+            $templates[$templateName] = [
+                'module' => $moduleName,
+                'is_core' => $isCore,
+                'html_path' => is_file($htmlFile) ? $htmlFile : null,
+                'txt_path' => is_file($txtFile) ? $txtFile : null,
+            ];
         }
 
         return $templates;

--- a/tests/Unit/Core/Email/LegacyEmailTemplateListerTest.php
+++ b/tests/Unit/Core/Email/LegacyEmailTemplateListerTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Email;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Email\LegacyEmailTemplateLister;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * A legacy mail template is a .html file, a .txt file, or both: which one is required depends on
+ * PS_MAIL_TYPE, and Mail::getTemplateBasePath() accepts a template as soon as either exists.
+ */
+class LegacyEmailTemplateListerTest extends TestCase
+{
+    private string $rootDir;
+    private string $mailsDir;
+    private string $modulesDir;
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem();
+        $this->rootDir = sys_get_temp_dir() . '/legacy_email_lister_' . uniqid('', true);
+        $this->mailsDir = $this->rootDir . '/mails';
+        $this->modulesDir = $this->rootDir . '/modules';
+        $this->filesystem->mkdir([$this->mailsDir . '/en', $this->modulesDir . '/probemodule/mails/en']);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->rootDir);
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider provideTemplateShapes
+     *
+     * @param string[] $files
+     */
+    public function testATemplateIsListedWhenEitherHalfExists(array $files, bool $expectHtml, bool $expectTxt): void
+    {
+        foreach ($files as $file) {
+            $this->filesystem->dumpFile($this->mailsDir . '/en/' . $file, 'content');
+        }
+
+        $templates = $this->createLister()->getLegacyTemplates('en');
+
+        $this->assertArrayHasKey('order_conf', $templates, 'The template was dropped from the listing.');
+        $this->assertSame($expectHtml, null !== $templates['order_conf']['html_path']);
+        $this->assertSame($expectTxt, null !== $templates['order_conf']['txt_path']);
+        $this->assertTrue($templates['order_conf']['is_core']);
+        $this->assertSame('', $templates['order_conf']['module']);
+    }
+
+    /**
+     * @return array<string, array{string[], bool, bool}>
+     */
+    public static function provideTemplateShapes(): array
+    {
+        return [
+            'both halves' => [['order_conf.html', 'order_conf.txt'], true, true],
+            // PS_MAIL_TYPE = TYPE_HTML or TYPE_BOTH_AUTOMATIC_TEXT sends these without a .txt.
+            'html only' => [['order_conf.html'], true, false],
+            'txt only' => [['order_conf.txt'], false, true],
+        ];
+    }
+
+    public function testAModuleTemplateWithOnlyOneHalfIsListed(): void
+    {
+        $this->filesystem->dumpFile($this->modulesDir . '/probemodule/mails/en/module_alert.html', 'content');
+
+        $templates = $this->createLister()->getLegacyTemplates('en');
+
+        $this->assertArrayHasKey('module_alert', $templates);
+        $this->assertSame('probemodule', $templates['module_alert']['module']);
+        $this->assertFalse($templates['module_alert']['is_core']);
+        $this->assertNull($templates['module_alert']['txt_path']);
+    }
+
+    public function testEachTemplateIsReportedOnceWhateverTheFileOrder(): void
+    {
+        $this->filesystem->dumpFile($this->mailsDir . '/en/order_conf.html', 'content');
+        $this->filesystem->dumpFile($this->mailsDir . '/en/order_conf.txt', 'content');
+        $this->filesystem->dumpFile($this->mailsDir . '/en/account.txt', 'content');
+
+        $templates = $this->createLister()->getLegacyTemplates('en');
+
+        $this->assertCount(2, $templates);
+        $this->assertNotNull($templates['order_conf']['html_path']);
+        $this->assertNotNull($templates['order_conf']['txt_path']);
+        $this->assertNull($templates['account']['html_path']);
+    }
+
+    public function testACoreTemplateSurvivesAModuleShippingTheSameName(): void
+    {
+        // ps_emailalerts really does ship order_changed and productoutofstock beside the core ones.
+        $this->filesystem->dumpFile($this->mailsDir . '/en/order_changed.html', 'core');
+        $this->filesystem->dumpFile($this->mailsDir . '/en/order_changed.txt', 'core');
+        // Both halves, so the module entry survives the scan and really does reach the merge.
+        $this->filesystem->dumpFile($this->modulesDir . '/probemodule/mails/en/order_changed.html', 'module');
+        $this->filesystem->dumpFile($this->modulesDir . '/probemodule/mails/en/order_changed.txt', 'module');
+
+        $templates = $this->createLister()->getLegacyTemplates('en');
+
+        $this->assertTrue($templates['order_changed']['is_core'], 'A module overwrote the core template.');
+        $this->assertSame('', $templates['order_changed']['module']);
+        $this->assertStringStartsWith($this->mailsDir, (string) $templates['order_changed']['html_path']);
+    }
+
+    public function testAMissingLanguageDirectoryYieldsNoTemplates(): void
+    {
+        $this->assertSame([], $this->createLister()->getLegacyTemplates('zz'));
+    }
+
+    private function createLister(): LegacyEmailTemplateLister
+    {
+        return new LegacyEmailTemplateLister($this->mailsDir, $this->modulesDir);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `LegacyEmailTemplateLister` describes the mail directories in two ways core does not, and `OrderStateType` builds the order status template dropdown from it. (1) It scanned for `*.html` and kept a template only when a sibling `.txt` existed, so one shipping a single half was dropped - while `Mail::getTemplateBasePath()` accepts a template as soon as either file exists, and `PS_MAIL_TYPE` decides which half is required at send time (`TYPE_HTML` needs no `.txt`, `TYPE_BOTH_AUTOMATIC_TEXT` generates it). (2) It merged module templates over core ones, so a module shipping an existing name replaced it - but resolution searches theme and core mail directories first and the modules directory only if none matched, so core is what actually gets sent. On a default install that misreported `order_changed` and `productoutofstock` as belonging to `ps_emailalerts`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | (1) Set Shop parameters > Email > "Send email as" to `HTML only`, drop a `.html` with no `.txt` into a module's `mails/en/`, then edit a status under Shop parameters > Order settings > Statuses: the template is absent from the "Template" dropdown before and selectable after. (2) On a stock install, dump `getLegacyTemplates('en')` and look at `order_changed`: `is_core` is `false` with a `ps_emailalerts` path before, `true` with a core path after. `tests/Unit/Core/Email/LegacyEmailTemplateListerTest.php` covers both without a shop.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Found while reviewing #11880
| Related PRs       | -
| Sponsor company   | -

## Evidence

**Core's rule**, `classes/Mail.php:710` and `:720`, is `||` in both branches:

    if (file_exists($templatePath . $isoTemplate . '.txt') || file_exists($templatePath . $isoTemplate . '.html'))

and `getTemplateBasePath()` tries the theme paths and `_PS_ROOT_DIR_ . '/mails/'` before it walks
`_PS_MODULE_DIR_`, so a core template of the same name wins. `EmailBodyTemplateRepository`, which
backs the migrated email body translation page, already scans `['*.html', '*.txt']`.

**Pairing**, measured with the lister pointed at a temporary fixture (its constructor takes both
directories): of `paired`, `html_only`, `txt_only` and a module's `mod_html_only`, only `paired`
was returned.

**Collision, measured on a stock install** (not a synthetic fixture) - before:

    order_changed      is_core=false module=ps_emailalerts   html=modules/ps_emailalerts/mails/en/order_changed.html
    productoutofstock  is_core=false module=ps_emailalerts   html=modules/ps_emailalerts/mails/en/productoutofstock.html

after:

    order_changed      is_core=true  module=(core)           html=mails/en/order_changed.html
    productoutofstock  is_core=true  module=(core)           html=mails/en/productoutofstock.html

Both names ship `.html` and `.txt` in core and in `ps_emailalerts`, in `en` and `fr`.

**Equivalence check on the one axis the rewrite could shift:** `getBasename('.html')` was replaced
by `getBasename('.' . $file->getExtension())`, which differs only for a name containing a dot before
the extension. There are none - 0 such basenames across `mails/*/` and `modules/*/mails/*/`.

RED on `9.2.x`: 4 of 6 pairing tests fail, with the paired template and the missing locale passing
as negative controls; the collision test fails with "A module overwrote the core template." That
collision test first had to be corrected - with an unpaired module template it passed on base,
because the old pairing rule dropped the module entry before any merge could happen, so it proved
nothing. GREEN with the fix: 7 tests, 27 assertions.

No change to the offered template names on a stock install: every core and module mail template in
the tree ships both files. The only unpaired files are 3 `.txt` under `mails/_partials/`, which is
not a locale directory and is never scanned.

Also green: `tests/Unit/Core/Email/` (10 tests) and behat `OrderState/order_state.feature`
(6 scenarios, 48 steps). php-cs-fixer clean with a sabotage control; PHPStan clean on the class, the
test and `OrderStateType`.
