### PR TITLE
Read a theme's configuration again when its files have changed

### DIFF
--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -19,6 +19,16 @@ use Symfony\Component\Yaml\Parser;
 class ThemeRepository implements AddonRepositoryInterface
 {
     /**
+     * Key under which the JSON copy of theme.yml records what it was made from: the checksum of
+     * the yml, so a yml that has changed since can be recognized, and the page layouts as the yml
+     * declared them, so a value the merchant has since changed can be told apart from a default.
+     *
+     * ThemeManager::saveTheme() writes the whole attribute set back, so this entry survives a page
+     * layout customization.
+     */
+    private const SOURCE_KEY = '_source';
+
+    /**
      * @var ConfigurationInterface
      */
     private $appConfiguration;
@@ -59,10 +69,44 @@ class ThemeRepository implements AddonRepositoryInterface
             $jsonConf = $confDir . '/shop' . $this->shop->id . '.json';
         }
 
+        $ymlConf = $dir . '/config/theme.yml';
+        $ymlChecksum = $this->filesystem->exists($ymlConf) ? (md5_file($ymlConf) ?: null) : null;
+        $data = null;
+        $customizedLayouts = [];
+
         if ($this->filesystem->exists($jsonConf)) {
-            $data = $this->getConfigFromFile($jsonConf);
-        } else {
-            $data = $this->getConfigFromFile($dir . '/config/theme.yml');
+            $cachedData = $this->getConfigFromFile($jsonConf);
+
+            // The JSON file is a copy of theme.yml kept to skip the parsing, but the page layout
+            // customization is saved into it as well, so it cannot just be dropped when it goes out
+            // of date. Whatever replaced the theme's files - an update, a re-imported archive, a
+            // deployment - left this copy behind, still advertising the version and the settings of
+            // the theme that was installed. Rewrite it from theme.yml, and carry the customization
+            // over.
+            if (null === $ymlChecksum
+                || (isset($cachedData[self::SOURCE_KEY]['checksum']) && $cachedData[self::SOURCE_KEY]['checksum'] === $ymlChecksum)
+            ) {
+                $data = $cachedData;
+            } else {
+                $customizedLayouts = $this->getCustomizedLayouts($cachedData);
+            }
+        }
+
+        if (null === $data) {
+            $data = $this->getConfigFromFile($ymlConf);
+            $themeLayouts = $data['theme_settings']['layouts'] ?? [];
+
+            // A layout the new theme.yml no longer offers cannot be rendered - getLayoutPath()
+            // builds the template path from the name with no fallback - so the theme's own value is
+            // kept for those pages.
+            $availableLayouts = $data['meta']['available_layouts'] ?? [];
+            foreach ($customizedLayouts as $page => $layout) {
+                if (isset($availableLayouts[$layout])) {
+                    $data['theme_settings']['layouts'][$page] = $layout;
+                }
+            }
+
+            $data[self::SOURCE_KEY] = ['checksum' => $ymlChecksum, 'layouts' => $themeLayouts];
 
             // Write parsed yml data into json conf (faster parsing next time)
             $this->filesystem->dumpFile($jsonConf, json_encode($data));
@@ -71,6 +115,23 @@ class ThemeRepository implements AddonRepositoryInterface
         $data['directory'] = $dir;
 
         return new Theme($data);
+    }
+
+    /**
+     * Page layouts the merchant has changed, which is what the saved copy holds on top of the
+     * layouts theme.yml declared when that copy was written. A copy written before this was
+     * recorded has no baseline to compare against, so all of its layouts are kept.
+     *
+     * @param array<string, mixed> $cachedData
+     *
+     * @return array<string, string>
+     */
+    private function getCustomizedLayouts(array $cachedData): array
+    {
+        return array_diff_assoc(
+            $cachedData['theme_settings']['layouts'] ?? [],
+            $cachedData[self::SOURCE_KEY]['layouts'] ?? []
+        );
     }
 
     public function getList()

