### PR TITLE
Match the full name when filtering grids by customer or employee

### DIFF
--- a/src/Core/Grid/Query/CustomerThreadQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerThreadQueryBuilder.php
@@ -198,7 +198,9 @@ class CustomerThreadQueryBuilder extends AbstractDoctrineQueryBuilder
             }
 
             if ($filterName === 'employee') {
-                $builder->andWhere('CONCAT(LEFT(e.`firstname`, 1),". ",e.`lastname`) LIKE :' . $filterName);
+                // The column is displayed abbreviated, but a merchant searching it types the real
+                // first name, so match the full name here - as the customer filter above already does.
+                $builder->andWhere('CONCAT(e.`firstname`," ",e.`lastname`) LIKE :' . $filterName);
                 $builder->setParameter($filterName, '%' . $filterValue . '%');
                 continue;
             }

--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -78,7 +78,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
         ;
         $paginatedIdsQb = $this->applyNewCustomerFilter($paginatedIdsQb, $searchCriteria->getFilters());
         // WHY: no `customer` SELECT alias exists in the id-only query, so sort by its expression.
-        $this->applySorting($paginatedIdsQb, $searchCriteria, $this->getCustomerField());
+        $this->applySorting($paginatedIdsQb, $searchCriteria, $this->getCustomerField(false));
         $this->criteriaApplicator
             ->applyPagination($searchCriteria, $paginatedIdsQb)
             ->applyDeterministicSorting($searchCriteria, $paginatedIdsQb, 'o', 'id_order')
@@ -86,7 +86,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
 
         $qb = $this->connection
             ->createQueryBuilder()
-            ->select($this->getCustomerField() . ' AS `customer`')
+            ->select($this->getCustomerField(false) . ' AS `customer`')
             ->addSelect('o.id_order, o.reference, o.total_paid_tax_incl, os.paid, osl.name AS osname')
             ->addSelect('o.id_currency, cur.iso_code')
             ->addSelect('o.current_state, o.id_customer')
@@ -258,10 +258,17 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
     }
 
     /**
+     * The customer column is displayed abbreviated to keep it narrow, but a merchant searching it
+     * types the real first name, so the filter has to match the full name.
+     *
      * @return string
      */
-    private function getCustomerField()
+    private function getCustomerField(bool $includeFullFirstname = true)
     {
+        if ($includeFullFirstname) {
+            return 'CONCAT(cu.`firstname`, \' \', cu.`lastname`)';
+        }
+
         return 'CONCAT(LEFT(cu.`firstname`, 1), \'. \', cu.`lastname`)';
     }
 

--- a/src/Core/Grid/Query/OutstandingQueryBuilder.php
+++ b/src/Core/Grid/Query/OutstandingQueryBuilder.php
@@ -68,7 +68,7 @@ final class OutstandingQueryBuilder implements DoctrineQueryBuilderInterface
     {
         $qb = $this->getBaseQueryBuilder($searchCriteria)
             ->addSelect('oi.id_order_invoice AS id_invoice, oi.date_add')
-            ->addSelect('CONCAT(LEFT(c.`firstname`, 1), \'. \' , c.`lastname`) AS customer')
+            ->addSelect($this->getCustomerField(false) . ' AS customer')
             ->addSelect('c.company, rl.name AS risk, r.color')
             ->addSelect('c.outstanding_allow_amount')
             ->addSelect('c.id_customer, o.id_order')
@@ -127,7 +127,7 @@ final class OutstandingQueryBuilder implements DoctrineQueryBuilderInterface
         ];
 
         $likeComparisonFilters = [
-            'customer' => 'CONCAT(LEFT(c.firstname, 1), \'. \' , c.lastname)',
+            'customer' => $this->getCustomerField(),
             'company' => 'c.company',
         ];
 
