### PR TITLE
Confirm before a multistore context switch discards unsaved changes

### DIFF
--- a/admin-dev/themes/new-theme/js/components/components-map.ts
+++ b/admin-dev/themes/new-theme/js/components/components-map.ts
@@ -17,6 +17,7 @@ export default {
     jsScrollbar: '.js-multishop-scrollbar',
     shopLinks: 'a.multishop-modal-shop-name',
     groupShopLinks: 'a.multishop-modal-group-name',
+    allShopsLink: 'a.multishop-modal-all-name',
     setContextUrl: (
       location: string,
       urlLetter: string,

--- a/admin-dev/themes/new-theme/js/components/multistore-header.ts
+++ b/admin-dev/themes/new-theme/js/components/multistore-header.ts
@@ -10,6 +10,7 @@ import AutoCompleteSearch from '@components/auto-complete-search';
 import PerfectScrollbar from 'perfect-scrollbar';
 import ComponentsMap from '@components/components-map';
 import initContextualNotification from '@components/contextual-notification';
+import {ConfirmModal} from '@components/modal';
 import 'perfect-scrollbar/css/perfect-scrollbar.css';
 
 const {$} = window;
@@ -25,7 +26,66 @@ const initMultistoreHeader = () => {
     searchTerm: '__QUERY__',
   });
 
+  const header = document.querySelector<HTMLElement>(MultistoreHeaderMap.headerMultiShop);
+
   new PerfectScrollbar(MultistoreHeaderMap.jsScrollbar);
+
+  /**
+   * Switching context reloads the page, so anything typed into a form on it is lost. Track whether
+   * that has happened and let the merchant confirm first.
+   *
+   * Any edit counts, including one the merchant undoes by hand: comparing the form's content against
+   * its initial state was considered and dropped as overkill in the discussion on this feature, since
+   * the only cost of a false positive is one extra confirmation.
+   */
+  let formModified = false;
+
+  /**
+   * Controls that carry no unsaved state, so typing in one is not a page modification: the store
+   * picker's own search field, the back office search bar, and the filters of both the migrated and
+   * the legacy lists, which are kept in the session and are still there after the context switch.
+   */
+  const transientControlSelector = [
+    MultistoreHeaderMap.headerMultiShop,
+    '[role="search"]',
+    '.js-grid-panel',
+    'tr.filter',
+  ].join(', ');
+
+  const markFormModified = (event: Event): void => {
+    const target = event.target as HTMLElement | null;
+
+    if (!target || !target.closest('form') || target.closest(transientControlSelector)) {
+      return;
+    }
+
+    formModified = true;
+  };
+
+  document.addEventListener('input', markFormModified, true);
+  document.addEventListener('change', markFormModified, true);
+
+  const switchContext = (url: string): void => {
+    if (!formModified) {
+      window.location.href = url;
+
+      return;
+    }
+
+    new ConfirmModal(
+      {
+        id: 'multistore-switch-context-modal',
+        confirmTitle: header?.dataset.switchContextTitle,
+        confirmMessage: header?.dataset.switchContextMessage,
+        confirmButtonLabel: header?.dataset.switchContextConfirm,
+        closeButtonLabel: header?.dataset.switchContextCancel,
+        confirmButtonClass: 'btn-primary',
+      },
+      () => {
+        window.location.href = url;
+      },
+    ).show();
+  };
 
   const source = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.obj.whitespace,
@@ -45,7 +105,7 @@ const initMultistoreHeader = () => {
         contextUrlLetter,
         selectedItem.id,
       );
-      window.location.href = setContextUrl;
+      switchContext(setContextUrl);
 
       return true;
     },
