### PR TITLE
Restore the unfiltered listing when going back from a faceted result

### DIFF
--- a/tests/UI/campaigns/functional/FO/hummingbird/08_menuAndNavigation/02_sortAndFilter/04_backNavigationAfterFilter.ts
+++ b/tests/UI/campaigns/functional/FO/hummingbird/08_menuAndNavigation/02_sortAndFilter/04_backNavigationAfterFilter.ts
@@ -1,0 +1,103 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {expect} from 'chai';
+import {
+  type BrowserContext,
+  foHummingbirdCategoryPage,
+  foHummingbirdHomePage,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_FO_hummingbird_menuAndNavigation_sortAndFilter_backNavigationAfterFilter';
+
+/*
+Scenario:
+- Go to FO > All products page and record the unfiltered listing
+- Filter products by composition
+- Go back with the browser and check the unfiltered listing is restored
+ */
+describe('FO - Menu and Navigation - Sort and filter : Browser back after filtering', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+  let unfilteredUrl: string;
+  let unfilteredProductsNumber: number;
+
+  // before and after functions
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  it('should open the shop page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'openShopPage', baseContext);
+
+    await foHummingbirdHomePage.goTo(page, global.FO.URL);
+
+    const result = await foHummingbirdHomePage.isHomePage(page);
+    expect(result).to.equal(true);
+  });
+
+  it('should go to all products page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToAllProducts', baseContext);
+
+    await foHummingbirdHomePage.changeLanguage(page, 'en');
+    await foHummingbirdHomePage.goToAllProductsPage(page, 'ps-featuredproducts');
+
+    const isCategoryPageVisible = await foHummingbirdCategoryPage.isCategoryPage(page);
+    expect(isCategoryPageVisible, 'Home category page was not opened').to.equal(true);
+  });
+
+  it('should record the unfiltered listing', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'recordUnfilteredListing', baseContext);
+
+    unfilteredUrl = await foHummingbirdCategoryPage.getCurrentURL(page);
+    unfilteredProductsNumber = await foHummingbirdCategoryPage.getNumberOfProducts(page);
+    expect(unfilteredProductsNumber).to.be.above(1);
+
+    const isActiveFilterNotVisible = await foHummingbirdCategoryPage.isActiveFilterNotVisible(page);
+    expect(isActiveFilterNotVisible).to.equal(true);
+  });
+
+  it('should filter products by composition \'Ceramic\'', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'filterByComposition', baseContext);
+
+    await foHummingbirdCategoryPage.filterByCheckbox(page, 'Composition', 'Composition-Ceramic', true);
+
+    const activeFilters = await foHummingbirdCategoryPage.getActiveFilters(page);
+    expect(activeFilters).to.contains('Composition: Ceramic');
+  });
+
+  it('should check that the filtered listing differs from the unfiltered one', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkFilteredListing', baseContext);
+
+    const filteredUrl = await foHummingbirdCategoryPage.getCurrentURL(page);
+    expect(filteredUrl).to.not.equal(unfilteredUrl);
+
+    const filteredProductsNumber = await foHummingbirdCategoryPage.getNumberOfProducts(page);
+    expect(filteredProductsNumber).to.be.below(unfilteredProductsNumber);
+  });
+
+  it('should go back with the browser and check the unfiltered listing is restored', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goBackToUnfilteredListing', baseContext);
+
+    await page.goBack();
+    // The filtered listing was rendered in the same document, so the restored entry is reloaded
+    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle');
+
+    const currentUrl = await foHummingbirdCategoryPage.getCurrentURL(page);
+    expect(currentUrl).to.equal(unfilteredUrl);
+
+    const isActiveFilterNotVisible = await foHummingbirdCategoryPage.isActiveFilterNotVisible(page);
+    expect(isActiveFilterNotVisible).to.equal(true);
+
+    const productsNumber = await foHummingbirdCategoryPage.getNumberOfProducts(page);
+    expect(productsNumber).to.equal(unfilteredProductsNumber);
+  });
+});