@@ -185,7 +185,7 @@ final class OutstandingQueryBuilder implements DoctrineQueryBuilderInterface
         $sortableFields = [
             'id_invoice' => 'oi.id_order_invoice',
             'date_add' => 'oi.date_add',
-            'customer' => 'CONCAT(LEFT(c.firstname, 1), \'. \' , c.lastname)',
+            'customer' => $this->getCustomerField(false),
             'company' => 'c.company',
             'risk' => 'r.id_risk',
             'outstanding_allow_amount' => 'c.outstanding_allow_amount',
@@ -194,5 +194,20 @@ final class OutstandingQueryBuilder implements DoctrineQueryBuilderInterface
         if (isset($sortableFields[$criteria->getOrderBy()])) {
             $qb->orderBy($sortableFields[$criteria->getOrderBy()], $criteria->getOrderWay());
         }
+    }
+
+    /**
+     * The customer column is displayed abbreviated to keep it narrow, but a merchant searching it
+     * types the real first name, so the filter has to match the full name.
+     *
+     * @return string
+     */
+    private function getCustomerField(bool $includeFullFirstname = true): string
+    {
+        if ($includeFullFirstname) {
+            return 'CONCAT(c.`firstname`, \' \', c.`lastname`)';
+        }
+
+        return 'CONCAT(LEFT(c.`firstname`, 1), \'. \', c.`lastname`)';
     }
 }

--- a/tests/Integration/Core/Grid/Query/CustomerThreadQueryBuilderTest.php
+++ b/tests/Integration/Core/Grid/Query/CustomerThreadQueryBuilderTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use PrestaShop\PrestaShop\Core\Grid\Query\CustomerThreadQueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicator;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class CustomerThreadQueryBuilderTest extends KernelTestCase
+{
+    private const CONTEXT_LANG_ID = 1;
+    private const CONTEXT_SHOP_ID = 1;
+
+    private Connection $connection;
+    private string $dbPrefix;
+    private CustomerThreadQueryBuilder $queryBuilder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->dbPrefix = self::getContainer()->getParameter('database_prefix');
+        $this->queryBuilder = new CustomerThreadQueryBuilder(
+            $this->connection,
+            $this->dbPrefix,
+            new DoctrineSearchCriteriaApplicator(),
+            [self::CONTEXT_SHOP_ID]
+        );
+    }
+
+    /**
+     * The Employee column is rendered abbreviated ("P. Mummy") and the filter used to match that
+     * same expression, so searching by an employee's real first name returned nothing - while the
+     * customer filter directly above it in the same method already matched the full name.
+     */
+    public function testEmployeeFilterMatchesTheFullFirstName(): void
+    {
+        $searchedEmployee = $this->insertEmployee('Zzjonathan', 'Zzsmith');
+        $otherEmployee = $this->insertEmployee('Zzmarianne', 'Zzjones');
+        $searchedThread = $this->insertThread();
+        $otherThread = $this->insertThread();
+        $searchedMessage = $this->insertMessage($searchedThread, $searchedEmployee);
+        $otherMessage = $this->insertMessage($otherThread, $otherEmployee);
+
+        try {
+            $this->assertSame([$searchedThread], $this->fetchThreadIds('Zzjonathan'));
+            $this->assertSame([$otherThread], $this->fetchThreadIds('Zzmarianne'));
+            // Searching by last name worked before the fix and must keep working.
+            $this->assertSame([$searchedThread], $this->fetchThreadIds('Zzsmith'));
+        } finally {
+            $this->deleteFrom('customer_message', 'id_customer_message', [$searchedMessage, $otherMessage]);
+            $this->deleteFrom('customer_thread', 'id_customer_thread', [$searchedThread, $otherThread]);
+            $this->deleteFrom('employee', 'id_employee', [$searchedEmployee, $otherEmployee]);
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    private function fetchThreadIds(string $search): array
+    {
+        $rows = $this->queryBuilder
+            ->getSearchQueryBuilder($this->createSearchCriteria(['employee' => $search]))
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map('intval', array_column($rows, 'id_customer_thread'));
+    }
+
+    private function insertEmployee(string $firstname, string $lastname): int
+    {
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'employee
+                (id_profile, id_lang, lastname, firstname, email, passwd, active)
+             VALUES (1, :lang, :lastname, :firstname, :email, :passwd, 1)',
+            [
+                'lang' => self::CONTEXT_LANG_ID,
+                'lastname' => $lastname,
+                'firstname' => $firstname,
+                'email' => strtolower($firstname . '.' . $lastname) . '@thread-grid-test.invalid',
+                'passwd' => 'thread-grid-test',
+            ]
+        );
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function insertThread(): int
+    {
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'customer_thread
+                (id_shop, id_lang, id_contact, id_customer, id_order, id_product, status, email,
+                 token, date_add, date_upd)
+             VALUES (:shop, :lang, 0, 0, 0, 0, :status, :email, :token, NOW(), NOW())',
+            [
+                'shop' => self::CONTEXT_SHOP_ID,
+                'lang' => self::CONTEXT_LANG_ID,
+                'status' => 'open',
+                'email' => 'thread@thread-grid-test.invalid',
+                'token' => 'zzgridtest',
+            ]
+        );
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function insertMessage(int $threadId, int $employeeId): int
+    {
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'customer_message
+                (id_customer_thread, id_employee, id_product, message, private, `read`, date_add, date_upd)
+             VALUES (:thread, :employee, 0, :message, 0, 0, NOW(), NOW())',
+            [
+                'thread' => $threadId,
+                'employee' => $employeeId,
+                'message' => 'Reply from the grid test employee',
+            ]
+        );
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    /**
+     * @param int[] $ids
+     */
+    private function deleteFrom(string $table, string $idColumn, array $ids): void
+    {
+        $this->connection->executeStatement(
+            'DELETE FROM ' . $this->dbPrefix . $table . ' WHERE ' . $idColumn . ' IN (:ids)',
+            ['ids' => $ids],
+            ['ids' => Connection::PARAM_INT_ARRAY]
+        );
+    }
+
+    private function createSearchCriteria(array $filters): SearchCriteriaInterface
+    {
+        return new class($filters) implements SearchCriteriaInterface {
+            /**
+             * @param array<string, mixed> $filters
+             */
+            public function __construct(private array $filters)
+            {
+            }
+
+            public function getOrderBy()
+            {
+                return 'id_customer_thread';
+            }
+
+            public function getOrderWay()
+            {
+                return 'DESC';
+            }
+
+            public function getOffset()
+            {
+                return 0;
+            }
+
+            public function getLimit()
+            {
+                return 50;
+            }
+
+            public function getFilters()
+            {
+                return $this->filters;
+            }
+        };
+    }
+}

--- a/tests/Integration/Core/Grid/Query/OrderQueryBuilderTest.php
+++ b/tests/Integration/Core/Grid/Query/OrderQueryBuilderTest.php
@@ -150,6 +150,77 @@ class OrderQueryBuilderTest extends KernelTestCase
         return array_map('intval', array_column($rows, 'id_order'));
     }
 
