### PR TITLE
Add the clear-formatting button to the rich text editor toolbar

### DIFF
--- a/admin-dev/themes/new-theme/js/components/tinymce-editor.js
+++ b/admin-dev/themes/new-theme/js/components/tinymce-editor.js
@@ -66,7 +66,7 @@ class TinyMCEEditor {
       browser_spellcheck: true,
       toolbar1:
         /* eslint-disable-next-line max-len */
-        'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect,hr',
+        'code,colorpicker,bold,italic,underline,strikethrough,removeformat,blockquote,link,align,bullist,numlist,table,image,media,formatselect,hr',
       toolbar2: '',
       language: window.iso_user,
       external_filemanager_path: `${config.baseAdminUrl}filemanager/`,
@@ -81,7 +81,7 @@ class TinyMCEEditor {
         plugins: ['lists', 'align', 'link', 'table', 'placeholder', 'advlist', 'code', 'hr'],
         toolbar:
           /* eslint-disable-next-line max-len */
-          'undo code colorpicker bold italic underline strikethrough blockquote link align bullist numlist table formatselect styleselect hr',
+          'undo code colorpicker bold italic underline strikethrough removeformat blockquote link align bullist numlist table formatselect styleselect hr',
       },
       menubar: false,
       statusbar: false,

--- a/js/admin/tinymce.inc.js
+++ b/js/admin/tinymce.inc.js
@@ -50,7 +50,7 @@ function tinySetup(config) {
     plugins: 'align colorpicker link image filemanager table media placeholder lists advlist code table autoresize',
     browser_spellcheck: true,
     toolbar1:
-      'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect',
+      'code,colorpicker,bold,italic,underline,strikethrough,removeformat,blockquote,link,align,bullist,numlist,table,image,media,formatselect',
     toolbar2: '',
     external_filemanager_path: baseAdminDir + 'filemanager/',
     filemanager_title: 'File manager',
@@ -64,7 +64,7 @@ function tinySetup(config) {
       theme: 'mobile',
       plugins: ['lists', 'align', 'link', 'table', 'placeholder', 'advlist', 'code'],
       toolbar:
-        'undo code colorpicker bold italic underline strikethrough blockquote link align bullist numlist table formatselect styleselect',
+        'undo code colorpicker bold italic underline strikethrough removeformat blockquote link align bullist numlist table formatselect styleselect',
     },
     menubar: false,
     statusbar: false,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The rich text editor has no way to strip pasted formatting. `RemoveFormat` and its `removeformat` toolbar button are already registered by the vendored TinyMCE 4.9.11 modern and mobile themes, so the button only has to be listed in the toolbar - no plugin, no dependency, no version bump. Added to both editor configurations (`admin-dev/themes/new-theme/js/components/tinymce-editor.js` for migrated pages, `js/admin/tinymce.inc.js` for the legacy back-office theme) and to the mobile toolbar of each, which is the whole set of default toolbars in core. The rest of the button list discussed on the issue is deliberately untouched.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open any page with a rich text editor (Design > Pages > edit, or a product description). A "Clear formatting" button sits between Strikethrough and Blockquote. Paste styled content from a word processor, select all, press it: inline styles and `<b>`/`<i>`/`<span>` go, while headings, paragraphs and list items stay. That is the difference from `Ctrl+Shift+V`, which also flattens the structure.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #12417
| Related PRs       |
| Sponsor company   |

## Why this is four tokens and not a configuration screen

The issue holds three asks and a fourth added in 2026. Only one of them is settled:
"Clear formatting" is what the reporter called a must, it carries `PM` approval, and it is
what the thread converged on. Text colour already exists - core ships a custom `colorpicker`
plugin at `js/tiny_mce/plugins/colorpicker/plugin.min.js` that registers its own toolbar
button, and it renders (measured below). Font size, a style dropdown and Bootstrap button
classes are the open "which buttons do we want" list that `Needs Specs` is about, and the
2026 comment shows that list is still growing. Adding to it here would put this change inside
that discussion instead of finishing the part that is already agreed.

The only technical objection on the thread was PierreRambaud's, in 2019: TinyMCE has to be
updated before features are added. That does not apply to this control. `removeformat` is
registered by the vendored theme itself:

```
removeformat:["Clear formatting","RemoveFormat"] ... i.addButton(t,{tooltip:e[0],cmd:e[1]})
```

in `js/tiny_mce/themes/modern/theme.min.js`, and the mobile theme has its own
(`f = n("removeformat")` in its item registry). So the button exists in the version core
already ships; it was simply never listed.

## Both configurations, and both toolbars in each

`git grep toolbar1` returns exactly two files: the new-theme component and the legacy
`js/admin/tinymce.inc.js` used by non-migrated pages. Each defines a desktop `toolbar1` and a
separate `mobile.toolbar`, and both merge `window.defaultTinyMceConfig` afterwards - nothing in
core sets that, so these four strings are every default toolbar in the back office. All four
carry the button.

## Verification

Measured by loading the vendored `js/tiny_mce/tinymce.min.js` with the `prestashop` skin and
the exact toolbar strings from before and after the change, then reading the rendered
`aria-label` of every `.mce-toolbar .mce-btn`:

- base: 16 buttons - `Source code, Color Picker, Bold, Italic, Underline, Strikethrough,
  Blockquote, Insert/edit link, (align), Bullet list, Numbered list, Table, Insert/edit image,
  Insert/edit video, Paragraph, Horizontal line`. No "Clear formatting".
- branch: 17 buttons, identical except "Clear formatting" between Strikethrough and Blockquote.

That measurement is the **desktop** `toolbar1` on the modern theme. The two `mobile.toolbar`
strings were not rendered: the mobile theme builds its toolbar into a full-screen editing UI that a
headless desktop run does not enter, and forcing `theme: 'mobile'` produced a container with no
toolbar buttons to read. The evidence for those two lines is the mobile theme's own item registry -
`js/tiny_mce/themes/mobile/theme.min.js` binds `removeformat` alongside `undo`, `redo`, `bold`,
`italic` and `underline` - not a render. Say so rather than letting the button counts stand for all
four strings. It is inert either way: that theme guards every name with
`isSupported: ... xt(o.buttons, n)`, so an unknown token is dropped silently rather than breaking
the toolbar. Worth knowing that the existing `mobile.toolbar` already relies on that - `colorpicker`,
`code`, `blockquote`, `align`, `table` and `formatselect` are all absent from the mobile registry and
render nothing today. Not touched here.

Functional check on the command itself, same harness. Content set to
`<h2 style="font-family:Calibri;color:#c00">`, a `<span style="font-size:22px;background:yellow">`
wrapping `<b>` and `<i>`, and a `<li style="color:red">`; select all, `RemoveFormat`:

```
<h2>Heading</h2>
<p>Bold word and italic</p>
<ul>
<li>one</li>
<li>two</li>
</ul>
```

Zero `style=` attributes left, no `<b>`/`<i>`/`<span>`/`<font>` left, and the `h2`, the `p`
and both `li` survive. That is the behaviour the reporter said `Ctrl+Shift+V` does not give,
and it is why the workaround in the thread was not a substitute.

`eslint -c .eslintrc.js js/components/tinymce-editor.js` exits 0. Verified the linter actually
reads the file rather than reporting a vacuous pass: with a deliberate `const unusedProbe = 1`
appended it reports `no-unused-vars` and `semi` on that line, and the file is clean again once
removed. The two edited lines are already covered by the existing
`/* eslint-disable-next-line max-len */`. `js/admin/` is not in any lint target.

No unit test. Core has none for the existing toolbar, and an assertion that the config string
contains `removeformat` would restate the diff rather than test anything; what needed proving
was that the token resolves to a control and that the control does the job, which is the
measurement above. `admin-dev/themes/new-theme/public/` is gitignored (`.gitignore:126`), so
there is no committed bundle to rebuild - 580 files tracked under `js/`, 0 under `public/`.

## Duplicate gate (run 2026-09-10, after the branch was built)

- **Already fixed?** No. The base `toolbar1` rendered from current `9.2.x` has 16 buttons and no
  "Clear formatting" - the measurement above is itself the check.
- **Timeline:** one cross-reference, the open EPIC #23062 "[EPIC] - BO CMS Pages". Not a fix.
- **Another author:** no open PR on `PrestaShop/PrestaShop` matches `tinymce` + a clear-formatting or
  `removeformat` change. The six open PRs a `tinymce` search returns are all mine.
- **Self-dup by exact file set:** none. My file set is
  `{admin-dev/themes/new-theme/js/components/tinymce-editor.js, js/admin/tinymce.inc.js}` and no open
  PR of mine has it. Three of mine touch the first file for unrelated reasons - #42533 (resize an
  editor when its tab becomes visible), #42335 (language codes), #42774 (eslint-disable cleanup) -
  and none touches `toolbar1`.
- **Two textual conflicts to expect**, neither a duplicate:
  - **#42335** changes `language: window.iso_user` at line 71 in a hunk headed `@@ -68,7 +73,7 @@`.
    Three lines of context put lines 68-74 inside it, and my change is line 69 - so whichever of the
    two merges second needs a rebase on this file.
  - **#42774** rewrites the `eslint-disable` comments across 60 files, `tinymce-editor.js` among
    them. My line sits directly under the `/* eslint-disable-next-line max-len */` that keeps it
    legal. If #42774 lands first, re-check that the disable is still there and still covers this
    line before pushing.
