### PR TITLE
Run the carrier module's extra content hook in the manual order form

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-map.ts
@@ -109,6 +109,7 @@ export default {
   shippingForm: '.js-shipping-form',
   noCarrierBlock: '.js-no-carrier-block',
   deliveryOptionSelect: '#delivery-option-select',
+  deliveryOptionExtraContent: '.js-delivery-option-extra-content',
   totalShippingField: '.js-total-shipping-tax-inc',
   freeShippingSwitch: '.js-free-shipping-switch',
   recycledPackagingSwitch: '.js-recycled-packaging-switch',

--- a/admin-dev/themes/new-theme/js/pages/order/create/shipping-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/shipping-renderer.ts
@@ -145,7 +145,9 @@ export default class ShippingRenderer {
    */
   private renderDeliveryOptions(deliveryOptions: Record<string, any>, selectedVal: any): void {
     const $deliveryOptionSelect = $(createOrderMap.deliveryOptionSelect);
+    const $extraContent = $(createOrderMap.deliveryOptionExtraContent);
     $deliveryOptionSelect.empty();
+    $extraContent.empty();
 
     Object.values(deliveryOptions).forEach((option: Record<string, any>) => {
       const deliveryOption: DeliveryOption = {
@@ -155,6 +157,11 @@ export default class ShippingRenderer {
 
       if (selectedVal === deliveryOption.value) {
         deliveryOption.selected = 'selected';
+        // Only the chosen carrier's content is shown, the way the front office shows it.
+        // Changing the selection reloads the cart, which renders this block again.
+        if (option.extraContent) {
+          $extraContent.html(option.extraContent);
+        }
       }
 
       $deliveryOptionSelect.append($('<option>', deliveryOption));

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -13,8 +13,10 @@ use Cart;
 use CartRule;
 use Currency;
 use Customer;
+use Hook;
 use Link;
 use Message;
+use Module;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
@@ -386,13 +388,40 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
                 $deliveryOptions[(int) $carrier->id] = new CartDeliveryOption(
                     (int) $carrier->id,
                     $carrier->name,
-                    $carrier->delay[$this->contextLangId]
+                    $carrier->delay[$this->contextLangId],
+                    $this->getCarrierExtraContent($carrier)
                 );
             }
         }
 
         // make sure array is not associative
         return array_values($deliveryOptions);
+    }
+
+    /**
+     * Same hook, same guards, as the front office delivery step, so a carrier module can offer
+     * the merchant the picker it already offers the customer.
+     *
+     * No module-HTML allowlist here on purpose: the other back office call sites that use one
+     * render module markup persisted in the database, which can outlive the module being
+     * disabled. This markup is produced on the spot, and `Hook::exec` builds its module list by
+     * joining `module_shop`, a row `Module::disable()` deletes - so a disabled module cannot
+     * reach this code at all.
+     */
+    private function getCarrierExtraContent(Carrier $carrier): string
+    {
+        if (!$carrier->is_module) {
+            return '';
+        }
+
+        // Dispatch to the carrier's own module. Without an id the hook would go to every module
+        // registered on it, which is not what the front office does.
+        $moduleId = (int) Module::getModuleIdByName($carrier->external_module_name);
+        if (!$moduleId) {
+            return '';
+        }
+
+        return (string) Hook::exec('displayCarrierExtraContent', ['carrier' => (array) $carrier], $moduleId);
     }
 
     /**

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartDeliveryOption.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartDeliveryOption.php
@@ -27,15 +27,21 @@ class CartDeliveryOption
     private $carrierDelay;
 
     /**
+     * @var string
+     */
+    private $extraContent;
+
+    /**
      * @param int $carrierId
      * @param string $carrierName
      * @param string $carrierDelay
      */
-    public function __construct(int $carrierId, string $carrierName, string $carrierDelay)
+    public function __construct(int $carrierId, string $carrierName, string $carrierDelay, string $extraContent = '')
     {
         $this->carrierId = $carrierId;
         $this->carrierName = $carrierName;
         $this->carrierDelay = $carrierDelay;
+        $this->extraContent = $extraContent;
     }
 
     /**
@@ -60,5 +66,14 @@ class CartDeliveryOption
     public function getCarrierDelay(): string
     {
         return $this->carrierDelay;
+    }
+
+    /**
+     * Markup a carrier's own module contributed for this delivery option, empty when the
+     * carrier belongs to no module or that module is not allowed to emit back office HTML.
+     */
+    public function getExtraContent(): string
+    {
+        return $this->extraContent;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig
@@ -15,6 +15,7 @@
         </label>
         <div class="col-md-6 col-xl-4">
           <select class="form-control" id="delivery-option-select" name="carrier-id"></select>
+          <div class="js-delivery-option-extra-content mt-2"></div>
         </div>
       </div>
       <div class="form-group row">

--- a/tests/Integration/Adapter/Cart/QueryHandler/GetCartForOrderCreationCarrierExtraContentTest.php
+++ b/tests/Integration/Adapter/Cart/QueryHandler/GetCartForOrderCreationCarrierExtraContentTest.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Cart\QueryHandler;
+
+use Cache;
+use Carrier;
+use Context;
+use Module;
+use PrestaShop\PrestaShop\Adapter\Cart\QueryHandler\GetCartForOrderCreationHandler;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForOrderCreation;
+use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\CartDeliveryOption;
+use ReflectionMethod;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The manual order form runs a carrier module's `displayCarrierExtraContent` hook, the way the
+ * front office delivery step does, so the module can render its own picker in the back office.
+ *
+ * A probe module is installed on disk and registered on that hook for the duration of these
+ * tests: without a carrier module that actually answers the hook, every assertion here would
+ * hold whether or not the dispatch happens at all.
+ */
+class GetCartForOrderCreationCarrierExtraContentTest extends KernelTestCase
+{
+    private const PROBE = 'probecarrier16131';
+    private const MARKUP = '<div class="probe-16131">pickup point picker</div>';
+
+    private $connection;
+
+    private int $probeModuleId = 0;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        // The legacy objects this handler builds reach for the container through the context.
+        Context::getContext()->container = $container;
+        $this->connection = $container->get('doctrine.dbal.default_connection');
+
+        $this->writeProbeModuleFile();
+
+        $this->connection->executeStatement(
+            'INSERT INTO ' . _DB_PREFIX_ . 'module (name, active, version) VALUES (:n, 1, :v)',
+            ['n' => self::PROBE, 'v' => '1.0.0']
+        );
+        $this->probeModuleId = (int) $this->connection->lastInsertId();
+
+        $hookId = (int) $this->connection->executeQuery(
+            'SELECT id_hook FROM ' . _DB_PREFIX_ . "hook WHERE name = 'displayCarrierExtraContent'"
+        )->fetchOne();
+        $this->assertGreaterThan(0, $hookId, 'The displayCarrierExtraContent hook must exist.');
+
+        // Registered for every shop: the hook's module list joins module_shop and filters it by
+        // the context shop list, which a CLI run does not necessarily set to shop 1.
+        foreach ($this->connection->executeQuery('SELECT id_shop FROM ' . _DB_PREFIX_ . 'shop')->fetchFirstColumn() as $shopId) {
+            $this->connection->executeStatement(
+                'INSERT INTO ' . _DB_PREFIX_ . 'module_shop (id_module, id_shop, enable_device) VALUES (:m, :s, 7)',
+                ['m' => $this->probeModuleId, 's' => (int) $shopId]
+            );
+            $this->connection->executeStatement(
+                'INSERT INTO ' . _DB_PREFIX_ . 'hook_module (id_module, id_shop, id_hook, position) VALUES (:m, :s, :h, 1)',
+                ['m' => $this->probeModuleId, 's' => (int) $shopId, 'h' => $hookId]
+            );
+        }
+
+        $this->resetCaches();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->probeModuleId) {
+            foreach (['hook_module', 'module_shop'] as $table) {
+                $this->connection->executeStatement(
+                    'DELETE FROM ' . _DB_PREFIX_ . $table . ' WHERE id_module = :m',
+                    ['m' => $this->probeModuleId]
+                );
+            }
+            $this->connection->executeStatement(
+                'DELETE FROM ' . _DB_PREFIX_ . 'module WHERE id_module = :m',
+                ['m' => $this->probeModuleId]
+            );
+            $this->probeModuleId = 0;
+        }
+        $this->removeProbeModuleFile();
+        $this->resetCaches();
+
+        parent::tearDown();
+    }
+
+    public function testItRendersTheCarrierModulesOwnContent(): void
+    {
+        $carrier = new Carrier();
+        $carrier->is_module = true;
+        $carrier->external_module_name = self::PROBE;
+
+        $this->assertSame(self::MARKUP, $this->getCarrierExtraContent($carrier));
+    }
+
+    public function testItLeavesACarrierThatBelongsToNoModuleAlone(): void
+    {
+        // Same module name, only the flag differs, so the empty result can come from nothing else.
+        $carrier = new Carrier();
+        $carrier->is_module = false;
+        $carrier->external_module_name = self::PROBE;
+
+        $this->assertSame('', $this->getCarrierExtraContent($carrier));
+    }
+
+    public function testItSkipsTheHookWhenTheCarriersModuleCannotBeResolved(): void
+    {
+        // Without the id the hook would go to every module registered on it - the probe among
+        // them - instead of the carrier's own module.
+        $carrier = new Carrier();
+        $carrier->is_module = true;
+        $carrier->external_module_name = 'a_module_that_is_not_installed';
+
+        $this->assertSame('', $this->getCarrierExtraContent($carrier));
+    }
+
+    public function testEveryDeliveryOptionCarriesTheField(): void
+    {
+        $cartId = (int) $this->connection->executeQuery(
+            'SELECT c.id_cart
+               FROM ' . _DB_PREFIX_ . 'cart c
+              WHERE c.id_customer > 0
+                AND c.id_address_delivery > 0
+                AND (SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'cart_product cp WHERE cp.id_cart = c.id_cart) > 0
+              ORDER BY c.id_cart
+              LIMIT 1'
+        )->fetchOne();
+
+        if (!$cartId) {
+            self::markTestSkipped('The fixtures hold no cart with a delivery address and a product.');
+        }
+
+        $shipping = self::getContainer()->get('prestashop.core.query_bus')
+            ->handle(new GetCartForOrderCreation($cartId))
+            ->getShipping();
+
+        if (null === $shipping) {
+            self::markTestSkipped(sprintf('Cart %d resolves to no shipping block.', $cartId));
+        }
+
+        $options = $shipping->getDeliveryOptions();
+        $this->assertNotEmpty($options, 'Expected at least one delivery option to inspect.');
+        foreach ($options as $option) {
+            $this->assertInstanceOf(CartDeliveryOption::class, $option);
+            // Native carriers belong to no module, so the field is empty; what this pins is that
+            // the handler fills it in and the value object carries it to the query result.
+            $this->assertSame('', $option->getExtraContent());
+        }
+    }
+
+    private function getCarrierExtraContent(Carrier $carrier): string
+    {
+        $container = self::getContainer();
+        $handler = new GetCartForOrderCreationHandler(
+            $container->get('prestashop.core.localization.locale.context_locale'),
+            (int) Context::getContext()->language->id,
+            Context::getContext()->link,
+            $container->get('prestashop.adapter.context_state_manager'),
+            0
+        );
+
+        $method = new ReflectionMethod($handler, 'getCarrierExtraContent');
+        $method->setAccessible(true);
+
+        return $method->invoke($handler, $carrier);
+    }
+
+    private function probeModuleDir(): string
+    {
+        return _PS_MODULE_DIR_ . self::PROBE;
+    }
+
+    private function writeProbeModuleFile(): void
+    {
+        if (!is_dir($this->probeModuleDir())) {
+            mkdir($this->probeModuleDir(), 0777, true);
+        }
+        file_put_contents(
+            $this->probeModuleDir() . '/' . self::PROBE . '.php',
+            '<?php' . PHP_EOL
+            . 'class ' . self::PROBE . ' extends Module' . PHP_EOL
+            . '{' . PHP_EOL
+            . '    public function __construct()' . PHP_EOL
+            . '    {' . PHP_EOL
+            . "        \$this->name = '" . self::PROBE . "';" . PHP_EOL
+            . "        \$this->version = '1.0.0';" . PHP_EOL
+            . "        \$this->author = 'PrestaShop tests';" . PHP_EOL
+            . '        parent::__construct();' . PHP_EOL
+            . "        \$this->displayName = 'Carrier extra content probe';" . PHP_EOL
+            . "        \$this->description = 'Fixture for GetCartForOrderCreationCarrierExtraContentTest.';" . PHP_EOL
+            . '    }' . PHP_EOL
+            . PHP_EOL
+            . '    public function hookDisplayCarrierExtraContent($params)' . PHP_EOL
+            . '    {' . PHP_EOL
+            . "        return '" . self::MARKUP . "';" . PHP_EOL
+            . '    }' . PHP_EOL
+            . '}' . PHP_EOL
+        );
+    }
+
+    private function removeProbeModuleFile(): void
+    {
+        $file = $this->probeModuleDir() . '/' . self::PROBE . '.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+        if (is_dir($this->probeModuleDir())) {
+            rmdir($this->probeModuleDir());
+        }
+    }
+
+    private function resetCaches(): void
+    {
+        Module::resetStaticCache();
+        Cache::clean('*');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A carrier that belongs to a module can contribute extra content to the front office delivery step through `displayCarrierExtraContent` - that is how a pickup point picker reaches the customer. The manual order form in the back office never ran the hook, so a merchant creating an order for the same carrier had nowhere to pick one. The delivery options that form builds now carry the module's content, dispatched to the carrier's own module exactly as the front office dispatches it, and the form renders it under the carrier it belongs to.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Needs a carrier provided by a module that implements `displayCarrierExtraContent` (any pickup point module). Orders > Add new order, pick a customer, add a product, choose that carrier as the delivery option: the module's content appears under the select, the same content the front office shows in the delivery step. Choose a native carrier instead and nothing extra is rendered.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #16131
| Related PRs       |
| Sponsor company   |

### Scope: the display hook only, deliberately not `actionCarrierProcess`

The issue asks for two things: the extra-content hook, and `actionCarrierProcess` "that could be
triggered to have the same behaviour in BO". This ships the first and not the second, on purpose.

`displayCarrierExtraContent` is a display hook - it renders and returns a string, so running it in
the back office cannot do anything but produce markup. `actionCarrierProcess` is fired once by
`CheckoutDeliveryStep` (`classes/checkout/CheckoutDeliveryStep.php:143`) at a defined point in the
front office checkout lifecycle, and modules listening to it act on that meaning. The manual order
form has no equivalent point: the merchant edits a cart repeatedly, and every carrier change
re-fetches it, so the hook would fire from an admin request against a cart mid-edit, possibly many
times, with no step to complete. Firing it there would give listeners an event whose contract they
cannot rely on. If a maintainer wants that half, it needs its own lifecycle decision rather than
being attached to this one.

### No module-HTML allowlist here, and why

`GetCartForViewingHandler` and `GetOrderProductsForViewingHandler` pass module markup through
`ModuleHtmlAuthorizationChecker` before the back office renders it. That guard is right for them and
wrong here: both render markup **persisted in the database**, which can outlive the module being
disabled, so they have to re-check the owner. This markup is produced on the spot by
`Hook::exec`, whose module list is built by `getAllHookRegistrations()` joining `module_shop` - the
row `Module::disable()` deletes (`classes/module/Module.php`). A disabled module therefore cannot
reach this code at all, and the extra check would only restate what the dispatch already enforces.
It was written, found to be untestable because it changed no outcome, and removed.

The two guards that do matter are the ones the front office also applies: the carrier must belong to
a module, and that module must resolve to an id - otherwise the hook would be dispatched to every
module registered on it instead of the carrier's own.

### Verification

New `tests/Integration/Adapter/Cart/QueryHandler/GetCartForOrderCreationCarrierExtraContentTest.php`,
4 tests, 10 assertions, green.

The test installs a probe module on disk and registers it on `displayCarrierExtraContent` for the
duration of the run, then removes both the rows and the file. This is the point of the test rather
than an incidental: no native carrier belongs to a module, so without a module that actually answers
the hook every assertion would hold whether the dispatch happened or not.

Mutation checks, both confirmed:

| Removed | Result |
| --- | --- |
| the `is_module` guard | the non-module carrier test fails, it receives the probe's markup |
| the resolved-module-id guard | the unresolvable-module test fails, the hook reaches every registered module including the probe |

Restoring the file returns all four to green.

Also run: `php -l` on all three PHP files, `php-cs-fixer` clean on each, `phpstan` reports no errors
on the two changed source files, `lint:twig` valid, `eslint` clean on both TypeScript files, and
`tsc --noEmit` reports no error in either changed file.
