### PR TITLE
Exclude the public account pages with noindex instead of robots.txt

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3027,11 +3027,21 @@ FileETag none
         ];
 
         // Friendly URLs blocked from crawling
+        // WHY: three public pages a visitor reaches without an account - authentication,
+        // registration and guest-tracking - are deliberately absent here. The first two are linked
+        // with a "back" parameter that gives them one URL per page of the shop, so blocking them
+        // from crawling left search engines indexing the URLs found in those links without ever
+        // reading the canonical or the noindex on the page. They send "noindex" instead, which only
+        // works while they stay crawlable. "password" is not among them on purpose: its controller
+        // acts on GET parameters - "?email=" stamps a reset token and sends mail - so it is not a
+        // page to invite a crawler onto, and a single parameterless link makes it no duplicate.
+        // Everything below is either behind a login or not a page at all.
         $disallow_controllers = [
-            'addresses', 'address', 'authentication', 'cart', 'discount', 'footer',
+            'addresses', 'address', 'cart', 'discount', 'footer',
             'get-file', 'header', 'history', 'identity', 'images.inc', 'init', 'my-account', 'order',
-            'order-slip', 'order-detail', 'order-follow', 'order-return', 'order-confirmation', 'pagination', 'password',
-            'pdf-invoice', 'pdf-order-return', 'pdf-order-slip', 'product-sort', 'registration', 'search', 'statistics', 'attachment', 'guest-tracking',
+            'order-slip', 'order-detail', 'order-follow', 'order-return', 'order-confirmation', 'pagination',
+            'password', 'pdf-invoice', 'pdf-order-return', 'pdf-order-slip', 'product-sort', 'search',
+            'statistics', 'attachment',
         ];
         $tab['Files'] = [];
         if (Configuration::get('PS_REWRITING_SETTINGS')) {
@@ -3052,9 +3062,11 @@ FileETag none
         // Non-friendly URLs and parameters blocked from crawling
         // For example, "q" is a filter query, "order" is sorting etc
         // Don't think about meaning of "GB"
+        // "back" is not listed: it is the parameter the sign-in and registration links carry, and
+        // blocking it would keep the noindex of those pages from ever being read.
         $tab['GB'] = [
-            '?order=', '?tag=', '?id_currency=', '?search_query=', '?back=', '?n=', '?q=',
-            '&order=', '&tag=', '&id_currency=', '&search_query=', '&back=', '&n=', '&q=',
+            '?order=', '?tag=', '?id_currency=', '?search_query=', '?n=', '?q=',
+            '&order=', '&tag=', '&id_currency=', '&search_query=', '&n=', '&q=',
         ];
 
         // List of list of non-friendly URLs to block from crawling.

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -99,4 +99,23 @@ class AuthControllerCore extends FrontController
     {
         return $this->context->link->getPageLink('authentication');
     }
+
+    /**
+     * Initializes a set of commonly used variables related to the current page, available for use
+     * in the template. @see FrontController::assignGeneralPurposeVariables for more information.
+     *
+     * @return array
+     */
+    public function getTemplateVarPage(): array
+    {
+        $page = parent::getTemplateVarPage();
+
+        // WHY: this page is reached through links that carry a "back" parameter, so it exists under
+        // one URL per page of the shop. The canonical collapses them only once a crawler is allowed
+        // to read it, which is why the robots.txt directives for these pages were dropped in favour
+        // of this - a page excluded by robots.txt can still be indexed from its inbound links.
+        $page['meta']['robots'] = 'noindex';
+
+        return $page;
+    }
 }

--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -180,4 +180,23 @@ class GuestTrackingControllerCore extends FrontController
     {
         return $this->context->link->getPageLink('guest-tracking');
     }
+
+    /**
+     * Initializes a set of commonly used variables related to the current page, available for use
+     * in the template. @see FrontController::assignGeneralPurposeVariables for more information.
+     *
+     * @return array
+     */
+    public function getTemplateVarPage(): array
+    {
+        $page = parent::getTemplateVarPage();
+
+        // WHY: this page is reached through links that carry a "back" parameter, so it exists under
+        // one URL per page of the shop. The canonical collapses them only once a crawler is allowed
+        // to read it, which is why the robots.txt directives for these pages were dropped in favour
+        // of this - a page excluded by robots.txt can still be indexed from its inbound links.
+        $page['meta']['robots'] = 'noindex';
+
+        return $page;
+    }
 }

