### PR TITLE
Allow configuring the database connection through a unix socket

### DIFF
--- a/app/config/doctrine.yml
+++ b/app/config/doctrine.yml
@@ -9,6 +9,7 @@ doctrine:
         wrapper_class: PrestaShopBundle\Doctrine\DatabaseConnection
         host: "%database_host%"
         port: "%database_port%"
+        unix_socket: "%database_unix_socket%"
         dbname: "%database_name%"
         user: "%database_user%"
         password: "%database_password%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -4,6 +4,8 @@
 parameters:
     database_host:     127.0.0.1
     database_port:     ~
+    # Absolute path to a MySQL unix socket. When set it replaces host/port.
+    database_unix_socket: ~
     database_name:     prestashop
     database_user:     root
     database_password: ~

--- a/app/config/set_parameters.php
+++ b/app/config/set_parameters.php
@@ -14,6 +14,7 @@ if (file_exists($parametersFilepath)) {
             'locale' => 'en',
             'database_host' => '',
             'database_port' => null,
+            'database_unix_socket' => null,
             'database_name' => '',
             'database_user' => '',
             'database_password' => '',
@@ -44,6 +45,14 @@ if (!defined('_PS_IN_TEST_') && isset($_SERVER['argv'])) {
 if (isset($container) && $container instanceof Symfony\Component\DependencyInjection\Container) {
     foreach ($parameters['parameters'] as $key => $value) {
         $container->setParameter($key, $value);
+    }
+
+    // The socket is optional and shops installed before it existed have no such key at all,
+    // while the installer writes an unset value as '' (see Install::generateSettingsFile).
+    // Doctrine tests this parameter with isset(), so '' would put "unix_socket=;" in the DSN
+    // and break every TCP connection - only null is skipped. Normalise both cases to null.
+    if (empty($parameters['parameters']['database_unix_socket'])) {
+        $container->setParameter('database_unix_socket', null);
     }
 
     $driver = 'array';

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -71,7 +71,12 @@ if ($lastParametersModificationTime) {
 
     $database_host = $config['parameters']['database_host'];
 
-    if (!empty($config['parameters']['database_port'])) {
+    // A unix socket replaces the port in the server string: DbPDO parses a trailing ":/path"
+    // back out of it and connects through unix_socket= instead of host=, so both the legacy
+    // and the Doctrine layer end up on the same socket.
+    if (!empty($config['parameters']['database_unix_socket'])) {
+        $database_host .= ':' . $config['parameters']['database_unix_socket'];
+    } elseif (!empty($config['parameters']['database_port'])) {
         $database_host .= ':'. $config['parameters']['database_port'];
     }
 

--- a/install-dev/controllers/http/database.php
+++ b/install-dev/controllers/http/database.php
@@ -179,7 +179,11 @@ class InstallControllerHttpDatabase extends InstallControllerHttp implements Htt
             }
 
             $this->database_server = $parameters['parameters']['database_host'];
-            if (!empty($parameters['parameters']['database_port'])) {
+            // Mirrors _DB_SERVER_: a socket takes the place of the port, so re-displaying the
+            // form round-trips a socket-configured shop instead of silently dropping it.
+            if (!empty($parameters['parameters']['database_unix_socket'])) {
+                $this->database_server .= ':' . $parameters['parameters']['database_unix_socket'];
+            } elseif (!empty($parameters['parameters']['database_port'])) {
                 $this->database_server .= ':' . $parameters['parameters']['database_port'];
             }
             $this->database_name = $parameters['parameters']['database_name'];

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -174,15 +174,10 @@ class Install extends AbstractInstall
         $secret = Tools::passwdGen(64);
         $cookie_key = defined('_COOKIE_KEY_') ? _COOKIE_KEY_ : Tools::passwdGen(64);
         $cookie_iv = defined('_COOKIE_IV_') ? _COOKIE_IV_ : Tools::passwdGen(32);
-        $database_port = null;
-
-        $splits = preg_split('#:#', $database_host);
-        $nbSplits = count($splits);
-
-        if ($nbSplits >= 2) {
-            $database_port = array_pop($splits);
-            $database_host = implode(':', $splits);
-        }
+        $databaseServer = self::parseDatabaseServer($database_host);
+        $database_host = $databaseServer['host'];
+        $database_port = $databaseServer['port'];
+        $database_unix_socket = $databaseServer['socket'];
 
         $key = PhpEncryption::createNewRandomKey();
         $privateKey = openssl_pkey_new([
@@ -196,6 +191,7 @@ class Install extends AbstractInstall
             'parameters' => [
                 'database_host' => $database_host,
                 'database_port' => $database_port,
+                'database_unix_socket' => $database_unix_socket,
                 'database_user' => $database_user,
                 'database_password' => $database_password,
                 'database_name' => $database_name,
@@ -226,6 +222,31 @@ class Install extends AbstractInstall
         }
 
         return true;
+    }
+
+    /**
+     * Split a server string of the form "host", "host:port" or "host:/path/to/socket".
+     *
+     * A unix socket is recognised by its leading slash, which is what DbPDO keys on when it
+     * parses _DB_SERVER_, so the installer and the legacy connection agree on what a socket is.
+     * Popping the path off as the port instead leaves Doctrine on the default socket while the
+     * legacy layer uses the configured one.
+     *
+     * @return array{host: string, port: string|null, socket: string|null}
+     */
+    public static function parseDatabaseServer(string $databaseServer): array
+    {
+        // These are the two patterns DbPDO applies to _DB_SERVER_, in its order, so a server
+        // string can never mean one thing to the installer and another to the connection.
+        if (preg_match('/^(.*):([0-9]+)$/', $databaseServer, $matches)) {
+            return ['host' => $matches[1], 'port' => $matches[2], 'socket' => null];
+        }
+
+        if (preg_match('#^(.*):(/.*)$#', $databaseServer, $matches)) {
+            return ['host' => $matches[1], 'port' => null, 'socket' => $matches[2]];
+        }
+
+        return ['host' => $databaseServer, 'port' => null, 'socket' => null];
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Doctrine/DatabaseUnixSocketParameterTest.php
+++ b/tests/Integration/PrestaShopBundle/Doctrine/DatabaseUnixSocketParameterTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Doctrine;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The socket itself cannot be exercised here - the test suite reaches MySQL over TCP - so what
+ * is pinned instead is the property that keeps every existing shop working: with no socket
+ * configured the option must vanish from the DSN entirely.
+ */
+class DatabaseUnixSocketParameterTest extends KernelTestCase
+{
+    public function testTheParameterIsNullWhenNoSocketIsConfigured(): void
+    {
+        self::bootKernel();
+
+        // parameters.php predates this option and carries no such key, and the installer writes
+        // an unset value as ''. Container compilation must survive both and resolve to null.
+        $this->assertNull(self::getContainer()->getParameter('database_unix_socket'));
+    }
+
+    public function testTheConnectionCarriesNoSocketWhenNoneIsConfigured(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+
+        // Doctrine builds the DSN with isset(): null is skipped, but '' would append
+        // "unix_socket=;" and break every TCP connection.
+        $this->assertNull(
+            $connection->getParams()['unix_socket'] ?? null,
+            'A shop with no socket configured must produce the same DSN as before.'
+        );
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Install/InstallTest.php
+++ b/tests/Unit/PrestaShopBundle/Install/InstallTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Install;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Install\Install;
+
+class InstallTest extends TestCase
+{
+    /**
+     * @dataProvider provideDatabaseServers
+     */
+    public function testItSplitsTheDatabaseServerString(string $server, array $expected): void
+    {
+        $this->assertSame($expected, Install::parseDatabaseServer($server));
+    }
+
+    public static function provideDatabaseServers(): iterable
+    {
+        yield 'host only' => [
+            'mysql',
+            ['host' => 'mysql', 'port' => null, 'socket' => null],
+        ];
+
+        yield 'host and port' => [
+            'mysql:3306',
+            ['host' => 'mysql', 'port' => '3306', 'socket' => null],
+        ];
+
+        // The socket path must not be taken for the port. Written to database_port it reaches
+        // Doctrine as "port=/var/run/...", which PDO ignores - so Doctrine falls back to the
+        // default socket while the legacy connection uses the configured one.
+        yield 'host and socket' => [
+            'localhost:/var/run/mysqld/mysqld.sock',
+            ['host' => 'localhost', 'port' => null, 'socket' => '/var/run/mysqld/mysqld.sock'],
+        ];
+
+        // A colon is legal in a socket path, and DbPDO reads this string the same way.
+        yield 'socket path containing a colon' => [
+            'localhost:/tmp/my:sql.sock',
+            ['host' => 'localhost', 'port' => null, 'socket' => '/tmp/my:sql.sock'],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Doctrine has no `unix_socket` option at all, so a non-default socket path cannot be used for the DBAL connection. The legacy layer already supports one, through the `":/path"` suffix `DbPDO` parses out of `_DB_SERVER_`, which leaves the two layers unable to agree on a socket-only MySQL server. This adds a `database_unix_socket` parameter that both layers honour. The installer previously popped a socket path off the server string as if it were the port, so it reached Doctrine as `port=/var/run/...`; PDO ignores a non-numeric port, so Doctrine fell back to the default socket while the legacy connection used the configured one. The installer now applies the same two patterns `DbPDO` applies, in the same order.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Needs a MySQL reachable over a unix socket. Set `database_unix_socket: '/var/run/mysqld/mysqld.sock'` in `app/config/parameters.php` and clear `var/cache`: both the Doctrine connection and the legacy one go through that socket. Leave it unset (or absent, as on any existing shop) and the DSN is byte-identical to before. Installing with `localhost:/var/run/mysqld/mysqld.sock` in the installer's Database server field now writes the path to `database_unix_socket` instead of `database_port`.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #14998
| Related PRs       |
| Sponsor company   |

### Notes for the reviewer

**Why the parameter must resolve to `null` and never `''`.** Doctrine's
`PDO\MySQL\Driver::constructPdoDsn` tests it with `isset()`, so an empty string appends
`unix_socket=;` to the DSN and breaks every TCP connection. Two paths produce an empty
value: a shop installed before this option has no such key at all, and
`Install::generateSettingsFile` writes unset values as `''` (its `array_walk` coerces
null). A real installed shop shows `database_port => ''` for exactly this reason.
`set_parameters.php` therefore normalises both cases to null after the parameter loop.
This mirrors the existing `database_port: ~` precedent.

**Measured PDO behaviour**, which is what makes the change inert for existing shops:

| DSN | Result |
| --- | --- |
| `host=<tcp host>` (today) | connects over TCP |
| `host=<tcp host>` + `unix_socket=<bogus>` | connects over TCP, socket ignored |
| `host=localhost` + `unix_socket=<bogus>` | fails on the socket path |

So a shop that never sets the parameter is unaffected, and a socket only takes effect
where the host already means "use a socket".

**Two layers, one parameter.** `config/bootstrap.php` appends the socket to `_DB_SERVER_`
in place of the port, reusing the seam `DbPDO` already has, rather than adding a second
legacy code path. A socket-only server would otherwise leave legacy queries failing over
TCP while Doctrine succeeded.

**`_DB_SERVER_` reaches `HostingInformation::getDatabaseInformation()`**, so the BO
Information page will show the socket path as the database server. That is what the shop
connects to, so it is reported deliberately rather than masked.

**The only non-socket behaviour change.** A server string whose suffix after `:` is neither
digits nor a path - `mysql:abc` - used to be split into host `mysql` and port `abc`. It now
stays in the host, because that is what `DbPDO` does with the same string. Both are broken
input; the difference is that the connection error now names the server string the user
actually typed.

**Scope.** No new field is added to the installer's UI: its existing Database server field
already accepts `host:/path`, and it now parses and round-trips one correctly. Both gates on
that field pass a socket string - `Validate::isGenericName` on the field itself and
`Validate::isUrl` in `Install\Database::testDatabaseSettings` - and the connection test hands
the raw string to `DbPDO`, which already parses the socket out of it. The IPv6
handling in the same split (`::1` becomes host `:` port `1`) is a separate defect and is
left exactly as it was.

`PrestaShop/docs#1784` ("Document using db through unix socket") asks for documentation of
this; there was previously no Doctrine-side option to document.

**Test coverage.** The suite reaches MySQL over TCP, so the socket connection itself is not
exercised - manufacturing a socket would test the fixture, not the change. What is pinned
is the property that protects existing shops: with nothing configured the parameter is
null and the option is absent from the resolved connection params, so the DSN is unchanged.
Setting it to `''` turns both assertions red. The unit test covers the server-string split,
and reverting it to the previous `array_pop` turns the two socket cases red while the
host-only and host:port cases stay green.
