### PR TITLE
Let each order status decide whether it reserves its products

### DIFF
--- a/classes/order/OrderState.php
+++ b/classes/order/OrderState.php
@@ -39,6 +39,11 @@ class OrderStateCore extends ObjectModel
     /** @var bool Shipped */
     public $shipped;
 
+    /**
+     * @var bool Whether an order in this state holds its products in reserved_quantity
+     */
+    public $reserve_products = true;
+
     /** @var bool Paid */
     public $paid;
 
@@ -65,6 +70,7 @@ class OrderStateCore extends ObjectModel
             'color' => ['type' => self::TYPE_STRING, 'validate' => 'isColor', 'size' => 32],
             'logable' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'shipped' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
+            'reserve_products' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'unremovable' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'delivery' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'hidden' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1576,6 +1576,7 @@ CREATE TABLE `PREFIX_order_state` (
   `logable` tinyint(1) NOT NULL DEFAULT '0',
   `delivery` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
   `shipped` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
+  `reserve_products` tinyint(1) UNSIGNED NOT NULL DEFAULT '1',
   `paid` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
   `pdf_invoice` tinyint(1) UNSIGNED NOT NULL default '0',
   `pdf_delivery` tinyint(1) UNSIGNED NOT NULL default '0',

--- a/install-dev/data/xml/order_state.xml
+++ b/install-dev/data/xml/order_state.xml
@@ -10,48 +10,49 @@
     <field name="logable"/>
     <field name="delivery"/>
     <field name="shipped"/>
+    <field name="reserve_products"/>
     <field name="paid"/>
     <field name="pdf_delivery"/>
     <field name="pdf_invoice"/>
   </fields>
   <entities>
-    <order_state id="Awaiting_cheque_payment" invoice="0" send_email="1" color="#34209E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Awaiting_cheque_payment" invoice="0" send_email="1" color="#34209E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" reserve_products="1" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name>ps_checkpayment</module_name>
     </order_state>
-    <order_state id="Payment_accepted" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="1" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="1">
+    <order_state id="Payment_accepted" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="1" delivery="0" shipped="0" reserve_products="1" paid="1" pdf_delivery="0" pdf_invoice="1">
       <module_name/>
     </order_state>
-    <order_state id="Preparation_in_progress" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="1" delivery="1" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Preparation_in_progress" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="1" delivery="1" shipped="0" reserve_products="1" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Shipped" invoice="1" send_email="1" color="#01B887" unremovable="1" hidden="0" logable="1" delivery="1" shipped="1" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Shipped" invoice="1" send_email="1" color="#01B887" unremovable="1" hidden="0" logable="1" delivery="1" shipped="1" reserve_products="0" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Delivered" invoice="1" send_email="0" color="#01B887" unremovable="1" hidden="0" logable="1" delivery="1" shipped="1" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Delivered" invoice="1" send_email="0" color="#01B887" unremovable="1" hidden="0" logable="1" delivery="1" shipped="1" reserve_products="0" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Canceled" invoice="0" send_email="1" color="#2C3E50" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Canceled" invoice="0" send_email="1" color="#2C3E50" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" reserve_products="0" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Refund" invoice="1" send_email="1" color="#01B887" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Refund" invoice="1" send_email="1" color="#01B887" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" reserve_products="1" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Payment_error" invoice="0" send_email="1" color="#E74C3C" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Payment_error" invoice="0" send_email="1" color="#E74C3C" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" reserve_products="0" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="On_backorder_paid" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="On_backorder_paid" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" reserve_products="1" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Awaiting_bank_wire_payment" invoice="0" send_email="1" color="#34209E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Awaiting_bank_wire_payment" invoice="0" send_email="1" color="#34209E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" reserve_products="1" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name>ps_wirepayment</module_name>
     </order_state>
-    <order_state id="Payment_remotely_accepted" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="1" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Payment_remotely_accepted" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="1" delivery="0" shipped="0" reserve_products="1" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="On_backorder_unpaid" invoice="0" send_email="1" color="#34209E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="On_backorder_unpaid" invoice="0" send_email="1" color="#34209E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" reserve_products="1" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Awaiting_cod_validation" invoice="0" send_email="0" color="#34209E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0">
+    <order_state id="Awaiting_cod_validation" invoice="0" send_email="0" color="#34209E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" reserve_products="1" paid="0">
       <module_name>ps_cashondelivery</module_name>
     </order_state>
   </entities>

--- a/src/Adapter/OrderState/CommandHandler/AddOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/AddOrderStateHandler.php
@@ -69,6 +69,7 @@ final class AddOrderStateHandler extends AbstractOrderStateHandler implements Ad
         $orderState->pdf_invoice = $command->isPdfInvoice();
         $orderState->pdf_delivery = $command->isPdfDelivery();
         $orderState->shipped = $command->isShipped();
+        $orderState->reserve_products = $command->reservesProducts();
         $orderState->paid = $command->isPaid();
         $orderState->delivery = $command->isDelivery();
         if ($command->isSendEmailEnabled()) {

--- a/src/Adapter/OrderState/CommandHandler/EditOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/EditOrderStateHandler.php
@@ -125,6 +125,10 @@ final class EditOrderStateHandler extends AbstractOrderStateHandler implements E
             $orderState->shipped = $command->isShipped();
         }
 
+        if (null !== $command->reservesProducts()) {
+            $orderState->reserve_products = $command->reservesProducts();
+        }
+
         if (null !== $command->isPaid()) {
             $orderState->paid = $command->isPaid();
         }

--- a/src/Adapter/OrderState/QueryHandler/GetOrderStateForEditingHandler.php
+++ b/src/Adapter/OrderState/QueryHandler/GetOrderStateForEditingHandler.php
@@ -53,7 +53,8 @@ final class GetOrderStateForEditingHandler implements GetOrderStateForEditingHan
             (bool) $orderState->paid,
             (bool) $orderState->delivery,
             $orderState->template,
-            (bool) $orderState->deleted
+            (bool) $orderState->deleted,
+            (bool) $orderState->reserve_products
         );
     }
 }

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -120,9 +120,13 @@ class StockManager
     }
 
     /**
+     * Which orders hold their products in reserve is decided by the order state's own
+     * `reserve_products` flag, so $errorState and $cancellationState are no longer read here. They stay
+     * in the signature because updatePhysicalProductQuantity() is public and called from modules.
+     *
      * @param int $shopId
-     * @param int $errorState
-     * @param int $cancellationState
+     * @param int $errorState no longer used
+     * @param int $cancellationState no longer used
      * @param int|null $idProduct
      * @param int|null $idOrder
      *
@@ -156,12 +160,8 @@ class StockManager
                 INNER JOIN {table_prefix}order_detail od ON od.id_order = o.id_order
                 INNER JOIN {table_prefix}order_state os ON os.id_order_state = o.current_state
                 WHERE ' . $orderScopeCondition . ' AND
-                os.shipped != 1 AND (
-                    o.valid = 1 OR (
-                        os.id_order_state != :error_state AND
-                        os.id_order_state != :cancellation_state
-                    )
-                ) AND sa.id_product = od.product_id AND
+                os.reserve_products = 1 AND
+                sa.id_product = od.product_id AND
                 sa.id_product_attribute = od.product_attribute_id
                 GROUP BY od.product_id, od.product_attribute_id
             )
@@ -174,8 +174,6 @@ class StockManager
             '{table_prefix}' => _DB_PREFIX_,
             ':stock_shop_id' => (int) $stockContext['shopId'],
             ':stock_shop_group_id' => (int) $stockContext['shopGroupId'],
-            ':error_state' => (int) $errorState,
-            ':cancellation_state' => (int) $cancellationState,
         ];
 
         if ($idProduct) {

--- a/src/Core/Domain/OrderState/Command/AddOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/AddOrderStateCommand.php
@@ -51,6 +51,11 @@ class AddOrderStateCommand
      * @var bool
      */
     private $shipped;