@@ -96,6 +156,31 @@ const initMultistoreHeader = () => {
 
   updateLinksAnchor();
   window.addEventListener('hashchange', updateLinksAnchor);
+
+  /**
+   * The store, group and "All stores" entries are plain links, so the confirmation has to happen
+   * before the browser follows them.
+   */
+  const contextLinks = [
+    MultistoreHeaderMap.allShopsLink,
+    MultistoreHeaderMap.groupShopLinks,
+    MultistoreHeaderMap.shopLinks,
+  ].join(', ');
+
+  header?.addEventListener('click', (event: Event) => {
+    const target = event.target as HTMLElement | null;
+    const link = target?.closest<HTMLAnchorElement>(contextLinks);
+
+    // A store with no configured URL is rendered without an href and switches nothing.
+    if (!link || !link.getAttribute('href') || !formModified) {
+      return;
+    }
+
+    event.preventDefault();
+    // Close the store picker first, so the confirmation is not stacked on top of its overlay.
+    toggleModal();
+    switchContext(link.href);
+  });
 };
 
 $(() => {

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/multistore_header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/multistore_header.html.twig
@@ -10,6 +10,10 @@
       {% if this.contextShopId %}data-shop-id="{{ this.contextShopId }}"{% elseif this.contextShopGroupId %}data-group-id="{{ this.contextShopGroupId }}"{% else %}data-all-shops="1"{% endif %}
       {% if this.colorConfigLink is not empty %}data-header-color-notification="{{ 'Customize your multistore header, [1]pick a color[/1] for this store context.'|trans({'[1]': '<a href="' ~ this.colorConfigLink ~ '">', '[/1]': '</a>'}, 'Admin.Navigation.Header') }}"{% endif %}
       data-checkbox-notification="{{ 'To apply specific settings to a store or a group of stores, select the parameter to modify, make your changes and save.'|trans({}, 'Admin.Navigation.Header') ~ ' ' }}"
+      data-switch-context-title="{{ 'Switch context?'|trans({}, 'Admin.Notifications.Warning') }}"
+      data-switch-context-message="{{ 'Switching context now will discard all unsaved changes.'|trans({}, 'Admin.Notifications.Warning') }}"
+      data-switch-context-confirm="{{ 'Switch context anyway'|trans({}, 'Admin.Actions') }}"
+      data-switch-context-cancel="{{ 'Cancel'|trans({}, 'Admin.Actions') }}"
     >
       <div class="header-multishop-top-bar"{% if this.contextColor is not empty %} style="background-color: {{ this.contextColor }};"{% endif %}>
         <div class="header-multishop-center js-header-multishop-open-modal">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Switching store context reloads the page and silently discards anything typed into a form on it. The multistore header now asks for confirmation first, with the title, body and buttons the multistore header specification calls for.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #23741
| Related PRs       | Supersedes #27884 (closed for staleness)
| Sponsor company   |

### Why

The spec is written and merged: https://github.com/PrestaShop/prestashop-specs/blob/master/content/1.7/back-office/multistoregeneralspecs.md

> If the user tries to change context without having saved, a modal appears: Title: "Switch context?"
> Body: "Switching context now will discard all unsaved changes." 2 CTA: "Switch context anyway" and
> "Cancel".

Nothing of it landed. `src/PrestaShopBundle/Resources/views/Admin/Multistore/` does not exist, and
`multistore-header.ts` navigates on a plain link click and on `window.location.href = setContextUrl`
from the store search.

### What it does

- `multistore_header.html.twig` carries the four strings as `data-*` attributes on `#header-multishop`,
  the pattern `header.ts` already uses for the quick-access confirmation.
- `multistore-header.ts` raises a flag on any `input` or `change` inside a form, ignoring events inside
  the controls that carry no unsaved state. The store, group and "All stores" links and the search's
  `onSelect` then route through a `ConfirmModal` when the flag is set.
- `components-map.ts` gains the "All stores" selector, which had none.

Design decisions taken from the discussion on the issue and on #27884 rather than invented:
- **Flag, not a content hash.** kpodemski asked for exactly this in the issue, and matthieu-rolland
  reported the core developers had ruled hashing overkill. An edit the merchant undoes by hand still
  asks for confirmation; the cost is one extra click.
- **Wording domains from the review.** Julievrz's `CHANGES_REQUESTED` on #27884 named them:
  "Switch context?" and "Switching context now will discard all unsaved changes." in
  `Admin.Notifications.Warning`, "Switch context anyway" in `Admin.Actions`. That review was never
  addressed; it is applied here. "Cancel" is the existing `Admin.Actions` string.
- **The dirty flag is scoped to forms that hold unsaved state.** `#header-multishop`, `[role="search"]`
  (the back office search bar), `.js-grid-panel` (migrated grid filters) and `tr.filter` (legacy list
  filters) are excluded. All four are session-persisted or navigational, so counting them would put a
  message on screen that is not true - the merchant would be told they are about to discard changes
  that survive the switch. Grid filter forms wrap every grid via `form_start(grid.filter_form)` in
  `Admin/Common/Grid/Blocks/table.html.twig`, so without the exclusion a filter keystroke on any listing
  page would arm the confirmation.
- **Known asymmetry, left as is.** A legacy `HelperList` bulk checkbox (`name="<list>Box[]"`) sits inside
  `form-<list_id>` and outside `tr.filter`, so ticking one still arms the confirmation, while the same
  action on a migrated grid does not (it is inside `.js-grid-panel`). Not a false positive though: a bulk
  selection is not session-persisted, so switching context really does lose it. Warning is the honest
  answer there; only the inconsistency with migrated grids is untidy, and matthieu-rolland accepted
  over-warning as the cheap failure mode.
- **The existing `ConfirmModal` component**, not a new Twig template. #27884 added
  `Admin/Multistore/switch_context_modal.html.twig`; the component gives the same modal with no new
  template and no new controller surface.

### How to test

Requires a multistore installation with at least two stores.

1. Open any back-office page carrying a form - Shop parameters > General, for instance.
2. Change a field and do not save.
3. Open the store picker in the header and choose another store, a group, or "All stores".
4. The confirmation appears. "Cancel" leaves the context alone; "Switch context anyway" switches.
5. Reload, change nothing, and switch again: no confirmation.
6. Reload, type a store name into the header's own search field, and pick a result: no confirmation,
   because the header's search is not part of the page's forms.
7. Reload, open a listing page (Sell > Catalogue > Products), type into a column filter, and switch:
   no confirmation, because grid filters are kept in the session.
