### PR TITLE
Resolve an imported country by its ISO code, and let the fallback create one

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -908,6 +908,35 @@ class AdminImportControllerCore extends AdminController
         return $tab;
     }
 
+    /**
+     * Resolves the country column of an imported row to an existing country id.
+     *
+     * WHY the name is tried before the ISO code: a shop is free to name a country with two letters,
+     * and that name has always won here. Looking the name up first keeps every import that already
+     * resolved resolving to the same country, so this only rescues the rows that would otherwise
+     * fall through to creating a duplicate country.
+     *
+     * WHY the ISO code is validated before it is used: Country::getByIso() throws on anything that
+     * is not an ISO code, and a country column holding a free-text name is the normal case here
+     * rather than an exceptional one.
+     *
+     * @param string $field the raw country column, either a name or an ISO code
+     *
+     * @return int the matching country id, or 0 when the column matches no existing country
+     */
+    protected static function resolveCountryId($field)
+    {
+        if ($id_country = Country::getIdByName(null, $field)) {
+            return (int) $id_country;
+        }
+
+        if (Validate::isLanguageIsoCode($field) && ($id_country = Country::getByIso($field))) {
+            return (int) $id_country;
+        }
+
+        return 0;
+    }
+
     protected static function createMultiLangField($field)
     {
         $res = [];
@@ -2917,7 +2946,7 @@ class AdminImportControllerCore extends AdminController
                 $address->id_country = (int) $address->country;
             }
         } elseif (!empty($address->country) && is_string($address->country)) {
-            if ($id_country = Country::getIdByName(null, $address->country)) {
+            if ($id_country = AdminImportController::resolveCountryId($address->country)) {
                 $address->id_country = (int) $id_country;
             } else {
                 $country = new Country();
@@ -2926,6 +2955,7 @@ class AdminImportControllerCore extends AdminController
                 $country->id_zone = 0; // Default zone for country to create
                 $country->iso_code = Tools::strtoupper(Tools::substr($address->country, 0, 2)); // Default iso for country to create
                 $country->contains_states = false; // Default value for country to create
+                $country->need_identification_number = false; // Required field, default value for country to create
                 $lang_field_error = $country->validateFieldsLang(UNFRIENDLY_ERROR, true);
                 if (($field_error = $country->validateFields(UNFRIENDLY_ERROR, true)) === true
                     && ($lang_field_error = $country->validateFieldsLang(UNFRIENDLY_ERROR, true)) === true
@@ -3552,7 +3582,7 @@ class AdminImportControllerCore extends AdminController
                 $store->id_country = (int) $store->country;
             }
         } elseif (isset($store->country) && is_string($store->country) && !empty($store->country)) {
-            if ($id_country = Country::getIdByName(null, $store->country)) {
+            if ($id_country = AdminImportController::resolveCountryId($store->country)) {
                 $store->id_country = (int) $id_country;
             } else {
                 $country = new Country();
@@ -3561,6 +3591,7 @@ class AdminImportControllerCore extends AdminController
                 $country->id_zone = 0; // Default zone for country to create
                 $country->iso_code = Tools::strtoupper(Tools::substr($store->country, 0, 2)); // Default iso for country to create
                 $country->contains_states = false; // Default value for country to create
+                $country->need_identification_number = false; // Required field, default value for country to create
                 $lang_field_error = $country->validateFieldsLang(UNFRIENDLY_ERROR, true);
                 if (($field_error = $country->validateFields(UNFRIENDLY_ERROR, true)) === true
                     && ($lang_field_error = $country->validateFieldsLang(UNFRIENDLY_ERROR, true)) === true

--- a/tests/Integration/Classes/controller/AdminImportControllerTest.php
+++ b/tests/Integration/Classes/controller/AdminImportControllerTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\Classes\controller;
+
+use AdminImportController;
+use Configuration;
+use Country;
+use Db;
+use Language;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Tests\Integration\Utility\ContextMockerTrait;
+
+class AdminImportControllerTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+    }
+
+    public function testACountryNameResolvesToThatCountry(): void
+    {
+        [$idCountry, $name] = $this->anExistingCountry();
+
+        $this->assertSame($idCountry, $this->resolveCountryId($name));
+    }
+
+    public function testAnIsoCodeResolvesToTheSameCountryAsItsName(): void
+    {
+        [$idCountry, , $isoCode] = $this->anExistingCountry();
+
+        // Without this the ISO code matched no name, and the import fell through to creating a
+        // second country called "PL" whose zone is 0, silently detaching the imported addresses
+        // from the real one.
+        $this->assertSame($idCountry, $this->resolveCountryId($isoCode));
+        $this->assertSame($idCountry, $this->resolveCountryId(strtolower($isoCode)));
+    }
+
+    public function testResolvingAnIsoCodeCreatesNoCountry(): void
+    {
+        [, , $isoCode] = $this->anExistingCountry();
+        $before = $this->countryCount();
+
+        $this->resolveCountryId($isoCode);
+
+        $this->assertSame($before, $this->countryCount());
+    }
+
+    public function testAnUnknownColumnResolvesToNothingWithoutThrowing(): void
+    {
+        // Country::getByIso() throws on a value that is not an ISO code, and a country column
+        // holding a free-text name is the normal case rather than an exceptional one.
+        $this->assertSame(0, $this->resolveCountryId('Not A Country At All'));
+        $this->assertSame(0, $this->resolveCountryId('ZZ'));
+    }
+
+    public function testACountryCreatedTheWayTheImportCreatesOneValidates(): void
+    {
+        // Mirrors what addressImport()/storeImport() build when the country column matches no
+        // existing country. need_identification_number was never set, and it is required, so the
+        // creation always failed with "Property Country->need_identification_number is empty."
+        // and the row was left with no country at all.
+        $country = new Country();
+        $country->active = true;
+        $country->name = [];
+        foreach (Language::getIDs(false) as $idLang) {
+            $country->name[$idLang] = 'Import Probe Country';
+        }
+        $country->id_zone = 0;
+        $country->iso_code = 'QQ';
+        $country->contains_states = false;
+
+        // Without it the creation branch could never succeed, whatever the country column held.
+        $this->assertSame(
+            'Property Country->need_identification_number is empty.',
+            $country->validateFields(false, true)
+        );
+
+        $country->need_identification_number = false;
+
+        $this->assertTrue($country->validateFields(false, true));
+        $this->assertTrue($country->validateFieldsLang(false, true));
+    }
+
+    /**
+     * @return array{0: int, 1: string, 2: string}
+     */
+    private function anExistingCountry(): array
+    {
+        $idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $row = Db::getInstance()->getRow(
+            'SELECT c.`id_country`, c.`iso_code`, cl.`name`
+            FROM `' . _DB_PREFIX_ . 'country` c
+            INNER JOIN `' . _DB_PREFIX_ . 'country_lang` cl
+                ON cl.`id_country` = c.`id_country` AND cl.`id_lang` = ' . $idLang . '
+            ORDER BY c.`id_country`'
+        );
+        $this->assertNotEmpty($row, 'the fixture shop has no country to resolve');
+
+        // The name must not itself be the ISO code, or the two lookups cannot be told apart and
+        // the ISO assertion would pass through the name branch alone.
+        $this->assertNotSame(
+            strtoupper($row['name']),
+            strtoupper($row['iso_code']),
+            'the fixture country is named like its own ISO code'
+        );
+
+        return [(int) $row['id_country'], $row['name'], $row['iso_code']];
+    }
+
+    private function countryCount(): int
+    {
+        return (int) Db::getInstance()->getValue('SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'country`');
+    }
+
+    private function resolveCountryId(string $field): int
+    {
+        $method = new ReflectionMethod(AdminImportController::class, 'resolveCountryId');
+        $method->setAccessible(true);
+
+        return (int) $method->invoke(null, $field);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The `country` column of an address or store import resolves through `Country::getIdByName()` alone. An ISO code matches no name, so it falls through to the branch that creates a country - and that branch never sets `need_identification_number`, which is required, so it fails validation with `Property Country->need_identification_number is empty.` and the row ends up with no country at all. That is the error reported in this issue's own comment thread in 2020, where it was deferred to a separate issue that was never opened. Two changes: `resolveCountryId()` tries the ISO code when the name matches nothing, and the two creation branches set the missing required field. The name lookup stays first, so a shop that has literally named a country with two letters keeps resolving it the way it always did and nothing that already worked changes.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Import an address CSV whose `country` column holds `PL` rather than `14`. Before, the import reports `Country->need_identification_number is empty` followed by `Address->id_country is empty` and the address is imported without a country. After, it resolves to the existing Poland. `tests/Integration/Classes/controller/AdminImportControllerTest.php` covers both halves. Also check a country name that the shop does not have at all: before, the creation failed the same way; after, the country is created.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #21736
| Related PRs       |
| Sponsor company   |

### Why this is a bug fix and not the feature the label says

The issue is filed as a `Feature` asking for ISO codes to be accepted, and its premise - "this column accepts only IDs" - is wrong: names have always resolved. What actually happens with an ISO code is a failed import, and the second commenter posted a screenshot of exactly that failure. Measured on 9.2.x:

```
input 'PL'      getIdByName=false   getByIso=14   -> falls through to creating a country
input 'FR'      getIdByName=false   getByIso=8    -> falls through to creating a country
input 'Poland'  getIdByName=14                    -> resolves
input 'France'  getIdByName=8                     -> resolves
```

and the creation it falls through to cannot succeed:

```
Country as the import builds it   -> validateFields: 'Property Country->need_identification_number is empty.'
plus need_identification_number   -> validateFields: true
```

`Country` declares six required fields (`id_zone`, `iso_code`, `contains_states`, `need_identification_number`, `display_tax_label`, `name`); the import sets four. So no duplicate country is created either - I checked that first, because a non-unique `country_iso_code` index would have allowed one. `add()` is never reached.

### Design notes

The name lookup runs before the ISO lookup on purpose. A shop may name a country with two letters, that name won before, and putting ISO first would silently move those imports to a different country. Ordering it second makes the change strictly additive: it only rescues input that previously resolved to nothing.

`Country::getByIso()` throws on anything that is not an ISO code, and a `country` column holding a free-text name is the normal case here rather than an exceptional one, so the value is checked with `Validate::isLanguageIsoCode()` - the same predicate `getByIso()` itself demands - before being passed in.

Both fixes are applied to the address import and the store import, which carry the same code.

### Verification

`tests/Integration/Classes/controller/AdminImportControllerTest.php` - 5 tests, 15 assertions green,
run in the container that mounts this branch (`test_prestashop` at `PS_VERSION_DB=9.2.0`). The resolver tests take their fixture country from the database rather than hardcoding a name, and assert the name and the ISO code resolve to the same id, that lowercase works, that resolving by ISO creates no country, and that free text and an unknown ISO return 0 without throwing. On base the run is 5 tests / 9 assertions / **4 errors** - four fail with `Method AdminImportController::resolveCountryId() does not exist`, which only proves they exercise the new code, and the fifth passes because it is a contract pin rather than a red test. The behavioural base evidence is the measured table above. The creation test discriminates on its own: it asserts the exact validation error before the required field is set and `true` after.

php-cs-fixer and phpstan clean on both files.