+
+    /**
+     * @var bool|null null keeps the historical rule: a state reserves unless it ships
+     */
+    private $reserveProducts;
     /**
      * @var bool
      */
@@ -100,7 +105,8 @@ class AddOrderStateCommand
         bool $shipped,
         bool $paid,
         bool $delivery,
-        array $localizedTemplates
+        array $localizedTemplates,
+        ?bool $reserveProducts = null
     ) {
         $this->setLocalizedNames($localizedNames);
         $this->color = $color;
@@ -114,6 +120,7 @@ class AddOrderStateCommand
         $this->paid = $paid;
         $this->delivery = $delivery;
         $this->localizedTemplates = $localizedTemplates;
+        $this->reserveProducts = $reserveProducts;
     }
 
     /**
@@ -204,6 +211,17 @@ class AddOrderStateCommand
     public function isShipped()
     {
         return $this->shipped;
+    }
+
+    /**
+     * Whether orders in this state hold their products in reserved_quantity. Left unset it follows the
+     * rule that applied before the flag existed: everything reserves except states that ship.
+     *
+     * @return bool
+     */
+    public function reservesProducts(): bool
+    {
+        return $this->reserveProducts ?? !$this->shipped;
     }
 
     /**

--- a/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
@@ -74,6 +74,11 @@ class EditOrderStateCommand
     /**
      * @var bool|null
      */