--- a/tests/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Addon\Theme;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Dumper;
+
+class ThemeRepositoryTest extends TestCase
+{
+    private const THEME_NAME = 'unit-test-theme';
+
+    /**
+     * @var string
+     */
+    private $workspace;
+
+    /**
+     * @var CountingFilesystem
+     */
+    private $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->workspace = sys_get_temp_dir() . '/ThemeRepositoryTest/' . uniqid('', true);
+        $this->filesystem = new CountingFilesystem();
+        $this->filesystem->mkdir($this->workspace . '/themes/' . self::THEME_NAME . '/config');
+        $this->filesystem->mkdir($this->workspace . '/config/themes');
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->workspace);
+
+        parent::tearDown();
+    }
+
+    public function testTheConfigurationIsReadFromTheThemeOnAFirstRead(): void
+    {
+        $this->writeThemeYml('1.0.0');
+
+        $this->assertSame('1.0.0', $this->getRepository()->getInstanceByName(self::THEME_NAME)->get('version'));
+        $this->assertFileExists($this->jsonConfPath());
+    }
+
+    public function testTheConfigurationIsReadAgainAfterTheThemeFilesAreReplaced(): void
+    {
+        $this->writeThemeYml('1.0.0');
+        $this->getRepository()->getInstanceByName(self::THEME_NAME);
+
+        // What an update, a re-imported archive or a deployment does: the theme's own files are
+        // replaced, and nothing touches the copy left under config/themes.
+        $this->writeThemeYml('2.0.0');
+
+        $theme = $this->getRepository()->getInstanceByName(self::THEME_NAME);
+
+        $this->assertSame('2.0.0', $theme->get('version'));
+        $this->assertSame('2.0.0', json_decode((string) file_get_contents($this->jsonConfPath()), true)['version']);
+    }
+
+    public function testTheCopyIsNotRewrittenWhileTheThemeIsUnchanged(): void
+    {
+        $this->writeThemeYml('1.0.0');
+
+        $this->getRepository()->getInstanceByName(self::THEME_NAME);
+        $writesAfterFirstRead = $this->filesystem->dumpFileCalls;
+        $this->getRepository()->getInstanceByName(self::THEME_NAME);
+
+        $this->assertSame(1, $writesAfterFirstRead);
+        $this->assertSame(1, $this->filesystem->dumpFileCalls, 'the parsed copy must still be used as a cache');
+    }
+
+    public function testThePageLayoutCustomizationSurvivesTheRefresh(): void
+    {
+        $this->writeThemeYml('1.0.0');
+        $this->getRepository()->getInstanceByName(self::THEME_NAME);
+        $this->customizeSavedLayouts(['category' => 'layout-left-column']);
+
+        // The new theme declares a different layout for a page the merchant never touched, so the
+        // two halves can be told apart: one value has to come from the copy, the other from the yml.
+        $this->writeThemeYml('2.0.0', null, ['category' => 'layout-full-width', 'contact' => 'layout-right-column']);
+
+        $layouts = $this->getRepository()->getInstanceByName(self::THEME_NAME)->getPageLayouts();
+
+        $this->assertSame('layout-left-column', $layouts['category'], 'the customized layout must survive');
+        $this->assertSame('layout-right-column', $layouts['contact'], 'an untouched page must follow the new theme');
+    }
+
+    public function testACustomizedLayoutTheNewThemeDroppedIsNotCarriedOver(): void
+    {
+        $this->writeThemeYml('1.0.0');
+        $this->getRepository()->getInstanceByName(self::THEME_NAME);
+        $this->customizeSavedLayouts(['category' => 'layout-left-column']);
+
+        $this->writeThemeYml('2.0.0', ['layout-full-width' => ['name' => 'Full width']]);
+
+        $layouts = $this->getRepository()->getInstanceByName(self::THEME_NAME)->getPageLayouts();
+
+        $this->assertSame('layout-full-width', $layouts['category']);
+    }
+
+    public function testACopyWrittenBeforeTheBaselineExistedKeepsItsLayouts(): void
+    {
+        // Every shop already on disk has a copy like this one: no record of what it was made from.
+        $this->writeThemeYml('1.0.0');
+        (new Filesystem())->dumpFile($this->jsonConfPath(), (string) json_encode([
+            'name' => self::THEME_NAME,
+            'version' => '0.9.0',
+            'theme_settings' => ['default_layout' => 'layout-full-width', 'layouts' => ['category' => 'layout-left-column']],
+        ]));
+
+        $theme = $this->getRepository()->getInstanceByName(self::THEME_NAME);
+
+        $this->assertSame('1.0.0', $theme->get('version'));
+        $this->assertSame('layout-left-column', $theme->getPageLayouts()['category']);
+    }
+
+    public function testTheCopyIsKeptWhenTheThemeConfigurationIsGone(): void
+    {
+        $this->writeThemeYml('1.0.0');
+        $this->getRepository()->getInstanceByName(self::THEME_NAME);
+        (new Filesystem())->remove($this->themeYmlPath());
+
+        $this->assertSame('1.0.0', $this->getRepository()->getInstanceByName(self::THEME_NAME)->get('version'));
+    }
+
+    private function getRepository(): ThemeRepository
+    {
+        $configuration = $this->createMock(ConfigurationInterface::class);
+        $configuration->method('get')->willReturnMap([
+            ['_PS_ALL_THEMES_DIR_', $this->workspace . '/themes/'],
+            ['_PS_CONFIG_DIR_', $this->workspace . '/config/'],
+        ]);
+
+        return new ThemeRepository($configuration, $this->filesystem, null);
+    }
+
+    private function jsonConfPath(): string
+    {
+        return $this->workspace . '/config/themes/' . self::THEME_NAME . '/theme.json';
+    }
+
+    private function themeYmlPath(): string
+    {
+        return $this->workspace . '/themes/' . self::THEME_NAME . '/config/theme.yml';
+    }
+
+    /**
+     * @param array<string, array<string, string>>|null $availableLayouts
+     * @param array<string, string>|null $layouts
+     */
+    private function writeThemeYml(string $version, ?array $availableLayouts = null, ?array $layouts = null): void
+    {
+        $configuration = [
+            'name' => self::THEME_NAME,
+            'display_name' => 'Unit test theme',
+            'version' => $version,
+            'meta' => ['available_layouts' => $availableLayouts ?? [
+                'layout-full-width' => ['name' => 'Full width'],
+                'layout-left-column' => ['name' => 'Left column'],
+                'layout-right-column' => ['name' => 'Right column'],
+            ]],
+            'theme_settings' => [
+                'default_layout' => 'layout-full-width',
+                'layouts' => $layouts ?? ['category' => 'layout-full-width', 'contact' => 'layout-full-width'],
+            ],
+        ];
+
+        (new Filesystem())->dumpFile($this->themeYmlPath(), (new Dumper())->dump($configuration, 4));
+    }
+
+    /**
+     * Replays what ThemeManager::saveTheme() writes when a merchant customizes the page layouts.
+     *
+     * @param array<string, string> $layouts
+     */
+    private function customizeSavedLayouts(array $layouts): void
+    {
+        $saved = json_decode((string) file_get_contents($this->jsonConfPath()), true);
+        $saved['theme_settings']['layouts'] = array_merge($saved['theme_settings']['layouts'], $layouts);
+
+        (new Filesystem())->dumpFile($this->jsonConfPath(), (string) json_encode($saved));
+    }
+}
+
+class CountingFilesystem extends Filesystem
+{
+    /**
+     * @var int
+     */
+    public $dumpFileCalls = 0;
+
+    public function dumpFile(string $filename, $content): void
+    {
+        ++$this->dumpFileCalls;
+
+        parent::dumpFile($filename, $content);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `config/themes/<theme>/shop<id>.json` is a parsed copy of the theme's `config/theme.yml`, and `ThemeRepository::getInstanceByName()` prefers it with nothing to invalidate it. Replacing a theme's files therefore leaves the shop reading the configuration of the version that was installed - the version shown on Design > Theme & Logo, but also `global_settings`, `theme_settings` and `assets`. The copy now records the checksum of the theme.yml it was made from and is rewritten from theme.yml when the two no longer match. It is rewritten rather than deleted, because the page layout customization is saved into that same file.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Note the version on Design > Theme & Logo, change `version` in `themes/<theme>/config/theme.yml`, and reload the page. Before: the old version. After: the new one, and `config/themes/<theme>/shop<id>.json` has been rewritten. Then set a page layout under Design > Theme & Logo > Choose layouts, change the theme's `version` again, and reload: the layout you chose is still chosen, while a page you did not touch follows the theme's new value. `tests/Unit/Core/Addon/Theme/ThemeRepositoryTest.php` covers both, and that an unchanged theme is still served from the copy.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes PrestaShop/autoupgrade#1759
| Related PRs       | #41851, #42623
| Sponsor company   |

## The copy is preferred and never invalidated

```php
$jsonConf = $confDir . '/shop' . $this->shop->id . '.json';
if ($this->filesystem->exists($jsonConf)) {
    $data = $this->getConfigFromFile($jsonConf);
} else {
    $data = $this->getConfigFromFile($dir . '/config/theme.yml');
    // Write parsed yml data into json conf (faster parsing next time)
    $this->filesystem->dumpFile($jsonConf, json_encode($data));
}
```

`Shop::setTheme()` builds the theme through that method, so this is the configuration the whole
shop runs on. The reported symptom is the version on Design > Theme & Logo, but `global_settings`
(image types, modules to enable, hooks), `theme_settings` and `assets` come out of the same copy,
which is why the fix belongs here and not in whatever renders the version.

The update path reaches it only when the merchant keeps their theme:
`CoreUpgrader::switchToDefaultTheme()` calls `ThemeManager::enable()`, which unlinks that file, but
it returns early when `shouldSwitchToDefaultTheme()` is false. Keeping the theme is the reported
case, and it is the default in the update wizard.

## Why it is fixed here rather than per path

The same staleness is reachable four ways: an update replaces the theme's files, a merchant
re-imports an upgraded archive (`installFromZip()` refuses to install over an existing directory,
so this means uninstall then import), a deployment checks the theme out, or a theme developer edits
`theme.yml`. Each has its own PR-sized fix, and #41851 is one of them; a single check in the
repository covers all four, and covers whatever comes next.

## Preserving the customization needed a baseline

`ThemePageLayoutsCustomizer::customize()` calls `Theme::setPageLayouts()`, which writes
`theme_settings.layouts`, then `ThemeManager::saveTheme()`, which dumps the *whole* attribute set
back into the same JSON. So the saved layouts are the merchant's choices merged over the previous
theme.yml's defaults, with nothing to tell the two apart. Keeping the whole map would pin the old
theme's layout defaults forever - the same staleness, narrowed to one key - and keeping none would
lose the customization, which is what @Hlavtox warned about on the issue.

So the copy also records the layouts as theme.yml declared them at the time it was written:

```php
$data[self::SOURCE_KEY] = ['checksum' => $ymlChecksum, 'layouts' => $themeLayouts];
```

and the customization is what the saved map holds on top of that baseline
(`array_diff_assoc`). `saveTheme()` writes the whole attribute set, so the baseline survives a
layout save without touching `ThemeManager`.

A copy written before this existed has no baseline, so all of its layouts are treated as
customization - conservative, and no worse than current behaviour, which keeps them anyway. After
the first refresh the baseline is there.

A customized layout the new theme.yml no longer lists is dropped in favour of the new file's value:
`Theme::getLayoutPath()` is `'layouts/' . $layoutName . '.tpl'` with no fallback, so keeping it
would point the front office at a template that is not there.

## The copy still works as a cache

The check is `md5_file()` on theme.yml, not a parse. Measured on PHP 8.1 against hummingbird's
`theme.yml` (6117 bytes), 300 iterations:

| operation | per call |
| --- | --- |
| `md5_file()` on theme.yml | 0.0115 ms |
| `json_decode()` of the copy | 0.0171 ms |
| `Yaml\Parser::parse()` of theme.yml | 1.0478 ms |

So the added cost is about two thirds of the read it guards, and it keeps avoiding a parse that is
61 times more expensive. That ratio is why the invalidation is a checksum and not "parse the yml and
compare the version": reading the version out of theme.yml costs the parse the copy exists to skip.

`filemtime()` is cheaper still (0.0009 ms) and was rejected: a release archive carries its own
entry timestamps, so a theme.yml extracted from it can be older than the copy it should invalidate,
and the check would silently do nothing.

`Filesystem::dumpFile()` writes to a temporary file and renames, so concurrent requests arriving on
a shop whose theme has just changed cannot see a partial file.

## Verification

- `tests/Unit/Core/Addon/Theme/ThemeRepositoryTest.php`: 7 tests, 12 assertions, green. The whole
  `tests/Unit/Core/Addon/Theme` directory is 17 tests / 36 assertions, and
  `tests/Integration/Core/Addon/Theme/ThemeRepositoryTest.php` is 4 / 6, both green.
- Mutation: reverting `ThemeRepository.php` fails 4 of the 7 - the version after a change
  (`'2.0.0'` vs `'1.0.0'`), the untouched page following the new theme
  (`'layout-right-column'` vs `'layout-full-width'`), the dropped layout
  (`'layout-full-width'` vs `'layout-left-column'`), and the copy with no baseline
  (`'1.0.0'` vs `'0.9.0'`). The other three pass on the base by construction: they are controls.
- The control that matters for the cache claim is
  `testTheCopyIsNotRewrittenWhileTheThemeIsUnchanged`, which counts `dumpFile()` calls through a
  `Filesystem` subclass. Forcing the refresh to fire unconditionally makes it fail with
  "Failed asserting that 2 is identical to 1" - so it discriminates, and a fix that quietly turned
  the cache off would not pass.
- The layout fixture had to be built so the two halves can be told apart: the new theme.yml declares
  a different layout for a page the merchant never touched, so one asserted value has to come from
  the copy and the other from the yml. With both pages on the same layout the test passed on the base
  branch as well.
- End to end on a running shop, through the same path `Shop::setTheme()` uses
  (`ThemeManagerBuilder::buildRepository($shop)->getInstanceByName()`): with hummingbird at 2.1.0 the
  read is 2.1.0 and the copy gains its baseline; after customizing one page layout and changing the
  yml version to 9.9.9 the read is 9.9.9, the customized page keeps `layout-full-width` while the
  theme declares `layout-left-column` for it, and an untouched page follows the new file. Restoring
  the yml reads 2.1.0 again. Those JSON files are gitignored, so the working tree stayed clean.
- `php-cs-fixer` reports 0 of 2 files to fix; `phpstan` on the changed source file: no errors.
