### PR TITLE
Let a theme template inline an SVG from its assets directory

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -3,6 +3,8 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeAssetInliner;
+
 global $smarty;
 
 $template_dirs = array(_PS_THEME_DIR_.'templates');
@@ -37,6 +39,64 @@ smartyRegisterFunction($smarty, 'function', 'widget', 'smartyWidget');
 smartyRegisterFunction($smarty, 'function', 'render', 'smartyRender');
 smartyRegisterFunction($smarty, 'function', 'form_field', 'smartyFormField');
 smartyRegisterFunction($smarty, 'block', 'widget_block', 'smartyWidgetBlock');
+smartyRegisterFunction($smarty, 'function', 'inline_svg', 'smartyInlineSvg');
+
+/**
+ * {inline_svg file='img/icon.svg'} writes the contents of an SVG living in the theme's assets
+ * directory straight into the page, so it can be styled by CSS.
+ *
+ * The file is read verbatim, never compiled: {include} would treat minified CSS inside the SVG
+ * ({fill:red}) or a custom property ({--c:red}) as Smarty tags and throw.
+ *
+ * The path is relative to `assets/`; a child theme's own assets win over its parent's, the way
+ * template directories already resolve.
+ *
+ * @param array $params
+ * @param Smarty_Internal_Template $smarty
+ *
+ * @return string
+ */
+function smartyInlineSvg($params, $smarty)
+{
+    if (empty($params['file'])) {
+        if (_PS_MODE_DEV_) {
+            trigger_error(
+                sprintf(
+                    'When using {inline_svg}, you must provide the `file` parameter. Template - %1$s',
+                    $smarty->source->filepath
+                ),
+                E_USER_NOTICE
+            );
+        }
+
+        return '';
+    }
+
+    $assetRoots = array(_PS_THEME_DIR_.'assets');
+    // @phpstan-ignore notIdentical.alwaysTrue
+    if (_PS_PARENT_THEME_DIR_ !== '') {
+        $assetRoots[] = _PS_PARENT_THEME_DIR_.'assets';
+    }
+
+    $svg = (new ThemeAssetInliner($assetRoots))->inline((string) $params['file']);
+
+    if ($svg === null) {
+        if (_PS_MODE_DEV_) {
+            trigger_error(
+                sprintf(
+                    '{inline_svg} could not read "%1$s" from the theme assets. Template - %2$s',
+                    $params['file'],
+                    $smarty->source->filepath
+                ),
+                E_USER_NOTICE
+            );
+        }
+
+        return '';
+    }
+
+    return $svg;
+}
 
 function withWidget($params, callable $cb, $smarty)
 {

--- a/src/Core/Addon/Theme/ThemeAssetInliner.php
+++ b/src/Core/Addon/Theme/ThemeAssetInliner.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Addon\Theme;
+
+/**
+ * Reads an SVG out of a theme's assets directory so that a template can inline it.
+ *
+ * Templates can only reach files through {include}, which compiles what it reads as a Smarty
+ * template - so an SVG carrying minified CSS ({fill:red}) or a custom property ({--c:red}) makes
+ * the compiler throw. This reads the file verbatim instead.
+ */
+final class ThemeAssetInliner
+{
+    private const ALLOWED_EXTENSION = 'svg';
+
+    /**
+     * Existing asset roots, resolved, in the order they are searched.
+     *
+     * @var string[]
+     */
+    private array $roots = [];
+
+    /**
+     * @param string[] $assetRoots asset directories to search, most specific first
+     */
+    public function __construct(array $assetRoots)
+    {
+        foreach ($assetRoots as $root) {
+            $resolved = realpath($root);
+            if ($resolved !== false && is_dir($resolved)) {
+                $this->roots[] = $resolved;
+            }
+        }
+    }
+
+    /**
+     * @param string $relativePath path of the SVG relative to an asset root, e.g. 'img/icon.svg'
+     *
+     * @return string|null the file contents, or null when it cannot be read from any root
+     */
+    public function inline(string $relativePath): ?string
+    {
+        $path = $this->resolve($relativePath);
+        if ($path === null) {
+            return null;
+        }
+
+        $contents = @file_get_contents($path);
+
+        return $contents === false ? null : $contents;
+    }
+
+    private function resolve(string $relativePath): ?string
+    {
+        $relativePath = trim($relativePath);
+        if ($relativePath === '' || str_contains($relativePath, "\0")) {
+            return null;
+        }
+
+        // The extension whitelist is the security control here: it is what keeps this from being an
+        // arbitrary file reader for anything a template can name.
+        if (strtolower(pathinfo($relativePath, PATHINFO_EXTENSION)) !== self::ALLOWED_EXTENSION) {
+            return null;
+        }
+
+        // Leading separators would otherwise turn the argument into an absolute path.
+        $relativePath = ltrim($relativePath, '/\\');
+
+        foreach ($this->roots as $root) {
+            $candidate = realpath($root . DIRECTORY_SEPARATOR . $relativePath);
+            if ($candidate === false || !is_file($candidate)) {
+                continue;
+            }
+
+            // realpath() has already collapsed any ../ and followed any symlink, so this is what
+            // rejects a path that climbs - or is linked - out of the theme.
+            if (str_starts_with($candidate, $root . DIRECTORY_SEPARATOR)) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Core/Addon/Theme/ThemeAssetInlinerTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeAssetInlinerTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Addon\Theme;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeAssetInliner;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ThemeAssetInlinerTest extends TestCase
+{
+    private const CHILD_SVG = '<svg viewBox="0 0 10 10"><style>.a{fill:red}</style><path d="M0 0"/></svg>';
+    private const PARENT_SVG = '<svg viewBox="0 0 20 20"><path d="M1 1"/></svg>';
+
+    private Filesystem $fs;
+    private string $root;
+    private string $childAssets;
+    private string $parentAssets;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fs = new Filesystem();
+        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'theme-asset-inliner-' . uniqid();
+        $this->childAssets = $this->root . '/themes/child/assets';
+        $this->parentAssets = $this->root . '/themes/parent/assets';
+
+        $this->fs->dumpFile($this->childAssets . '/img/icon.svg', self::CHILD_SVG);
+        $this->fs->dumpFile($this->parentAssets . '/img/icon.svg', self::PARENT_SVG);
+        $this->fs->dumpFile($this->parentAssets . '/img/parent-only.svg', self::PARENT_SVG);
+        $this->fs->dumpFile($this->childAssets . '/img/not-an-image.txt', 'plain');
+        $this->fs->dumpFile($this->root . '/themes/child/config/theme.yml', 'name: child');
+        $this->fs->dumpFile($this->root . '/outside.svg', '<svg id="outside"/>');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->fs->remove($this->root);
+    }
+
+    private function inliner(): ThemeAssetInliner
+    {
+        return new ThemeAssetInliner([$this->childAssets, $this->parentAssets]);
+    }
+
+    public function testItReadsAnSvgVerbatim(): void
+    {
+        // verbatim matters: the CSS braces are exactly what makes {include} throw
+        $this->assertSame(self::CHILD_SVG, $this->inliner()->inline('img/icon.svg'));
+    }
+
+    public function testItFallsBackToTheNextRoot(): void
+    {
+        $this->assertSame(self::PARENT_SVG, $this->inliner()->inline('img/parent-only.svg'));
+    }
+
+    public function testTheFirstRootWins(): void
+    {
+        $this->assertSame(self::CHILD_SVG, $this->inliner()->inline('img/icon.svg'));
+        $this->assertSame(self::PARENT_SVG, (new ThemeAssetInliner([$this->parentAssets]))->inline('img/icon.svg'));
+    }
+
+    public function testItAcceptsAnUppercaseExtension(): void
+    {
+        $this->fs->dumpFile($this->childAssets . '/img/upper.SVG', self::CHILD_SVG);
+        $this->assertSame(self::CHILD_SVG, $this->inliner()->inline('img/upper.SVG'));
+    }
+
+    public function testItResolvesADotSegmentThatStaysInside(): void
+    {
+        $this->assertSame(self::CHILD_SVG, $this->inliner()->inline('img/../img/icon.svg'));
+    }
+
+    /**
+     * @dataProvider provideRejectedPaths
+     */
+    public function testItRejects(string $relativePath): void
+    {
+        $this->assertNull($this->inliner()->inline($relativePath));
+    }
+
+    public static function provideRejectedPaths(): array
+    {
+        return [
+            'empty' => [''],
+            'blank' => ['   '],
+            'missing file' => ['img/nope.svg'],
+            'a directory' => ['img'],
+            'another extension' => ['img/not-an-image.txt'],
+            'no extension' => ['img/icon'],
+            'a theme file that is not an asset' => ['../config/theme.yml'],
+            'climbing out of the root' => ['../../../outside.svg'],
+            'climbing out with a leading slash' => ['/../../../outside.svg'],
+            'an absolute path' => ['/etc/hosts.svg'],
+            'a null byte' => ["img/icon.svg\0.txt"],
+            'a backslash prefix' => ['\\..\\..\\..\\outside.svg'],
+        ];
+    }
+
+    public function testItRejectsASymlinkPointingOutsideTheRoot(): void
+    {
+        if (!@symlink($this->root . '/outside.svg', $this->childAssets . '/img/linked.svg')) {
+            $this->markTestSkipped('symlinks are not available here');
+        }
+
+        $this->assertNull($this->inliner()->inline('img/linked.svg'));
+    }
+
+    public function testItIgnoresARootThatDoesNotExist(): void
+    {
+        $inliner = new ThemeAssetInliner([$this->root . '/themes/gone/assets', $this->childAssets]);
+
+        $this->assertSame(self::CHILD_SVG, $inliner->inline('img/icon.svg'));
+    }
+
+    public function testItReturnsNullWithNoRootsAtAll(): void
+    {
+        $this->assertNull((new ThemeAssetInliner([]))->inline('img/icon.svg'));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A theme template cannot inline an SVG kept outside `templates/`. It is not that no mechanism exists - `{include file=$smarty.const._PS_THEME_DIR_\|cat:'assets/img/icon.svg'}` does work - it is that the only mechanism **compiles the asset as a Smarty template**. Any SVG whose inline CSS is minified (`{fill:red}`) or uses a custom property (`{--c:red}`) raises `SmartyCompilerException`, which is most SVGs that have been through SVGO or exported from a design tool, and every SVG that does render leaves a compiled PHP copy behind. This adds `{inline_svg file='img/icon.svg'}`, which reads the file verbatim.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Put `<svg><style>.a{fill:red}</style><path d="M0 0"/></svg>` at `themes/<your-theme>/assets/img/icon.svg`. In a template, `{include file=$smarty.const._PS_THEME_DIR_\|cat:'assets/img/icon.svg'}` throws `Syntax error in template ... unknown tag 'fill:red'`. `{inline_svg file='img/icon.svg'}` writes the file into the page unchanged and it can be styled by CSS. Then check the refusals: `{inline_svg file='../config/theme.yml'}`, `{inline_svg file='../../../../config/settings.inc.php'}`, a missing file and a bare `{inline_svg}` all render nothing (with a developer notice under `_PS_MODE_DEV_`, like `{widget}`).
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #20354
| Related PRs       | -
| Sponsor company   | -

#### Why not just document `$smarty.const._PS_THEME_DIR_`

Measured in a 9.2 front office, rendering the same template against four SVGs that differ only in their
inline CSS:

```
                        {include ... _PS_THEME_DIR_}       {inline_svg}
plain                   renders                            renders verbatim
pretty CSS { fill: red; }  renders                         renders verbatim
minified CSS {fill:red}    SmartyCompilerException         renders verbatim
CSS custom property {--c:red}  SmartyCompilerException     renders verbatim
```

`{` followed by a space is literal text to Smarty, which is why the pretty-printed case survives and the
minified one does not. An asset pipeline decides which of the two a theme ends up shipping, so the
existing mechanism works or throws for reasons that have nothing to do with the template.

#### Design

- **Resolution order is child theme, then parent** - the same order `setTemplateDir()` already gives
  `{include}`. Note this is deliberately *not* the order of `$urls.theme_assets`, which points at the
  **parent** when `use_parent_assets` is set and exposes the child separately as
  `$urls.child_theme_assets`. Matching `{include}` seemed the less surprising of the two for a function
  that replaces `{include}`.
- **The `.svg` whitelist is the security control.** It is what keeps this from being a general file
  reader for anything a template can name. The path is then resolved with `realpath()` and required to
  sit under the asset root, so `../` and a symlink pointing out of the theme are both refused - and a
  leading `/` is stripped rather than treated as an absolute path.
- **Roots are theme-only.** A module inlining its own SVG is out of scope here; modules render their own
  templates and can already read their own files.
- **Front office only.** `config/smartyadmin.config.inc.php` is untouched.
- Registered through `smartyRegisterFunction()` next to `{widget}`, `{render}`, `{form_field}` and
  `{widget_block}`, and it follows `{widget}`'s convention of returning an empty string and raising a
  developer notice under `_PS_MODE_DEV_` rather than throwing, so a missing asset cannot take a shop down.
- A registered plugin shadows a same-named file in a theme's `plugins/` directory - measured. A theme
  already shipping its own `function.inline_svg.php` would therefore get core's from now on. That is why
  the resolution logic lives in a small injectable class rather than in the callback, so a theme that
  wants different behaviour can still register a differently-named function around it.

#### Tests

`tests/Unit/Core/Addon/Theme/ThemeAssetInlinerTest.php`, 20 tests / 21 assertions, green: verbatim read,
parent fallback, first-root-wins, uppercase extension, a `../` that stays inside, and twelve refusals
(empty, blank, missing, a directory, another extension, no extension, a non-asset theme file, climbing
out with and without a leading separator, an absolute path, a null byte, a backslash prefix) plus a
symlink pointing outside the root and a root that does not exist.

End to end in a 9.2 front office with `escape_html = true`, 19 checks green: all four SVGs above render
byte-identical, the output is **not** HTML-escaped while ordinary `{$var}` output still is, and each of
the four refusal cases emits no file content and raises no exception.