+    private $reserveProducts;
+
+    /**
+     * @var bool|null
+     */
     private $paid;
 
     /**
@@ -282,6 +287,24 @@ class EditOrderStateCommand
     public function setShipped(?bool $shipped)
     {
         $this->shipped = $shipped;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function reservesProducts(): ?bool
+    {
+        return $this->reserveProducts;
+    }
+
+    /**
+     * @return self
+     */
+    public function setReserveProducts(?bool $reserveProducts)
+    {
+        $this->reserveProducts = $reserveProducts;
 
         return $this;
     }

--- a/src/Core/Domain/OrderState/QueryResult/EditableOrderState.php
+++ b/src/Core/Domain/OrderState/QueryResult/EditableOrderState.php
@@ -59,6 +59,11 @@ class EditableOrderState
      * @var bool
      */
     private $shipped;
+
+    /**
+     * @var bool
+     */
+    private $reserveProducts;
     /**
      * @var bool
      */
@@ -91,7 +96,8 @@ class EditableOrderState
         bool $paid,
         bool $delivery,
         array $localizedTemplates,
-        bool $isDeleted
+        bool $isDeleted,
+        bool $reserveProducts = true
     ) {
         $this->orderStateId = $orderStateId;
         $this->localizedNames = $name;
@@ -108,6 +114,7 @@ class EditableOrderState
         $this->delivery = $delivery;
         $this->localizedTemplates = $localizedTemplates;
         $this->isDeleted = $isDeleted;
+        $this->reserveProducts = $reserveProducts;
     }
 
     /**
@@ -196,6 +203,14 @@ class EditableOrderState
     public function isShipped()
     {
         return $this->shipped;
+    }
+
+    /**
+     * @return bool
+     */
+    public function reservesProducts(): bool
+    {
+        return $this->reserveProducts;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataHandler/OrderStateFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/OrderStateFormDataHandler.php
@@ -69,7 +69,8 @@ final class OrderStateFormDataHandler implements FormDataHandlerInterface
             $data['shipped'],
             $data['paid'],
             $data['delivery'],
-            $data['template']
+            $data['template'],
+            $data['reserve_products']
         );
 
         if (isset($data['icon'])) {
@@ -106,6 +107,7 @@ final class OrderStateFormDataHandler implements FormDataHandlerInterface
             ->setShipped($data['shipped'])
             ->setPaid($data['paid'])
             ->setDelivery($data['delivery'])
+            ->setReserveProducts($data['reserve_products'])
             ->setTemplate($data['template'])
         ;
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/OrderStateFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/OrderStateFormDataProvider.php
@@ -45,6 +45,7 @@ final class OrderStateFormDataProvider implements FormDataProviderInterface
             'pdf_invoice' => $editableOrderState->isPdfInvoice(),
             'pdf_delivery' => $editableOrderState->isPdfDelivery(),
             'shipped' => $editableOrderState->isShipped(),
+            'reserve_products' => $editableOrderState->reservesProducts(),
             'paid' => $editableOrderState->isPaid(),
             'delivery' => $editableOrderState->isDelivery(),
             'template' => $editableOrderState->getLocalizedTemplates(),
@@ -58,6 +59,9 @@ final class OrderStateFormDataProvider implements FormDataProviderInterface
     {
         return [
             'color' => '#ffffff',
+            // A new status holds its orders' products in reserve unless the merchant says otherwise,
+            // which is what every non-shipping status did before the flag existed.
+            'reserve_products' => true,
         ];
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
@@ -192,6 +192,14 @@ class OrderStateType extends TranslatorAwareType
                 ],
                 'help' => $this->trans('This will mark the order as shipped. It will register a stock movement entry, prevent modifying the order and other things.', 'Admin.Shopparameters.Help'),
             ])