--- a/controllers/front/RegistrationController.php
+++ b/controllers/front/RegistrationController.php
@@ -99,4 +99,23 @@ class RegistrationControllerCore extends FrontController
     {
         return $this->context->link->getPageLink('registration');
     }
+
+    /**
+     * Initializes a set of commonly used variables related to the current page, available for use
+     * in the template. @see FrontController::assignGeneralPurposeVariables for more information.
+     *
+     * @return array
+     */
+    public function getTemplateVarPage(): array
+    {
+        $page = parent::getTemplateVarPage();
+
+        // WHY: this page is reached through links that carry a "back" parameter, so it exists under
+        // one URL per page of the shop. The canonical collapses them only once a crawler is allowed
+        // to read it, which is why the robots.txt directives for these pages were dropped in favour
+        // of this - a page excluded by robots.txt can still be indexed from its inbound links.
+        $page['meta']['robots'] = 'noindex';
+
+        return $page;
+    }
 }

--- a/tests/Integration/Classes/ToolsTest.php
+++ b/tests/Integration/Classes/ToolsTest.php
@@ -6,6 +6,7 @@
 
 namespace Tests\Integration\Classes;
 
+use Configuration;
 use PHPUnit\Framework\TestCase;
 use Tests\Integration\Utility\ContextMockerTrait;
 use Tools;
