### PR TITLE
Keep the multishop console options on the command that runs

### DIFF
--- a/src/PrestaShopBundle/EventListener/Console/MultishopCommandListener.php
+++ b/src/PrestaShopBundle/EventListener/Console/MultishopCommandListener.php
@@ -35,12 +35,24 @@ class MultishopCommandListener
 
     public function onConsoleCommand(ConsoleCommandEvent $event)
     {
-        $definition = $event->getCommand()->getDefinition();
+        $command = $event->getCommand();
         $input = $event->getInput();
 
-        $definition->addOption(new InputOption('id_shop', null, InputOption::VALUE_OPTIONAL, 'Specify shop context.'));
-        $definition->addOption(new InputOption('id_shop_group', null, InputOption::VALUE_OPTIONAL, 'Specify shop group context.'));
-        $input->bind($definition);
+        // The options go on the command's own definition, not on the merged one getDefinition()
+        // returns: Command::run() calls mergeApplicationDefinition() before binding, which rebuilds
+        // the merged definition from this one, so anything added to the merged copy is discarded and
+        // the option is rejected as unknown. Merging again here is what lets this listener read the
+        // values it just declared.
+        $definition = $command->getNativeDefinition();
+        if (!$definition->hasOption('id_shop')) {
+            $definition->addOption(new InputOption('id_shop', null, InputOption::VALUE_OPTIONAL, 'Specify shop context.'));
+        }
+        if (!$definition->hasOption('id_shop_group')) {
+            $definition->addOption(new InputOption('id_shop_group', null, InputOption::VALUE_OPTIONAL, 'Specify shop group context.'));
+        }
+
+        $command->mergeApplicationDefinition();
+        $input->bind($command->getDefinition());
 
         $id_shop = $input->getOption('id_shop');
         $id_shop_group = $input->getOption('id_shop_group');

--- a/tests/Integration/PrestaShopBundle/EventListener/MultishopCommandListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/EventListener/MultishopCommandListenerTest.php
@@ -11,10 +11,13 @@ use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShopBundle\EventListener\Console\MultishopCommandListener;
 use Shop;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class MultishopCommandListenerTest extends KernelTestCase
 {
@@ -36,6 +39,13 @@ class MultishopCommandListenerTest extends KernelTestCase
 
         $this->multishopContext = self::$kernel->getContainer()->get('prestashop.adapter.shop.context');
         $this->commandListener = new MultishopCommandListener($this->multishopContext, self::$kernel->getProjectDir());
+    }
+
+    protected function tearDown(): void
+    {
+        Shop::resetContext();
+
+        parent::tearDown();
     }
 
     public function testDefaultMultishopContext(): void
@@ -74,6 +84,35 @@ class MultishopCommandListenerTest extends KernelTestCase
 
         // Check!
         $this->assertTrue($this->multishopContext->isGroupShopContext());
+    }
+
+    /**
+     * The cases above build a Command with no Application attached, where getDefinition() falls back
+     * to the command's own definition and nothing rebuilds it. A real console run has an Application,
+     * and Command::run() then rebuilds its merged definition from the command's own one before
+     * binding - so an option added to the merged copy is dropped and rejected as unknown. This runs
+     * the command the way the console does.
+     */
+    public function testTheOptionsSurviveARealConsoleRun(): void
+    {
+        Shop::resetContext();
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('console.command', [$this->commandListener, 'onConsoleCommand']);
+
+        $command = new Command('fake');
+        $command->setCode(static fn (): int => 0);
+
+        $application = new Application();
+        $application->setDispatcher($dispatcher);
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->add($command);
+
+        $exitCode = $application->run(new ArgvInput(['bin/console', 'fake', '--id_shop=1']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($this->multishopContext->isShopContext(), 'isShopContext');
     }
 
     public function testExceptionWhenIdShopAndIdShopGroupSet(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `--id_shop` and `--id_shop_group` are added to every console command by `MultishopCommandListener`, and neither has worked: the console rejects them as unknown options. The listener adds them to the merged definition that `Command::getDefinition()` returns, and `Command::run()` opens by rebuilding that from the command's own definition, so both options are discarded before the input is bound. They are declared on the command's own definition now.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `bin/console prestashop:theme:export classic --id_shop=1`. Before: `The "--id_shop" option does not exist.` After: the export runs. `bin/console prestashop:theme:enable <theme> --id_shop=2` likewise, and the usage line shows `[--id_shop [ID_SHOP]] [--id_shop_group [ID_SHOP_GROUP]]`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #14577
| Related PRs       |
| Sponsor company   |

## The mechanism, from the vendored Symfony

`MultishopCommandListener::onConsoleCommand()` did:

```php
$definition = $event->getCommand()->getDefinition();
$definition->addOption(new InputOption('id_shop', ...));
$definition->addOption(new InputOption('id_shop_group', ...));
$input->bind($definition);
```

`Command::getDefinition()` is `return $this->fullDefinition ?? $this->getNativeDefinition();`, and
`Command::run()` starts with

```php
$this->mergeApplicationDefinition();
try { $input->bind($this->getDefinition()); } catch (ExceptionInterface $e) { ... }
```

where `mergeApplicationDefinition()` assigns a **new** `InputDefinition` to `$this->fullDefinition`,
filled from `$this->definition` plus the application's options. Once an application is attached -
always, in a real console run - the listener therefore writes into an object that the very next call
replaces, and the bind at `Command.php:285` throws
`RuntimeException: The "--id_shop" option does not exist.` from `ArgvInput::addLongOption()`.

The listener is registered and does run: `debug:event-dispatcher console.command` lists it at
priority 0. The options simply never reach the definition that is bound.

## The fix

Declare both on `getNativeDefinition()` - the definition `mergeApplicationDefinition()` rebuilds
from - then call `mergeApplicationDefinition()` and bind, so this listener can still read the values
it just declared. Guarded with `hasOption()` because the native definition now persists for the life
of the command object, so a second pass, or a command that declares `id_shop` itself, must not hit
`InputDefinition::addOption()`'s "already exists" throw.

## Why it survived a test that covers the listener

`MultishopCommandListenerTest` has covered this listener since before 8.0 and is green. It builds
`new Command('Fake')` with **no Application attached**. With no application
`mergeApplicationDefinition()` returns on its first line, `getDefinition()` falls back to the native
definition, the listener's options stay where it put them, and the assertion passes. The one
condition that triggers the bug - an attached `Application` - is the one the fixture leaves out.

The branch adds `testTheOptionsSurviveARealConsoleRun()`, which wires the listener to an
`EventDispatcher`, attaches a real `Application` with `setCatchExceptions(false)`, and runs
`new ArgvInput(['bin/console', 'fake', '--id_shop=1'])`.

## Verification

- `tests/Integration/PrestaShopBundle/EventListener/MultishopCommandListenerTest.php`: 5 tests, green
  (4 pre-existing plus the new one). `tearDown()` calls `Shop::resetContext()` so the shop context is
  not left switched for later tests.
- Mutation: with the listener reverted, the new test fails with the production error verbatim -
  `Symfony\Component\Console\Exception\RuntimeException: The "--id_shop" option does not exist.` -
  while the four pre-existing tests still pass, which is exactly the blind spot described above.
- End to end on a running shop, before and after: `prestashop:theme:export classic --id_shop=1` goes
  from `The "--id_shop" option does not exist.` to `Your theme has been correctly exported`, and
  `prestashop:theme:enable`'s usage line gains both options. The `themes/classic.zip` the check
  produced was deleted again.
- Regression: `prestashop:module:list`, `prestashop:theme:export` and `list` all still run.
- `php-cs-fixer`: 0 of 2 files to fix. `phpstan`: no errors on the changed source file.
