### PR TITLE
Show how many are left in the low-stock label

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -1428,11 +1428,13 @@ class ProductLazyArray extends AbstractLazyArray
             // If the products are the last items remaining, we show different message and exclamation mark
             if ($availableQuantity < $settings->lastRemainingItems) {
                 $this->product['availability'] = 'last_remaining_items';
+                // The stock itself, not what is left after the wanted quantity: the shopper is told
+                // how many the shop has, and the label has to stay true on the cart page too.
                 $this->product[
                     'availability_message'
                 ] = $this->translator->trans(
-                    'Last items in stock',
-                    [],
+                    'Only %quantity% left in stock',
+                    ['%quantity%' => $stockQuantity],
                     'Shop.Theme.Catalog'
                 );
             } else {

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -140,7 +140,9 @@ class ProductLazyArrayTest extends TestCase
         $this->mockTranslatorInterface
             ->method('trans')
             ->willReturnCallback(function ($id, array $parameters = [], $domain = null, $locale = null) {
-                return $id;
+                // Substitute like the real translator does, otherwise a message that carries a
+                // placeholder is asserted against its untranslated source and the value is never checked.
+                return empty($parameters) ? $id : strtr($id, $parameters);
             })
         ;
     }
@@ -223,6 +225,73 @@ class ProductLazyArrayTest extends TestCase
         );
 
         $this->assertEquals($availabilityMessage, $productLazyArray->availability_message);