@@ -14,10 +15,27 @@ class ToolsTest extends TestCase
 {
     use ContextMockerTrait;
 
+    /**
+     * @var mixed the value to put back into PS_REWRITING_SETTINGS, null when it was never changed
+     */
+    private $originalRewritingSettings;
+
     protected function setUp(): void
     {
         parent::setUp();
         self::mockContext();
+    }
+
+    protected function tearDown(): void
+    {
+        // WHY: the friendly-URL assertions below have to switch rewriting on, and this configuration
+        // is process-global - leaving it on would flip the behaviour of every later test in the run.
+        if ($this->originalRewritingSettings !== null) {
+            Configuration::updateValue('PS_REWRITING_SETTINGS', $this->originalRewritingSettings);
+            $this->originalRewritingSettings = null;
+        }
+
+        parent::tearDown();
     }
 
     /**
@@ -133,5 +151,114 @@ class ToolsTest extends TestCase
             'http://www.prestahop-project.org',
             '/shop_sub_folder',
         ];
+    }
+
+    /**
+     * The public utility pages carry a "back" parameter, so they exist under one URL per page of the
+     * shop. Excluding them with robots.txt does not keep them out of the index - it only stops a
+     * crawler from reading the canonical and the noindex those pages send. So neither the pages nor
+     * the parameter may be disallowed.
+     *
+     * @return void
+     */
+    /**
+     * A URL that robots.txt excludes is still indexed when enough links point at it, and the page's
+     * own noindex is never read while it is - so a page that sends noindex has to stay crawlable.
+     *
+     * @return void
+     */
+    public function testRobotsContentDoesNotBlockPagesThatSendNoindex(): void
+    {
+        $robots = $this->getRobotsContentWithFriendlyUrls();
+        $friendlyUrls = $this->getDisallowedFriendlyUrls($robots);
+
+        $this->assertNotEmpty(
+            $friendlyUrls,
+            'No page was blocked by its friendly URL, so the assertions below would hold vacuously.'
+        );
+
+        $noindexPages = [
+            'authentication' => 'login',
+            'registration' => 'registration',
+            'guest-tracking' => 'guest-tracking',
+        ];
+
+        foreach ($noindexPages as $controller => $urlRewrite) {
+            $this->assertNotContains(
+                $urlRewrite,
+                $friendlyUrls,
+                sprintf('The "%s" page must stay crawlable so that its noindex is read.', $controller)
+            );
+            $this->assertNotContains(
+                'controller=' . $controller,
+                $robots['GB'],
+                sprintf('The "%s" page must stay crawlable so that its noindex is read.', $controller)
+            );
+        }
+
+        foreach (['?back=', '&back='] as $parameter) {
+            $this->assertNotContains(
+                $parameter,
+                $robots['GB'],
+                'Blocking the "back" parameter hides the noindex of every page reached through it.'
+            );
+        }
+    }
+
+    /**
+     * The pages that stay blocked are the ones behind a login, the ones that are not pages at all,
+     * and password recovery - whose controller acts on GET parameters. This asserts the change
+     * above narrowed the list rather than emptying it.
+     *
+     * @return void
+     */
+    public function testRobotsContentStillBlocksPrivateAndNonPageControllers(): void
+    {
+        $robots = $this->getRobotsContentWithFriendlyUrls();
+        $friendlyUrls = $this->getDisallowedFriendlyUrls($robots);
+
+        $blockedPages = [
+            'my-account' => 'my-account',
+            'identity' => 'identity',
+            'order' => 'order',
+            'password' => 'password-recovery',
+        ];
+
+        foreach ($blockedPages as $controller => $urlRewrite) {
+            $this->assertContains($urlRewrite, $friendlyUrls);
+            $this->assertContains('controller=' . $controller, $robots['GB']);
+        }
+
+        foreach (['pdf-invoice', 'get-file', 'cart'] as $controller) {
+            $this->assertContains('controller=' . $controller, $robots['GB']);
+        }
+
+        foreach (['?q=', '&q=', '?order=', '&order='] as $parameter) {
+            $this->assertContains($parameter, $robots['GB']);
+        }
+    }
+
+    /**
+     * The friendly-URL half of the file is where the "Disallow: /login" line comes from, and it is
+     * only generated when rewriting is on, so both tests above need it enabled to mean anything.
+     *
+     * @return array
+     */
+    private function getRobotsContentWithFriendlyUrls(): array
+    {
+        $this->originalRewritingSettings = Configuration::get('PS_REWRITING_SETTINGS');
+        Configuration::updateValue('PS_REWRITING_SETTINGS', 1);
+
+        return Tools::getRobotsContent();
+    }
+
+    /**
+     * @param array $robots
+     *
+     * @return array the blocked friendly URLs of every active language, flattened
+     */
+    private function getDisallowedFriendlyUrls(array $robots): array
+    {
+        return array_merge([], ...array_values($robots['Files']));
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The sign-in link carries `?back=<current url>`, so the login page exists under one URL per page of the shop. `AuthController::getCanonicalURL()` already collapses them, but `robots.txt` disallows both the page and the `back` parameter, so a crawler never reads that canonical - and a URL blocked by robots.txt is still indexed when enough links point at it, which is what the reporter sees in Search Console. The three pages a crawlable page links and that must not be indexed - authentication, registration and guest-tracking - now send `noindex`, and the robots.txt directives that were keeping that `noindex` unreadable are removed. The rest of the list is unchanged.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open `/login?back=<any url>` and read the head: `<meta name="robots" content="noindex">` alongside the existing `<link rel="canonical" href=".../login">`. Same on `/registration` and `/guest-tracking`. `/password-recovery`, a category, the home page and `/brands` send no robots meta. Then regenerate robots.txt from Shop Parameters > Traffic & SEO: the `Disallow` lines for those three controllers - both the `controller=` form and the friendly-URL form in every active language - and for `?back=` / `&back=` are gone, while `password-recovery`, `my-account`, `order`, `identity`, `pdf-invoice` and the rest are untouched. `tests/Integration/Classes/ToolsTest.php` covers the generator.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes PrestaShop/hummingbird#708
| Related PRs       |
| Sponsor company   |

Existing shops get the robots.txt half only when the merchant regenerates the file from
Shop Parameters > Traffic & SEO; the `noindex` meta applies immediately.

## Why the canonical was not enough

Everything needed to collapse those URLs already exists and is correct: `AuthController`,
`RegistrationController` and `GuestTrackingController` each define `getCanonicalURL()`, and both
shipped themes render `$page.canonical`. Measured on 9.2.x, the login page emits
`<link rel="canonical" href="http://.../login">` with the `back` parameter stripped.

It has no effect because `Tools::getRobotsContent()` blocks the page from being fetched at all.
A crawler that cannot fetch the page cannot read the canonical, and cannot read a `noindex` either -
so the URLs it found in the sign-in link on every page get indexed URL-only. That is the documented
behaviour of robots.txt, not a search engine bug: exclusion by crawl-blocking is not exclusion from
the index. The reporter's own workaround - `noindex` plus removing the disallows - is the same
conclusion.

So the two halves have to move together. Adding `noindex` while leaving the directives in place
would ship something that cannot work.

## One list drives both halves of the file

`$disallow_controllers` feeds two sections. It produces the `Disallow: /*controller=<page>`
directives, and - when `PS_REWRITING_SETTINGS` is on, which is the case on any shop with friendly
URLs - it is also the `IN (...)` list of the `ps_meta` query that produces the friendly-URL section,
so `Disallow: /login` comes from the same array. Removing a controller from it therefore drops both
forms, in every active language, which is what makes the change work on a real shop rather than only
on the non-friendly URLs.

## What decides the scope

Not "is the page public". Core deliberately uses both mechanisms, and
`ProductListingFrontController::getTemplateVarPage()` says so in its own comment: "This should
correlate with robots.txt content. Make sure to update it also, if you change anything here." Where a
blocked URL is linked from nowhere, the block is sufficient and the unreadable `noindex` behind it
costs nothing. The defect appears only where a **crawlable page links a blocked URL**, because then
the URL is indexed from that link with nothing to suppress it. The sitewide sign-in link with a
per-page `back` parameter is that case, at the scale of one URL per page of the shop.

That is why the following stay exactly as they are, even though they have the same
blocked-and-noindexed shape:

- `search` sends `noindex` in `controllers/front/listing/SearchController.php` and stays in
  `$disallow_controllers`. Its query space is unbounded and nothing links it at scale, so
  crawl-blocking is the intended protection and unblocking it would buy nothing.
- `?q=` and `?order=` stay in the parameter list while `ProductListingFrontController` sends
  `noindex` for those same two parameters. The unfiltered listing is the indexable, canonical URL;
  the parameterised variants are not linked sitewide.
- `password` stays blocked. It is linked by a single parameterless URL from the login form, so it
  never had the duplication problem, and there is nothing to gain from making it crawlable. One
  consequence to expect: with the login page crawlable, `/password-recovery` becomes discoverable
  from it, so it can appear as a single URL-only entry - one URL, not thousands.

`?back=` had to leave the parameter list rather than just the controller entries, because it is what
those pages are linked with: `/login?back=...` matches `Disallow: /*?back=` regardless of the
controller entry. That directive is global, so any other page a module links with a `back` parameter
also becomes crawlable; in core nothing else does - the only producers are the sign-in link, the
one-page-checkout links, and the `address` form, which stays blocked.

The theme's `rel="nofollow"` on the sign-in link stays as it is. It is a hint about following, not
about indexing, which is why the reporter still saw the URLs indexed with it in place.

## The alternative, and why it was rejected

Keep the robots.txt directives and drop `?back=` from the sign-in link, so only one login URL
exists. That fixes the indexing at the cost of the feature: the customer no longer returns to the
page they were on after signing in. A crawl-budget objection to the change as made is fair - a
crawler may now fetch one login URL per page of the shop - but each of those fetches returns
`noindex` plus a canonical, which is what makes them stop mattering, and the pages are cheap.

## Verification

Measured on 9.2.x (`a200e3bd986`) plus this change, hummingbird 2.1.0, on a shop with friendly URLs
on and two active languages.

- `tests/Integration/Classes/ToolsTest.php`: 19 tests, 41 assertions, green. The new tests assert on
  the friendly-URL section as well as the `controller=` section, and guard with `assertNotEmpty` so
  an empty section cannot pass silently.
- Mutation, both directions. Reverting `classes/Tools.php` alone fails only the first test, on
  `Failed asserting that an array does not contain 'login'` - the friendly-URL line, which is the one
  that matters on a real shop. Removing `password` from the list as well fails only the second test,
  on `Failed asserting that an array contains 'password-recovery'`. So each test discriminates, and
  neither fails wholesale.
- The tests switch `PS_REWRITING_SETTINGS` on and restore it in `tearDown`, because it is
  process-global. Checked after the run rather than assumed: the value in the test database is back
  to its original falsy state.
- Live: `/login?back=...`, `/registration` and `/guest-tracking` each send
  `<meta name="robots" content="noindex">`, and the login page keeps its canonical.
  `/password-recovery`, the home page, `/brands` and a category send no robots meta at all.
- Not theme-dependent: both `themes/classic` and `themes/hummingbird` render `$page.meta.robots` in
  `templates/_partials/head.tpl`.
- Generator, end to end: robots.txt generated from the base and from the branch on the same shop
  differ by 14 removed lines and no added ones - `/*?back=`, `/*&back=`, the three
  `/*controller=<page>` entries, and the nine friendly-URL entries for those three pages across `en`
  and `fr`. 27 of the 30 `controller=` directives remain, `Disallow: /password-recovery` and
  `Disallow: /*controller=password` among them.
- The two PHPUnit deprecations the run reports are pre-existing - the file's existing
  `testSanitizeAdminUrl` reports the same two on its own.
- `php-cs-fixer` clean over the five changed files, `phpstan` "No errors" on the four changed source
  files.