+            ->add('reserve_products', CheckboxType::class, [
+                'required' => false,
+                'label' => $this->trans('Reserve the products of the associated order.', 'Admin.Shopparameters.Feature'),
+                'attr' => [
+                    'material_design' => true,
+                ],
+                'help' => $this->trans('While an order is in this status its products count as reserved, so they are subtracted from the quantity available for sale without having left the stock yet.', 'Admin.Shopparameters.Help'),
+            ])
             ->add('paid', CheckboxType::class, [
                 'required' => false,
                 'label' => $this->trans('Set the associated order as paid.', 'Admin.Shopparameters.Feature'),

--- a/tests/Integration/Adapter/Stock/ReserveProductsPerOrderStateTest.php
+++ b/tests/Integration/Adapter/Stock/ReserveProductsPerOrderStateTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Stock;
+
+use Configuration;
+use Doctrine\DBAL\Connection;
+use PrestaShop\PrestaShop\Adapter\StockManager;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Which orders hold their products in reserve used to be hardcoded - not shipped, and either valid or
+ * neither the error nor the cancellation status - so a merchant could not decide it. It is now the order
+ * status' own reserve_products flag.
+ */
+class ReserveProductsPerOrderStateTest extends KernelTestCase
+{
+    private Connection $connection;
+    private string $dbPrefix;
+    private StockManager $stockManager;
+    private int $orderStateId;
+    private int $productId;
+    private int $combinationId;
+    private int $initialFlag;
+    private int $initialReservedQuantity;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->dbPrefix = self::getContainer()->getParameter('database_prefix');
+        $this->stockManager = new StockManager();
+
+        // Restoring whole tables would drop the column on a database built before it existed, and this
+        // test only ever changes one flag and one quantity - so it puts those two back itself.
+        // Pick a valid order and the product it holds, so there is something to reserve.
+        $row = $this->connection->executeQuery(
+            'SELECT o.current_state, od.product_id, od.product_attribute_id
+             FROM ' . $this->dbPrefix . 'orders o
+             INNER JOIN ' . $this->dbPrefix . 'order_detail od ON od.id_order = o.id_order
+             INNER JOIN ' . $this->dbPrefix . 'order_state os ON os.id_order_state = o.current_state
+             WHERE o.id_shop = 1 AND os.reserve_products = 1
+             LIMIT 1'
+        )->fetchAssociative();
+
+        $this->assertNotFalse($row, 'The fixture needs an order in a reserving status.');
+        $this->orderStateId = (int) $row['current_state'];
+        $this->productId = (int) $row['product_id'];
+        $this->combinationId = (int) $row['product_attribute_id'];
+
+        $this->initialFlag = (int) $this->connection->executeQuery(
+            'SELECT reserve_products FROM ' . $this->dbPrefix . 'order_state WHERE id_order_state = :id',
+            ['id' => $this->orderStateId]
+        )->fetchOne();
+        $this->initialReservedQuantity = $this->readReservedQuantity();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setReserveProducts((bool) $this->initialFlag);
+        $this->connection->executeStatement(
+            'UPDATE ' . $this->dbPrefix . 'stock_available SET reserved_quantity = :quantity
+             WHERE id_product = :product AND id_product_attribute = :combination AND id_shop = 1',
+            [
+                'quantity' => $this->initialReservedQuantity,
+                'product' => $this->productId,
+                'combination' => $this->combinationId,
+            ]
+        );
+
+        parent::tearDown();
+    }
+
+    public function testAStatusStopsReservingWhenTheFlagIsCleared(): void
+    {
+        // Control: with the flag on, the order's products are reserved.
+        $reservedWhileFlagged = $this->resyncAndReadReservedQuantity();
+        $this->assertGreaterThan(
+            0,
+            $reservedWhileFlagged,
+            'The fixture order should be reserving its products to begin with.'
+        );
+
+        $this->setReserveProducts(false);
+        $this->assertSame(0, $this->resyncAndReadReservedQuantity());
+
+        // ...and putting it back restores the reservation, so the flag is what decides it.
+        $this->setReserveProducts(true);
+        $this->assertSame($reservedWhileFlagged, $this->resyncAndReadReservedQuantity());
+    }
+
+    private function setReserveProducts(bool $reserve): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE ' . $this->dbPrefix . 'order_state SET reserve_products = :reserve WHERE id_order_state = :id',
+            ['reserve' => (int) $reserve, 'id' => $this->orderStateId]
+        );
+    }
+
+    private function resyncAndReadReservedQuantity(): int
+    {
+        $this->stockManager->updatePhysicalProductQuantity(
+            1,
+            (int) Configuration::get('PS_OS_ERROR'),
+            (int) Configuration::get('PS_OS_CANCELED'),
+            $this->productId
+        );
+
+        return $this->readReservedQuantity();
+    }
+
+    private function readReservedQuantity(): int
+    {
+        return (int) $this->connection->executeQuery(
+            'SELECT reserved_quantity FROM ' . $this->dbPrefix . 'stock_available
+             WHERE id_product = :product AND id_product_attribute = :combination AND id_shop = 1',
+            ['product' => $this->productId, 'combination' => $this->combinationId]
+        )->fetchOne();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Which orders hold their products in `reserved_quantity` was hardcoded in one SQL condition in `StockManager::updateReservedProductQuantity()` - not shipped, and either valid or neither the error nor the cancellation status - so a merchant could not change it. Adds a `reserve_products` flag to the order status, a checkbox on the status form, and makes that condition read the flag.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Shop Parameters > Order Settings > Statuses, edit a status and clear "Reserve the products of the associated order". Put an order into that status and check Catalog > Stock: its products are no longer counted as reserved, and the quantity available for sale rises accordingly. Tick it again and the reservation comes back. `tests/Integration/Adapter/Stock/ReserveProductsPerOrderStateTest.php` covers both directions.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #24084
| Related PRs       |
| Sponsor company   |

### The condition being replaced

```sql
os.shipped != 1 AND (
    o.valid = 1 OR (
        os.id_order_state != :error_state AND
        os.id_order_state != :cancellation_state
    )
)
```
becomes `os.reserve_products = 1`, which is what @Hlavtox proposed on the issue.

### Seeded so a fresh install behaves exactly as before

`o.valid` is the status' `logable`, so error and cancelled statuses (both `logable = 0`) already failed the
`OR`. The rule reduces to *reserve unless the status ships, and not for the error or cancelled statuses*:

| status | reserve_products |
| --- | --- |
| Shipped, Delivered | 0 (they ship) |
| Payment error, Canceled | 0 |
| everything else, including **Refund** | 1 |

**Refund keeps reserving**, because it did before - it neither ships nor is one of those two statuses.
That is preserved deliberately rather than quietly corrected, and it is arguably the best argument for
this feature: it is exactly the kind of thing a merchant should be able to decide.

### Backward compatibility

- `AddOrderStateCommand` takes the flag as an **optional trailing argument**; unset, `reservesProducts()`
  answers `!$shipped`, so every existing caller builds the same status as before. The Behat context in
  `OrderStateFeatureContext` omits it and needs no change.
- `updatePhysicalProductQuantity()` keeps `$errorState` and `$cancellationState` even though the query no
  longer reads them - it is public and called from six places including modules. The docblock says so.
- No upgrade SQL: 9.x core ships schema only in `install-dev/data/db_structure.sql` and the upgrade path
  is the autoupgrade module (this is how `image_fitment` shipped). The column default is `1`, and existing
  shipped/error/cancelled statuses will need the flag cleared - **worth confirming with the autoupgrade
  maintainers whether that belongs in a migration step**, since a plain `ADD COLUMN DEFAULT 1` would make
  shipped statuses start reserving on an upgraded shop.

### Verification

- Mutation - the query ignores the flag and uses `os.shipped != 1` again: the test fails
  ("Failed asserting that 2 is identical to 0").
- The test asserts all three directions: reserving to begin with, zero once the flag is cleared, and the
  original quantity again once it is restored - so it cannot pass by the value being zero throughout.
- PHPStan `[OK]` across all changed classes, php-cs-fixer clean, `order_state.xml` parses.

### Test-harness note

`DatabaseDump::restoreTables(['order_state'])` restores from a dump taken before the column existed, so it
silently drops it and the next query fails with "Unknown column 'os.reserve_products'". The test therefore
saves and restores just the flag and the quantity it changes instead of whole tables. On CI, where the
test database is built from `db_structure.sql`, the column is present from the start.