+    }
+
+    /**
+     * The low-stock label. No case in this file reached it before: lastRemainingItems is left null on
+     * the settings mock, and "0 < null" is false, so the branch never fired.
+     *
+     * @param array $product
+     * @param int $lastRemainingItems
+     * @param string $expectedMessage
+     *
+     * @dataProvider providerLastRemainingItemsCases
+     */
+    public function testLastRemainingItemsMessageCarriesTheStock(
+        array $product,
+        int $lastRemainingItems,
+        string $expectedMessage
+    ): void {
+        $this->setDefaultConfiguration();
+
+        $this->mockProductPresentationSettings
+            ->method('shouldShowPrice')
+            ->willReturn(true);
+        $this->mockProductPresentationSettings->showLabelOOSListingPages = true;
+        $this->mockProductPresentationSettings->stock_management_enabled = true;
+        $this->mockProductPresentationSettings->showPrices = true;
+        $this->mockProductPresentationSettings->catalog_mode = false;
+        $this->mockProductPresentationSettings->lastRemainingItems = $lastRemainingItems;
+
+        $productLazyArray = new ProductLazyArray(
+            $this->mockProductPresentationSettings,
+            $product,
+            $this->mockLanguage,
+            $this->mockImageRetriever,
+            $this->mockLink,
+            $this->mockPriceFormatter,
+            $this->mockProductColorsRetriever,
+            $this->mockTranslatorInterface,
+            $this->mockHookManager,
+            $this->mockConfiguration
+        );
+
+        $this->assertSame($expectedMessage, $productLazyArray->availability_message);
+    }
+
+    public function providerLastRemainingItemsCases(): iterable
+    {
+        $lowStock = array_merge($this->baseProduct, [
+            'show_price' => 1,
+            'quantity' => 3,
+            'stock_quantity' => 3,
+            'quantity_wanted' => 1,
+            'show_availability' => 1,
+            'available_date' => false,
+            'available_now' => self::PRODUCT_AVAILABLE_NOW,
+            'allow_oosp' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
+        ]);
+
+        // The number shown is the stock, not the stock minus what the visitor is about to add: with a
+        // quantity of 2 wanted the shop still has 3.
+        yield 'stock below the threshold' => [$lowStock, 5, 'Only 3 left in stock'];
+        yield 'quantity wanted does not change the number' => [
+            array_merge($lowStock, ['quantity_wanted' => 2]),
+            5,
+            'Only 3 left in stock',
+        ];
+        // Above the threshold the usual in-stock label wins.
+        yield 'stock above the threshold' => [$lowStock, 2, self::PRODUCT_AVAILABLE_NOW];
     }
 
     /**

--- a/translations/default/ShopThemeCatalog.xlf
+++ b/translations/default/ShopThemeCatalog.xlf
@@ -299,11 +299,6 @@
         <target>Items</target>
         <note>File: controllers/front/ProductController.php [Line: 1253]</note>
       </trans-unit>
-      <trans-unit id="348325afced7f3da215310efbe21f1c1">
-        <source>Last items in stock</source>
-        <target>Last items in stock</target>
-        <note>File: src/Adapter/Presenter/Product/ProductLazyArray.php [Line: 1398]</note>
-      </trans-unit>
       <trans-unit id="160b4798999cb85c815beeb40ac268cc">
         <source>Last time this product was added to a cart: %date_last_cart%</source>
         <target>Last time this product was added to a cart: %date_last_cart%</target>
@@ -458,6 +453,11 @@
         <source>Online only</source>
         <target>Online only</target>
         <note>File: src/Adapter/Presenter/Product/ProductLazyArray.php [Line: 701]</note>
+      </trans-unit>
+      <trans-unit id="9674d821f60baf95c0f672322692b26a">
+        <source>Only %quantity% left in stock</source>
+        <target>Only %quantity% left in stock</target>
+        <note>File: src/Adapter/Presenter/Product/ProductLazyArray.php [Line: 1436]</note>
       </trans-unit>
       <trans-unit id="99f0c07c3b8b3bc78f5f9733019ec3d5">
         <source>Order totals</source>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The label shown when stock falls under "Display remaining quantities when the quantity is lower than" read "Last items in stock" and never said how many. @Julievrz proposed and @marionf approved "Only X left in stock", which also avoids a plural form. The number is the stock itself, not the stock minus the quantity the visitor is about to add. The theme half - colouring that state as in stock rather than as a warning, and showing availability on the classic cart line - is two separate PRs.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set Shop Parameters > Product Settings > "Display remaining quantities when the quantity is lower than" to 5 and put a product's stock at 3. Its page shows "Only 3 left in stock" instead of "Last items in stock", and with the theme PR applied the label is green rather than orange. Changing the quantity selector does not change the number.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #24768
| Related PRs       | The two theme halves (the green colour, and the cart line in classic) follow as separate PRs once PrestaShop/hummingbird#1108 and PrestaShop/classic-theme#241 land: all of them edit the same availability mapping in `product-add-to-cart.tpl`.
| Sponsor company   |

### What the issue asked for, and what was already true

| Ask | State on 9.2 |
| --- | --- |
| Replace "X last item(s) in stock" with "Only X left in stock" | The label had no quantity at all - it read "Last items in stock". Changed here. |
| Show it in green | Both themes coloured it `warning`, sharing a branch with `available`. Changed in both theme PRs. |
| Put it before the delivery time | Already the case in hummingbird: `product_availability` precedes `product_delivery_times` in `product-add-to-cart.tpl`. Nothing to do. |
| Show it in the cart too | Already the case in hummingbird (`cart-detailed-product-line.tpl`). **Absent in classic** - added there. |
| Quantity follows the selected combination | Already the case: `availability_message` is part of the combination refresh payload. |

### Which quantity

`$stockQuantity`, not `$availableQuantity` (= stock minus the quantity wanted). The shopper is being told
what the shop has; and the same label renders on the cart page, where the wanted quantity is whatever is
already in the cart, so subtracting it would make the sentence untrue. One of the test cases varies only
`quantity_wanted` and pins the number, so this choice is load-bearing rather than incidental.

### The existing test suite could not have caught this

No case in `ProductLazyArrayTest` reached the low-stock branch: `lastRemainingItems` is left null on the
settings mock and `0 < null` is false in PHP 8. And the translator mock returned its `$id` untouched, so a
message carrying a placeholder would have been asserted against its raw source with the value never
checked. The mock now substitutes parameters - all 46 existing tests still pass - and three cases cover
the branch.

### Verification

- Mutation A - restore "Last items in stock": both low-stock cases fail.
- Mutation B - pass `$availableQuantity` instead of `$stockQuantity`: both fail, including the case that
  varies only the wanted quantity.
- 46 tests / 63 assertions green. PHPStan `[OK]`, php-cs-fixer clean, the .xlf parses and stays sorted
  (new id `9674d821f60baf95c0f672322692b26a` = md5 of the new source, between "Online only" and "Order totals").
- Theme change verified on a running 9.2 shop: with `PS_LAST_QTIES` = 5 and stock 3, the rendered class
  goes `product__availability-status text-warning` -> `text-success`. Shop restored afterwards.

### Cost to state in the PR

Existing translations are keyed on "Last items in stock" and will fall back to the new English source
until the translation project catches up, and the new string carries a `%quantity%` placeholder that
translators must keep. Inherent to the wording change, which was approved on the issue.
