### PR TITLE
Let setQuantity say what the stock movement it records is for

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -375,10 +375,11 @@ class StockAvailableCore extends ObjectModel
      * @param int $quantity
      * @param int|null $id_shop
      * @param bool $add_movement
+     * @param array $params Optional parameters for the stock movement, e.g. `id_stock_mvt_reason`
      *
      * @return bool|void
      */
-    public static function setQuantity($id_product, $id_product_attribute, $quantity, $id_shop = null, $add_movement = true)
+    public static function setQuantity($id_product, $id_product_attribute, $quantity, $id_shop = null, $add_movement = true, $params = [])
     {
         if (!Validate::isUnsignedId($id_product)) {
             return false;
@@ -402,7 +403,7 @@ class StockAvailableCore extends ObjectModel
             $stock_available->update();
 
             if (true === $add_movement && 0 != $deltaQuantity) {
-                $stockManager->saveMovement($id_product, $id_product_attribute, $deltaQuantity);
+                $stockManager->saveMovement($id_product, $id_product_attribute, $deltaQuantity, $params);
             }
         } else {
             $out_of_stock = StockAvailable::outOfStock($id_product, $id_shop);
@@ -427,7 +428,7 @@ class StockAvailableCore extends ObjectModel
             $stock_available->add();
 
             if (true === $add_movement && 0 != $quantity) {
-                $stockManager->saveMovement($id_product, $id_product_attribute, (int) $quantity);
+                $stockManager->saveMovement($id_product, $id_product_attribute, (int) $quantity, $params);
             }
         }
 

--- a/tests/Integration/Core/Stock/StockAvailableMovementTest.php
+++ b/tests/Integration/Core/Stock/StockAvailableMovementTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Stock;
+
+use Db;
+use Language;
+use Shop;
+use StockAvailable;
+use StockMvtReason;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\Resetter\ShopResetter;
+
+/**
+ * StockAvailable::setQuantity() records a stock movement but used to give the caller no say in what
+ * it is attributed to, unlike its sibling updateQuantity(). These cover the movement parameters
+ * reaching the recorded movement.
+ */
+class StockAvailableMovementTest extends KernelTestCase
+{
+    private const PRODUCT_ID = 1;
+    private const DEFAULT_SHOP_ID = 1;
+
+    private ?int $reasonId = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::bootKernel();
+        // Global var read by legacy code resolving the container (SymfonyContainer::getInstance).
+        // Without it StockManager::saveMovement() returns false before recording anything.
+        global $kernel;
+        $kernel = self::$kernel;
+
+        ShopResetter::resetShops();
+
+        Shop::resetStaticCache();
+        Shop::resetContext();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        ShopResetter::resetShops();
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // StockAvailable memoizes the stock_available id per product in a static.
+        StockAvailable::resetStaticCache();
+        Shop::resetStaticCache();
+    }
+
+    protected function tearDown(): void
+    {
+        if (null !== $this->reasonId) {
+            (new StockMvtReason($this->reasonId))->delete();
+            $this->reasonId = null;
+        }
+        parent::tearDown();
+    }
+
+    public function testSetQuantityRecordsTheMovementReasonTheCallerAsked(): void
+    {
+        Shop::setContext(Shop::CONTEXT_SHOP, self::DEFAULT_SHOP_ID);
+        $this->reasonId = $this->createReason('Sync from an external system');
+        $quantity = $this->quantityOf(self::DEFAULT_SHOP_ID);
+
+        StockAvailable::setQuantity(self::PRODUCT_ID, 0, $quantity + 7, self::DEFAULT_SHOP_ID, true, [
+            'id_stock_mvt_reason' => $this->reasonId,
+        ]);
+
+        $movement = $this->latestMovementForShop(self::DEFAULT_SHOP_ID);
+        $this->assertNotNull($movement, 'no stock movement was recorded');
+        $this->assertSame($this->reasonId, (int) $movement['id_stock_mvt_reason']);
+        $this->assertSame(7, (int) $movement['physical_quantity']);
+
+        StockAvailable::setQuantity(self::PRODUCT_ID, 0, $quantity, self::DEFAULT_SHOP_ID, false);
+    }
+
+    private function quantityOf(int $shopId): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT `quantity` FROM `' . _DB_PREFIX_ . 'stock_available`
+            WHERE `id_product` = ' . self::PRODUCT_ID . ' AND `id_product_attribute` = 0
+                AND `id_shop` = ' . $shopId
+        );
+    }
+
+    private function stockIdOf(int $shopId): int
+    {
+        return (int) Db::getInstance()->getValue(
+            'SELECT `id_stock_available` FROM `' . _DB_PREFIX_ . 'stock_available`
+            WHERE `id_product` = ' . self::PRODUCT_ID . ' AND `id_product_attribute` = 0
+                AND `id_shop` = ' . $shopId
+        );
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function latestMovementForShop(int $shopId): ?array
+    {
+        $row = Db::getInstance()->getRow(
+            'SELECT * FROM `' . _DB_PREFIX_ . 'stock_mvt`
+            WHERE `id_stock` = ' . $this->stockIdOf($shopId) . '
+            ORDER BY `id_stock_mvt` DESC'
+        );
+
+        return empty($row) ? null : $row;
+    }
+
+    private function createReason(string $name): int
+    {
+        $reason = new StockMvtReason();
+        $reason->sign = 1;
+        // A multilang field is declared as its scalar type but validateFieldsLang() requires the
+        // per-language array, so the property type and the runtime contract disagree here.
+        // @phpstan-ignore-next-line
+        $reason->name = array_fill_keys(Language::getIDs(false), $name);
+        $reason->add();
+
+        return (int) $reason->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `StockAvailable::updateQuantity()` takes a `$params` array and forwards it to the stock movement it saves, so a caller can attribute that movement - `StockManager::prepareMovement()` reads `id_stock_mvt_reason`, `id_order` and `id_shop` out of it. `StockAvailable::setQuantity()` records a movement too, but accepted no such array and called `saveMovement()` with three arguments, so everything written through it landed under the default reason. That is the case in this issue: a quantity pushed in from an external system is indistinguishable from a merchant editing stock by hand. This gives `setQuantity()` the same optional array and forwards it to both of its `saveMovement()` calls. Reasons are an ObjectModel (`StockMvtReason`), so an integration can register its own - "Sync from an external system" - and then name it on every write.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `tests/Integration/Core/Stock/StockAvailableMovementTest.php`. It creates a `StockMvtReason`, calls `StockAvailable::setQuantity()` passing `['id_stock_mvt_reason' => $id]`, and asserts the recorded `stock_mvt` row carries that reason and the right quantity. Without the change the row carries reason 4, "Employee Edition".
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #20765
| Related PRs       |
| Sponsor company   |

### Design notes

The parameter is optional and last, so every existing call is unaffected, and the array is passed
through untouched rather than interpreted - `setQuantity()` gains no knowledge of which keys
`StockManager` honours, which keeps the two methods symmetrical and means a future key needs no change
here.

The issue also floated a separate `$module_name` argument. That is not needed: a module registers its
own `StockMvtReason` once and refers to it by id, which reuses the existing model instead of adding a
second, parallel way to label a movement.

### What was deliberately left out

A first version also defaulted the resolved `$id_shop` into the movement parameters, on the reasoning
that the movement is attached to a `stock_available` row `StockManager` resolves separately and that
lookup falls back to the context shop. **Dropped, because I could not verify it.** With a second shop
built through `ShopResetter` the write reached the right row (its quantity moved 10 to 13) but no
movement was recorded for it at all, and I did not establish why. Shipping a behaviour change to shop
scoping on that basis would be guessing, and it is outside what this issue asks. It stays a separate
open question.

### Verification

Run in the container that mounts this branch, against a `test_prestashop` at `PS_VERSION_DB=9.2.0`,
after confirming an unmodified `KernelTestCase` (`StockManagerTest`, 19 tests / 57 assertions) passes
there.

| | reason recorded |
| --- | --- |
| base | `4` - the built-in "Employee Edition" |
| with the change | the id the caller passed |

Three consecutive green runs, and the base run fails on exactly that assertion. php-cs-fixer and phpstan
clean on both files.

### Harness note for whoever runs this

`StockManager::saveMovement()` returns `false` before recording anything when
`SymfonyContainer::getInstance()` is null, and that getter reads the **global `$kernel`**, which
`KernelTestCase::bootKernel()` does not set. A test touching stock movements has to do
`global $kernel; $kernel = self::$kernel;` after booting, the way
`ExtraPropertyMultiShopTest::setUpBeforeClass()` does, or it silently observes no movements.