+    /**
+     * The customer column is rendered abbreviated ("J. Doe"), and the filter used to match that same
+     * expression, so searching the grid for a customer's real first name returned nothing. The
+     * filter has to match the full name while the column keeps its narrow display form.
+     */
+    public function testCustomerFilterMatchesTheFullFirstName(): void
+    {
+        $address = $this->insertAddress(1);
+        $searched = $this->insertCustomer('Zzjonathan', 'Zzsmith');
+        $other = $this->insertCustomer('Zzmarianne', 'Zzjones');
+        $searchedOrder = $this->insertOrder($address, 1, $searched);
+        $otherOrder = $this->insertOrder($address, 1, $other);
+
+        try {
+            // The first name is only present in full in the underlying column, never in "Z. Zzsmith".
+            $this->assertSame(
+                [$searchedOrder],
+                $this->fetchOrderIds($this->createSearchCriteria(['customer' => 'Zzjonathan'], 'id_order', 'DESC', 50, 0))
+            );
+
+            // The other customer must not come along: proves the filter still discriminates.
+            $this->assertSame(
+                [$otherOrder],
+                $this->fetchOrderIds($this->createSearchCriteria(['customer' => 'Zzmarianne'], 'id_order', 'DESC', 50, 0))
+            );
+
+            // Searching by last name kept working before the fix and must keep working after it.
+            $this->assertSame(
+                [$searchedOrder],
+                $this->fetchOrderIds($this->createSearchCriteria(['customer' => 'Zzsmith'], 'id_order', 'DESC', 50, 0))
+            );
+        } finally {
+            $this->deleteOrders([$searchedOrder, $otherOrder]);
+            $this->deleteCustomers([$searched, $other]);
+            $this->deleteAddresses([$address]);
+        }
+    }
+
+    private function insertCustomer(string $firstname, string $lastname): int
+    {
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'customer
+                (id_shop_group, id_shop, id_gender, id_default_group, id_lang, firstname, lastname,
+                 email, passwd, active, date_add, date_upd)
+             VALUES (1, :shop, 0, 3, :lang, :firstname, :lastname, :email, :passwd, 1, NOW(), NOW())',
+            [
+                'shop' => self::CONTEXT_SHOP_ID,
+                'lang' => self::CONTEXT_LANG_ID,
+                'firstname' => $firstname,
+                'lastname' => $lastname,
+                'email' => strtolower($firstname . '.' . $lastname) . '@order-grid-test.invalid',
+                'passwd' => 'order-grid-test',
+            ]
+        );
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function deleteCustomers(array $customerIds): void
+    {
+        if (empty($customerIds)) {
+            return;
+        }
+
+        $this->connection->executeStatement(
+            'DELETE FROM ' . $this->dbPrefix . 'customer WHERE id_customer IN (:ids)',
+            ['ids' => $customerIds],
+            ['ids' => Connection::PARAM_INT_ARRAY]
+        );
+    }
+
     private function insertAddress(int $countryId): int
     {
         $this->connection->executeStatement(
@@ -170,7 +241,7 @@ class OrderQueryBuilderTest extends KernelTestCase
         return (int) $this->connection->lastInsertId();
     }
 
-    private function insertOrder(int $addressId, int $orderStateId = 1): int
+    private function insertOrder(int $addressId, int $orderStateId = 1, ?int $customerId = null): int
     {
         $this->connection->executeStatement(
             'INSERT INTO ' . $this->dbPrefix . 'orders
@@ -185,7 +256,7 @@ class OrderQueryBuilderTest extends KernelTestCase
                 'orderState' => $orderStateId,
                 'currency' => 1,
                 'lang' => self::CONTEXT_LANG_ID,
-                'customer' => self::DEMO_CUSTOMER_ID,
+                'customer' => $customerId ?? self::DEMO_CUSTOMER_ID,
                 'payment' => 'Test payment',
                 'reference' => 'ORDERGRIDTEST',
                 'shop' => self::CONTEXT_SHOP_ID,

--- a/tests/Integration/Core/Grid/Query/OutstandingQueryBuilderTest.php
+++ b/tests/Integration/Core/Grid/Query/OutstandingQueryBuilderTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicator;
+use PrestaShop\PrestaShop\Core\Grid\Query\OutstandingQueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class OutstandingQueryBuilderTest extends KernelTestCase
+{
+    private const CONTEXT_LANG_ID = 1;
+    private const CONTEXT_SHOP_ID = 1;
+
+    private Connection $connection;
+    private string $dbPrefix;
+    private OutstandingQueryBuilder $queryBuilder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->dbPrefix = self::getContainer()->getParameter('database_prefix');
+        $this->queryBuilder = new OutstandingQueryBuilder(
+            $this->connection,
+            $this->dbPrefix,
+            new DoctrineSearchCriteriaApplicator(),
+            self::CONTEXT_LANG_ID,
+            [self::CONTEXT_SHOP_ID]
+        );
+    }
+
+    /**
+     * The customer column is rendered abbreviated ("J. Doe") and the filter used to match that same
+     * expression, so searching the outstanding grid for a customer's real first name returned
+     * nothing. The filter has to match the full name while the column keeps its display form.
+     */
+    public function testCustomerFilterMatchesTheFullFirstName(): void
+    {
+        $searched = $this->insertCustomer('Zzjonathan', 'Zzsmith');
+        $other = $this->insertCustomer('Zzmarianne', 'Zzjones');
+        $searchedOrder = $this->insertOrder($searched);
+        $otherOrder = $this->insertOrder($other);
+        $searchedInvoice = $this->insertInvoice($searchedOrder);
+        $otherInvoice = $this->insertInvoice($otherOrder);
+
+        try {
+            $this->assertSame([$searchedInvoice], $this->fetchInvoiceIds('Zzjonathan'));
+            $this->assertSame([$otherInvoice], $this->fetchInvoiceIds('Zzmarianne'));
+            // Searching by last name worked before the fix and must keep working.
+            $this->assertSame([$searchedInvoice], $this->fetchInvoiceIds('Zzsmith'));
+        } finally {
+            $this->connection->executeStatement(
+                'DELETE FROM ' . $this->dbPrefix . 'order_invoice WHERE id_order_invoice IN (:ids)',
+                ['ids' => [$searchedInvoice, $otherInvoice]],
+                ['ids' => Connection::PARAM_INT_ARRAY]
+            );
+            $this->connection->executeStatement(
+                'DELETE FROM ' . $this->dbPrefix . 'orders WHERE id_order IN (:ids)',
+                ['ids' => [$searchedOrder, $otherOrder]],
+                ['ids' => Connection::PARAM_INT_ARRAY]
+            );
+            $this->connection->executeStatement(
+                'DELETE FROM ' . $this->dbPrefix . 'customer WHERE id_customer IN (:ids)',
+                ['ids' => [$searched, $other]],
+                ['ids' => Connection::PARAM_INT_ARRAY]
+            );
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    private function fetchInvoiceIds(string $search): array
+    {
+        $rows = $this->queryBuilder
+            ->getSearchQueryBuilder($this->createSearchCriteria(['customer' => $search]))
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map('intval', array_column($rows, 'id_invoice'));
+    }
+
+    private function insertCustomer(string $firstname, string $lastname): int
+    {
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'customer
+                (id_shop_group, id_shop, id_gender, id_default_group, id_lang, firstname, lastname,
+                 email, passwd, active, date_add, date_upd)
+             VALUES (1, :shop, 0, 3, :lang, :firstname, :lastname, :email, :passwd, 1, NOW(), NOW())',
+            [
+                'shop' => self::CONTEXT_SHOP_ID,
+                'lang' => self::CONTEXT_LANG_ID,
+                'firstname' => $firstname,
+                'lastname' => $lastname,
+                'email' => strtolower($firstname . '.' . $lastname) . '@outstanding-grid-test.invalid',
+                'passwd' => 'outstanding-grid-test',
+            ]
+        );
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function insertOrder(int $customerId): int
+    {
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'orders
+                (id_address_delivery, id_address_invoice, id_cart, id_currency, id_lang, id_customer,
+                 id_carrier, current_state, payment, reference, id_shop, id_shop_group,
+                 date_add, date_upd, delivery_date, invoice_date, valid)
+             VALUES (0, 0, 0, 1, :lang, :customer, 0, 1, :payment, :reference, :shop, 1,
+                 NOW(), NOW(), NOW(), NOW(), 1)',
+            [
+                'lang' => self::CONTEXT_LANG_ID,
+                'customer' => $customerId,
+                'payment' => 'Test payment',
+                'reference' => 'OUTSTANDINGTEST',
+                'shop' => self::CONTEXT_SHOP_ID,
+            ]
+        );
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function insertInvoice(int $orderId): int
+    {
+        // The grid only lists invoices with a number, hence `number > 0` in the base query.
+        $this->connection->executeStatement(
+            'INSERT INTO ' . $this->dbPrefix . 'order_invoice
+                (id_order, number, delivery_number, shipping_tax_computation_method, date_add)
+             VALUES (:order, 1, 0, 0, NOW())',
+            ['order' => $orderId]
+        );
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function createSearchCriteria(array $filters): SearchCriteriaInterface
+    {
+        return new class($filters) implements SearchCriteriaInterface {
+            /**
+             * @param array<string, mixed> $filters
+             */
+            public function __construct(private array $filters)
+            {
+            }
+
+            public function getOrderBy()
+            {
+                return 'id_invoice';
+            }
+
+            public function getOrderWay()
+            {
+                return 'DESC';
+            }
+
+            public function getOffset()
+            {
+                return 0;
+            }
+
+            public function getLimit()
+            {
+                return 50;
+            }
+
+            public function getFilters()
+            {
+                return $this->filters;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | The Orders, Outstanding and Customer Service grids render the person's name abbreviated (`CONCAT(LEFT(firstname, 1), '. ', lastname)`) to keep the column narrow, and their filters matched that same expression. Searching any of them by the customer's or employee's real first name therefore returns nothing. Filtering now matches the full name; the displayed value and the sort order are unchanged. This is what `LogQueryBuilder` already does for its employee column, and what `CustomerThreadQueryBuilder`'s own customer filter does two branches above the employee filter this fixes.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop whose customer is "John DOE", open BO > Orders and filter the Customer column by `John`: before the change no order is listed, after it every order of that customer is. `DOE` keeps working in both. Same on BO > Customers > Outstanding (Customer column) and BO > Customer Service (Employee column). `tests/Integration/Core/Grid/Query/` covers all three.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #24993
| Related PRs       |
| Sponsor company   |

### Measured on a 9.2 install (4 orders, 2 customers)

```
term       current hits   fixed hits
John                  0            3
Marie                 0            1
DOE                   3            3
MARTIN                1            1
John DOE              0            3
```

The second customer matters: with only "John DOE" in the table, every query returns 0 or 3 and
"3" cannot distinguish "matched John" from "matched everything" ([[vary-arity-not-just-values]]).

### Sites

| File | Filter before | After |
| --- | --- | --- |
| `OrderQueryBuilder:186` | `getCustomerField()` = abbreviated | `getCustomerField()` = full; display and sort call `getCustomerField(false)` |
| `OutstandingQueryBuilder:130` | inline abbreviated CONCAT | new `getCustomerField(bool)` helper, same shape |
| `CustomerThreadQueryBuilder:201` | abbreviated employee CONCAT | full name |

In-tree counter-examples that were already correct and set the pattern: `LogQueryBuilder::getEmployeeField(bool)`,
`CartQueryBuilder:219`, `CustomerThreadQueryBuilder:194` (customer).

### Verification

- Mutation per grid: revert that grid's filter expression to the abbreviated form -> that grid's test
  fails and no other. Done for all three.
- `tests/Integration/Core/Grid/Query/`: 6 tests, 13 assertions, green. php-cs-fixer clean, PHPStan `[OK]`.
- `CartQueryBuilder:219` deliberately untouched: it already searches real names, and its
  un-parenthesised `A OR B OR C` inside `andWhere()` is safe because DBAL's
  `CompositeExpression::__toString()` wraps every part in parentheses (read in `vendor/`).

### Observed, deliberately NOT changed

- **Sorting** still uses the abbreviated expression (`OrderQueryBuilder:81`, `OutstandingQueryBuilder:188`),
  so the Customer column sorts by first initial then surname and surnames interleave. Separate defect,
  separate decision; not folded in.
- **`CustomerThreadQueryBuilder` display vs filter semantics**: the `employee` column is a correlated
  sub-select resolving the LAST employee to reply, while the filter matches ANY employee who replied on
  the thread (through the outer `cm`/`e` join, which does exist - the alias is valid). Pre-existing and
  arguably the more useful semantics; out of scope here.
- The Outstanding and Customer Service grids have no issue of their own. They are fixed here because
  they are the same defect, and this note is the record of that ([[fix-the-whole-class-not-a-list]]).

### Not what the issue asked for

#24993 asks for the full name to be DISPLAYED. That stays a product call - @matks raised column width
on the thread and @Hlavtox said the table is already too wide - and this PR does not change the display.
What it fixes is the side effect nobody noticed: the abbreviation silently broke first-name search.
