### PR TITLE
Let a predefined order message be as long as its column allows

### DIFF
--- a/src/Core/Domain/OrderMessage/OrderMessageConstraint.php
+++ b/src/Core/Domain/OrderMessage/OrderMessageConstraint.php
@@ -6,11 +6,20 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\OrderMessage;
 
+use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
+
 /**
  * Defines constraints for Order message attributes
  */
 class OrderMessageConstraint
 {
     public const MAX_NAME_LENGTH = 128;
-    public const MAX_MESSAGE_LENGTH = 1200;
+
+    /**
+     * `order_message_lang`.`message` is a mediumtext column and OrderMessage's model already
+     * declares the matching size for that field, so the storage was never the limit. The same
+     * value bounds the message written on an order, which is prefilled from a predefined one and
+     * would otherwise refuse what this form accepts.
+     */
+    public const MAX_MESSAGE_LENGTH = FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4;
 }

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageTypeTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageTypeTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Sell\CustomerService;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShopBundle\Form\Admin\Sell\CustomerService\OrderMessageType;
+use Symfony\Component\Form\FormInterface;
+use Tests\Integration\PrestaShopBundle\Form\AbstractFormTester;
+
+class OrderMessageTypeTest extends AbstractFormTester
+{
+    private const DEFAULT_LANG_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // A kernel booted outside a request has no shop or language context, and the
+        // DefaultLanguage constraint on this form reads both.
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopId(1);
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(self::DEFAULT_LANG_ID);
+        $languageContextBuilder->setDefaultLanguageId(self::DEFAULT_LANG_ID);
+    }
+
+    /**
+     * A predefined message is stored in `order_message_lang`.`message`, a mediumtext column, and
+     * OrderMessage's own model declares the matching size for that field. Only the form used to
+     * hold it to a far shorter length, so a merchant could not write one longer than that.
+     */
+    public function testAPredefinedMessageLongerThanTwelveHundredCharactersIsAccepted(): void
+    {
+        $message = str_repeat('a', 5000);
+
+        $form = $this->submitPredefinedMessage($message);
+
+        self::assertTrue(
+            $form->isValid(),
+            sprintf('A %d character predefined message was refused: %s', strlen($message), $this->violations($form))
+        );
+        self::assertSame($message, $form->getData()['message'][self::DEFAULT_LANG_ID]);
+    }
+
+    /**
+     * Control: the same form still refuses what it has always refused, so the assertion above is
+     * about the length limit and not about validation having stopped running.
+     */
+    public function testAnEmptyPredefinedMessageIsStillRefused(): void
+    {
+        $form = $this->submitPredefinedMessage('');
+
+        self::assertFalse($form->isValid(), 'An empty predefined message was accepted.');
+    }
+
+    private function submitPredefinedMessage(string $message): FormInterface
+    {
+        // No token is submitted here, so CSRF has to be off or every assertion below would be
+        // about the token rather than about the field.
+        $form = $this->createForm(OrderMessageType::class, ['csrf_protection' => false]);
+        $form->submit([
+            'name' => [self::DEFAULT_LANG_ID => 'Length probe'],
+            'message' => [self::DEFAULT_LANG_ID => $message],
+        ]);
+
+        return $form;
+    }
+
+    private function violations(FormInterface $form): string
+    {
+        $messages = [];
+        foreach ($form->getErrors(true) as $error) {
+            $messages[] = $error->getMessage();
+        }
+
+        return $messages === [] ? '(no violation reported)' : implode(' | ', $messages);
+    }
+}

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageTypeTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageTypeTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\Admin\Sell\Order;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShopBundle\Form\Admin\Sell\Order\OrderMessageType;
+use Tests\Integration\PrestaShopBundle\Form\AbstractFormTester;
+
+class OrderMessageTypeTest extends AbstractFormTester
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var ShopContextBuilder $shopContextBuilder */
+        $shopContextBuilder = self::getContainer()->get('test_shop_context_builder');
+        $shopContextBuilder->setShopId(1);
+        $shopContextBuilder->setShopConstraint(ShopConstraint::shop(1));
+
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = self::getContainer()->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId(1);
+        $languageContextBuilder->setDefaultLanguageId(1);
+    }
+
+    /**
+     * Selecting a predefined message on an order copies its text straight into this field, so this
+     * form has to accept whatever the predefined message form accepts. If the two limits diverge,
+     * picking a long predefined message fills the box with a value the box then refuses.
+     */
+    public function testTheMessageOnAnOrderAcceptsWhatAPredefinedMessageMayContain(): void
+    {
+        $message = str_repeat('a', 5000);
+
+        $form = $this->createForm(OrderMessageType::class, ['csrf_protection' => false]);
+        $form->submit(['message' => $message]);
+
+        $errors = [];
+        foreach ($form->getErrors(true) as $error) {
+            $errors[] = $error->getMessage();
+        }
+
+        self::assertTrue(
+            $form->isValid(),
+            sprintf('A %d character message was refused on an order: %s', strlen($message), implode(' | ', $errors))
+        );
+    }
+
+    /**
+     * Control, so the assertion above cannot pass because validation stopped running.
+     */
+    public function testAnEmptyMessageOnAnOrderIsStillRefused(): void
+    {
+        $form = $this->createForm(OrderMessageType::class, ['csrf_protection' => false]);
+        $form->submit(['message' => '']);
+
+        self::assertFalse($form->isValid(), 'An empty message was accepted on an order.');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | A predefined order message was capped at 1200 characters by the form, while `order_message_lang`.`message` is a mediumtext column and `OrderMessage`'s model already declares `LIMIT_MEDIUMTEXT_UTF8_MB4` as the size for that same field. The cap now follows the storage, which is what `Message` and `CustomerMessage` already do for the columns this text gets copied into. The same constant also bounds the message written on an order, and it has to: selecting a predefined message copies its text into that field, so a shorter limit there would refuse what the predefined form had just accepted.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Customer Service > Order Messages, add a message longer than 1200 characters and save: it is accepted, where before it failed with "This value is too long. It should have 1200 characters or less." Then open an order, pick that predefined message from the dropdown, and send it - the order message box accepts the prefilled text instead of refusing it. Covered by `tests/Integration/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageTypeTest.php` and its counterpart under `.../Sell/Order/`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #18223
| Related PRs       | -
| Sponsor company   | -

## Why the storage limit, and not a number

The thread disagrees about the value, so this is the reasoning rather than a preference.

The storage was never the constraint. `classes/order/OrderMessage.php` already declares

    'message' => [... 'validate' => 'isMessage', 'required' => true, 'size' => FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4],

for the same field, `order_message_lang`.`message` is `mediumtext`, and `Validate::isMessage()` only
rejects `<>{}` with no length of its own. So core already contradicted itself: the model allowed
4194303 characters and the form allowed 1200. Measured end to end - a 5000 character message passes
`validateFields()` and `validateFieldsLang()`, saves, and comes back as `LENGTH(message) = 5000`.

Picking 5000, as requested, would replace one arbitrary number with another and re-open the same
question later; the requests in this thread alone are 2200 and 5000. Following the storage removes the
contradiction instead, and matches what `Message::message` and `CustomerMessage::message` - the two
`mediumtext` columns this text is copied into - already use.

A back-office setting for the limit was also suggested. That adds a configuration key, a form and a
settings row to govern a bound whose only technical job is to avoid exceeding the column;
`Product::description` and the other mediumtext fields are not configurable either. Letting each shop
write as long a message as it wants answers the same objection without the extra surface.

**Both forms move together, deliberately.** `OrderMessageConstraint::MAX_MESSAGE_LENGTH` is read by the
predefined-message form and by the message box on an order.
`order-view-page-messages-handler.ts` copies the selected predefined message's text into that box, so
divergent limits would prefill a value the box then rejects. That coupling is why the constant is
shared and why this change does not split it.

## Evidence

RED on `9.2.x` with the tests in place and the constant untouched, each form failing for its own
reason:

    A 5000 character predefined message was refused: This value is too long. It should have 1200 characters or less.
    A 5000 character message was refused on an order: This field cannot be longer than 1200 characters

GREEN after: 4 tests, 5 assertions. Reverting only the constant fails exactly those two tests and
leaves the two empty-message controls passing, so the controls are not vacuous and the assertions are
about the length rather than about validation having stopped running.

The tests go through `AbstractFormTester`, which takes `form.factory` from the real container, so the
`Length` constraint actually runs - a mocked validator would have passed either way. CSRF is disabled
in them because no token is submitted; with it on, every assertion would have been about the token.

No regression: nothing in `tests/` pins the old value (no test references `MAX_MESSAGE_LENGTH` or
`1200` for this field), and `tests/Integration/Adapter/OrderMessage` stays green. php-cs-fixer and
PHPStan clean on all three files, the cs-fixer result checked against a deliberately broken copy.

## Note for the reviewer

The `order_message` behat suite reports 3 scenarios skipped in this environment. That is unrelated to
this change - it is identical on the pristine base branch, so it is a local harness condition and not
a regression introduced here.

Referencing `FormattedTextareaType` from a `Core\Domain` constants class follows what
`ProductSettings`, `DiscountSettings` and `ApiClientSettings` already do; the alternative was
duplicating the literal 4194303.
