### PR TITLE
Refresh stock quantities only for the products the Stocks grid displays

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -175,13 +175,94 @@ class StockRepository extends StockManagementRepository
      */
     public function getData(QueryParamsCollection $queryParams)
     {
-        $this->stockManager->updatePhysicalProductQuantity(
-            $this->getContextualShopId(),
-            $this->orderStates['error'],
-            $this->orderStates['cancellation']
-        );
+        return $this->refreshQuantitiesOfDisplayedProducts(parent::getData($queryParams));
+    }
 
-        return parent::getData($queryParams);
+    /**
+     * The reserved and physical quantities held in stock_available are already maintained by every
+     * path that can change them - order creation, order status change, order product edits, product
+     * and combination stock edits - and each of those scopes the update to the order or product it
+     * touches. This grid ran the same update unscoped on every page load as a repair pass, which
+     * makes MySQL evaluate one correlated sub-select over orders, order_detail and order_state for
+     * every stock_available row of the shop. That cost grows with both the catalogue and the order
+     * history, until the page stops loading.
+     *
+     * Only the rows about to be displayed have to be accurate, so the repair pass is scoped to their
+     * products and the refreshed values are read back into the rows.
+     *
+     * @param array $rows
+     *
+     * @return array
+     */
+    private function refreshQuantitiesOfDisplayedProducts(array $rows)
+    {
+        $productIds = array_values(array_unique(array_map('intval', array_column($rows, 'product_id'))));
+
+        if (empty($productIds)) {
+            return $rows;
+        }
+
+        $shopId = $this->getContextualShopId();
+
+        foreach ($productIds as $productId) {
+            $this->stockManager->updatePhysicalProductQuantity(
+                $shopId,
+                $this->orderStates['error'],
+                $this->orderStates['cancellation'],
+                $productId
+            );
+        }
+
+        return $this->applyStoredQuantities($rows, $productIds);
+    }
+
+    /**
+     * Reads back the two columns the repair pass writes, for the displayed products only, and copies
+     * them into the rows already fetched. Without this the grid would show the values as they were
+     * before the refresh.
+     *
+     * @param array $rows
+     * @param int[] $productIds
+     *
+     * @return array
+     */
+    private function applyStoredQuantities(array $rows, array $productIds)
+    {
+        $shop = $this->getCurrentShop();
+        $shopGroup = $shop->getGroup();
+
+        // Same scoping as the grid's own query: a group sharing its stock stores it under id_shop 0.
+        $stockShopId = $shopGroup->share_stock ? 0 : $shop->getContextualShopId();
+        $stockGroupId = $shopGroup->share_stock ? (int) $shopGroup->id : 0;
+
+        $refreshed = $this->connection->executeQuery(
+            'SELECT id_product, id_product_attribute, physical_quantity, reserved_quantity
+             FROM ' . $this->tablePrefix . 'stock_available
+             WHERE id_shop = :stockShopId AND id_shop_group = :stockGroupId AND id_product IN (:productIds)',
+            [
+                'stockShopId' => $stockShopId,
+                'stockGroupId' => $stockGroupId,
+                'productIds' => $productIds,
+            ],
+            ['productIds' => Connection::PARAM_INT_ARRAY]
+        )->fetchAllAssociative();
+
+        $quantitiesByProduct = [];
+        foreach ($refreshed as $quantities) {
+            $quantitiesByProduct[(int) $quantities['id_product']][(int) $quantities['id_product_attribute']] = $quantities;
+        }
+
+        foreach ($rows as &$row) {
+            $quantities = $quantitiesByProduct[(int) $row['product_id']][(int) $row['combination_id']] ?? null;
+
+            if (null !== $quantities) {
+                $row['product_physical_quantity'] = (int) $quantities['physical_quantity'];
+                $row['product_reserved_quantity'] = (int) $quantities['reserved_quantity'];
+            }
+        }
+        unset($row);
+
+        return $rows;
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Entity/Repository/StockRepositoryTest.php
+++ b/tests/Integration/PrestaShopBundle/Entity/Repository/StockRepositoryTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Entity\Repository;
+
+use Doctrine\DBAL\Connection;
+use PrestaShopBundle\Api\QueryStockParamsCollection;
+use PrestaShopBundle\Entity\Repository\StockRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class StockRepositoryTest extends KernelTestCase
+{
+    private const BOGUS_RESERVED_QUANTITY = 999;
+
+    private Connection $connection;
+    private string $dbPrefix;
+    private StockRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->dbPrefix = self::getContainer()->getParameter('database_prefix');
+        $this->repository = self::getContainer()->get('prestashop.core.api.stock.repository');
+    }
+
+    /**
+     * The grid used to recompute reserved and physical quantities for every stock_available row of
+     * the shop on each page load, which costs one correlated sub-select over the order tables per
+     * row. Only the products the page displays need refreshing; everything else must be left alone.
+     */
+    public function testOnlyTheDisplayedProductsAreRefreshed(): void
+    {
+        $this->setReservedQuantityEverywhere(self::BOGUS_RESERVED_QUANTITY);
+
+        $rows = $this->repository->getData(
+            (new QueryStockParamsCollection())->fromArray(['page_size' => 1, 'page_index' => 1])
+        );
+
+        $this->assertCount(1, $rows, 'The fixture needs exactly one row on the page.');
+        $displayedProductId = (int) $rows[0]['product_id'];
+
+        $stillBogus = $this->productIdsWithReservedQuantity(self::BOGUS_RESERVED_QUANTITY);
+
+        // The displayed product was refreshed...
+        $this->assertNotContains($displayedProductId, $stillBogus);
+        // ...and it is the only one, so the pass no longer walks the whole catalogue.
+        $this->assertGreaterThan(
+            0,
+            count($stillBogus),
+            'Every product was refreshed, so the update was not scoped to the page.'
+        );
+    }
+
+    /**
+     * The rows are fetched before the refresh runs, so the refreshed values have to be read back
+     * into them - otherwise the grid keeps showing the quantities as they were on the previous load.
+     */
+    public function testTheRefreshedValuesReachTheReturnedRows(): void
+    {
+        $this->setReservedQuantityEverywhere(self::BOGUS_RESERVED_QUANTITY);
+
+        $rows = $this->repository->getData(
+            (new QueryStockParamsCollection())->fromArray(['page_size' => 1, 'page_index' => 1])
+        );
+
+        $this->assertNotSame(
+            self::BOGUS_RESERVED_QUANTITY,
+            (int) $rows[0]['product_reserved_quantity'],
+            'The row still carries the value stored before the refresh.'
+        );
+        $this->assertSame(
+            $this->storedReservedQuantity((int) $rows[0]['product_id'], (int) $rows[0]['combination_id']),
+            (int) $rows[0]['product_reserved_quantity']
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setReservedQuantityEverywhere(0);
+        parent::tearDown();
+    }
+
+    private function setReservedQuantityEverywhere(int $quantity): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE ' . $this->dbPrefix . 'stock_available SET reserved_quantity = :quantity',
+            ['quantity' => $quantity]
+        );
+    }
+
+    /**
+     * @return int[]
+     */
+    private function productIdsWithReservedQuantity(int $quantity): array
+    {
+        return array_map('intval', $this->connection->executeQuery(
+            'SELECT DISTINCT id_product FROM ' . $this->dbPrefix . 'stock_available WHERE reserved_quantity = :quantity',
+            ['quantity' => $quantity]
+        )->fetchFirstColumn());
+    }
+
+    private function storedReservedQuantity(int $productId, int $combinationId): int
+    {
+        return (int) $this->connection->executeQuery(
+            'SELECT reserved_quantity FROM ' . $this->dbPrefix . 'stock_available
+             WHERE id_product = :productId AND id_product_attribute = :combinationId',
+            ['productId' => $productId, 'combinationId' => $combinationId]
+        )->fetchOne();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | `StockRepository::getData()` asked `StockManager` to recompute `reserved_quantity` and `physical_quantity` for every `stock_available` row of the shop, on every load and every filter or paging request of Catalog > Stocks. That statement evaluates one correlated sub-select over `orders`, `order_detail` and `order_state` per row, so its cost grows with the catalogue and the order history together. Every path that changes those values already maintains them scoped to the order or product it touches, so this pass is a repair pass rather than the source of truth. It is now scoped to the products the page is about to display, and the refreshed values are read back into the rows that were already fetched.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On a shop with a large catalogue and a long order history, open Catalog > Stocks. Before the change the list does not appear, or takes minutes; after it, it loads. To see the mechanism without that volume, set `reserved_quantity` to a wrong value on every `stock_available` row and load one page: only the products on that page are corrected. `tests/Integration/PrestaShopBundle/Entity/Repository/StockRepositoryTest.php` covers both directions.
| UI Tests          | Not run. A campaign can be launched on request.
| Fixed issue or discussion?     | Fixes #24975
| Related PRs       |
| Sponsor company   |

### Measured

Synthetic MySQL fixture matching the shape the reporters describe - 40,000 `stock_available` rows and
20,000 orders - running the exact statement `updateReservedProductQuantity()` builds. Both variants
measured warm, after a discarded warm-up pass, because the InnoDB buffer pool genuinely persists
between requests:

| order lines | whole catalogue (what the grid did) | one page of 50 products |
| --- | --- | --- |
| 40,000 | 316 ms | 9.0 ms |
| 400,000 | 1,238 ms | 4.9 ms |

The unscoped statement grows with the order history; the scoped one does not, because it is bound by
the page size. `ps_order_detail` has index `product_id (product_id, product_attribute_id)` and
`ps_stock_available` has `product_sqlstock (id_product, id_product_attribute, id_shop, id_shop_group)`,
so each scoped update is index-bound.

The first, cold run of the unscoped statement on the 40,000-line fixture had still not finished when it
was killed at 157 s. That number is cold-cache and includes first-touch I/O on data inserted moments
earlier, so it is not the figure to quote - but it is the state a merchant meets on a page that has not
been opened recently, and it matches "content never loads" in the report.

Two earlier attempts to reproduce failed on volume: #24517 was closed as "not a PrestaShop core bug,
most likely a server problem", and the QA check on this issue used a shop with 81 orders.

### Why scoping is safe

`updatePhysicalProductQuantity()` is called from six places and every one of them is already scoped:

| Caller | Scope |
| --- | --- |
| `classes/PaymentModule.php:793` | `$idOrder` |
| `classes/order/OrderHistory.php:326` | `$idOrder` |
| `src/Adapter/Order/CommandHandler/AbstractOrderCommandHandler.php:57` | `$idOrder` |
| `src/Adapter/Order/OrderProductQuantityUpdater.php:388` | `$idOrder` |
| `src/Adapter/Product/Stock/Repository/StockAvailableRepository.php:316` | `StockId` |
| `src/PrestaShopBundle/Entity/Repository/StockRepository.php:134` (`syncAllStock`) | `$idProduct` |

So order creation, status changes, order product edits and product/combination stock edits all keep
the values correct incrementally. Only the grid ran it unscoped.

### The one real objection, stated first

`orderBy()` in `StockManagementRepository` maps `{physical_quantity}` to `product_physical_quantity`,
which is `sa.physical_quantity` - a column this pass writes. Sorting the grid by physical quantity now
orders on the values as stored rather than on values recomputed a moment earlier, so on a shop whose
stored values have drifted the page composition could differ. `{available_quantity}` is `sa.quantity`,
which the pass never writes, so sorting by available quantity is unaffected. Given the table above,
drift requires a write that bypassed all six paths.

### Approach, and why not the earlier one

prestaalba proposed the same idea in #24989 ("update stock only for displayed products"). It was closed
by @PierreRambaud with "feel free to reopen if you can provide another way to fix bugs". Its
implementation called `parent::getData()` **twice** - once to learn the ids, once to return - so the
heavy grid query ran on every page load in addition to the syncs. Here the grid query runs once, the
ids come from its result, and a single small indexed `SELECT` reads the refreshed quantities back.

### File relationship with an open PR

`#34863` (ociohogar) is open on `src/Adapter/StockManager.php` and rewrites both
`updatePhysicalProductQuantity()` and `updateReservedProductQuantity()` to add pack support. This
branch deliberately does **not** touch that file - it changes only
`src/PrestaShopBundle/Entity/Repository/StockRepository.php` - so there is no overlap. #34863 is a
different defect (packs, issues 23646 and 28713), currently `mergeable_state=dirty`, last commit
2023-12-28, no reviews, labelled `BC break`, and its author states he tested only on 1.7.8.

### Verification

- Mutation A - restore the unscoped call: `testOnlyTheDisplayedProductsAreRefreshed` fails
  ("Every product was refreshed, so the update was not scoped to the page"), the other passes.
- Mutation B - drop the read-back: `testTheRefreshedValuesReachTheReturnedRows` fails
  ("The row still carries the value stored before the refresh"), the other passes.
- PHPStan `-c phpstan.neon.dist`: `[OK] No errors`. php-cs-fixer clean.

### Checked and NOT a bug

`updateReservedProductQuantity()` sets `reserved_quantity` from a sub-select that returns `NULL` for a
product with no live order lines, and the column is `INT NOT NULL`. Under a strict `sql_mode` that is
`ERROR 1048: Column 'reserved_quantity' cannot be null` - reproduced on the CLI. It does not happen in
the application because `DbPDO.php:120` and `DbMySQLi.php:71` issue `SET SESSION sql_mode = ''` on the
legacy connection, so the value coerces to 0. Recording it because the CLI reproduction looks alarming
and is not the app's behaviour.