--- a/themes/_core/js/facets.js
+++ b/themes/_core/js/facets.js
@@ -9,6 +9,17 @@ let currentRequest = null;
 
 function updateResults(data) {
   prestashop.emit('updateProductList', data);
+
+  // WHY: the entry the visitor landed on carries no history state, so a later back
+  // navigation to it fires popstate with a null state. Themes restore the listing from
+  // state.current_url, so with no state nothing happens: the address bar returns to the
+  // unfiltered listing while the page keeps showing the filtered one. Seeding that entry
+  // before the first push makes it restore like every other entry. Whatever a module already
+  // put on that entry is kept, since the state object is shared.
+  if (!window.history.state || !window.history.state.current_url) {
+    window.history.replaceState({...window.history.state, current_url: window.location.href}, document.title);
+  }
+
   window.history.pushState(data, document.title, data.current_url);
 }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Every faceted filter update pushes a history entry carrying the AJAX payload, and themes restore the listing for an entry from `state.current_url`. The entry the visitor landed on is never given a state, so a back navigation to it fires `popstate` with a null state and no theme can act on it: the address bar returns to the unfiltered listing while the page keeps showing the filtered one, which reads as the back button doing nothing. `updateResults()` now seeds that entry with its own URL before the first push, so it restores like every other entry.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `themes/core.js` is a build artifact and is not tracked, so rebuild the front-office assets after checking out the branch (`make assets`, or `npm run build` in `themes/`). If `PS_JS_THEME_CACHE` is on, the shop serves one combined `themes/<theme>/assets/cache/bottom-*.js` and the rebuild stays invisible until that cache is regenerated or turned off - worth checking the page's script tags before concluding anything. Then, on a shop with faceted search active, open a category listing that has filters, apply one filter, wait for the listing to update and press the browser back button. Before: the URL returns to the unfiltered listing but the active-filter chips and the filtered products stay on screen. After: the unfiltered listing is shown. `tests/UI/campaigns/functional/FO/hummingbird/08_menuAndNavigation/02_sortAndFilter/04_backNavigationAfterFilter.ts` covers it.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes PrestaShop/ps_facetedsearch#1199
| Related PRs       |
| Sponsor company   |

## Why the fix is here and not in the module or the theme

`ps_facetedsearch` contains no `history` or `location` code at all - `_dev/front/`, `src/`,
`views/dist/front.js` and `ps_facetedsearch.php` have zero matches. The history entries come from
core, `themes/_core/js/facets.js:12`, and the restore is the theme's: hummingbird
`src/js/modules/facetedsearch/update.ts:113-119`, classic-theme `_dev/js/listing.js:243-245`. Both
read the same `state.current_url` contract, so seeding the landing entry in core fixes both, and any
third-party theme following that contract, with one guard instead of one per theme.

## What the reporter saw, and what is left of it

The report is against 9.0.1, where `composer.json` requires `prestashop/hummingbird: ^1.0.1`. In
hummingbird v1.0.0 and v1.0.1 the handler reads:

```ts
window.location.href = state && state.current_url ? state.current_url : history;
```

With no state on the landing entry that assigns the `History` object, which stringifies to
`[object History]` - the exact URL in the report. Every 2.x tag from v2.0.0-beta.1 onwards guards the
null state instead, so that symptom is gone: measured on 9.2.x with hummingbird 2.1.0 and
ps_facetedsearch 5.0.0, no request for such a URL is made at any point.

What the guard did not do is restore the listing. It turned a broken navigation into a silent one,
so the reporter's expectation - that back should work on a faceted listing - is still unmet on
current code. That is what this changes.

## Verification

Measured on 9.2.x (`a200e3bd986`) plus the fix, hummingbird 2.1.0, ps_facetedsearch 5.0.0, with the
theme's JS combination cache off so the browser loads `themes/core.js` directly.

- `tests/UI/.../04_backNavigationAfterFilter.ts`: 6 passing.
- Mutation: reverting `themes/_core/js/facets.js` and rebuilding the bundle - confirmed by grepping
  the built asset, not assumed - fails the last test on `isActiveFilterNotVisible` (expected false to
  equal true), with the five preceding tests still green. Restoring it returns 6 passing.
- The URL assertion in that same test passes in both states, which is the point: the URL does go
  back, only the document does not follow.
- Instrumented history probe over the sequence land, filter, filter, back, back, forward. Before:
  the second back is a single same-document traversal, `history.state` null, active filters still
  rendered. After: traversal plus one reload, `history.state` carries `current_url`, active filters
  gone. History length stays at 4 and no further navigation happens in the four seconds after, so
  the same-URL assignment settles rather than looping. Forward still returns to the first filtered
  entry.

## Trade-off, stated because a reviewer will ask

Back to the landing entry now costs one page reload, because that is how the themes restore any
entry - back between two filtered entries already reloads today. The alternative is for core to
re-run the facet request on `popstate` and re-render in place, with no reload at all. That is the
better end state, but it only works once the themes stop assigning `location.href` in their own
`popstate` handlers, so it needs coordinated changes in core, hummingbird and classic-theme. This
change makes the existing strategy uniform in one file and does not stand in the way of that.

`themes/core.js` is not tracked, so the diff is the source file plus the test.

## Why the seed spreads the existing state

`history.state` is shared global state on a platform where any module can push to it. The guard only
skips entries that already carry a `current_url`, so an entry holding some other author's state would
otherwise be replaced outright. `{...window.history.state, current_url: ...}` keeps it, and `{...null}`
is `{}`, so the null case is unchanged. Core itself does not collide here: its other listing-page
`pushState` is in `themes/_core/js/product.js`, inside `prestashop.on('updatedProduct')`, which returns
unless the payload carries both `product_url` and `id_product_attribute`, so no state of core's own
lands on a listing entry. This is defensive rather than a fix for a second defect.
