### PR TITLE
Resolve the friendly URL setting per shop when generating .htaccess

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2571,8 +2571,11 @@ class ToolsCore
 
     public static function generateHtaccess($path = null, $rewrite_settings = null, $cache_control = null, $specific = '', $disable_multiviews = null, $medias = false, $disable_modsec = null)
     {
+        // The test guard is about not rewriting the shop's own .htaccess. A caller that names a
+        // path is not touching it, so it is allowed through and the generation stays testable -
+        // the same shape as the installation guard on the next line.
         if (
-            defined('_PS_IN_TEST_')
+            (defined('_PS_IN_TEST_') && $path === null)
             || (defined('PS_INSTALLATION_IN_PROGRESS') && $rewrite_settings === null)
         ) {
             return true;
@@ -2681,11 +2684,19 @@ class ToolsCore
         fwrite($write_fd, "RewriteCond %{HTTP:Authorization} .\n");
         fwrite($write_fd, "RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]\n\n");
 
+        // A value given by the caller applies to the whole file; without one, every shop URL
+        // resolves its own setting below. Kept apart from the loop variable so that one shop's
+        // setting cannot carry over to the next.
+        $forced_rewrite_settings = $rewrite_settings;
+
         foreach ($domains as $domain => $list_uri) {
             // As we use regex in the htaccess, ipv6 surrounded by brackets must be escaped
             $domain = str_replace(['[', ']'], ['\[', '\]'], $domain);
 
             $domain_rewrite_cond = '';
+            // The dispatcher rules below are written once per domain, so they apply as soon as any
+            // shop served by that domain rewrites its URLs.
+            $domain_rewrite_settings = false;
             foreach ($list_uri as $uri) {
                 fwrite($write_fd, PHP_EOL . PHP_EOL . '#Domain: ' . $domain . PHP_EOL);
                 if (Shop::isFeatureActive()) {
@@ -2698,14 +2709,13 @@ class ToolsCore
                 // upload folder
                 fwrite($write_fd, 'RewriteRule ^upload/.+$ %{ENV:REWRITEBASE}index.php [QSA,L]' . "\n\n");
 
-                if (!$rewrite_settings) {
-                    $rewrite_settings = (int) Configuration::get('PS_REWRITING_SETTINGS', null, null, (int) $uri['id_shop']);
-                }
+                $uri_rewrite_settings = $forced_rewrite_settings ?? (int) Configuration::get('PS_REWRITING_SETTINGS', null, null, (int) $uri['id_shop']);
+                $domain_rewrite_settings = $domain_rewrite_settings || $uri_rewrite_settings;
 
                 $domain_rewrite_cond = 'RewriteCond %{HTTP_HOST} ^' . $domain . '$' . PHP_EOL;
                 // Rewrite virtual multishop uri
                 if ($uri['virtual']) {
-                    if (!$rewrite_settings) {
+                    if (!$uri_rewrite_settings) {
                         fwrite($write_fd, $media_domains);
                         fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^' . trim($uri['virtual'], '/') . '/?$ ' . $uri['physical'] . $uri['virtual'] . "index.php [L,R]\n");
@@ -2719,7 +2729,7 @@ class ToolsCore
                     fwrite($write_fd, 'RewriteRule ^' . ltrim($uri['virtual'], '/') . '(.*) ' . $uri['physical'] . "$1 [L]\n\n");
                 }
 
-                if ($rewrite_settings) {
+                if ($uri_rewrite_settings) {
                     // Compatibility with the old image filesystem
                     fwrite($write_fd, "# Rewrites for product images (support up to < 10 million images)\n");
 
@@ -2750,7 +2760,7 @@ class ToolsCore
             }
 
             // Redirections to dispatcher
-            if ($rewrite_settings) {
+            if ($domain_rewrite_settings) {
                 fwrite($write_fd, "\n# Send all other traffic to dispatcher\n");
                 fwrite($write_fd, "RewriteCond %{REQUEST_FILENAME} -s [OR]\n");
                 fwrite($write_fd, "RewriteCond %{REQUEST_FILENAME} -l [OR]\n");

--- a/tests/Integration/Classes/GenerateHtaccessMultishopTest.php
+++ b/tests/Integration/Classes/GenerateHtaccessMultishopTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Db;
+use PHPUnit\Framework\TestCase;
+use Shop;
+use Throwable;
+use Tools;
+
+/**
+ * Friendly URLs are a per shop setting, so two shops of the same installation may disagree, and
+ * the generated .htaccess has to reflect that shop by shop.
+ */
+class GenerateHtaccessMultishopTest extends TestCase
+{
+    private const PROBE_URI = '/htaccess-multishop-test/';
+
+    private ?int $probeShopId = null;
+    private ?string $multishopBackup = null;
+    private string $outputFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->outputFile = sys_get_temp_dir() . '/htaccess_multishop_test_' . getmypid();
+        $this->createProbeShop();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeProbeShop();
+        @unlink($this->outputFile);
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider provideSettingsPerShop
+     */
+    public function testEachShopGetsTheRewriteRulesItsOwnSettingAskedFor(int $mainShopSetting, int $probeShopSetting): void
+    {
+        $this->writeRewriteSetting(1, $mainShopSetting);
+        $this->writeRewriteSetting((int) $this->probeShopId, $probeShopSetting);
+        $this->refreshCaches();
+
+        Tools::generateHtaccess($this->outputFile);
+        $blocks = $this->rewriteRuleCountPerShop();
+
+        $this->assertSame(
+            $mainShopSetting > 0,
+            $blocks['/'] > 0,
+            'The main shop got the wrong rules for its own setting.'
+        );
+        $this->assertSame(
+            $probeShopSetting > 0,
+            $blocks[self::PROBE_URI] > 0,
+            'The second shop got rules belonging to another shop.'
+        );
+        // Both shops share a domain and the dispatcher rules are written once per domain, so
+        // they belong there as soon as any shop served by it rewrites its URLs.
+        $this->assertSame(
+            $mainShopSetting > 0 || $probeShopSetting > 0 ? 1 : 0,
+            $this->dispatcherBlockCount(),
+            'The dispatcher rules do not match what the shops on this domain asked for.'
+        );
+    }
+
+    /**
+     * @return array<string, array{int, int}>
+     */
+    public static function provideSettingsPerShop(): array
+    {
+        return [
+            // The order matters: before the fix the first enabled shop pinned the setting for
+            // every shop after it, so only this direction was broken.
+            'enabled shop first, disabled second' => [1, 0],
+            'disabled shop first, enabled second' => [0, 1],
+            'both enabled' => [1, 1],
+            'both disabled' => [0, 0],
+        ];
+    }
+
+    public function testAnExplicitSettingFromTheCallerAppliesToEveryShop(): void
+    {
+        $this->writeRewriteSetting(1, 0);
+        $this->writeRewriteSetting((int) $this->probeShopId, 0);
+        $this->refreshCaches();
+
+        Tools::generateHtaccess($this->outputFile, 1);
+        $blocks = $this->rewriteRuleCountPerShop();
+
+        foreach ($blocks as $base => $count) {
+            $this->assertGreaterThan(0, $count, sprintf('%s ignored the value the caller imposed.', $base));
+        }
+        $this->assertSame(1, $this->dispatcherBlockCount(), 'The imposed value did not reach the dispatcher rules.');
+    }
+
+    /**
+     * Number of product image rewrite rules written for each shop, keyed by its physical URI.
+     *
+     * @return array<string, int>
+     */
+    private function rewriteRuleCountPerShop(): array
+    {
+        $content = (string) file_get_contents($this->outputFile);
+        $counts = [];
+        $blocks = preg_split('/^RewriteRule \. - \[E=REWRITEBASE:/m', $content) ?: [];
+
+        foreach ($blocks as $index => $block) {
+            if (0 === $index) {
+                continue;
+            }
+            $counts[(string) strtok($block, ']')] = substr_count($block, 'img/p/');
+        }
+
+        return $counts;
+    }
+
+    /**
+     * How many times the per domain dispatcher rules were written.
+     */
+    private function dispatcherBlockCount(): int
+    {
+        return substr_count((string) file_get_contents($this->outputFile), '# Send all other traffic to dispatcher');
+    }
+
+    private function createProbeShop(): void
+    {
+        $db = Db::getInstance();
+        // The row is not present on every installation, so remember whether it existed at all
+        // rather than writing an empty string back over it.
+        $storedValue = $db->getValue(
+            'SELECT `value` FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"'
+        );
+        $this->multishopBackup = (false === $storedValue || null === $storedValue) ? null : (string) $storedValue;
+        if (null === $this->multishopBackup) {
+            $db->execute('INSERT INTO `' . _DB_PREFIX_ . 'configuration` (`id_shop_group`, `id_shop`, `name`, `value`, `date_add`, `date_upd`)
+                VALUES (NULL, NULL, "PS_MULTISHOP_FEATURE_ACTIVE", "1", NOW(), NOW())');
+        } else {
+            $db->execute('UPDATE `' . _DB_PREFIX_ . 'configuration` SET `value` = 1 WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"');
+        }
+
+        $db->execute('INSERT INTO `' . _DB_PREFIX_ . 'shop` (`id_shop_group`, `name`, `id_category`, `theme_name`, `active`, `deleted`)
+            SELECT `id_shop_group`, "HtaccessMultishopTest", `id_category`, `theme_name`, 1, 0
+            FROM `' . _DB_PREFIX_ . 'shop` WHERE `id_shop` = 1');
+        $this->probeShopId = (int) $db->Insert_ID();
+
+        $mainUrl = $db->getRow('SELECT * FROM `' . _DB_PREFIX_ . 'shop_url` WHERE `id_shop` = 1');
+        $db->execute('INSERT INTO `' . _DB_PREFIX_ . 'shop_url`
+            (`id_shop`, `domain`, `domain_ssl`, `physical_uri`, `virtual_uri`, `main`, `active`) VALUES ('
+            . (int) $this->probeShopId . ', "' . pSQL($mainUrl['domain']) . '", "' . pSQL($mainUrl['domain_ssl'])
+            . '", "' . self::PROBE_URI . '", "", 1, 1)');
+    }
+
+    private function removeProbeShop(): void
+    {
+        $db = Db::getInstance();
+        // Each step is independent: one failing must not leave the rest of the fixture behind.
+        foreach ([
+            fn () => $db->execute('DELETE FROM `' . _DB_PREFIX_ . 'shop_url` WHERE `id_shop` = ' . (int) $this->probeShopId),
+            fn () => $db->execute('DELETE FROM `' . _DB_PREFIX_ . 'configuration` WHERE `id_shop` = ' . (int) $this->probeShopId),
+            fn () => $db->execute('DELETE FROM `' . _DB_PREFIX_ . 'shop` WHERE `id_shop` = ' . (int) $this->probeShopId),
+            fn () => $db->execute('DELETE FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = "PS_REWRITING_SETTINGS" AND `id_shop` = 1'),
+            fn () => null === $this->multishopBackup
+                ? $db->execute('DELETE FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"')
+                : $db->execute('UPDATE `' . _DB_PREFIX_ . 'configuration` SET `value` = "'
+                    . pSQL((string) $this->multishopBackup) . '" WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"'),
+        ] as $step) {
+            try {
+                $step();
+            } catch (Throwable) {
+                // keep unwinding the rest of the fixture
+            }
+        }
+        $this->probeShopId = null;
+        $this->refreshCaches();
+    }
+
+    private function writeRewriteSetting(int $shopId, int $value): void
+    {
+        $db = Db::getInstance();
+        $db->execute('DELETE FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = "PS_REWRITING_SETTINGS" AND `id_shop` = ' . $shopId);
+        $db->execute('INSERT INTO `' . _DB_PREFIX_ . 'configuration` (`id_shop_group`, `id_shop`, `name`, `value`, `date_add`, `date_upd`)
+            VALUES (NULL, ' . $shopId . ', "PS_REWRITING_SETTINGS", "' . $value . '", NOW(), NOW())');
+    }
+
+    /**
+     * Shop::isFeatureActive() and the configuration values are both resolved once and kept, so a
+     * fixture built after boot is invisible until they are dropped.
+     */
+    private function refreshCaches(): void
+    {
+        Shop::resetStaticCache();
+        Configuration::clearConfigurationCacheForTesting();
+        Configuration::loadConfiguration();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `PS_REWRITING_SETTINGS` is a per shop setting, but `generateHtaccess()` read it into the function parameter it was already using as loop state, and only while that was still falsy. The first shop with friendly URLs enabled therefore pinned the setting for every shop URL after it, so a shop with friendly URLs turned off was written the friendly URL image rewrites and the enabled branch of the virtual URI rule. Each shop URL now resolves its own setting.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Two shops on one installation, friendly URLs on for the first and off for the second. Save anything that regenerates `.htaccess` (Shop URLs, or SEO and URLs). Before: the second shop's block carries the seven `img/p/` rewrite rules it should not have. After: its block has none, while the first shop keeps them. Reversing which shop is enabled behaves correctly both before and after, see below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Relates to #13226
| Related PRs       |
| Sponsor company   |

### Notes for the reviewer

**Why it stayed hidden.** The leak only goes one way. The guard re-reads the setting while the
value is still falsy, so with the disabled shop first it is read again for the next shop and the
result is correct. Only enabled-then-disabled is wrong. Measured on the unfixed code with two
shops on one domain, counting `img/p/` rewrite lines per shop block:

| order | shop 1 | shop 2 | correct? |
| --- | --- | --- | --- |
| enabled first, disabled second | 7 | 7 | no, the second shop should have 0 |
| disabled first, enabled second | 0 | 7 | yes, by accident |

With the change: 7 / 0 and 0 / 7 respectively, and a value passed by the caller still produces
7 / 7 regardless of what either shop has configured.

**The dispatcher block is per domain, not per shop URL.** It sits in the outer loop and already
uses `$domain_rewrite_cond` left from the last URL of that domain, so it now keys off whether any
shop on the domain rewrites its URLs rather than off whichever value happened to be left in the
variable.

**Reachability.** Most callers pass no arguments, so the parameter starts as null and the per shop
read is the one that runs: `Meta.php` in three places, `AdminShopController`, and
`AdminShopUrlController`, the last being the multistore shop URL screen.

**The change to the test guard.** `generateHtaccess()` returned early whenever `_PS_IN_TEST_` was
defined, which is why this function has no test today. The guard exists so a test run does not
rewrite the shop's own `.htaccess`; a caller that passes its own path is not touching it. The guard
now matches the shape of the installation guard on the following line, which likewise only applies
when the caller did not specify. No existing test called this function, so nothing depended on the
previous behaviour.

**Test.** `tests/Integration/Classes/GenerateHtaccessMultishopTest.php` builds a second shop on the
same domain, writes a different setting for each, and counts the rules each shop's block receives.
Reverting only the resolution change, keeping the guard, turns exactly one of the five cases red
with "The second shop got rules belonging to another shop" - the enabled-then-disabled ordering.
The other four pass on the unfixed code, which is the point: they pin the behaviour that was
already correct so it stays that way.
